### PR TITLE
feat(docs): AI-as-Code positioning and hero section redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Wave
+# Wave — AI-as-Code
 
-**Multi-agent pipelines for AI-assisted development.**
+**Infrastructure thinking for AI-native workflows.**
 
-Wave orchestrates LLM agents through structured pipelines — each step runs a specialized persona with scoped permissions, validated contracts, and isolated workspaces.
+Wave brings Infrastructure-as-Code principles to AI. Define multi-agent pipelines in YAML, version them in git, and run them with contracts, isolation, and audit trails.
 
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,18 +4,18 @@ import { withMermaid } from 'vitepress-plugin-mermaid'
 export default withMermaid(
   defineConfig({
     title: 'Wave',
-    description: 'AI Pipelines as Code - Define multi-step AI workflows in YAML with validation, isolation, and reproducible results.',
+    description: 'AI-as-Code - Infrastructure thinking for AI-native workflows. Define, version, and run multi-agent pipelines.',
 
     head: [
       ['meta', { name: 'keywords', content: 'AI, pipelines, orchestration, LLM, Claude, automation, YAML, DevOps' }],
       ['meta', { name: 'author', content: 'Michael W. Czechowski' }],
-      ['meta', { property: 'og:title', content: 'Wave - AI Pipelines as Code' }],
-      ['meta', { property: 'og:description', content: 'Define multi-step AI workflows in YAML with validation, isolation, and reproducible results.' }],
+      ['meta', { property: 'og:title', content: 'Wave - AI-as-Code' }],
+      ['meta', { property: 'og:description', content: 'Infrastructure thinking for AI-native workflows. Define, version, and run multi-agent pipelines.' }],
       ['meta', { property: 'og:type', content: 'website' }],
       ['meta', { property: 'og:image', content: '/og-image.png' }],
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-      ['meta', { name: 'twitter:title', content: 'Wave - AI Pipelines as Code' }],
-      ['meta', { name: 'twitter:description', content: 'Define multi-step AI workflows in YAML with validation, isolation, and reproducible results.' }],
+      ['meta', { name: 'twitter:title', content: 'Wave - AI-as-Code' }],
+      ['meta', { name: 'twitter:description', content: 'Infrastructure thinking for AI-native workflows. Define, version, and run multi-agent pipelines.' }],
       ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }]
     ],
 
@@ -28,6 +28,7 @@ export default withMermaid(
           text: 'Concepts',
           items: [
             { text: 'Overview', link: '/concepts/' },
+            { text: 'AI-as-Code', link: '/concepts/ai-as-code' },
             { text: 'Pipelines', link: '/concepts/pipelines' },
             { text: 'Personas', link: '/concepts/personas' },
             { text: 'Contracts', link: '/concepts/contracts' },
@@ -105,6 +106,7 @@ export default withMermaid(
             text: 'Concepts',
             items: [
               { text: 'Overview', link: '/concepts/' },
+              { text: 'AI-as-Code', link: '/concepts/ai-as-code' },
               { text: 'Pipelines', link: '/concepts/pipelines' },
               { text: 'Personas', link: '/concepts/personas' },
               { text: 'Contracts', link: '/concepts/contracts' },

--- a/docs/.vitepress/theme/components/HeroSection.vue
+++ b/docs/.vitepress/theme/components/HeroSection.vue
@@ -1,30 +1,572 @@
 <script setup lang="ts">
-import type { HeroSectionProps } from '../types'
+import { computed, ref } from 'vue'
+import type { HeroSectionProps, TerminalLineVariant, TerminalIcon } from '../types'
 
 const props = withDefaults(defineProps<HeroSectionProps>(), {
-  secondaryAction: undefined
+  secondaryAction: undefined,
+  terminal: undefined,
+  valuePills: undefined,
+  github: undefined,
+  showBackground: undefined
 })
+
+// Determine if we should use two-column layout (when terminal is provided)
+const isTwoColumn = computed(() => !!props.terminal)
+
+// Determine if background should be shown
+const hasBackground = computed(() => {
+  if (props.showBackground !== undefined) {
+    return props.showBackground
+  }
+  return isTwoColumn.value
+})
+
+// Terminal prompt with fallback
+const terminalPrompt = computed(() => props.terminal?.prompt ?? '$')
+
+// Build full terminal command display
+const terminalCommand = computed(() => {
+  if (!props.terminal) return ''
+  return `${terminalPrompt.value} ${props.terminal.command}`
+})
+
+// Get shields.io badge URL
+const githubBadgeUrl = computed(() => {
+  if (!props.github) return ''
+  const style = props.github.style ?? 'social'
+  return `https://img.shields.io/github/stars/${props.github.repo}?style=${style}`
+})
+
+// Get GitHub repo URL
+const githubRepoUrl = computed(() => {
+  if (!props.github) return ''
+  return `https://github.com/${props.github.repo}`
+})
+
+// Clipboard state for copy button
+const copied = ref(false)
+
+// Copy terminal content to clipboard
+function copyTerminalContent() {
+  if (!props.terminal) return
+
+  const content = [
+    `${terminalPrompt.value} ${props.terminal.command}`,
+    '',
+    ...props.terminal.outputLines.map(line => line.text)
+  ].join('\n')
+
+  navigator.clipboard.writeText(content).then(() => {
+    copied.value = true
+    setTimeout(() => {
+      copied.value = false
+    }, 2000)
+  })
+}
+
+// Get CSS class for terminal line variant
+function getLineVariantClass(variant?: TerminalLineVariant): string {
+  if (!variant || variant === 'default') return ''
+  return `line-${variant}`
+}
+
+// Get icon for terminal line
+function getLineIcon(icon?: TerminalIcon): string {
+  switch (icon) {
+    case 'check': return '\u2713'
+    case 'cross': return '\u2717'
+    case 'spinner': return '\u25CB'
+    case 'arrow': return '\u2192'
+    case 'dot': return '\u2022'
+    default: return ''
+  }
+}
 </script>
 
 <template>
-  <section class="hero-section">
-    <h1>{{ props.title }}</h1>
-    <p class="tagline">{{ props.tagline }}</p>
-    <div class="hero-actions">
-      <a :href="props.primaryAction.link" class="btn btn-primary">
-        {{ props.primaryAction.text }}
-      </a>
-      <a
-        v-if="props.secondaryAction"
-        :href="props.secondaryAction.link"
-        class="btn btn-secondary"
-      >
-        {{ props.secondaryAction.text }}
-      </a>
+  <section
+    class="hero-section"
+    :class="{
+      'hero-two-column': isTwoColumn,
+      'hero-with-background': hasBackground
+    }"
+  >
+    <!-- Background pattern -->
+    <div v-if="hasBackground" class="hero-background-pattern" aria-hidden="true"></div>
+
+    <div class="hero-container">
+      <!-- Left column: Content -->
+      <div class="hero-content">
+        <h1>{{ props.title }}</h1>
+        <p class="tagline">{{ props.tagline }}</p>
+
+        <!-- Value proposition pills -->
+        <div v-if="props.valuePills && props.valuePills.length > 0" class="hero-pills">
+          <template v-for="(pill, index) in props.valuePills" :key="index">
+            <a
+              v-if="pill.link"
+              :href="pill.link"
+              class="hero-pill"
+              :title="pill.tooltip"
+            >
+              <span v-if="pill.icon" class="pill-icon">{{ pill.icon }}</span>
+              <span class="pill-label">{{ pill.label }}</span>
+            </a>
+            <span
+              v-else
+              class="hero-pill"
+              :title="pill.tooltip"
+            >
+              <span v-if="pill.icon" class="pill-icon">{{ pill.icon }}</span>
+              <span class="pill-label">{{ pill.label }}</span>
+            </span>
+          </template>
+        </div>
+
+        <!-- CTA buttons and GitHub badge -->
+        <div class="hero-actions">
+          <a :href="props.primaryAction.link" class="btn btn-primary">
+            {{ props.primaryAction.text }}
+          </a>
+          <a
+            v-if="props.secondaryAction"
+            :href="props.secondaryAction.link"
+            class="btn btn-secondary"
+          >
+            {{ props.secondaryAction.text }}
+          </a>
+
+          <!-- GitHub stars badge -->
+          <a
+            v-if="props.github"
+            :href="githubRepoUrl"
+            class="github-badge"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View on GitHub"
+          >
+            <img
+              :src="githubBadgeUrl"
+              alt="GitHub stars"
+              loading="lazy"
+            />
+          </a>
+        </div>
+      </div>
+
+      <!-- Right column: Terminal preview -->
+      <div v-if="props.terminal" class="hero-terminal">
+        <div class="terminal-window">
+          <div class="terminal-header">
+            <div class="terminal-dots">
+              <span class="dot red"></span>
+              <span class="dot yellow"></span>
+              <span class="dot green"></span>
+            </div>
+            <span v-if="props.terminal.title" class="terminal-title">{{ props.terminal.title }}</span>
+            <button
+              class="terminal-copy-btn"
+              :class="{ copied }"
+              @click="copyTerminalContent"
+              :aria-label="copied ? 'Copied!' : 'Copy to clipboard'"
+            >
+              <svg v-if="!copied" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            </button>
+          </div>
+          <div class="terminal-content" role="region" aria-label="Terminal output preview">
+            <div class="terminal-line command">{{ terminalCommand }}</div>
+            <div class="terminal-line empty"></div>
+            <div
+              v-for="(line, index) in props.terminal.outputLines"
+              :key="index"
+              class="terminal-line"
+              :class="getLineVariantClass(line.variant)"
+            >
+              <span v-if="line.icon" class="line-icon">{{ getLineIcon(line.icon) }}</span>
+              {{ line.text }}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </template>
 
 <style scoped>
-/* Styles are in styles/components.css */
+/* Base hero section - maintains backwards compatibility */
+.hero-section {
+  position: relative;
+  text-align: center;
+  padding: 80px 24px;
+  max-width: 900px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+/* Two-column layout mode */
+.hero-section.hero-two-column {
+  max-width: 1200px;
+  text-align: left;
+}
+
+.hero-container {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-two-column .hero-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: 3.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, var(--wave-primary) 0%, var(--wave-accent) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-content .tagline {
+  font-size: 1.5rem;
+  color: var(--vp-c-text-2);
+  margin-bottom: 24px;
+  max-width: 600px;
+  line-height: 1.5;
+}
+
+.hero-section:not(.hero-two-column) .hero-content .tagline {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Value proposition pills */
+.hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.hero-section:not(.hero-two-column) .hero-pills {
+  justify-content: center;
+}
+
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 20px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.hero-pill:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: var(--wave-primary);
+  color: var(--wave-primary);
+}
+
+a.hero-pill {
+  cursor: pointer;
+}
+
+.pill-icon {
+  font-size: 16px;
+}
+
+/* Hero actions */
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.hero-section:not(.hero-two-column) .hero-actions {
+  justify-content: center;
+}
+
+.hero-two-column .hero-actions {
+  justify-content: flex-start;
+}
+
+.hero-actions .btn {
+  padding: 12px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.hero-actions .btn-primary {
+  background: var(--wave-primary);
+  color: white;
+}
+
+.hero-actions .btn-primary:hover {
+  background: var(--wave-primary-dark);
+  transform: translateY(-2px);
+}
+
+.hero-actions .btn-secondary {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  border: 1px solid var(--vp-c-divider);
+}
+
+.hero-actions .btn-secondary:hover {
+  border-color: var(--wave-primary);
+  color: var(--wave-primary);
+}
+
+.github-badge {
+  display: inline-flex;
+  align-items: center;
+  transition: opacity 0.2s ease;
+}
+
+.github-badge:hover {
+  opacity: 0.8;
+}
+
+.github-badge img {
+  height: 24px;
+}
+
+/* Terminal preview */
+.hero-terminal {
+  display: flex;
+  justify-content: center;
+}
+
+.terminal-window {
+  width: 100%;
+  max-width: 100%;
+  background: #1a1a2e;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #2d2d44;
+  gap: 12px;
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-dots .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dots .dot.red { background: #ff5f56; }
+.terminal-dots .dot.yellow { background: #ffbd2e; }
+.terminal-dots .dot.green { background: #27c93f; }
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: 13px;
+  color: #a9b1d6;
+  font-family: var(--wave-font-mono, 'SF Mono', 'Fira Code', monospace);
+}
+
+.terminal-copy-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+}
+
+.terminal-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #a9b1d6;
+}
+
+.terminal-copy-btn.copied {
+  color: #27c93f;
+}
+
+.terminal-content {
+  padding: 16px 20px;
+  font-family: var(--wave-font-mono, 'SF Mono', 'Fira Code', monospace);
+  font-size: 13px;
+  line-height: 1.7;
+  color: #a9b1d6;
+  min-height: 200px;
+  max-height: 320px;
+  overflow-x: auto;
+  overflow-y: auto;
+}
+
+.terminal-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.terminal-line.empty {
+  height: 1.7em;
+}
+
+.terminal-line.command {
+  color: #7dd3fc;
+}
+
+.terminal-line .line-icon {
+  margin-right: 8px;
+}
+
+/* Terminal line variants */
+.terminal-line.line-success { color: #27c93f; }
+.terminal-line.line-error { color: #ff5f56; }
+.terminal-line.line-warning { color: #ffbd2e; }
+.terminal-line.line-info { color: #7dd3fc; }
+.terminal-line.line-muted { color: #6b7280; }
+.terminal-line.line-highlight { color: #c4b5fd; font-weight: 500; }
+
+/* Background pattern */
+.hero-background-pattern {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-image: radial-gradient(circle, var(--vp-c-divider) 1px, transparent 1px);
+  background-size: 40px 40px;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.dark .hero-background-pattern {
+  opacity: 0.15;
+}
+
+/* Responsive: Tablet */
+@media (max-width: 1023px) {
+  .hero-two-column .hero-container {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+
+  .hero-section.hero-two-column {
+    text-align: center;
+  }
+
+  .hero-two-column .hero-pills {
+    justify-content: center;
+  }
+
+  .hero-two-column .hero-actions {
+    justify-content: center;
+  }
+
+  .hero-two-column .hero-content .tagline {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .terminal-content {
+    max-height: 240px;
+  }
+}
+
+/* Responsive: Mobile */
+@media (max-width: 640px) {
+  .hero-section {
+    padding: 48px 20px;
+  }
+
+  .hero-content h1 {
+    font-size: 2.5rem;
+  }
+
+  .hero-content .tagline {
+    font-size: 1.2rem;
+  }
+
+  .hero-pills {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+
+  .hero-pill {
+    justify-content: center;
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-actions .btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .github-badge {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .terminal-window {
+    max-width: 100%;
+  }
+
+  .terminal-content {
+    min-height: 160px;
+    max-height: 180px;
+    font-size: 12px;
+    padding: 12px 16px;
+  }
+}
+
+/* Accessibility: Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .hero-pill,
+  .hero-actions .btn,
+  .terminal-copy-btn,
+  .github-badge {
+    transition: none;
+  }
+
+  .hero-pill:hover,
+  .hero-actions .btn-primary:hover {
+    transform: none;
+  }
+}
 </style>

--- a/docs/.vitepress/theme/components/TerminalPreview.vue
+++ b/docs/.vitepress/theme/components/TerminalPreview.vue
@@ -1,0 +1,432 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+
+export interface TerminalPreviewProps {
+  command: string
+  outputLines: string[]
+  typingSpeed?: number
+  autoplay?: boolean
+}
+
+const props = withDefaults(defineProps<TerminalPreviewProps>(), {
+  typingSpeed: 50,
+  autoplay: true
+})
+
+const emit = defineEmits<{
+  (e: 'animationStart'): void
+  (e: 'animationComplete'): void
+}>()
+
+// Animation state
+const displayedCommand = ref('')
+const visibleOutputLines = ref<number>(0)
+const isTyping = ref(false)
+const isComplete = ref(false)
+const cursorVisible = ref(true)
+
+// Cursor blink effect
+let cursorInterval: ReturnType<typeof setInterval> | null = null
+
+const startCursorBlink = () => {
+  if (cursorInterval) clearInterval(cursorInterval)
+  cursorInterval = setInterval(() => {
+    cursorVisible.value = !cursorVisible.value
+  }, 530)
+}
+
+const stopCursorBlink = () => {
+  if (cursorInterval) {
+    clearInterval(cursorInterval)
+    cursorInterval = null
+  }
+  cursorVisible.value = true
+}
+
+// Type the command character by character
+const typeCommand = async (): Promise<void> => {
+  isTyping.value = true
+  displayedCommand.value = ''
+
+  for (let i = 0; i < props.command.length; i++) {
+    displayedCommand.value += props.command[i]
+    await sleep(props.typingSpeed)
+  }
+
+  isTyping.value = false
+}
+
+// Show output lines one by one
+const showOutputLines = async (): Promise<void> => {
+  // Small pause after command before output appears
+  await sleep(300)
+
+  for (let i = 0; i < props.outputLines.length; i++) {
+    visibleOutputLines.value = i + 1
+    await sleep(100)
+  }
+}
+
+// Utility sleep function
+const sleep = (ms: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Main animation sequence
+const runAnimation = async (): Promise<void> => {
+  // Reset state
+  displayedCommand.value = ''
+  visibleOutputLines.value = 0
+  isComplete.value = false
+
+  emit('animationStart')
+  startCursorBlink()
+
+  await typeCommand()
+  await showOutputLines()
+
+  stopCursorBlink()
+  isComplete.value = true
+  emit('animationComplete')
+}
+
+// Reset and replay
+const replay = (): void => {
+  runAnimation()
+}
+
+// Computed classes for cursor
+const cursorClass = computed(() => ({
+  cursor: true,
+  'cursor--visible': cursorVisible.value,
+  'cursor--typing': isTyping.value
+}))
+
+// Get visible output lines
+const displayedOutputLines = computed(() => {
+  return props.outputLines.slice(0, visibleOutputLines.value)
+})
+
+// Helper function to format output lines with color codes
+// Format: [color:text] e.g., [green:SUCCESS] or [blue:step-1]
+const formatLine = (line: string): string => {
+  return line
+    .replace(/\[green:([^\]]+)\]/g, '<span class="text-green">$1</span>')
+    .replace(/\[blue:([^\]]+)\]/g, '<span class="text-blue">$1</span>')
+    .replace(/\[yellow:([^\]]+)\]/g, '<span class="text-yellow">$1</span>')
+    .replace(/\[red:([^\]]+)\]/g, '<span class="text-red">$1</span>')
+    .replace(/\[cyan:([^\]]+)\]/g, '<span class="text-cyan">$1</span>')
+    .replace(/\[dim:([^\]]+)\]/g, '<span class="text-dim">$1</span>')
+    .replace(/\[bold:([^\]]+)\]/g, '<span class="text-bold">$1</span>')
+}
+
+// Lifecycle
+onMounted(() => {
+  if (props.autoplay) {
+    // Small delay before starting animation
+    setTimeout(() => {
+      runAnimation()
+    }, 500)
+  }
+})
+
+onUnmounted(() => {
+  stopCursorBlink()
+})
+
+// Watch for autoplay changes
+watch(() => props.autoplay, (newVal) => {
+  if (newVal && !isTyping.value && !isComplete.value) {
+    runAnimation()
+  }
+})
+
+// Expose replay method for parent components
+defineExpose({ replay })
+</script>
+
+<template>
+  <div class="terminal-preview">
+    <div class="terminal-window">
+      <!-- macOS-style title bar -->
+      <div class="terminal-header">
+        <div class="terminal-buttons">
+          <span class="terminal-button terminal-button--close"></span>
+          <span class="terminal-button terminal-button--minimize"></span>
+          <span class="terminal-button terminal-button--maximize"></span>
+        </div>
+        <div class="terminal-title">wave</div>
+        <div class="terminal-spacer"></div>
+      </div>
+
+      <!-- Terminal content -->
+      <div class="terminal-body">
+        <!-- Command line -->
+        <div class="terminal-line terminal-line--command">
+          <span class="terminal-prompt">$</span>
+          <span class="terminal-command">{{ displayedCommand }}</span>
+          <span :class="cursorClass"></span>
+        </div>
+
+        <!-- Output lines -->
+        <TransitionGroup name="output-line" tag="div" class="terminal-output">
+          <div
+            v-for="(line, index) in displayedOutputLines"
+            :key="index"
+            class="terminal-line terminal-line--output"
+          >
+            <span v-html="formatLine(line)"></span>
+          </div>
+        </TransitionGroup>
+      </div>
+    </div>
+
+    <!-- Replay button (shown when animation is complete) -->
+    <button
+      v-if="isComplete"
+      class="terminal-replay"
+      @click="replay"
+      aria-label="Replay animation"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+        <path d="M3 3v5h5"/>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.terminal-preview {
+  position: relative;
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.terminal-window {
+  background: #1a1b26;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.1),
+    0 0 30px rgba(99, 102, 241, 0.15),
+    0 0 60px rgba(99, 102, 241, 0.1);
+  font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace;
+}
+
+/* Subtle glow effect on the border */
+.terminal-window::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 13px;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.4),
+    rgba(99, 102, 241, 0.1) 50%,
+    rgba(99, 102, 241, 0.4)
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Title bar */
+.terminal-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #24253a;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.terminal-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: opacity 0.2s ease;
+}
+
+.terminal-button--close {
+  background: #ff5f56;
+}
+
+.terminal-button--minimize {
+  background: #ffbd2e;
+}
+
+.terminal-button--maximize {
+  background: #27c93f;
+}
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+}
+
+.terminal-spacer {
+  width: 52px; /* Balance the buttons on the left */
+}
+
+/* Terminal body */
+.terminal-body {
+  padding: 20px 24px;
+  min-height: 180px;
+}
+
+.terminal-line {
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.terminal-line--command {
+  display: flex;
+  align-items: center;
+  color: #c0caf5;
+  font-size: 14px;
+}
+
+.terminal-prompt {
+  color: #7aa2f7;
+  margin-right: 10px;
+  font-weight: 600;
+}
+
+.terminal-command {
+  color: #c0caf5;
+}
+
+/* Cursor */
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 18px;
+  background: #7aa2f7;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.cursor--visible {
+  opacity: 1;
+}
+
+.cursor--typing {
+  animation: none;
+}
+
+/* Output lines */
+.terminal-output {
+  margin-top: 12px;
+}
+
+.terminal-line--output {
+  color: #9aa5ce;
+  font-size: 13px;
+  padding: 2px 0;
+}
+
+/* Output line transition */
+.output-line-enter-active {
+  transition: all 0.3s ease;
+}
+
+.output-line-enter-from {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+/* Color classes for formatted output */
+:deep(.text-green) {
+  color: #9ece6a;
+}
+
+:deep(.text-blue) {
+  color: #7aa2f7;
+}
+
+:deep(.text-yellow) {
+  color: #e0af68;
+}
+
+:deep(.text-red) {
+  color: #f7768e;
+}
+
+:deep(.text-cyan) {
+  color: #7dcfff;
+}
+
+:deep(.text-dim) {
+  color: #565f89;
+}
+
+:deep(.text-bold) {
+  font-weight: 600;
+  color: #c0caf5;
+}
+
+/* Replay button */
+.terminal-replay {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(122, 162, 247, 0.15);
+  color: #7aa2f7;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: all 0.2s ease;
+  z-index: 2;
+}
+
+.terminal-replay:hover {
+  opacity: 1;
+  background: rgba(122, 162, 247, 0.25);
+  transform: scale(1.05);
+}
+
+.terminal-replay:active {
+  transform: scale(0.95);
+}
+
+/* Dark theme adjustments - works in both light and dark mode */
+/* The terminal intentionally stays dark even in light mode for authenticity */
+
+/* Responsive */
+@media (max-width: 640px) {
+  .terminal-body {
+    padding: 16px 18px;
+  }
+
+  .terminal-line--command {
+    font-size: 13px;
+  }
+
+  .terminal-line--output {
+    font-size: 12px;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -17,6 +17,7 @@ import PermissionMatrix from './components/PermissionMatrix.vue'
 import HeroSection from './components/HeroSection.vue'
 import FeatureCards from './components/FeatureCards.vue'
 import TrustSignals from './components/TrustSignals.vue'
+import TerminalPreview from './components/TerminalPreview.vue'
 
 // Pipeline Learning Components
 import PipelineVisualizer from './components/PipelineVisualizer.vue'
@@ -46,6 +47,7 @@ export default {
     app.component('HeroSection', HeroSection)
     app.component('FeatureCards', FeatureCards)
     app.component('TrustSignals', TrustSignals)
+    app.component('TerminalPreview', TerminalPreview)
 
     // Register pipeline learning components
     app.component('PipelineVisualizer', PipelineVisualizer)

--- a/docs/.vitepress/theme/styles/components.css
+++ b/docs/.vitepress/theme/styles/components.css
@@ -485,3 +485,748 @@
     align-items: center;
   }
 }
+
+
+/* ===========================================
+   ENHANCED HERO SECTION
+   Issue #022 - Hero section redesign with
+   terminal preview and value prop pills
+   =========================================== */
+
+/* -------------------------------------------
+   Custom Properties (Design Tokens)
+   ------------------------------------------- */
+
+:root {
+  /* Terminal Colors - Dark theme for code preview */
+  --hero-terminal-bg: #0d1117;
+  --hero-terminal-border: #30363d;
+  --hero-terminal-header-bg: #161b22;
+  --hero-terminal-shadow: rgba(0, 0, 0, 0.4);
+
+  /* Terminal syntax highlighting (GitHub Dark inspired) */
+  --hero-syntax-comment: #8b949e;
+  --hero-syntax-keyword: #ff7b72;
+  --hero-syntax-string: #a5d6ff;
+  --hero-syntax-function: #d2a8ff;
+  --hero-syntax-variable: #79c0ff;
+  --hero-syntax-constant: #ffa657;
+  --hero-syntax-operator: #ff7b72;
+  --hero-syntax-text: #e6edf3;
+  --hero-syntax-yaml-key: #7ee787;
+  --hero-syntax-yaml-value: #a5d6ff;
+
+  /* Terminal glow effect for emphasis */
+  --hero-terminal-glow: rgba(79, 70, 229, 0.15);
+  --hero-terminal-glow-hover: rgba(79, 70, 229, 0.25);
+
+  /* Value Prop Pills - Small badges showing key benefits */
+  --hero-pill-bg: rgba(255, 255, 255, 0.05);
+  --hero-pill-border: rgba(255, 255, 255, 0.1);
+  --hero-pill-text: var(--vp-c-text-2);
+  --hero-pill-icon: var(--wave-primary);
+  --hero-pill-hover-bg: rgba(79, 70, 229, 0.1);
+  --hero-pill-hover-border: rgba(79, 70, 229, 0.3);
+
+  /* Grid Background Pattern - Subtle dot/grid pattern for depth */
+  --hero-grid-color: rgba(79, 70, 229, 0.08);
+  --hero-grid-size: 24px;
+  --hero-grid-dot-size: 1px;
+
+  /* Layout Spacing - Gaps and padding for two-column layout */
+  --hero-section-padding-y: 80px;
+  --hero-section-padding-x: 24px;
+  --hero-column-gap: 64px;
+  --hero-content-max-width: 1280px;
+
+  /* Animation Timing - Durations and easing for animations */
+  --hero-animation-duration: 0.3s;
+  --hero-animation-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --hero-typing-speed: 50ms;
+  --hero-cursor-blink: 1s;
+}
+
+/* Dark mode adjustments for enhanced hero */
+.dark {
+  --hero-terminal-bg: #0d1117;
+  --hero-terminal-border: #30363d;
+  --hero-terminal-glow: rgba(129, 140, 248, 0.2);
+  --hero-terminal-glow-hover: rgba(129, 140, 248, 0.35);
+
+  --hero-pill-bg: rgba(255, 255, 255, 0.03);
+  --hero-pill-border: rgba(255, 255, 255, 0.08);
+  --hero-pill-hover-bg: rgba(129, 140, 248, 0.15);
+  --hero-pill-hover-border: rgba(129, 140, 248, 0.4);
+
+  --hero-grid-color: rgba(129, 140, 248, 0.06);
+}
+
+
+/* -------------------------------------------
+   Grid/Dot Background Pattern
+   ------------------------------------------- */
+
+/**
+ * Creates a subtle dot grid pattern behind the hero content.
+ * Uses a radial gradient repeated at fixed intervals.
+ * Works well in both light and dark modes.
+ */
+.hero-enhanced {
+  position: relative;
+  overflow: hidden;
+  padding: var(--hero-section-padding-y) var(--hero-section-padding-x);
+}
+
+.hero-enhanced::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: radial-gradient(
+    circle at center,
+    var(--hero-grid-color) var(--hero-grid-dot-size),
+    transparent var(--hero-grid-dot-size)
+  );
+  background-size: var(--hero-grid-size) var(--hero-grid-size);
+  background-position: center center;
+  pointer-events: none;
+  z-index: 0;
+
+  /* Fade out at edges for softer look */
+  mask-image: radial-gradient(
+    ellipse 80% 60% at 50% 50%,
+    black 0%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse 80% 60% at 50% 50%,
+    black 0%,
+    transparent 100%
+  );
+}
+
+
+/* -------------------------------------------
+   Two-Column Hero Layout
+   ------------------------------------------- */
+
+/**
+ * Main hero container with two-column layout:
+ * - Left column: Headline, tagline, pills, CTA buttons
+ * - Right column: Terminal preview
+ */
+.hero-enhanced__container {
+  position: relative;
+  z-index: 1;
+  max-width: var(--hero-content-max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--hero-column-gap);
+  align-items: center;
+}
+
+/* Left column: Text content */
+.hero-enhanced__content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero-enhanced__headline {
+  font-size: 3.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--vp-c-text-1);
+}
+
+/* Gradient text for emphasis */
+.hero-enhanced__headline .gradient-text {
+  background: linear-gradient(
+    135deg,
+    var(--wave-primary) 0%,
+    var(--wave-accent) 50%,
+    var(--wave-secondary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-enhanced__tagline {
+  font-size: 1.25rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  max-width: 480px;
+}
+
+/* Right column: Terminal */
+.hero-enhanced__preview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+
+/* -------------------------------------------
+   Terminal Preview Component
+   ------------------------------------------- */
+
+/**
+ * A styled terminal window showing Wave in action.
+ * Features:
+ * - macOS-style window chrome
+ * - Syntax highlighted code
+ * - Subtle glow effect on hover
+ * - Typing animation for the command line
+ */
+.terminal-preview {
+  width: 100%;
+  max-width: 560px;
+  background: var(--hero-terminal-bg);
+  border: 1px solid var(--hero-terminal-border);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow:
+    0 4px 6px -1px var(--hero-terminal-shadow),
+    0 2px 4px -2px var(--hero-terminal-shadow),
+    0 0 0 1px var(--hero-terminal-border),
+    0 0 60px -10px var(--hero-terminal-glow);
+  transition:
+    box-shadow var(--hero-animation-duration) var(--hero-animation-easing),
+    transform var(--hero-animation-duration) var(--hero-animation-easing);
+}
+
+.terminal-preview:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 20px 25px -5px var(--hero-terminal-shadow),
+    0 8px 10px -6px var(--hero-terminal-shadow),
+    0 0 0 1px var(--hero-terminal-border),
+    0 0 80px -5px var(--hero-terminal-glow-hover);
+}
+
+/* Terminal header with traffic light buttons */
+.terminal-preview__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--hero-terminal-header-bg);
+  border-bottom: 1px solid var(--hero-terminal-border);
+}
+
+.terminal-preview__buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-preview__button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--hero-terminal-border);
+}
+
+.terminal-preview__button--close {
+  background: #ff5f56;
+}
+
+.terminal-preview__button--minimize {
+  background: #ffbd2e;
+}
+
+.terminal-preview__button--maximize {
+  background: #27c93f;
+}
+
+.terminal-preview__title {
+  flex: 1;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--hero-syntax-comment);
+  font-family: var(--wave-font-mono);
+}
+
+/* Terminal content area */
+.terminal-preview__content {
+  padding: 20px;
+  font-family: var(--wave-font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--hero-syntax-text);
+  min-height: 280px;
+}
+
+/* Command line prompt */
+.terminal-preview__line {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 4px;
+}
+
+.terminal-preview__prompt {
+  color: var(--hero-syntax-function);
+  margin-right: 8px;
+  user-select: none;
+}
+
+.terminal-preview__command {
+  color: var(--hero-syntax-text);
+}
+
+/* Output area */
+.terminal-preview__output {
+  margin-top: 16px;
+  padding-left: 0;
+}
+
+.terminal-preview__output-line {
+  margin-bottom: 2px;
+  animation: fade-in-up 0.3s ease-out forwards;
+  opacity: 0;
+}
+
+/* Staggered delays for output lines */
+.terminal-preview__output-line:nth-child(1) { animation-delay: 2.5s; }
+.terminal-preview__output-line:nth-child(2) { animation-delay: 2.7s; }
+.terminal-preview__output-line:nth-child(3) { animation-delay: 2.9s; }
+.terminal-preview__output-line:nth-child(4) { animation-delay: 3.1s; }
+.terminal-preview__output-line:nth-child(5) { animation-delay: 3.3s; }
+.terminal-preview__output-line:nth-child(6) { animation-delay: 3.5s; }
+
+/* Syntax highlighting classes */
+.syntax-comment { color: var(--hero-syntax-comment); }
+.syntax-keyword { color: var(--hero-syntax-keyword); }
+.syntax-string { color: var(--hero-syntax-string); }
+.syntax-function { color: var(--hero-syntax-function); }
+.syntax-variable { color: var(--hero-syntax-variable); }
+.syntax-constant { color: var(--hero-syntax-constant); }
+.syntax-operator { color: var(--hero-syntax-operator); }
+.syntax-yaml-key { color: var(--hero-syntax-yaml-key); }
+.syntax-yaml-value { color: var(--hero-syntax-yaml-value); }
+
+/* Status indicators in output */
+.terminal-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.terminal-status__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.terminal-status__dot--success {
+  background: var(--wave-trust-green);
+  box-shadow: 0 0 8px var(--wave-trust-green);
+}
+
+.terminal-status__dot--running {
+  background: var(--wave-secondary);
+  box-shadow: 0 0 8px var(--wave-secondary);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.terminal-status__dot--pending {
+  background: var(--hero-syntax-comment);
+}
+
+
+/* -------------------------------------------
+   Value Prop Pills
+   ------------------------------------------- */
+
+/**
+ * Small badge-like elements showing key benefits.
+ * Can include optional icons before the text.
+ * Arranged in a horizontal row with wrapping.
+ */
+.hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--hero-pill-text);
+  background: var(--hero-pill-bg);
+  border: 1px solid var(--hero-pill-border);
+  border-radius: 20px;
+  transition: all var(--hero-animation-duration) var(--hero-animation-easing);
+  white-space: nowrap;
+}
+
+.hero-pill:hover {
+  background: var(--hero-pill-hover-bg);
+  border-color: var(--hero-pill-hover-border);
+  color: var(--vp-c-text-1);
+}
+
+.hero-pill__icon {
+  width: 14px;
+  height: 14px;
+  color: var(--hero-pill-icon);
+  flex-shrink: 0;
+}
+
+/* Pill variants for different emphasis levels */
+.hero-pill--primary {
+  background: rgba(79, 70, 229, 0.1);
+  border-color: rgba(79, 70, 229, 0.3);
+  color: var(--wave-primary);
+}
+
+.hero-pill--primary:hover {
+  background: rgba(79, 70, 229, 0.2);
+  border-color: var(--wave-primary);
+}
+
+.hero-pill--security {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: var(--wave-trust-green);
+}
+
+.hero-pill--security:hover {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: var(--wave-trust-green);
+}
+
+
+/* -------------------------------------------
+   Typing Animation Keyframes
+   ------------------------------------------- */
+
+/**
+ * Simulates typing effect for terminal commands.
+ * Uses CSS animations with steps() for character-by-character reveal.
+ * Includes blinking cursor effect.
+ */
+
+/* Typing container - hides overflow during animation */
+.typing-text {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid var(--hero-syntax-text);
+  animation:
+    typing 2s steps(30, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite;
+}
+
+/* Typing animation - reveals text from left to right */
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+/* Cursor blink animation */
+@keyframes blink-cursor {
+  from, to {
+    border-color: var(--hero-syntax-text);
+  }
+  50% {
+    border-color: transparent;
+  }
+}
+
+/* Remove cursor after typing completes (optional) */
+.typing-text--no-cursor {
+  animation: typing 2s steps(30, end) forwards;
+  border-right: none;
+}
+
+/* Staggered typing for multiple lines */
+.typing-text--delay-1 {
+  animation-delay: 0.5s;
+  opacity: 0;
+  animation:
+    appear 0.01s 0.5s forwards,
+    typing 1.5s 0.5s steps(25, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite 0.5s;
+}
+
+.typing-text--delay-2 {
+  animation-delay: 2s;
+  opacity: 0;
+  animation:
+    appear 0.01s 2s forwards,
+    typing 1.5s 2s steps(25, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite 2s;
+}
+
+@keyframes appear {
+  to {
+    opacity: 1;
+  }
+}
+
+/* Pulse animation for status indicators */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Fade in animation for output lines */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+
+/* -------------------------------------------
+   Hero Action Buttons
+   ------------------------------------------- */
+
+/**
+ * CTA buttons in the hero section.
+ * Primary button has gradient background.
+ * Secondary button has outlined style.
+ */
+.hero-enhanced__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.hero-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 28px;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all var(--hero-animation-duration) var(--hero-animation-easing);
+  cursor: pointer;
+  border: none;
+}
+
+.hero-btn--primary {
+  background: linear-gradient(
+    135deg,
+    var(--wave-primary) 0%,
+    var(--wave-accent) 100%
+  );
+  color: white;
+  box-shadow:
+    0 4px 14px rgba(79, 70, 229, 0.3),
+    0 0 0 0 rgba(79, 70, 229, 0);
+}
+
+.hero-btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 20px rgba(79, 70, 229, 0.4),
+    0 0 0 2px rgba(79, 70, 229, 0.1);
+}
+
+.hero-btn--secondary {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  border: 1px solid var(--vp-c-divider);
+}
+
+.hero-btn--secondary:hover {
+  border-color: var(--wave-primary);
+  color: var(--wave-primary);
+  background: rgba(79, 70, 229, 0.05);
+}
+
+/* Icon in buttons */
+.hero-btn__icon {
+  width: 18px;
+  height: 18px;
+}
+
+
+/* -------------------------------------------
+   Enhanced Hero - Responsive Breakpoints
+   ------------------------------------------- */
+
+/**
+ * Breakpoint strategy:
+ * - Desktop (>= 1024px): Two columns, full terminal preview
+ * - Tablet (768px - 1023px): Single column, terminal below
+ * - Mobile (< 768px): Single column, smaller typography, compact terminal
+ */
+
+/* Large desktop: Increase spacing */
+@media (min-width: 1280px) {
+  .hero-enhanced {
+    --hero-column-gap: 80px;
+    --hero-section-padding-y: 100px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 4rem;
+  }
+}
+
+/* Tablet: Stack to single column */
+@media (max-width: 1023px) {
+  .hero-enhanced {
+    --hero-column-gap: 48px;
+    --hero-section-padding-y: 64px;
+  }
+
+  .hero-enhanced__container {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-enhanced__content {
+    align-items: center;
+  }
+
+  .hero-enhanced__tagline {
+    max-width: 600px;
+  }
+
+  .hero-pills {
+    justify-content: center;
+  }
+
+  .terminal-preview {
+    max-width: 100%;
+  }
+}
+
+/* Small tablet / large mobile */
+@media (max-width: 768px) {
+  .hero-enhanced {
+    --hero-section-padding-y: 48px;
+    --hero-grid-size: 20px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 2.5rem;
+  }
+
+  .hero-enhanced__tagline {
+    font-size: 1.1rem;
+  }
+
+  .terminal-preview__content {
+    padding: 16px;
+    font-size: 12px;
+    min-height: 240px;
+  }
+
+  .hero-pill {
+    padding: 5px 12px;
+    font-size: 12px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  .hero-enhanced {
+    --hero-section-padding-x: 16px;
+    --hero-section-padding-y: 40px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 2rem;
+  }
+
+  .hero-enhanced__tagline {
+    font-size: 1rem;
+  }
+
+  .terminal-preview {
+    border-radius: 8px;
+  }
+
+  .terminal-preview__header {
+    padding: 10px 12px;
+  }
+
+  .terminal-preview__button {
+    width: 10px;
+    height: 10px;
+  }
+
+  .terminal-preview__content {
+    padding: 12px;
+    font-size: 11px;
+    min-height: 200px;
+  }
+
+  .hero-pills {
+    gap: 8px;
+  }
+
+  .hero-pill__icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  .hero-enhanced__actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .terminal-preview,
+  .hero-pill {
+    transition: none;
+  }
+
+  .terminal-preview:hover {
+    transform: none;
+  }
+
+  .typing-text {
+    animation: none;
+    width: 100%;
+    border-right: none;
+  }
+
+  .terminal-preview__output-line {
+    animation: none;
+    opacity: 1;
+  }
+
+  .terminal-status__dot--running {
+    animation: none;
+  }
+}

--- a/docs/.vitepress/theme/types.ts
+++ b/docs/.vitepress/theme/types.ts
@@ -3,7 +3,9 @@
  * TypeScript types for Vue components
  */
 
+// =============================================================================
 // Feature Card Types
+// =============================================================================
 export interface FeatureCard {
   icon: string
   title: string
@@ -11,7 +13,10 @@ export interface FeatureCard {
   link?: string
 }
 
+// =============================================================================
 // Trust Signal Types
+// =============================================================================
+
 export type ComplianceStatus = 'certified' | 'in-progress' | 'planned'
 
 export interface TrustBadge {
@@ -21,7 +26,10 @@ export interface TrustBadge {
   link?: string
 }
 
+// =============================================================================
 // Platform Tab Types
+// =============================================================================
+
 export type Platform = 'macos' | 'linux' | 'windows'
 
 export interface PlatformContent {
@@ -30,7 +38,10 @@ export interface PlatformContent {
   content: string
 }
 
+// =============================================================================
 // Use Case Types
+// =============================================================================
+
 export type UseCaseCategory =
   | 'code-quality'
   | 'security'
@@ -52,7 +63,10 @@ export interface UseCase {
   link: string
 }
 
+// =============================================================================
 // Permission Matrix Types
+// =============================================================================
+
 export type PermissionLevel = 'allow' | 'deny' | 'conditional'
 
 export interface PersonaPermission {
@@ -66,7 +80,10 @@ export interface PersonaPermission {
   }
 }
 
+// =============================================================================
 // Pipeline Visualizer Types
+// =============================================================================
+
 export interface PipelineStep {
   id: string
   name: string
@@ -81,7 +98,10 @@ export interface Pipeline {
   steps: PipelineStep[]
 }
 
+// =============================================================================
 // YAML Playground Types
+// =============================================================================
+
 export interface ValidationResult {
   valid: boolean
   errors: ValidationError[]
@@ -94,16 +114,194 @@ export interface ValidationError {
   severity: 'error' | 'warning'
 }
 
+// =============================================================================
 // Navigation Types
+// =============================================================================
+
 export interface BreadcrumbItem {
   text: string
   link?: string
 }
 
+// =============================================================================
 // Component Props Types
+// =============================================================================
+
 export interface CopyButtonProps {
   code: string
   lang?: string
+}
+
+// =============================================================================
+// Terminal Preview Types (for HeroSection)
+// =============================================================================
+
+export type TerminalLineVariant =
+  | 'default'   // Standard output
+  | 'success'   // Green text (e.g., "Done!")
+  | 'error'     // Red text
+  | 'warning'   // Yellow text
+  | 'info'      // Blue text
+  | 'muted'     // Dimmed/gray text
+  | 'highlight' // Emphasized text
+
+export type TerminalIcon =
+  | 'check'     // Checkmark for success
+  | 'cross'     // X for failure
+  | 'spinner'   // Loading spinner
+  | 'arrow'     // Arrow indicator
+  | 'dot'       // Bullet point
+
+/**
+ * A single line of terminal output with optional styling
+ */
+export interface TerminalOutputLine {
+  /** The text content of the line */
+  text: string
+  /** Optional color variant for the line */
+  variant?: TerminalLineVariant
+  /** Delay before showing this line (for staggered animation) */
+  delay?: number
+  /** Optional icon prefix (e.g., checkmark, spinner) */
+  icon?: TerminalIcon
+}
+
+/**
+ * Configuration for animated terminal preview
+ * Shows a simulated CLI interaction to demonstrate Wave usage
+ */
+export interface TerminalPreviewConfig {
+  /** The command being typed/executed (e.g., "wave run pipeline.yaml") */
+  command: string
+  /** Lines of output displayed after command execution */
+  outputLines: TerminalOutputLine[]
+  /** Enable typing animation for the command (default: true) */
+  typingAnimation?: boolean
+  /** Typing speed in milliseconds per character (default: 50) */
+  typingSpeed?: number
+  /** Delay before showing output after command is typed (default: 500) */
+  outputDelay?: number
+  /** Terminal prompt prefix (default: "$") */
+  prompt?: string
+  /** Optional title for the terminal window */
+  title?: string
+}
+
+// =============================================================================
+// Value Proposition Types (for HeroSection)
+// =============================================================================
+
+/**
+ * A small pill/badge highlighting a key feature or value prop
+ */
+export interface ValuePropositionPill {
+  /** Short label text */
+  label: string
+  /** Optional icon name or emoji */
+  icon?: string
+  /** Optional tooltip for more detail */
+  tooltip?: string
+  /** Optional link to learn more */
+  link?: string
+}
+
+// =============================================================================
+// Social Proof Types (for HeroSection)
+// =============================================================================
+
+export type SocialProofType = 'github-stars' | 'custom-badge'
+
+/**
+ * Social proof configuration for the hero section
+ * Can show GitHub stars, download counts, or custom badges
+ */
+export interface SocialProofConfig {
+  /** Type of social proof to display */
+  type: SocialProofType
+  /** Configuration specific to the type */
+  config: GitHubStarsConfig | CustomBadgeConfig
+}
+
+/**
+ * GitHub stars badge configuration
+ * Fetches and displays live star count from GitHub API
+ */
+export interface GitHubStarsConfig {
+  type: 'github-stars'
+  /** GitHub repository URL (e.g., "https://github.com/re-cinq/wave") */
+  repoUrl: string
+  /** Optional label override (default: "GitHub Stars") */
+  label?: string
+  /** Cache duration in seconds (default: 3600) */
+  cacheDuration?: number
+}
+
+/**
+ * Custom badge configuration for arbitrary social proof
+ */
+export interface CustomBadgeConfig {
+  type: 'custom-badge'
+  /** Badge label text */
+  label: string
+  /** Badge value/count */
+  value: string | number
+  /** Optional icon */
+  icon?: string
+  /** Optional link */
+  link?: string
+}
+
+// =============================================================================
+// Visual Variant Types (Enhanced HeroSection)
+// =============================================================================
+
+/**
+ * Background style variant for the hero section
+ */
+export type HeroBackgroundVariant =
+  | 'grid'     // Subtle grid pattern
+  | 'dots'     // Dot matrix pattern
+  | 'gradient' // Gradient background
+  | 'none'     // No background decoration
+
+/**
+ * Layout variant for the hero section
+ */
+export type HeroLayoutVariant =
+  | 'centered'   // Content centered, stacked vertically
+  | 'two-column' // Text left, terminal preview right
+
+/**
+ * Extended background configuration for custom styling
+ */
+export interface HeroBackgroundConfig {
+  /** Base variant */
+  variant: HeroBackgroundVariant
+  /** Custom gradient colors (for 'gradient' variant) */
+  gradientColors?: {
+    from: string
+    to: string
+    direction?: 'to-right' | 'to-bottom' | 'to-bottom-right'
+  }
+  /** Grid/dots opacity (0-1, default: 0.1) */
+  patternOpacity?: number
+  /** Enable animated gradient shift */
+  animated?: boolean
+}
+
+// =============================================================================
+// HeroSection Props
+// =============================================================================
+
+/**
+ * Simple GitHub badge configuration for HeroSection
+ * Uses shields.io to display star count
+ */
+export interface HeroGitHubBadge {
+  /** GitHub org/repo path (e.g., "re-cinq/wave") */
+  repo: string
+  /** Badge style (default: 'social') */
+  style?: 'social' | 'flat' | 'flat-square'
 }
 
 export interface HeroSectionProps {
@@ -117,6 +315,85 @@ export interface HeroSectionProps {
     text: string
     link: string
   }
+  /** Terminal preview configuration (enables two-column layout) */
+  terminal?: TerminalPreviewConfig
+  /** Array of value proposition pills to display */
+  valuePills?: ValuePropositionPill[]
+  /** GitHub stars badge configuration */
+  github?: HeroGitHubBadge
+  /** Show background pattern (default: true when terminal is provided) */
+  showBackground?: boolean
+}
+
+/**
+ * Enhanced HeroSection component props
+ *
+ * Backwards compatible with existing HeroSectionProps:
+ * - title, tagline, primaryAction, secondaryAction remain unchanged
+ *
+ * New capabilities:
+ * - Terminal preview with typing animation
+ * - Value proposition pills
+ * - Social proof integration
+ * - Background and layout variants
+ */
+export interface EnhancedHeroSectionProps extends HeroSectionProps {
+  /** Social proof badge configuration */
+  socialProof?: SocialProofConfig
+  /** Background variant (default: 'grid') */
+  background?: HeroBackgroundVariant | HeroBackgroundConfig
+  /** Layout variant (default: 'centered', 'two-column' when terminal provided) */
+  layout?: HeroLayoutVariant
+}
+
+// =============================================================================
+// Terminal Animation State (Internal)
+// =============================================================================
+
+/**
+ * Internal state for terminal animation
+ */
+export interface TerminalAnimationState {
+  /** Current phase of animation */
+  phase: 'idle' | 'typing' | 'executing' | 'complete'
+  /** Characters typed so far */
+  typedChars: number
+  /** Output lines revealed so far */
+  revealedLines: number
+  /** Whether animation is paused */
+  paused: boolean
+}
+
+// =============================================================================
+// Hero Section Defaults
+// =============================================================================
+
+export const HERO_DEFAULTS = {
+  background: 'grid' as HeroBackgroundVariant,
+  layout: 'centered' as HeroLayoutVariant,
+  terminal: {
+    typingAnimation: true,
+    typingSpeed: 50,
+    outputDelay: 500,
+    prompt: '$',
+  },
+} as const
+
+// =============================================================================
+// Type Guards (Enhanced HeroSection)
+// =============================================================================
+
+/**
+ * Type guard to check if props are enhanced
+ */
+export function isEnhancedHeroProps(
+  props: HeroSectionProps | EnhancedHeroSectionProps
+): props is EnhancedHeroSectionProps {
+  return (
+    'socialProof' in props ||
+    'background' in props ||
+    'layout' in props
+  )
 }
 
 export interface FeatureCardsProps {

--- a/docs/concepts/ai-as-code.md
+++ b/docs/concepts/ai-as-code.md
@@ -1,0 +1,135 @@
+# AI-as-Code
+
+Wave brings Infrastructure-as-Code principles to AI workflows. Define your AI pipelines declaratively, version them in git, and run them with the same rigor you apply to infrastructure.
+
+## The Evolution of X-as-Code
+
+The industry has progressively codified operational concerns:
+
+| Era | Paradigm | Tools |
+|-----|----------|-------|
+| 2000s | **Infrastructure-as-Code** | Terraform, Pulumi, CloudFormation |
+| 2010s | **Configuration-as-Code** | Ansible, Chef, Puppet |
+| 2016+ | **Policy-as-Code** | Open Policy Agent, Sentinel |
+| 2018+ | **GitOps** | ArgoCD, Flux |
+| Now | **AI-as-Code** | Wave |
+
+Each evolution brought the same benefits: version control, reproducibility, collaboration, and audit trails. AI workflows deserve the same treatment.
+
+## Why AI Needs the Same Treatment
+
+AI outputs are non-deterministic by nature. Without guardrails:
+
+- **Chat history is not version control** — Prompts drift, context gets lost, and successful patterns disappear
+- **Copy-paste prompts don't scale** — Teams can't share, review, or iterate on workflows
+- **No reproducibility** — The same task produces different results each time
+- **No audit trail** — When something goes wrong, there's no trace to investigate
+- **No permission boundaries** — AI agents have unbounded access to your codebase
+
+Enterprise adoption requires the same predictability we expect from infrastructure.
+
+## Wave's AI-as-Code Principles
+
+Wave implements six core principles borrowed from Infrastructure-as-Code:
+
+### 1. Declarative Pipelines
+
+Define **what** you want, not **how** to get there. Your pipeline is a YAML file that describes steps, dependencies, and contracts.
+
+```yaml
+kind: WavePipeline
+metadata:
+  name: code-review
+
+steps:
+  - id: analyze
+    persona: navigator
+  - id: review
+    persona: auditor
+    dependencies: [analyze]
+```
+
+### 2. Version Controlled
+
+Pipelines live in git, not chat history. You can:
+- Review pipeline changes in PRs
+- Roll back to previous versions
+- Share workflows across teams
+- Track who changed what and when
+
+### 3. Contract Validation
+
+Every step validates its output against a schema before the next step begins. Malformed outputs trigger retries or halt the pipeline — no garbage in, no garbage out.
+
+```yaml
+output_artifacts:
+  - name: analysis
+    path: output/analysis.json
+    type: json
+    contract: contracts/analysis-schema.json
+```
+
+### 4. Fresh Memory Isolation
+
+Each step runs with completely fresh context in an ephemeral workspace. No context bleed between steps means:
+- Predictable behavior regardless of history
+- No accidental information leakage
+- Each persona sees only what it needs
+
+### 5. Git-Native Workflows
+
+Wave integrates with your existing git workflow:
+- Initialize with `wave init` in any repo
+- Pipelines are just YAML files in `.wave/`
+- Artifacts are git-friendly
+
+### 6. Observable Execution
+
+Complete audit trails with credential scrubbing:
+- Every tool call logged
+- Execution traces for debugging
+- Permission decisions recorded
+- No sensitive data in logs
+
+## IaC Principle Mapping
+
+| IaC Principle | How Wave Implements It |
+|---------------|------------------------|
+| **Declarative** | YAML pipeline definitions, not imperative scripts |
+| **Version controlled** | Pipelines live in git, not chat history |
+| **Reproducible** | Contract validation ensures consistent outputs |
+| **Idempotent** | Fresh memory at every step boundary |
+| **Auditable** | Complete execution traces with credential scrubbing |
+| **Reviewable** | PR your AI workflows like any other code |
+
+## Comparison with Alternatives
+
+Wave's approach differs from other multi-agent tools:
+
+| | Wave | Gastown | Claude Flow |
+|--|:----:|:-------:|:-----------:|
+| **Declarative pipelines** | YAML | JSON/TOML | Programmatic |
+| **Version controlled** | ✅ | ✅ (git worktree) | ❌ |
+| **Contract validation** | ✅ | ❌ | ❌ |
+| **Step isolation** | Fresh memory | Shared context | Shared memory |
+| **Permission scoping** | Per-persona | ❌ | ❌ |
+
+### Gastown
+
+Multi-agent workspace manager with Mayor/Polecat architecture. Strong git integration with worktree-based persistence. Different philosophy: persistent shared state vs Wave's fresh-memory isolation.
+
+### Claude Flow
+
+Agent swarm orchestration with 60+ agents and MCP tools. Optimized for parallel execution and collective learning. Different philosophy: shared knowledge base vs Wave's contract-validated handoffs.
+
+### Raw Claude Code
+
+Direct LLM interaction. Great for ad-hoc tasks. Wave adds structure for repeatable, team-scalable workflows.
+
+## Getting Started
+
+Ready to bring Infrastructure-as-Code rigor to your AI workflows?
+
+1. [Quickstart Guide](/quickstart) — Get Wave running in 5 minutes
+2. [Pipelines Concept](/concepts/pipelines) — Deep dive into pipeline structure
+3. [Use Cases](/use-cases/) — Real-world examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ layout: home
 
 <script setup>
 const heroProps = {
-  title: 'AI Pipelines as Code',
-  tagline: 'Define multi-step AI workflows in YAML. Run them with validation, isolation, and reproducible results.',
+  title: 'Wave · AI-as-Code for multi-agent pipelines',
+  tagline: 'Define, version, and run AI workflows like you manage infrastructure.',
   primaryAction: {
     text: 'Get Started',
     link: '/quickstart'
@@ -13,10 +13,37 @@ const heroProps = {
   secondaryAction: {
     text: 'View Examples',
     link: '/use-cases/'
-  }
+  },
+  terminal: {
+    title: 'wave',
+    command: 'wave run speckit-flow "add OAuth"',
+    outputLines: [
+      { text: '[wave] Loading pipeline: speckit-flow', variant: 'info' },
+      { text: '[wave] Persona: navigator (read-only)', variant: 'muted' },
+      { text: '[wave] Step 1/4: navigate ............. done  1m 12s', variant: 'success' },
+      { text: '[wave] Step 2/4: specify .............. done  2m 34s', variant: 'success' },
+      { text: '[wave] Step 3/4: implement ............ done  4m 18s', variant: 'success' },
+      { text: '[wave] Step 4/4: review ............... done  1m 45s', variant: 'success' },
+      { text: '' },
+      { text: '[wave] Pipeline completed in 9m 49s', variant: 'success' }
+    ]
+  },
+  valuePills: [
+    { label: 'Declarative', link: '/concepts/pipelines', tooltip: 'YAML-based configuration' },
+    { label: 'Contracts', link: '/concepts/contracts', tooltip: 'Output validation' },
+    { label: 'Isolation', link: '/concepts/workspaces', tooltip: 'Fresh memory each step' },
+    { label: 'Auditable', link: '/trust-center/', tooltip: 'Full execution traces' }
+  ],
+  showBackground: true
 }
 
 const features = [
+  {
+    icon: 'evolution',
+    title: 'The Next X-as-Code',
+    description: 'Infrastructure → Policy → Security → AI. Bring the same rigor to AI that transformed how you manage infrastructure.',
+    link: '/concepts/ai-as-code'
+  },
   {
     icon: 'pipeline',
     title: 'Pipelines as Code',
@@ -34,12 +61,6 @@ const features = [
     title: 'Step Isolation',
     description: 'Each step runs with fresh memory in an ephemeral workspace. No context bleed between steps.',
     link: '/concepts/workspaces'
-  },
-  {
-    icon: 'persona',
-    title: 'Specialized Personas',
-    description: 'AI agents with defined roles, permissions, and capabilities. Navigator, Auditor, Craftsman, and more.',
-    link: '/concepts/personas'
   },
   {
     icon: 'audit',
@@ -80,6 +101,23 @@ const trustBadges = [
 <HeroSection v-bind="heroProps" />
 
 <FeatureCards :features="features" />
+
+<div class="comparison-section">
+
+## How Wave Compares
+
+<div class="comparison-table">
+
+| | Wave | Gastown | Claude Flow |
+|--|:----:|:-------:|:-----------:|
+| **Declarative pipelines** | YAML | JSON/TOML | Programmatic |
+| **Git integration** | ✅ | ✅ | ❌ |
+| **Contract validation** | ✅ | ❌ | ❌ |
+| **Step isolation** | Fresh memory | Shared | Shared |
+| **Permission scoping** | Per-persona | ❌ | ❌ |
+
+</div>
+</div>
 
 <div class="trust-section">
   <h2 class="trust-heading">Built for Security</h2>
@@ -133,6 +171,38 @@ Each step runs in complete isolation with fresh memory. Artifacts flow between s
 </div>
 
 <style>
+.comparison-section {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+.comparison-section h2 {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.comparison-table {
+  overflow-x: auto;
+}
+
+.comparison-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 12px 16px;
+  text-align: center;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.comparison-table th:first-child,
+.comparison-table td:first-child {
+  text-align: left;
+}
+
 .trust-section {
   text-align: center;
   padding: 48px 24px;

--- a/specs/022-hero-section-redesign/TerminalPreview.vue
+++ b/specs/022-hero-section-redesign/TerminalPreview.vue
@@ -1,0 +1,431 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+
+export interface TerminalPreviewProps {
+  command: string
+  outputLines: string[]
+  typingSpeed?: number
+  autoplay?: boolean
+}
+
+const props = withDefaults(defineProps<TerminalPreviewProps>(), {
+  typingSpeed: 50,
+  autoplay: true
+})
+
+const emit = defineEmits<{
+  (e: 'animationStart'): void
+  (e: 'animationComplete'): void
+}>()
+
+// Animation state
+const displayedCommand = ref('')
+const visibleOutputLines = ref<number>(0)
+const isTyping = ref(false)
+const isComplete = ref(false)
+const cursorVisible = ref(true)
+
+// Cursor blink effect
+let cursorInterval: ReturnType<typeof setInterval> | null = null
+
+const startCursorBlink = () => {
+  if (cursorInterval) clearInterval(cursorInterval)
+  cursorInterval = setInterval(() => {
+    cursorVisible.value = !cursorVisible.value
+  }, 530)
+}
+
+const stopCursorBlink = () => {
+  if (cursorInterval) {
+    clearInterval(cursorInterval)
+    cursorInterval = null
+  }
+  cursorVisible.value = true
+}
+
+// Type the command character by character
+const typeCommand = async (): Promise<void> => {
+  isTyping.value = true
+  displayedCommand.value = ''
+
+  for (let i = 0; i < props.command.length; i++) {
+    displayedCommand.value += props.command[i]
+    await sleep(props.typingSpeed)
+  }
+
+  isTyping.value = false
+}
+
+// Show output lines one by one
+const showOutputLines = async (): Promise<void> => {
+  // Small pause after command before output appears
+  await sleep(300)
+
+  for (let i = 0; i < props.outputLines.length; i++) {
+    visibleOutputLines.value = i + 1
+    await sleep(100)
+  }
+}
+
+// Utility sleep function
+const sleep = (ms: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Main animation sequence
+const runAnimation = async (): Promise<void> => {
+  // Reset state
+  displayedCommand.value = ''
+  visibleOutputLines.value = 0
+  isComplete.value = false
+
+  emit('animationStart')
+  startCursorBlink()
+
+  await typeCommand()
+  await showOutputLines()
+
+  stopCursorBlink()
+  isComplete.value = true
+  emit('animationComplete')
+}
+
+// Reset and replay
+const replay = (): void => {
+  runAnimation()
+}
+
+// Computed classes for cursor
+const cursorClass = computed(() => ({
+  cursor: true,
+  'cursor--visible': cursorVisible.value,
+  'cursor--typing': isTyping.value
+}))
+
+// Get visible output lines
+const displayedOutputLines = computed(() => {
+  return props.outputLines.slice(0, visibleOutputLines.value)
+})
+
+// Lifecycle
+onMounted(() => {
+  if (props.autoplay) {
+    // Small delay before starting animation
+    setTimeout(() => {
+      runAnimation()
+    }, 500)
+  }
+})
+
+// Watch for autoplay changes
+watch(() => props.autoplay, (newVal) => {
+  if (newVal && !isTyping.value && !isComplete.value) {
+    runAnimation()
+  }
+})
+
+// Expose replay method for parent components
+defineExpose({ replay })
+</script>
+
+<template>
+  <div class="terminal-preview">
+    <div class="terminal-window">
+      <!-- macOS-style title bar -->
+      <div class="terminal-header">
+        <div class="terminal-buttons">
+          <span class="terminal-button terminal-button--close"></span>
+          <span class="terminal-button terminal-button--minimize"></span>
+          <span class="terminal-button terminal-button--maximize"></span>
+        </div>
+        <div class="terminal-title">wave</div>
+        <div class="terminal-spacer"></div>
+      </div>
+
+      <!-- Terminal content -->
+      <div class="terminal-body">
+        <!-- Command line -->
+        <div class="terminal-line terminal-line--command">
+          <span class="terminal-prompt">$</span>
+          <span class="terminal-command">{{ displayedCommand }}</span>
+          <span :class="cursorClass"></span>
+        </div>
+
+        <!-- Output lines -->
+        <TransitionGroup name="output-line" tag="div" class="terminal-output">
+          <div
+            v-for="(line, index) in displayedOutputLines"
+            :key="index"
+            class="terminal-line terminal-line--output"
+          >
+            <span v-html="formatLine(line)"></span>
+          </div>
+        </TransitionGroup>
+      </div>
+    </div>
+
+    <!-- Replay button (shown when animation is complete) -->
+    <button
+      v-if="isComplete"
+      class="terminal-replay"
+      @click="replay"
+      aria-label="Replay animation"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+        <path d="M3 3v5h5"/>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+// Helper function to format output lines with color codes
+function formatLine(line: string): string {
+  // Support basic ANSI-style color markers
+  // Format: [color:text] e.g., [green:SUCCESS] or [blue:step-1]
+  return line
+    .replace(/\[green:([^\]]+)\]/g, '<span class="text-green">$1</span>')
+    .replace(/\[blue:([^\]]+)\]/g, '<span class="text-blue">$1</span>')
+    .replace(/\[yellow:([^\]]+)\]/g, '<span class="text-yellow">$1</span>')
+    .replace(/\[red:([^\]]+)\]/g, '<span class="text-red">$1</span>')
+    .replace(/\[cyan:([^\]]+)\]/g, '<span class="text-cyan">$1</span>')
+    .replace(/\[dim:([^\]]+)\]/g, '<span class="text-dim">$1</span>')
+    .replace(/\[bold:([^\]]+)\]/g, '<span class="text-bold">$1</span>')
+}
+</script>
+
+<style scoped>
+.terminal-preview {
+  position: relative;
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.terminal-window {
+  background: #1a1b26;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.1),
+    0 0 30px rgba(99, 102, 241, 0.15),
+    0 0 60px rgba(99, 102, 241, 0.1);
+  font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', Consolas, monospace;
+}
+
+/* Subtle glow effect on the border */
+.terminal-window::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 13px;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.4),
+    rgba(99, 102, 241, 0.1) 50%,
+    rgba(99, 102, 241, 0.4)
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Title bar */
+.terminal-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #24253a;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.terminal-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: opacity 0.2s ease;
+}
+
+.terminal-button--close {
+  background: #ff5f56;
+}
+
+.terminal-button--minimize {
+  background: #ffbd2e;
+}
+
+.terminal-button--maximize {
+  background: #27c93f;
+}
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+}
+
+.terminal-spacer {
+  width: 52px; /* Balance the buttons on the left */
+}
+
+/* Terminal body */
+.terminal-body {
+  padding: 20px 24px;
+  min-height: 180px;
+}
+
+.terminal-line {
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.terminal-line--command {
+  display: flex;
+  align-items: center;
+  color: #c0caf5;
+  font-size: 14px;
+}
+
+.terminal-prompt {
+  color: #7aa2f7;
+  margin-right: 10px;
+  font-weight: 600;
+}
+
+.terminal-command {
+  color: #c0caf5;
+}
+
+/* Cursor */
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 18px;
+  background: #7aa2f7;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.cursor--visible {
+  opacity: 1;
+}
+
+.cursor--typing {
+  animation: none;
+}
+
+/* Output lines */
+.terminal-output {
+  margin-top: 12px;
+}
+
+.terminal-line--output {
+  color: #9aa5ce;
+  font-size: 13px;
+  padding: 2px 0;
+}
+
+/* Output line transition */
+.output-line-enter-active {
+  transition: all 0.3s ease;
+}
+
+.output-line-enter-from {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+/* Color classes for formatted output */
+:deep(.text-green) {
+  color: #9ece6a;
+}
+
+:deep(.text-blue) {
+  color: #7aa2f7;
+}
+
+:deep(.text-yellow) {
+  color: #e0af68;
+}
+
+:deep(.text-red) {
+  color: #f7768e;
+}
+
+:deep(.text-cyan) {
+  color: #7dcfff;
+}
+
+:deep(.text-dim) {
+  color: #565f89;
+}
+
+:deep(.text-bold) {
+  font-weight: 600;
+  color: #c0caf5;
+}
+
+/* Replay button */
+.terminal-replay {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(122, 162, 247, 0.15);
+  color: #7aa2f7;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: all 0.2s ease;
+  z-index: 2;
+}
+
+.terminal-replay:hover {
+  opacity: 1;
+  background: rgba(122, 162, 247, 0.25);
+  transform: scale(1.05);
+}
+
+.terminal-replay:active {
+  transform: scale(0.95);
+}
+
+/* Dark theme adjustments - works in both light and dark mode */
+/* The terminal intentionally stays dark even in light mode for authenticity */
+
+/* Responsive */
+@media (max-width: 640px) {
+  .terminal-body {
+    padding: 16px 18px;
+  }
+
+  .terminal-line--command {
+    font-size: 13px;
+  }
+
+  .terminal-line--output {
+    font-size: 12px;
+  }
+}
+</style>

--- a/specs/022-hero-section-redesign/plan.md
+++ b/specs/022-hero-section-redesign/plan.md
@@ -1,0 +1,477 @@
+# Implementation Plan: Hero Section Redesign
+
+**Branch**: `022-hero-section-redesign` | **Date**: 2026-02-05
+**Context**: VitePress documentation site with Vue 3 components
+
+## Summary
+
+Redesign the hero section on the Wave documentation landing page to improve visual impact, user engagement, and messaging clarity. The current implementation is minimal - this plan enhances it with better typography, animated elements, responsive design, and clearer call-to-action hierarchy.
+
+## Current State
+
+### Existing Files
+
+| File | Purpose | Size |
+|------|---------|------|
+| `docs/index.md` | Landing page with hero props | 5.1 KB |
+| `docs/.vitepress/theme/components/HeroSection.vue` | Hero component (minimal) | 736 B |
+| `docs/.vitepress/theme/types.ts` | TypeScript definitions | 2.7 KB |
+| `docs/.vitepress/theme/styles/components.css` | Component styles (hero: lines 42-106) | 9.7 KB |
+| `docs/.vitepress/theme/styles/custom.css` | Theme variables | 2.7 KB |
+| `docs/.vitepress/theme/index.ts` | Theme entry (already registers HeroSection) | 2.2 KB |
+
+### Current HeroSectionProps Interface
+
+```typescript
+export interface HeroSectionProps {
+  title: string
+  tagline: string
+  primaryAction: { text: string; link: string }
+  secondaryAction?: { text: string; link: string }
+}
+```
+
+## Files to Modify (in order of dependency)
+
+### Phase A: Types (Independent)
+
+1. **`docs/.vitepress/theme/types.ts`**
+   - Extend `HeroSectionProps` interface with new fields
+   - Add new types for hero features/badges if needed
+
+### Phase B: Styles (Independent)
+
+2. **`docs/.vitepress/theme/styles/custom.css`**
+   - Add CSS custom properties for hero-specific colors/gradients
+   - Add animation keyframes
+
+3. **`docs/.vitepress/theme/styles/components.css`**
+   - Enhance hero section styles (lines 42-106)
+   - Add responsive breakpoints
+   - Add animation classes
+
+### Phase C: Component (Depends on Phase A)
+
+4. **`docs/.vitepress/theme/components/HeroSection.vue`**
+   - Implement enhanced template structure
+   - Add optional slots for extensibility
+   - Implement animations with Vue transitions
+
+### Phase D: Integration (Depends on Phases A, C)
+
+5. **`docs/index.md`**
+   - Update heroProps with any new fields
+   - Test integration with redesigned component
+
+## New Files to Create
+
+| File | Purpose |
+|------|---------|
+| `docs/.vitepress/theme/styles/hero.css` | (Optional) Dedicated hero styles if substantial |
+
+**Note**: Creating a separate `hero.css` is optional. If changes to `components.css` remain under 100 lines, keep styles consolidated.
+
+## Step-by-Step Implementation Tasks
+
+### Task 1: Extend TypeScript Types
+
+**File**: `docs/.vitepress/theme/types.ts`
+
+**Changes**:
+```typescript
+// Update HeroSectionProps (around line 109)
+export interface HeroSectionProps {
+  title: string
+  tagline: string
+  subtitle?: string               // NEW: Optional subtitle below title
+  primaryAction: {
+    text: string
+    link: string
+    icon?: string                 // NEW: Optional icon
+  }
+  secondaryAction?: {
+    text: string
+    link: string
+    icon?: string                 // NEW: Optional icon
+  }
+  badges?: HeroBadge[]            // NEW: Trust/feature badges
+  codePreview?: string            // NEW: Optional inline code preview
+  animated?: boolean              // NEW: Enable/disable animations
+}
+
+// NEW: Badge type for hero section
+export interface HeroBadge {
+  text: string
+  icon?: string
+  link?: string
+}
+```
+
+**Effort**: ~15 minutes
+
+---
+
+### Task 2: Add CSS Custom Properties and Animations
+
+**File**: `docs/.vitepress/theme/styles/custom.css`
+
+**Changes** (append after line 31):
+```css
+/* Hero Animation Properties */
+--hero-animation-duration: 0.8s;
+--hero-animation-timing: cubic-bezier(0.16, 1, 0.3, 1);
+--hero-gradient-1: linear-gradient(135deg, var(--wave-primary) 0%, var(--wave-accent) 100%);
+--hero-gradient-2: linear-gradient(135deg, var(--wave-secondary) 0%, var(--wave-primary) 100%);
+```
+
+**Add keyframes** (append at end of file):
+```css
+/* Hero Animations */
+@keyframes hero-fade-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes hero-gradient-shift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+```
+
+**Effort**: ~10 minutes
+
+---
+
+### Task 3: Enhance Hero Component Styles
+
+**File**: `docs/.vitepress/theme/styles/components.css`
+
+**Replace** lines 42-106 with enhanced styles:
+
+Key enhancements:
+- Staggered fade-in animations for title, tagline, actions
+- Improved gradient text with animation
+- Badge strip styling
+- Better mobile responsive scaling
+- Hover micro-interactions on buttons
+- Optional code preview styling
+
+**Effort**: ~30 minutes
+
+---
+
+### Task 4: Redesign HeroSection Vue Component
+
+**File**: `docs/.vitepress/theme/components/HeroSection.vue`
+
+**Complete rewrite** with:
+```vue
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue'
+import type { HeroSectionProps } from '../types'
+
+const props = withDefaults(defineProps<HeroSectionProps>(), {
+  secondaryAction: undefined,
+  badges: () => [],
+  animated: true,
+  codePreview: undefined,
+  subtitle: undefined
+})
+
+const isVisible = ref(false)
+
+onMounted(() => {
+  // Trigger animations after mount
+  if (props.animated) {
+    requestAnimationFrame(() => { isVisible.value = true })
+  } else {
+    isVisible.value = true
+  }
+})
+
+const animationClass = computed(() =>
+  props.animated ? 'hero--animated' : ''
+)
+</script>
+
+<template>
+  <section
+    class="hero-section"
+    :class="[animationClass, { 'hero--visible': isVisible }]"
+  >
+    <!-- Badge strip -->
+    <div v-if="props.badges?.length" class="hero-badges">
+      <a
+        v-for="badge in props.badges"
+        :key="badge.text"
+        :href="badge.link"
+        class="hero-badge"
+      >
+        <span v-if="badge.icon" class="hero-badge-icon">{{ badge.icon }}</span>
+        {{ badge.text }}
+      </a>
+    </div>
+
+    <!-- Title -->
+    <h1 class="hero-title">{{ props.title }}</h1>
+
+    <!-- Subtitle -->
+    <p v-if="props.subtitle" class="hero-subtitle">{{ props.subtitle }}</p>
+
+    <!-- Tagline -->
+    <p class="hero-tagline">{{ props.tagline }}</p>
+
+    <!-- Code preview -->
+    <div v-if="props.codePreview" class="hero-code-preview">
+      <code>{{ props.codePreview }}</code>
+    </div>
+
+    <!-- Actions -->
+    <div class="hero-actions">
+      <a :href="props.primaryAction.link" class="btn btn-primary">
+        <span v-if="props.primaryAction.icon" class="btn-icon">
+          {{ props.primaryAction.icon }}
+        </span>
+        {{ props.primaryAction.text }}
+      </a>
+      <a
+        v-if="props.secondaryAction"
+        :href="props.secondaryAction.link"
+        class="btn btn-secondary"
+      >
+        <span v-if="props.secondaryAction.icon" class="btn-icon">
+          {{ props.secondaryAction.icon }}
+        </span>
+        {{ props.secondaryAction.text }}
+      </a>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+/* Component-specific overrides only - base styles in components.css */
+</style>
+```
+
+**Effort**: ~45 minutes
+
+---
+
+### Task 5: Update Landing Page Integration
+
+**File**: `docs/index.md`
+
+**Update heroProps** (lines 6-17) to use new features:
+```javascript
+const heroProps = {
+  title: 'Wave',
+  subtitle: 'AI-as-Code',
+  tagline: 'Define, version, and run AI workflows like you manage infrastructure.',
+  primaryAction: {
+    text: 'Get Started',
+    link: '/quickstart',
+    icon: '→'
+  },
+  secondaryAction: {
+    text: 'View Examples',
+    link: '/use-cases/'
+  },
+  badges: [
+    { text: 'v0.1.0', link: '/changelog' },
+    { text: 'Open Source', link: 'https://github.com/re-cinq/wave' }
+  ],
+  animated: true
+}
+```
+
+**Effort**: ~15 minutes
+
+---
+
+### Task 6: Add Responsive Media Queries
+
+**File**: `docs/.vitepress/theme/styles/components.css`
+
+**Enhance** existing responsive section (lines 470-487):
+- Add tablet breakpoint (768px)
+- Improve mobile hero sizing
+- Ensure badges wrap properly
+- Adjust animation timing for mobile
+
+**Effort**: ~20 minutes
+
+---
+
+## Parallel Work Streams
+
+The following can be worked on simultaneously by different contributors:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Work Stream Diagram                      │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Stream A (Types)          Stream B (Styles)                 │
+│  ─────────────────         ─────────────────                 │
+│  Task 1: types.ts          Task 2: custom.css                │
+│       │                    Task 3: components.css            │
+│       │                         │                            │
+│       └────────┬────────────────┘                            │
+│                │                                             │
+│                ▼                                             │
+│         Stream C (Component)                                 │
+│         ────────────────────                                 │
+│         Task 4: HeroSection.vue                              │
+│                │                                             │
+│                ▼                                             │
+│         Stream D (Integration)                               │
+│         ──────────────────────                               │
+│         Task 5: index.md                                     │
+│         Task 6: Responsive polish                            │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Parallel Assignments
+
+| Stream | Tasks | Can Start | Dependencies |
+|--------|-------|-----------|--------------|
+| A | Task 1 | Immediately | None |
+| B | Tasks 2, 3 | Immediately | None |
+| C | Task 4 | After A completes | Task 1 |
+| D | Tasks 5, 6 | After C completes | Task 4 |
+
+## Testing Checklist
+
+### Unit Tests
+
+- [ ] TypeScript types compile without errors
+- [ ] Props defaults work correctly (animated: true, badges: [])
+- [ ] Optional props (subtitle, codePreview) render conditionally
+
+### Visual/Manual Tests
+
+- [ ] Hero displays correctly on desktop (1920px, 1440px, 1280px)
+- [ ] Hero displays correctly on tablet (768px, 1024px)
+- [ ] Hero displays correctly on mobile (375px, 414px)
+- [ ] Animations trigger on page load when `animated: true`
+- [ ] Animations disabled when `animated: false`
+- [ ] Badges display horizontally, wrap on narrow screens
+- [ ] Primary action button has prominent styling
+- [ ] Secondary action button has subtle styling
+- [ ] Gradient text animates smoothly
+- [ ] Dark mode colors are appropriate
+- [ ] Links navigate correctly
+
+### Accessibility Tests
+
+- [ ] Heading hierarchy is correct (h1 for title)
+- [ ] Color contrast meets WCAG AA (4.5:1 for text)
+- [ ] Focus states visible on all interactive elements
+- [ ] Animations respect `prefers-reduced-motion`
+- [ ] Screen reader announces hero content properly
+
+### Performance Tests
+
+- [ ] No layout shift during animation (CLS < 0.1)
+- [ ] Animation runs at 60fps
+- [ ] Component hydrates in < 50ms
+
+### Integration Tests
+
+- [ ] VitePress builds without errors: `npm run docs:build`
+- [ ] Dev server works: `npm run docs:dev`
+- [ ] No console errors in browser
+- [ ] Hero props passed correctly from index.md
+
+### Browser Compatibility
+
+- [ ] Chrome (latest)
+- [ ] Firefox (latest)
+- [ ] Safari (latest)
+- [ ] Edge (latest)
+
+## Rollback Plan
+
+### If Component Changes Break Build
+
+1. **Immediate**: Revert `HeroSection.vue` to previous version
+   ```bash
+   git checkout main -- docs/.vitepress/theme/components/HeroSection.vue
+   ```
+
+2. **Keep**: Type and style changes (backward compatible)
+
+### If Style Changes Break Layout
+
+1. **Immediate**: Revert style files
+   ```bash
+   git checkout main -- docs/.vitepress/theme/styles/components.css
+   git checkout main -- docs/.vitepress/theme/styles/custom.css
+   ```
+
+### If Type Changes Break Build
+
+1. **Immediate**: Revert types and component together
+   ```bash
+   git checkout main -- docs/.vitepress/theme/types.ts
+   git checkout main -- docs/.vitepress/theme/components/HeroSection.vue
+   ```
+
+### Full Rollback
+
+If all changes need reverting:
+```bash
+git checkout main -- docs/.vitepress/theme/
+git checkout main -- docs/index.md
+```
+
+### Partial Rollback Strategy
+
+The implementation is designed for partial rollback:
+
+| Layer | Can Rollback Independently | Notes |
+|-------|---------------------------|-------|
+| Styles | Yes | Existing styles still work |
+| Types | No | Component depends on types |
+| Component | No | index.md depends on component |
+| index.md | Yes | Can use old props format |
+
+### Feature Flags
+
+If needed, add feature flag support:
+
+```javascript
+// In index.md
+const heroProps = {
+  // ... existing props
+  animated: import.meta.env.VITE_HERO_ANIMATIONS !== 'false'
+}
+```
+
+Then disable animations without code changes:
+```bash
+VITE_HERO_ANIMATIONS=false npm run docs:build
+```
+
+## Estimated Effort
+
+| Task | Effort | Assignee |
+|------|--------|----------|
+| Task 1: Types | 15 min | - |
+| Task 2: CSS Props | 10 min | - |
+| Task 3: Component Styles | 30 min | - |
+| Task 4: Vue Component | 45 min | - |
+| Task 5: Integration | 15 min | - |
+| Task 6: Responsive | 20 min | - |
+| Testing | 30 min | - |
+| **Total** | **~2.5 hours** | - |
+
+## Success Criteria
+
+1. Hero section renders with all new features
+2. All tests in checklist pass
+3. No regressions in existing functionality
+4. VitePress build succeeds
+5. Animations are smooth and optional
+6. Mobile experience is improved

--- a/specs/022-hero-section-redesign/research-additional.md
+++ b/specs/022-hero-section-redesign/research-additional.md
@@ -1,0 +1,174 @@
+# Hero Section Research: Additional Developer-Focused Sites
+
+Research conducted on February 5, 2026, analyzing hero section design patterns from three leading developer-focused platforms.
+
+---
+
+## 1. Stripe (stripe.com)
+
+### Layout Structure
+- **Single-column centered layout** with vertical stacking
+- Primary heading anchors the top, followed by descriptive body text
+- Call-to-action buttons stack vertically below the text for mobile responsiveness
+- Maximum width constraints maintain readability on large screens
+
+### Visual Elements
+- **Decorative wave illustration** positioned beneath CTA buttons adds visual interest without overwhelming content
+- Minimal design approach keeps focus on messaging
+- Clean, sophisticated aesthetic aligned with financial services branding
+- Client-variant wrapper elements suggest conditional rendering for personalization
+
+### Code/Product Previews
+- No traditional code snippets in the hero section
+- Product value communicated through messaging rather than technical demonstrations
+- Visual focus on brand partnerships over feature showcases
+
+### Social Proof Elements
+- **Carousel of customer logos** (Amazon, Shopify, N26, Google, Figma)
+- "Visual credibility through association" approach
+- Emphasizes enterprise adoption and scale
+- Rotates through recognizable brands to communicate trustworthiness
+
+### Typography Hierarchy
+- **Large sans-serif heading** dominates the visual hierarchy
+- Smaller supporting text provides context
+- Clear hierarchy: Headline > Subtext > CTAs
+- Value proposition stated directly: "Financial infrastructure for revenue growth"
+
+### Background Treatments
+- Minimal decorative elements maintain content focus
+- Single wave illustration adds subtle sophistication
+- Clean backgrounds emphasize text legibility
+
+### Interactive Elements
+- Two primary CTAs: "Start now" and "Sign in with Google"
+- Logo carousel invites passive engagement
+- Social authentication pathway reduces friction
+
+---
+
+## 2. Linear (linear.app)
+
+### Layout Structure
+- **Centered, single-column design** with maximum width constraints
+- Generous vertical spacing creates breathing room between elements
+- Content stacks vertically with balanced proportions
+- Responsive design adapts from multi-line desktop to single-column mobile
+
+### Visual Elements
+- **Dark theme styling** as the default presentation
+- CSS custom properties control color schemes throughout
+- Gradient treatments on text: `linear-gradient(to right, var(--color-text-primary), transparent 80%)`
+- Dynamic theme switching between light/dark with system preference detection
+- Overlapping avatar arrangements in icon piles
+
+### Code/Product Previews
+- **UI mockups** showcasing product functionality
+- Project management boards with status indicators
+- Issue tracking examples (bug reports, feature requests)
+- Timeline and progress visualizations with percentage completion
+- Team member avatars and activity feeds
+
+### Social Proof Elements
+- "Powering the world's best product teams" positioning statement
+- Customer testimonials and case studies section
+- Company logos in dedicated section
+- Icon piles with overlapping avatars suggest active teams
+
+### Typography Hierarchy
+Multi-tier text system with CSS custom properties:
+- **Title-8 size** for primary headlines (medium font-weight)
+- **Title-2 and Title-3** for section headers
+- **Text-regular and text-small** for body copy in tertiary colors
+- **Title-1** for prominent display text
+- `text-wrap: balance` for improved heading readability
+
+### Background Treatments
+- **Dark backgrounds** (#08090a theme color)
+- Tertiary-colored text creates contrast layers
+- CSS custom properties (`--height` variables) ensure consistent spacing rhythm
+- Dark mode creates premium, focused aesthetic
+
+### Interactive Elements
+- Navigation links in header and footer
+- Call-to-action buttons: "Start building," "Learn more"
+- Announcement banner linking to beta features
+- Responsive menu structures with skip navigation for accessibility
+
+---
+
+## 3. Supabase (supabase.com)
+
+### Layout Structure
+- **Centered, single-column layout** with vertical stacking
+- Main heading aligns center, followed by descriptive text
+- Dual call-to-action buttons positioned below
+- Clean separation between hero content and subsequent sections
+
+### Visual Elements
+- **Theme toggle** handling dark/light mode transitions
+- Animated color scheme switching on mode change
+- Logo imagery displays both light and dark variants
+- Seamless visual adaptation between themes
+
+### Code/Product Previews
+- **CLI command preview** in Edge Functions section: `$ supabase functions deploy`
+- Provides immediate technical context for developers
+- Demonstrates product functionality through actual commands
+- Developer-first approach with code-centric previews
+
+### Social Proof Elements
+- "Trusted by fast-growing companies worldwide" positioning
+- **Carousel of 16+ company logos**: Mozilla, GitHub, 1Password, and others
+- Continuous scrolling animation effect
+- Repeated carousel structure suggests infinite scroll pattern
+
+### Typography Hierarchy
+- **Primary headline**: Large, bold sans-serif emphasizing dual value proposition
+- Headline: "Build in a weekend. Scale to millions."
+- **Subheading**: Medium-weight body text explaining core features
+- **CTAs**: Button-styled text with contrasting colors for action emphasis
+
+### Background Treatments
+- **System preference detection** for dark/light mode
+- HTML style attributes and data attributes manage visual presentation
+- Adaptive backgrounds based on user preferences
+- Clean, minimal background allows content focus
+
+### Interactive Elements
+- Two prominent buttons: "Start your project" (primary) and "Request a demo" (secondary)
+- Theme toggle for user preference
+- Logo carousel with continuous animation
+- Multiple engagement paths for different user intents
+
+---
+
+## Key Design Patterns Summary
+
+### Common Patterns Across All Three Sites
+
+| Pattern | Stripe | Linear | Supabase |
+|---------|--------|--------|----------|
+| Centered single-column layout | Yes | Yes | Yes |
+| Dark mode support | Partial | Primary | Full toggle |
+| Logo carousel for social proof | Yes | Yes | Yes |
+| Dual CTA buttons | Yes | Yes | Yes |
+| Minimal background treatments | Yes | Yes | Yes |
+| Code/product previews | No | UI mockups | CLI commands |
+
+### Differentiated Approaches
+
+1. **Stripe**: Enterprise credibility through brand associations; minimal technical demonstration; financial services aesthetic
+2. **Linear**: Dark-first design; product-focused UI mockups; sophisticated gradient effects; developer tool aesthetic
+3. **Supabase**: Developer-first with CLI previews; adaptive theming; scale-focused messaging; startup/growth aesthetic
+
+### Actionable Insights for Wave Hero Section
+
+1. **Layout**: Adopt centered single-column layout with maximum width constraints
+2. **Theme**: Consider dark mode as default or primary option (Linear pattern)
+3. **Social Proof**: Implement logo carousel if customer logos are available
+4. **Code Previews**: Include CLI command examples (Supabase pattern) showing Wave commands
+5. **Typography**: Use clear hierarchy with large headline, supporting text, and prominent CTAs
+6. **CTAs**: Dual button pattern - primary action + secondary engagement
+7. **Background**: Keep minimal, use subtle gradients or illustrations (Stripe wave pattern)
+8. **Interactivity**: Theme toggle, smooth animations on mode transitions

--- a/specs/022-hero-section-redesign/spec.md
+++ b/specs/022-hero-section-redesign/spec.md
@@ -1,0 +1,432 @@
+# Hero Section Redesign Specification
+
+**Spec ID:** 022-hero-section-redesign
+**Status:** Draft
+**Author:** Wave Team
+**Created:** 2026-02-05
+
+---
+
+## 1. Overview
+
+### What We're Building
+
+A redesigned hero section for the Wave documentation site that transforms the current minimal implementation into an engaging, modern hero that effectively communicates Wave's value proposition and drives conversions.
+
+### Why We're Building It
+
+The current hero section is too simple:
+- Just a title, tagline, and two buttons
+- No visual demonstration of the product
+- No social proof or trust signals
+- Fails to differentiate from competitors
+
+Competitor analysis shows modern DevTool landing pages (ngrok, Vercel, Railway, Dagger, Pulumi) feature:
+- Interactive code/terminal previews
+- Social proof badges (GitHub stars, user counts)
+- Value proposition pills/badges
+- Two-column layouts with visual balance
+- Subtle background treatments for depth
+
+### Goals
+
+1. **Increase engagement** - Terminal preview demonstrates product value immediately
+2. **Build trust** - GitHub stars badge provides social proof
+3. **Communicate value** - Pills highlight core differentiators at a glance
+4. **Modern aesthetics** - Two-column layout with background pattern matches industry standards
+
+---
+
+## 2. Requirements
+
+### Must-Have Elements
+
+#### 2.1 Terminal Preview
+
+A mock terminal window showing a `wave run` command with realistic output:
+
+```
+$ wave run code-review --issue 42
+
+[wave] Loading pipeline: code-review
+[wave] Persona: reviewer (read-only, no network)
+[wave] Step 1/3: analyze-diff .............. done
+[wave] Step 2/3: check-contracts ........... done
+[wave] Step 3/3: generate-report ........... done
+[wave] Output: artifacts/review-report.md
+[wave] Pipeline completed in 23.4s
+```
+
+**Requirements:**
+- macOS-style window chrome (red/yellow/green dots)
+- Syntax highlighting for prompt vs output
+- Subtle typing animation on initial load (optional enhancement)
+- Copy button in top-right corner
+
+#### 2.2 Value Proposition Pills
+
+Four pills highlighting core Wave features:
+
+| Pill | Icon | Description |
+|------|------|-------------|
+| Declarative | `yaml` icon | YAML-based configuration |
+| Contracts | `shield-check` icon | Output validation |
+| Isolation | `lock` icon | Secure workspaces |
+| Audit | `scroll` icon | Full traceability |
+
+**Requirements:**
+- Horizontal layout on desktop, 2x2 grid on mobile
+- Subtle hover effect (scale + shadow)
+- Each pill links to relevant docs section
+
+#### 2.3 GitHub Stars Badge
+
+Display current star count using shields.io:
+
+```
+https://img.shields.io/github/stars/re-cinq/wave?style=social
+```
+
+**Requirements:**
+- Positioned near CTA buttons
+- Links to GitHub repository
+- Fallback to static badge if API fails
+
+#### 2.4 Two-Column Layout
+
+| Left Column (55%) | Right Column (45%) |
+|-------------------|-------------------|
+| Title | Terminal Preview |
+| Tagline | |
+| Value Pills | |
+| CTA Buttons + GitHub Badge | |
+
+**Requirements:**
+- Left column is text-focused, right is visual
+- Columns stack vertically on mobile (text first, terminal second)
+- Maintain visual balance with proper spacing
+
+#### 2.5 Background Pattern
+
+Subtle grid/dot pattern for visual depth:
+
+**Requirements:**
+- Very low opacity (0.03-0.05) to not distract
+- Dot grid pattern with ~40px spacing
+- Respects dark/light mode color variables
+- CSS-only implementation (no images)
+
+---
+
+## 3. Component Props Interface
+
+```typescript
+/**
+ * Terminal line types for syntax highlighting
+ */
+export type TerminalLineType = 'command' | 'output' | 'success' | 'error' | 'info'
+
+export interface TerminalLine {
+  text: string
+  type: TerminalLineType
+  /** Optional delay before showing this line (ms) - for typing animation */
+  delay?: number
+}
+
+/**
+ * Value proposition pill configuration
+ */
+export interface ValuePill {
+  /** Display label */
+  label: string
+  /** Icon name (from iconify or local icon set) */
+  icon: string
+  /** Link to relevant documentation */
+  link: string
+  /** Tooltip text on hover */
+  tooltip?: string
+}
+
+/**
+ * GitHub badge configuration
+ */
+export interface GitHubBadge {
+  /** GitHub org/repo path */
+  repo: string
+  /** Badge style: 'social' | 'flat' | 'flat-square' */
+  style?: 'social' | 'flat' | 'flat-square'
+}
+
+/**
+ * Action button configuration
+ */
+export interface HeroAction {
+  text: string
+  link: string
+  /** Button variant */
+  variant?: 'primary' | 'secondary'
+}
+
+/**
+ * Enhanced HeroSection props
+ */
+export interface HeroSectionProps {
+  /** Main headline */
+  title: string
+  /** Supporting tagline */
+  tagline: string
+  /** Primary CTA button */
+  primaryAction: HeroAction
+  /** Secondary CTA button (optional) */
+  secondaryAction?: HeroAction
+
+  /** Terminal preview configuration */
+  terminal?: {
+    /** Lines to display in the terminal */
+    lines: TerminalLine[]
+    /** Terminal window title */
+    title?: string
+    /** Enable typing animation */
+    animate?: boolean
+  }
+
+  /** Value proposition pills */
+  valuePills?: ValuePill[]
+
+  /** GitHub stars badge */
+  github?: GitHubBadge
+
+  /** Show background pattern */
+  showBackground?: boolean
+}
+```
+
+---
+
+## 4. Visual Mockup
+
+### Desktop Layout (>= 1024px)
+
+```
++-----------------------------------------------------------------------------------+
+|  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .   |
+|  . . . . . . . . . . . . . (subtle dot pattern background) . . . . . . . . . .   |
+|  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .   |
+|  +----------------------------------+  +--------------------------------------+   |
+|  |                                  |  |  +--------------------------------+  |   |
+|  |  AI-as-Code for Multi-Agent     |  |  | $ wave run code-review --issue |  |   |
+|  |  Pipelines                       |  |  |                                |  |   |
+|  |                                  |  |  | [wave] Loading pipeline...     |  |   |
+|  |  Orchestrate AI agents with      |  |  | [wave] Persona: reviewer       |  |   |
+|  |  declarative YAML. Enforce       |  |  | [wave] Step 1/3: analyze-diff  |  |   |
+|  |  contracts. Ship with confidence.|  |  | [wave] Step 2/3: check-contra  |  |   |
+|  |                                  |  |  | [wave] Step 3/3: generate-rep  |  |   |
+|  |  +----------+ +----------+       |  |  | [wave] Pipeline completed      |  |   |
+|  |  |Declarativ| |Contracts |       |  |  +--------------------------------+  |   |
+|  |  +----------+ +----------+       |  |                                      |   |
+|  |  +----------+ +----------+       |  +--------------------------------------+   |
+|  |  |Isolation | | Audit    |       |                                            |
+|  |  +----------+ +----------+       |                                            |
+|  |                                  |                                            |
+|  |  [Get Started]  [View on GitHub] |                                            |
+|  |                   * 1.2k         |                                            |
+|  +----------------------------------+                                            |
+|  . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .   |
++-----------------------------------------------------------------------------------+
+```
+
+### Tablet Layout (768px - 1023px)
+
+```
++-----------------------------------------------+
+|  . . . . . . . . . . . . . . . . . . . . . .  |
+|  +------------------------------------------+ |
+|  |                                          | |
+|  |     AI-as-Code for Multi-Agent           | |
+|  |     Pipelines                            | |
+|  |                                          | |
+|  |     Orchestrate AI agents with           | |
+|  |     declarative YAML...                  | |
+|  |                                          | |
+|  |  +-----------+ +-----------+             | |
+|  |  |Declarative| | Contracts |             | |
+|  |  +-----------+ +-----------+             | |
+|  |  +-----------+ +-----------+             | |
+|  |  | Isolation | |   Audit   |             | |
+|  |  +-----------+ +-----------+             | |
+|  |                                          | |
+|  |     [Get Started] [GitHub] * 1.2k        | |
+|  |                                          | |
+|  +------------------------------------------+ |
+|  +------------------------------------------+ |
+|  | +--------------------------------------+ | |
+|  | | $ wave run code-review --issue 42   | | |
+|  | | [wave] Loading pipeline...          | | |
+|  | | [wave] Step 1/3: analyze-diff       | | |
+|  | +--------------------------------------+ | |
+|  +------------------------------------------+ |
++-----------------------------------------------+
+```
+
+### Mobile Layout (< 768px)
+
+```
++---------------------------+
+|  . . . . . . . . . . . .  |
+|  +-----------------------+ |
+|  |                       | |
+|  | AI-as-Code for        | |
+|  | Multi-Agent Pipelines | |
+|  |                       | |
+|  | Orchestrate AI agents | |
+|  | with declarative...   | |
+|  |                       | |
+|  | +--------+ +--------+ | |
+|  | |Declara.| |Contract| | |
+|  | +--------+ +--------+ | |
+|  | +--------+ +--------+ | |
+|  | |Isolat. | | Audit  | | |
+|  | +--------+ +--------+ | |
+|  |                       | |
+|  |    [Get Started]      | |
+|  |    [GitHub] * 1.2k    | |
+|  +-----------------------+ |
+|  +-----------------------+ |
+|  | $ wave run...         | |
+|  | [wave] Loading...     | |
+|  +-----------------------+ |
++---------------------------+
+```
+
+---
+
+## 5. Responsive Behavior
+
+| Breakpoint | Layout | Changes |
+|------------|--------|---------|
+| >= 1024px | Two-column (55/45) | Full terminal preview, all pills visible |
+| 768-1023px | Single-column stacked | Terminal below content, full width |
+| < 768px | Single-column stacked | Smaller title (2.5rem), condensed pills (2x2), abbreviated terminal |
+
+### Detailed Responsive Rules
+
+#### Typography
+- **Desktop:** Title 3.5rem, tagline 1.5rem
+- **Tablet:** Title 3rem, tagline 1.35rem
+- **Mobile:** Title 2.5rem, tagline 1.2rem
+
+#### Value Pills
+- **Desktop:** Single row, 4 pills
+- **Tablet/Mobile:** 2x2 grid
+
+#### Terminal Preview
+- **Desktop:** Full height (~280px), 8+ lines visible
+- **Tablet:** Medium height (~220px), 6 lines visible
+- **Mobile:** Compact height (~160px), 4 lines visible with scroll
+
+#### CTA Buttons
+- **Desktop:** Inline with GitHub badge
+- **Mobile:** Stacked vertically, full width
+
+---
+
+## 6. Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Two-column layout renders correctly on desktop (>= 1024px)
+- [ ] Layout stacks to single column on tablet and mobile
+- [ ] Terminal preview displays with macOS-style window chrome
+- [ ] Terminal content syntax highlights commands vs output
+- [ ] Copy button in terminal copies all commands
+- [ ] Four value proposition pills render with icons
+- [ ] Each pill links to corresponding documentation page
+- [ ] GitHub stars badge loads from shields.io
+- [ ] GitHub badge links to repository
+- [ ] Primary CTA button navigates to getting started
+- [ ] Secondary CTA button navigates to GitHub
+- [ ] Dot pattern background is visible but subtle
+- [ ] Background respects dark/light mode
+
+### Visual/Design Requirements
+
+- [ ] Title uses gradient text effect (existing Wave brand)
+- [ ] Terminal has proper monospace font styling
+- [ ] Pills have hover states (scale + shadow)
+- [ ] Buttons maintain existing Wave styling
+- [ ] Spacing is balanced and consistent
+- [ ] No horizontal scroll at any breakpoint
+
+### Performance Requirements
+
+- [ ] No layout shift on initial load
+- [ ] Terminal animation (if enabled) is smooth 60fps
+- [ ] Total hero section bundle size < 10KB gzipped
+- [ ] Background pattern is CSS-only (no image requests)
+
+### Accessibility Requirements
+
+- [ ] All interactive elements are keyboard accessible
+- [ ] Terminal content is in an `aria-label` or accessible container
+- [ ] Color contrast meets WCAG AA standards
+- [ ] Reduced motion preference disables animations
+
+### Browser Support
+
+- [ ] Chrome/Edge (latest 2 versions)
+- [ ] Firefox (latest 2 versions)
+- [ ] Safari (latest 2 versions)
+- [ ] Mobile Safari iOS 15+
+- [ ] Chrome Android (latest)
+
+---
+
+## 7. Implementation Notes
+
+### File Changes Required
+
+1. **`docs/.vitepress/theme/types.ts`** - Add new interfaces
+2. **`docs/.vitepress/theme/components/HeroSection.vue`** - Complete rewrite
+3. **`docs/.vitepress/theme/styles/components.css`** - Add hero styles
+4. **`docs/index.md`** - Update hero configuration
+
+### Dependencies
+
+- No new npm dependencies required
+- Uses existing VitePress CSS variables
+- Icons from existing icon system or inline SVGs
+
+### CSS Variables to Use
+
+```css
+--wave-primary          /* Brand blue */
+--wave-primary-dark     /* Hover state */
+--wave-accent           /* Gradient end */
+--vp-c-bg              /* Background */
+--vp-c-bg-soft         /* Soft background */
+--vp-c-text-1          /* Primary text */
+--vp-c-text-2          /* Secondary text */
+--vp-c-divider         /* Borders */
+--wave-font-mono       /* Monospace font */
+```
+
+---
+
+## 8. Out of Scope
+
+The following are explicitly NOT part of this spec:
+
+- Animated typing effect (nice-to-have, can be added later)
+- Trust logos from companies (no social proof logos yet)
+- Video demo (future enhancement)
+- A/B testing infrastructure
+- Analytics event tracking
+
+---
+
+## 9. References
+
+- Current component: `/docs/.vitepress/theme/components/HeroSection.vue`
+- Current styles: `/docs/.vitepress/theme/styles/components.css`
+- Type definitions: `/docs/.vitepress/theme/types.ts`
+- Competitor examples: ngrok.com, vercel.com, railway.app, dagger.io, pulumi.com

--- a/specs/022-hero-section-redesign/styles.css
+++ b/specs/022-hero-section-redesign/styles.css
@@ -1,0 +1,788 @@
+/**
+ * Wave Hero Section Redesign - CSS Design Spec
+ *
+ * This file defines the CSS custom properties and styles for the enhanced
+ * hero section featuring a terminal preview, value prop pills, and grid
+ * background pattern.
+ *
+ * Organization:
+ * 1. Custom Properties (Design Tokens)
+ * 2. Grid/Dot Background Pattern
+ * 3. Two-Column Hero Layout
+ * 4. Terminal Preview Component
+ * 5. Value Prop Pills
+ * 6. Typing Animation
+ * 7. Responsive Breakpoints
+ */
+
+/* ===========================================
+   1. CUSTOM PROPERTIES (DESIGN TOKENS)
+   =========================================== */
+
+:root {
+  /* -----------------------------------------
+     Terminal Colors
+     Dark theme colors for the code preview
+     ----------------------------------------- */
+  --hero-terminal-bg: #0d1117;
+  --hero-terminal-border: #30363d;
+  --hero-terminal-header-bg: #161b22;
+  --hero-terminal-shadow: rgba(0, 0, 0, 0.4);
+
+  /* Terminal syntax highlighting (GitHub Dark inspired) */
+  --hero-syntax-comment: #8b949e;
+  --hero-syntax-keyword: #ff7b72;
+  --hero-syntax-string: #a5d6ff;
+  --hero-syntax-function: #d2a8ff;
+  --hero-syntax-variable: #79c0ff;
+  --hero-syntax-constant: #ffa657;
+  --hero-syntax-operator: #ff7b72;
+  --hero-syntax-text: #e6edf3;
+  --hero-syntax-yaml-key: #7ee787;
+  --hero-syntax-yaml-value: #a5d6ff;
+
+  /* Terminal glow effect for emphasis */
+  --hero-terminal-glow: rgba(79, 70, 229, 0.15);
+  --hero-terminal-glow-hover: rgba(79, 70, 229, 0.25);
+
+  /* -----------------------------------------
+     Value Prop Pills
+     Small badges showing key benefits
+     ----------------------------------------- */
+  --hero-pill-bg: rgba(255, 255, 255, 0.05);
+  --hero-pill-border: rgba(255, 255, 255, 0.1);
+  --hero-pill-text: var(--vp-c-text-2);
+  --hero-pill-icon: var(--wave-primary);
+  --hero-pill-hover-bg: rgba(79, 70, 229, 0.1);
+  --hero-pill-hover-border: rgba(79, 70, 229, 0.3);
+
+  /* -----------------------------------------
+     Grid Background Pattern
+     Subtle dot/grid pattern for depth
+     ----------------------------------------- */
+  --hero-grid-color: rgba(79, 70, 229, 0.08);
+  --hero-grid-size: 24px;
+  --hero-grid-dot-size: 1px;
+
+  /* -----------------------------------------
+     Layout Spacing
+     Gaps and padding for the two-column layout
+     ----------------------------------------- */
+  --hero-section-padding-y: 80px;
+  --hero-section-padding-x: 24px;
+  --hero-column-gap: 64px;
+  --hero-content-max-width: 1280px;
+
+  /* -----------------------------------------
+     Animation Timing
+     Durations and easing for animations
+     ----------------------------------------- */
+  --hero-animation-duration: 0.3s;
+  --hero-animation-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --hero-typing-speed: 50ms;
+  --hero-cursor-blink: 1s;
+}
+
+/* Dark mode adjustments */
+.dark {
+  --hero-terminal-bg: #0d1117;
+  --hero-terminal-border: #30363d;
+  --hero-terminal-glow: rgba(129, 140, 248, 0.2);
+  --hero-terminal-glow-hover: rgba(129, 140, 248, 0.35);
+
+  --hero-pill-bg: rgba(255, 255, 255, 0.03);
+  --hero-pill-border: rgba(255, 255, 255, 0.08);
+  --hero-pill-hover-bg: rgba(129, 140, 248, 0.15);
+  --hero-pill-hover-border: rgba(129, 140, 248, 0.4);
+
+  --hero-grid-color: rgba(129, 140, 248, 0.06);
+}
+
+
+/* ===========================================
+   2. GRID/DOT BACKGROUND PATTERN
+   =========================================== */
+
+/**
+ * Creates a subtle dot grid pattern behind the hero content.
+ * Uses a radial gradient repeated at fixed intervals.
+ * Works well in both light and dark modes.
+ */
+.hero-enhanced {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-enhanced::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: radial-gradient(
+    circle at center,
+    var(--hero-grid-color) var(--hero-grid-dot-size),
+    transparent var(--hero-grid-dot-size)
+  );
+  background-size: var(--hero-grid-size) var(--hero-grid-size);
+  background-position: center center;
+  pointer-events: none;
+  z-index: 0;
+
+  /* Fade out at edges for softer look */
+  mask-image: radial-gradient(
+    ellipse 80% 60% at 50% 50%,
+    black 0%,
+    transparent 100%
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse 80% 60% at 50% 50%,
+    black 0%,
+    transparent 100%
+  );
+}
+
+/* Alternative: Line grid pattern (uncomment to use instead of dots) */
+/*
+.hero-enhanced::before {
+  background-image:
+    linear-gradient(var(--hero-grid-color) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hero-grid-color) 1px, transparent 1px);
+  background-size: var(--hero-grid-size) var(--hero-grid-size);
+}
+*/
+
+
+/* ===========================================
+   3. TWO-COLUMN HERO LAYOUT
+   =========================================== */
+
+/**
+ * Main hero container with two-column layout:
+ * - Left column: Headline, tagline, pills, CTA buttons
+ * - Right column: Terminal preview
+ */
+.hero-enhanced {
+  padding: var(--hero-section-padding-y) var(--hero-section-padding-x);
+}
+
+.hero-enhanced__container {
+  position: relative;
+  z-index: 1;
+  max-width: var(--hero-content-max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--hero-column-gap);
+  align-items: center;
+}
+
+/* Left column: Text content */
+.hero-enhanced__content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero-enhanced__headline {
+  font-size: 3.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--vp-c-text-1);
+}
+
+/* Gradient text for emphasis */
+.hero-enhanced__headline .gradient-text {
+  background: linear-gradient(
+    135deg,
+    var(--wave-primary) 0%,
+    var(--wave-accent) 50%,
+    var(--wave-secondary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-enhanced__tagline {
+  font-size: 1.25rem;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  max-width: 480px;
+}
+
+/* Right column: Terminal */
+.hero-enhanced__preview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+
+/* ===========================================
+   4. TERMINAL PREVIEW COMPONENT
+   =========================================== */
+
+/**
+ * A styled terminal window showing Wave in action.
+ * Features:
+ * - macOS-style window chrome
+ * - Syntax highlighted code
+ * - Subtle glow effect on hover
+ * - Typing animation for the command line
+ */
+.terminal-preview {
+  width: 100%;
+  max-width: 560px;
+  background: var(--hero-terminal-bg);
+  border: 1px solid var(--hero-terminal-border);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow:
+    0 4px 6px -1px var(--hero-terminal-shadow),
+    0 2px 4px -2px var(--hero-terminal-shadow),
+    0 0 0 1px var(--hero-terminal-border),
+    0 0 60px -10px var(--hero-terminal-glow);
+  transition:
+    box-shadow var(--hero-animation-duration) var(--hero-animation-easing),
+    transform var(--hero-animation-duration) var(--hero-animation-easing);
+}
+
+.terminal-preview:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 20px 25px -5px var(--hero-terminal-shadow),
+    0 8px 10px -6px var(--hero-terminal-shadow),
+    0 0 0 1px var(--hero-terminal-border),
+    0 0 80px -5px var(--hero-terminal-glow-hover);
+}
+
+/* Terminal header with traffic light buttons */
+.terminal-preview__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--hero-terminal-header-bg);
+  border-bottom: 1px solid var(--hero-terminal-border);
+}
+
+.terminal-preview__buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-preview__button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--hero-terminal-border);
+}
+
+.terminal-preview__button--close {
+  background: #ff5f56;
+}
+
+.terminal-preview__button--minimize {
+  background: #ffbd2e;
+}
+
+.terminal-preview__button--maximize {
+  background: #27c93f;
+}
+
+.terminal-preview__title {
+  flex: 1;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--hero-syntax-comment);
+  font-family: var(--wave-font-mono);
+}
+
+/* Terminal content area */
+.terminal-preview__content {
+  padding: 20px;
+  font-family: var(--wave-font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--hero-syntax-text);
+  min-height: 280px;
+}
+
+/* Command line prompt */
+.terminal-preview__line {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 4px;
+}
+
+.terminal-preview__prompt {
+  color: var(--hero-syntax-function);
+  margin-right: 8px;
+  user-select: none;
+}
+
+.terminal-preview__command {
+  color: var(--hero-syntax-text);
+}
+
+/* Output area */
+.terminal-preview__output {
+  margin-top: 16px;
+  padding-left: 0;
+}
+
+.terminal-preview__output-line {
+  margin-bottom: 2px;
+}
+
+/* Syntax highlighting classes */
+.syntax-comment { color: var(--hero-syntax-comment); }
+.syntax-keyword { color: var(--hero-syntax-keyword); }
+.syntax-string { color: var(--hero-syntax-string); }
+.syntax-function { color: var(--hero-syntax-function); }
+.syntax-variable { color: var(--hero-syntax-variable); }
+.syntax-constant { color: var(--hero-syntax-constant); }
+.syntax-operator { color: var(--hero-syntax-operator); }
+.syntax-yaml-key { color: var(--hero-syntax-yaml-key); }
+.syntax-yaml-value { color: var(--hero-syntax-yaml-value); }
+
+/* Status indicators in output */
+.terminal-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.terminal-status__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.terminal-status__dot--success {
+  background: var(--wave-trust-green);
+  box-shadow: 0 0 8px var(--wave-trust-green);
+}
+
+.terminal-status__dot--running {
+  background: var(--wave-secondary);
+  box-shadow: 0 0 8px var(--wave-secondary);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.terminal-status__dot--pending {
+  background: var(--hero-syntax-comment);
+}
+
+
+/* ===========================================
+   5. VALUE PROP PILLS
+   =========================================== */
+
+/**
+ * Small badge-like elements showing key benefits.
+ * Can include optional icons before the text.
+ * Arranged in a horizontal row with wrapping.
+ */
+.hero-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--hero-pill-text);
+  background: var(--hero-pill-bg);
+  border: 1px solid var(--hero-pill-border);
+  border-radius: 20px;
+  transition: all var(--hero-animation-duration) var(--hero-animation-easing);
+  white-space: nowrap;
+}
+
+.hero-pill:hover {
+  background: var(--hero-pill-hover-bg);
+  border-color: var(--hero-pill-hover-border);
+  color: var(--vp-c-text-1);
+}
+
+.hero-pill__icon {
+  width: 14px;
+  height: 14px;
+  color: var(--hero-pill-icon);
+  flex-shrink: 0;
+}
+
+/* Pill variants for different emphasis levels */
+.hero-pill--primary {
+  background: rgba(79, 70, 229, 0.1);
+  border-color: rgba(79, 70, 229, 0.3);
+  color: var(--wave-primary);
+}
+
+.hero-pill--primary:hover {
+  background: rgba(79, 70, 229, 0.2);
+  border-color: var(--wave-primary);
+}
+
+.hero-pill--security {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: var(--wave-trust-green);
+}
+
+.hero-pill--security:hover {
+  background: rgba(16, 185, 129, 0.2);
+  border-color: var(--wave-trust-green);
+}
+
+
+/* ===========================================
+   6. TYPING ANIMATION
+   =========================================== */
+
+/**
+ * Simulates typing effect for terminal commands.
+ * Uses CSS animations with steps() for character-by-character reveal.
+ * Includes blinking cursor effect.
+ */
+
+/* Typing container - hides overflow during animation */
+.typing-text {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid var(--hero-syntax-text);
+  animation:
+    typing 2s steps(30, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite;
+}
+
+/* Typing animation - reveals text from left to right */
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+/* Cursor blink animation */
+@keyframes blink-cursor {
+  from, to {
+    border-color: var(--hero-syntax-text);
+  }
+  50% {
+    border-color: transparent;
+  }
+}
+
+/* Remove cursor after typing completes (optional) */
+.typing-text--no-cursor {
+  animation: typing 2s steps(30, end) forwards;
+  border-right: none;
+}
+
+/* Staggered typing for multiple lines */
+.typing-text--delay-1 {
+  animation-delay: 0.5s;
+  opacity: 0;
+  animation:
+    appear 0.01s 0.5s forwards,
+    typing 1.5s 0.5s steps(25, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite 0.5s;
+}
+
+.typing-text--delay-2 {
+  animation-delay: 2s;
+  opacity: 0;
+  animation:
+    appear 0.01s 2s forwards,
+    typing 1.5s 2s steps(25, end) forwards,
+    blink-cursor var(--hero-cursor-blink) step-end infinite 2s;
+}
+
+@keyframes appear {
+  to {
+    opacity: 1;
+  }
+}
+
+/* Pulse animation for status indicators */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Fade in animation for output lines */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.terminal-preview__output-line {
+  animation: fade-in-up 0.3s ease-out forwards;
+  opacity: 0;
+}
+
+/* Staggered delays for output lines */
+.terminal-preview__output-line:nth-child(1) { animation-delay: 2.5s; }
+.terminal-preview__output-line:nth-child(2) { animation-delay: 2.7s; }
+.terminal-preview__output-line:nth-child(3) { animation-delay: 2.9s; }
+.terminal-preview__output-line:nth-child(4) { animation-delay: 3.1s; }
+.terminal-preview__output-line:nth-child(5) { animation-delay: 3.3s; }
+.terminal-preview__output-line:nth-child(6) { animation-delay: 3.5s; }
+
+
+/* ===========================================
+   7. RESPONSIVE BREAKPOINTS
+   =========================================== */
+
+/**
+ * Breakpoint strategy:
+ * - Desktop (>= 1024px): Two columns, full terminal preview
+ * - Tablet (768px - 1023px): Single column, terminal below
+ * - Mobile (< 768px): Single column, smaller typography, compact terminal
+ */
+
+/* Large desktop: Increase spacing */
+@media (min-width: 1280px) {
+  :root {
+    --hero-column-gap: 80px;
+    --hero-section-padding-y: 100px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 4rem;
+  }
+}
+
+/* Tablet: Stack to single column */
+@media (max-width: 1023px) {
+  :root {
+    --hero-column-gap: 48px;
+    --hero-section-padding-y: 64px;
+  }
+
+  .hero-enhanced__container {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-enhanced__content {
+    align-items: center;
+  }
+
+  .hero-enhanced__tagline {
+    max-width: 600px;
+  }
+
+  .hero-pills {
+    justify-content: center;
+  }
+
+  .terminal-preview {
+    max-width: 100%;
+  }
+}
+
+/* Small tablet / large mobile */
+@media (max-width: 768px) {
+  :root {
+    --hero-section-padding-y: 48px;
+    --hero-grid-size: 20px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 2.5rem;
+  }
+
+  .hero-enhanced__tagline {
+    font-size: 1.1rem;
+  }
+
+  .terminal-preview__content {
+    padding: 16px;
+    font-size: 12px;
+    min-height: 240px;
+  }
+
+  .hero-pill {
+    padding: 5px 12px;
+    font-size: 12px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  :root {
+    --hero-section-padding-x: 16px;
+    --hero-section-padding-y: 40px;
+  }
+
+  .hero-enhanced__headline {
+    font-size: 2rem;
+  }
+
+  .hero-enhanced__tagline {
+    font-size: 1rem;
+  }
+
+  .terminal-preview {
+    border-radius: 8px;
+  }
+
+  .terminal-preview__header {
+    padding: 10px 12px;
+  }
+
+  .terminal-preview__button {
+    width: 10px;
+    height: 10px;
+  }
+
+  .terminal-preview__content {
+    padding: 12px;
+    font-size: 11px;
+    min-height: 200px;
+  }
+
+  .hero-pills {
+    gap: 8px;
+  }
+
+  .hero-pill__icon {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .terminal-preview,
+  .hero-pill {
+    transition: none;
+  }
+
+  .terminal-preview:hover {
+    transform: none;
+  }
+
+  .typing-text {
+    animation: none;
+    width: 100%;
+    border-right: none;
+  }
+
+  .terminal-preview__output-line {
+    animation: none;
+    opacity: 1;
+  }
+
+  .terminal-status__dot--running {
+    animation: none;
+  }
+}
+
+
+/* ===========================================
+   8. HERO ACTION BUTTONS
+   =========================================== */
+
+/**
+ * CTA buttons in the hero section.
+ * Primary button has gradient background.
+ * Secondary button has outlined style.
+ */
+.hero-enhanced__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.hero-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 28px;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all var(--hero-animation-duration) var(--hero-animation-easing);
+  cursor: pointer;
+  border: none;
+}
+
+.hero-btn--primary {
+  background: linear-gradient(
+    135deg,
+    var(--wave-primary) 0%,
+    var(--wave-accent) 100%
+  );
+  color: white;
+  box-shadow:
+    0 4px 14px rgba(79, 70, 229, 0.3),
+    0 0 0 0 rgba(79, 70, 229, 0);
+}
+
+.hero-btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 20px rgba(79, 70, 229, 0.4),
+    0 0 0 2px rgba(79, 70, 229, 0.1);
+}
+
+.hero-btn--secondary {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  border: 1px solid var(--vp-c-divider);
+}
+
+.hero-btn--secondary:hover {
+  border-color: var(--wave-primary);
+  color: var(--wave-primary);
+  background: rgba(79, 70, 229, 0.05);
+}
+
+/* Icon in buttons */
+.hero-btn__icon {
+  width: 18px;
+  height: 18px;
+}
+
+/* Button group responsive */
+@media (max-width: 480px) {
+  .hero-enhanced__actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/specs/022-hero-section-redesign/types.ts
+++ b/specs/022-hero-section-redesign/types.ts
@@ -1,0 +1,342 @@
+/**
+ * Wave Documentation - Enhanced HeroSection Types
+ * TypeScript interfaces for the redesigned HeroSection component
+ *
+ * Design Goals:
+ * - Backwards compatible with existing HeroSectionProps
+ * - Support for terminal preview with typing animation
+ * - Value proposition pills for quick feature highlights
+ * - Social proof integration (GitHub stars, badges)
+ * - Flexible background and layout variants
+ */
+
+// =============================================================================
+// Action Types (unchanged for compatibility)
+// =============================================================================
+
+export interface HeroAction {
+  text: string
+  link: string
+}
+
+// =============================================================================
+// Terminal Preview Types
+// =============================================================================
+
+/**
+ * Configuration for animated terminal preview
+ * Shows a simulated CLI interaction to demonstrate Wave usage
+ */
+export interface TerminalPreviewConfig {
+  /** The command being typed/executed (e.g., "wave run pipeline.yaml") */
+  command: string
+
+  /** Lines of output displayed after command execution */
+  outputLines: TerminalOutputLine[]
+
+  /** Enable typing animation for the command (default: true) */
+  typingAnimation?: boolean
+
+  /** Typing speed in milliseconds per character (default: 50) */
+  typingSpeed?: number
+
+  /** Delay before showing output after command is typed (default: 500) */
+  outputDelay?: number
+
+  /** Terminal prompt prefix (default: "$") */
+  prompt?: string
+
+  /** Optional title for the terminal window */
+  title?: string
+}
+
+/**
+ * A single line of terminal output with optional styling
+ */
+export interface TerminalOutputLine {
+  /** The text content of the line */
+  text: string
+
+  /** Optional color variant for the line */
+  variant?: TerminalLineVariant
+
+  /** Delay before showing this line (for staggered animation) */
+  delay?: number
+
+  /** Optional icon prefix (e.g., checkmark, spinner) */
+  icon?: TerminalIcon
+}
+
+export type TerminalLineVariant =
+  | 'default'   // Standard output
+  | 'success'   // Green text (e.g., "Done!")
+  | 'error'     // Red text
+  | 'warning'   // Yellow text
+  | 'info'      // Blue text
+  | 'muted'     // Dimmed/gray text
+  | 'highlight' // Emphasized text
+
+export type TerminalIcon =
+  | 'check'     // Checkmark for success
+  | 'cross'     // X for failure
+  | 'spinner'   // Loading spinner
+  | 'arrow'     // Arrow indicator
+  | 'dot'       // Bullet point
+
+// =============================================================================
+// Value Proposition Types
+// =============================================================================
+
+/**
+ * A small pill/badge highlighting a key feature or value prop
+ * Displayed as a horizontal row of compact badges
+ */
+export interface ValuePropositionPill {
+  /** Short label text (e.g., "Zero Config", "Type Safe") */
+  label: string
+
+  /** Optional icon name or emoji */
+  icon?: string
+
+  /** Optional tooltip for more detail */
+  tooltip?: string
+
+  /** Optional link to learn more */
+  link?: string
+}
+
+// =============================================================================
+// Social Proof Types
+// =============================================================================
+
+/**
+ * Social proof configuration for the hero section
+ * Can show GitHub stars, download counts, or custom badges
+ */
+export interface SocialProofConfig {
+  /** Type of social proof to display */
+  type: SocialProofType
+
+  /** Configuration specific to the type */
+  config: GitHubStarsConfig | CustomBadgeConfig
+}
+
+export type SocialProofType = 'github-stars' | 'custom-badge'
+
+/**
+ * GitHub stars badge configuration
+ * Fetches and displays live star count from GitHub API
+ */
+export interface GitHubStarsConfig {
+  type: 'github-stars'
+
+  /** GitHub repository URL (e.g., "https://github.com/re-cinq/wave") */
+  repoUrl: string
+
+  /** Optional label override (default: "GitHub Stars") */
+  label?: string
+
+  /** Cache duration in seconds (default: 3600) */
+  cacheDuration?: number
+}
+
+/**
+ * Custom badge configuration for arbitrary social proof
+ */
+export interface CustomBadgeConfig {
+  type: 'custom-badge'
+
+  /** Badge label text */
+  label: string
+
+  /** Badge value/count */
+  value: string | number
+
+  /** Optional icon */
+  icon?: string
+
+  /** Optional link */
+  link?: string
+}
+
+// =============================================================================
+// Visual Variant Types
+// =============================================================================
+
+/**
+ * Background style variant for the hero section
+ */
+export type HeroBackgroundVariant =
+  | 'grid'     // Subtle grid pattern
+  | 'dots'     // Dot matrix pattern
+  | 'gradient' // Gradient background
+  | 'none'     // No background decoration
+
+/**
+ * Layout variant for the hero section
+ */
+export type HeroLayoutVariant =
+  | 'centered'   // Content centered, stacked vertically
+  | 'two-column' // Text left, terminal preview right
+
+// =============================================================================
+// Background Configuration (advanced)
+// =============================================================================
+
+/**
+ * Extended background configuration for custom styling
+ */
+export interface HeroBackgroundConfig {
+  /** Base variant */
+  variant: HeroBackgroundVariant
+
+  /** Custom gradient colors (for 'gradient' variant) */
+  gradientColors?: {
+    from: string
+    to: string
+    direction?: 'to-right' | 'to-bottom' | 'to-bottom-right'
+  }
+
+  /** Grid/dots opacity (0-1, default: 0.1) */
+  patternOpacity?: number
+
+  /** Enable animated gradient shift */
+  animated?: boolean
+}
+
+// =============================================================================
+// Enhanced HeroSection Props
+// =============================================================================
+
+/**
+ * Enhanced HeroSection component props
+ *
+ * Backwards compatible with existing HeroSectionProps:
+ * - title, tagline, primaryAction, secondaryAction remain unchanged
+ *
+ * New capabilities:
+ * - Terminal preview with typing animation
+ * - Value proposition pills
+ * - Social proof integration
+ * - Background and layout variants
+ */
+export interface EnhancedHeroSectionProps {
+  // -------------------------------------------------------------------------
+  // Core Content (existing, unchanged for compatibility)
+  // -------------------------------------------------------------------------
+
+  /** Main headline text */
+  title: string
+
+  /** Supporting tagline/description */
+  tagline: string
+
+  /** Primary CTA button */
+  primaryAction: HeroAction
+
+  /** Optional secondary CTA button */
+  secondaryAction?: HeroAction
+
+  // -------------------------------------------------------------------------
+  // Terminal Preview (new)
+  // -------------------------------------------------------------------------
+
+  /** Terminal preview configuration */
+  terminal?: TerminalPreviewConfig
+
+  // -------------------------------------------------------------------------
+  // Value Propositions (new)
+  // -------------------------------------------------------------------------
+
+  /** Array of value proposition pills to display */
+  valuePills?: ValuePropositionPill[]
+
+  // -------------------------------------------------------------------------
+  // Social Proof (new)
+  // -------------------------------------------------------------------------
+
+  /** Social proof badge configuration */
+  socialProof?: SocialProofConfig
+
+  // -------------------------------------------------------------------------
+  // Visual Configuration (new)
+  // -------------------------------------------------------------------------
+
+  /** Background variant (default: 'grid') */
+  background?: HeroBackgroundVariant | HeroBackgroundConfig
+
+  /** Layout variant (default: 'centered', 'two-column' when terminal provided) */
+  layout?: HeroLayoutVariant
+}
+
+// =============================================================================
+// Backwards Compatibility Type
+// =============================================================================
+
+/**
+ * Original HeroSectionProps type for reference
+ * EnhancedHeroSectionProps extends this with additional optional properties
+ */
+export interface HeroSectionProps {
+  title: string
+  tagline: string
+  primaryAction: {
+    text: string
+    link: string
+  }
+  secondaryAction?: {
+    text: string
+    link: string
+  }
+}
+
+/**
+ * Type guard to check if props are enhanced
+ */
+export function isEnhancedHeroProps(
+  props: HeroSectionProps | EnhancedHeroSectionProps
+): props is EnhancedHeroSectionProps {
+  return (
+    'terminal' in props ||
+    'valuePills' in props ||
+    'socialProof' in props ||
+    'background' in props ||
+    'layout' in props
+  )
+}
+
+// =============================================================================
+// Component State Types (for internal use)
+// =============================================================================
+
+/**
+ * Internal state for terminal animation
+ */
+export interface TerminalAnimationState {
+  /** Current phase of animation */
+  phase: 'idle' | 'typing' | 'executing' | 'complete'
+
+  /** Characters typed so far */
+  typedChars: number
+
+  /** Output lines revealed so far */
+  revealedLines: number
+
+  /** Whether animation is paused */
+  paused: boolean
+}
+
+// =============================================================================
+// Default Values
+// =============================================================================
+
+export const HERO_DEFAULTS = {
+  background: 'grid' as HeroBackgroundVariant,
+  layout: 'centered' as HeroLayoutVariant,
+  terminal: {
+    typingAnimation: true,
+    typingSpeed: 50,
+    outputDelay: 500,
+    prompt: '$',
+  },
+} as const


### PR DESCRIPTION
## Summary

- Update landing page with "AI-as-Code" positioning
- Add two-column hero with terminal preview component
- Add value proposition pills (Declarative, Contracts, Isolation, Auditable)
- Add competitor comparison table (Wave vs Gastown vs Claude Flow)
- Create `/concepts/ai-as-code` page explaining the X-as-Code evolution
- Update meta tags and README with new tagline

## Test plan

- [x] Run `cd docs && npm run dev` and verify landing page
- [x] Check terminal preview renders correctly
- [x] Verify responsive behavior on mobile/tablet
- [x] Click through to AI-as-Code concept page