### PR TITLE
fix(pipeline): prevent create-new-feature.sh from switching main repo branch

### DIFF
--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -93,7 +93,8 @@ else
 fi
 
 if [ "$HAS_GIT" = true ]; then
-    git checkout -b "$BRANCH_NAME"
+    # Create branch without switching — worktrees handle checkout isolation
+    git branch "$BRANCH_NAME" 2>/dev/null || true
 else
     >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi

--- a/.wave/prompts/github-issue-impl/fetch-assess.md
+++ b/.wave/prompts/github-issue-impl/fetch-assess.md
@@ -4,16 +4,16 @@ Input: {{ input }}
 
 The input format is `owner/repo number` (e.g. `re-cinq/wave 42`).
 
-## IMPORTANT: Working Directory
+## IMPORTANT: Workspace Isolation
 
 Your current working directory is a Wave workspace, NOT the project root.
-Before running any commands, navigate to the project root:
+Use `REPO_ROOT` for any commands that need project root access:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 ```
 
-Run this FIRST before any other bash commands.
+Do NOT `cd` to the project root — this step is read-only and should not mutate the main checkout.
 
 ## Instructions
 

--- a/.wave/prompts/github-issue-impl/plan.md
+++ b/.wave/prompts/github-issue-impl/plan.md
@@ -26,20 +26,26 @@ Read `artifacts/issue_assessment` to extract:
 
 ### Step 2: Create Feature Branch via Worktree
 
-Use the `create-new-feature.sh` script to create a properly numbered branch:
+Create the branch without switching the main repo checkout:
 
 ```bash
-cd "$REPO_ROOT"
-.specify/scripts/bash/create-new-feature.sh --json --number <ISSUE_NUMBER> --short-name "<SHORT_NAME>" "<ISSUE_TITLE>"
+BRANCH_NAME="<NNN>-<short-name>"  # from assessment
+git -C "$REPO_ROOT" branch "$BRANCH_NAME" 2>/dev/null || true
 ```
 
-If the branch already exists (e.g. from a resume), skip creation.
+If the branch already exists (e.g. from a resume), the `|| true` handles it.
 
 Now create an isolated worktree for this branch:
 
 ```bash
-git -C "$REPO_ROOT" worktree add "$PWD/repo" <BRANCH_NAME>
+git -C "$REPO_ROOT" worktree add "$PWD/repo" "$BRANCH_NAME"
 cd repo
+```
+
+Run the feature setup script inside the worktree (not the main repo):
+
+```bash
+.specify/scripts/bash/create-new-feature.sh --json --number <ISSUE_NUMBER> --short-name "<SHORT_NAME>" "<ISSUE_TITLE>"
 ```
 
 All subsequent commands run inside this worktree.

--- a/.wave/prompts/speckit-flow/specify.md
+++ b/.wave/prompts/speckit-flow/specify.md
@@ -26,11 +26,10 @@ Follow the `/speckit.specify` workflow to generate a complete feature specificat
    ```
 4. Create the feature branch and worktree:
    ```bash
-   cd "$REPO_ROOT"
-   .specify/scripts/bash/create-new-feature.sh --json --number <N> --short-name "<name>" "{{ input }}"
-   cd "$OLDPWD"
+   git -C "$REPO_ROOT" branch "<NNN>-<short-name>" 2>/dev/null || true
    git -C "$REPO_ROOT" worktree add "$PWD/repo" <BRANCH_NAME>
    cd repo
+   .specify/scripts/bash/create-new-feature.sh --json --number <N> --short-name "<name>" "{{ input }}"
    ```
 5. Load `.specify/templates/spec-template.md` for the required structure
 6. Write the specification to the SPEC_FILE returned by the script

--- a/internal/defaults/prompts/github-issue-impl/fetch-assess.md
+++ b/internal/defaults/prompts/github-issue-impl/fetch-assess.md
@@ -4,16 +4,16 @@ Input: {{ input }}
 
 The input format is `owner/repo number` (e.g. `re-cinq/wave 42`).
 
-## IMPORTANT: Working Directory
+## IMPORTANT: Workspace Isolation
 
 Your current working directory is a Wave workspace, NOT the project root.
-Before running any commands, navigate to the project root:
+Use `REPO_ROOT` for any commands that need project root access:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 ```
 
-Run this FIRST before any other bash commands.
+Do NOT `cd` to the project root — this step is read-only and should not mutate the main checkout.
 
 ## Instructions
 

--- a/internal/defaults/prompts/speckit-flow/specify.md
+++ b/internal/defaults/prompts/speckit-flow/specify.md
@@ -2,37 +2,49 @@ You are creating a feature specification for the following request:
 
 {{ input }}
 
-## IMPORTANT: Working Directory
+## IMPORTANT: Workspace Isolation via Git Worktree
 
 Your current working directory is a Wave workspace, NOT the project root.
-Before running any scripts or accessing project files, navigate to the project root:
+Use `git worktree` to create an isolated checkout — this allows multiple pipeline runs
+to work concurrently without conflicts.
 
 ```bash
-cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 ```
-
-Run this FIRST before any other bash commands.
 
 ## Instructions
 
 Follow the `/speckit.specify` workflow to generate a complete feature specification:
 
-1. Navigate to the project root (see above)
+1. Set up the repo root reference (see above)
 2. Generate a concise short name (2-4 words) for the feature branch
 3. Check existing branches to determine the next available number:
    ```bash
-   git fetch --all --prune
-   git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-'
-   git branch | grep -E '^[* ]*[0-9]+-'
+   git -C "$REPO_ROOT" fetch --all --prune
+   git -C "$REPO_ROOT" ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-'
+   git -C "$REPO_ROOT" branch | grep -E '^[* ]*[0-9]+-'
    ```
-4. Run the feature creation script:
+4. Create the feature branch and worktree:
    ```bash
+   git -C "$REPO_ROOT" branch "<NNN>-<short-name>" 2>/dev/null || true
+   git -C "$REPO_ROOT" worktree add "$PWD/repo" <BRANCH_NAME>
+   cd repo
    .specify/scripts/bash/create-new-feature.sh --json --number <N> --short-name "<name>" "{{ input }}"
    ```
 5. Load `.specify/templates/spec-template.md` for the required structure
 6. Write the specification to the SPEC_FILE returned by the script
 7. Create the quality checklist at `FEATURE_DIR/checklists/requirements.md`
 8. Run self-validation against the checklist (up to 3 iterations)
+9. Commit planning artifacts:
+   ```bash
+   git add specs/
+   git commit -m "docs: add feature spec for <short-name>"
+   ```
+10. Clean up worktree:
+    ```bash
+    cd "$OLDPWD"
+    git -C "$REPO_ROOT" worktree remove "$PWD/repo"
+    ```
 
 ## Agent Usage
 


### PR DESCRIPTION
## Summary

- `create-new-feature.sh` used `git checkout -b` which switched the main repo's HEAD during pipeline runs, causing concurrent runs to collide
- Changed to `git branch` (create without switching) — worktrees handle the checkout isolation
- Updated `plan.md` and `specify.md` prompts to create branches with `git -C` before worktree creation
- Updated `fetch-assess.md` to use `REPO_ROOT` variable instead of `cd` to project root

## Root Cause

Found via `git reflog` after 3 concurrent pipeline runs all switched the main repo to their feature branches:
```
checkout: moving from main to 056-tui-pause-audit
checkout: moving from main to 052-docs-unreleased-cleanup
```

## Test plan

- [x] `go test -race ./...` — all green
- [x] Root cause verified via reflog analysis of 3 concurrent pipeline runs
