### PR TITLE
fix(adapter): count cache tokens and fix display formatting

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -223,7 +223,14 @@ func runRun(opts RunOptions, debug bool) error {
 
 	// Show human summary only in auto/text modes — json and quiet stay clean
 	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
-		fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs)\n", p.Metadata.Name, elapsed.Seconds())
+		totalTokens := executor.GetTotalTokens()
+		if totalTokens > 0 {
+			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs, %s tokens)\n",
+				p.Metadata.Name, elapsed.Seconds(), display.FormatTokenCount(totalTokens))
+		} else {
+			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs)\n",
+				p.Metadata.Name, elapsed.Seconds())
+		}
 
 		if deliverables := executor.GetDeliverables(); deliverables != "" {
 			fmt.Fprint(os.Stderr, "\n")

--- a/internal/display/progress.go
+++ b/internal/display/progress.go
@@ -217,7 +217,7 @@ func (ss *StepStatus) Render() string {
 
 	// Tokens used (for completed steps)
 	if ss.TokensUsed > 0 && (ss.State == StateCompleted || ss.State == StateFailed) {
-		sb.WriteString(codec.Muted(fmt.Sprintf(" • %dk tokens", ss.TokensUsed/1000)))
+		sb.WriteString(codec.Muted(fmt.Sprintf(" • %s tokens", FormatTokenCount(ss.TokensUsed))))
 	}
 
 	// Message
@@ -556,8 +556,8 @@ func (bpd *BasicProgressDisplay) EmitProgress(ev event.Event) error {
 				fmt.Fprintf(bpd.writer, "[%s] → %s (%s)\n", timestamp, ev.StepID, ev.Persona)
 			}
 		case "completed":
-			fmt.Fprintf(bpd.writer, "[%s] ✓ %s completed (%.1fs, %dk tokens)\n",
-				timestamp, ev.StepID, float64(ev.DurationMs)/1000.0, ev.TokensUsed/1000)
+			fmt.Fprintf(bpd.writer, "[%s] ✓ %s completed (%.1fs, %s tokens)\n",
+				timestamp, ev.StepID, float64(ev.DurationMs)/1000.0, FormatTokenCount(ev.TokensUsed))
 		case "failed":
 			fmt.Fprintf(bpd.writer, "[%s] ✗ %s failed: %s\n", timestamp, ev.StepID, ev.Message)
 		case "step_progress":

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1140,6 +1140,22 @@ func (e *DefaultPipelineExecutor) GetDeliverableTracker() *deliverable.Tracker {
 	return e.deliverableTracker
 }
 
+// GetTotalTokens returns the sum of tokens used across all completed steps.
+func (e *DefaultPipelineExecutor) GetTotalTokens() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	var total int
+	for _, execution := range e.pipelines {
+		for _, result := range execution.Results {
+			if tokens, ok := result["tokens_used"].(int); ok {
+				total += tokens
+			}
+		}
+	}
+	return total
+}
+
 func (e *DefaultPipelineExecutor) Resume(ctx context.Context, pipelineID string, fromStep string) error {
 	e.mu.RLock()
 	execution, exists := e.pipelines[pipelineID]


### PR DESCRIPTION
## Summary

- **Count cache tokens**: `parseOutput()` and `parseStreamLine()` now include `cache_read_input_tokens` and `cache_creation_input_tokens` from Claude API usage — these represent the majority of tokens when prompt caching is active
- **Fix display rounding**: Replace integer division `tokens/1000` (`0k` for anything under 1000) with `FormatTokenCount()` that shows `"750"` / `"1.5k"` / `"15k"`
- **Fix multi-turn overcounting**: Take last assistant event's usage (peak context) instead of summing across turns, which double-counted because each turn's input already includes full history
- **Add pipeline token total**: Completion summary now shows total tokens across all steps

### Before
```
[09:46:06] ✓ greet completed (6.1s, 0k tokens)
✓ Pipeline 'hello-world' completed successfully (13.3s)
```

### After
```
[09:54:11] ✓ greet completed (6.1s, 22.5k tokens)
✓ Pipeline 'hello-world' completed successfully (14.3s, 66.3k tokens)
```

## Test plan

- [x] `go test ./...` passes
- [ ] Run `wave run hello-world "test" -o text` — verify realistic token counts per step and total
- [ ] Run a multi-step pipeline — verify total tokens shown and no single step exceeds 200k