### PR TITLE
fix(display): show pipeline run ID with hash in TUI header

### DIFF
--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -122,7 +122,7 @@ func runDo(input string, opts DoOptions) error {
 		runner = adapter.ResolveAdapter(adapterName)
 	}
 
-	result := CreateEmitter(opts.Output, "adhoc", p.Steps, &m)
+	result := CreateEmitter(opts.Output, "adhoc", "adhoc", p.Steps, &m)
 	defer result.Cleanup()
 
 	wsRoot := m.Runtime.WorkspaceRoot

--- a/cmd/wave/commands/meta.go
+++ b/cmd/wave/commands/meta.go
@@ -103,7 +103,7 @@ func runMeta(input string, opts MetaOptions) error {
 	}
 
 	// Create emitter (no steps known yet for meta - generated dynamically)
-	emitterResult := CreateEmitter(opts.Output, "meta", nil, &m)
+	emitterResult := CreateEmitter(opts.Output, "meta", "meta", nil, &m)
 	defer emitterResult.Cleanup()
 
 	// Set up workspace manager

--- a/cmd/wave/commands/output.go
+++ b/cmd/wave/commands/output.go
@@ -48,7 +48,7 @@ type EmitterResult struct {
 //   - text:  Plain text progress to stderr, no stdout
 //   - quiet: Only final result to stderr, no stdout
 //   - auto:  BubbleTea TUI if TTY, plain text if pipe
-func CreateEmitter(cfg OutputConfig, pipelineName string, steps []pipeline.Step, m *manifest.Manifest) EmitterResult {
+func CreateEmitter(cfg OutputConfig, pipelineID, pipelineName string, steps []pipeline.Step, m *manifest.Manifest) EmitterResult {
 	switch cfg.Format {
 	case OutputFormatJSON:
 		return EmitterResult{
@@ -75,18 +75,18 @@ func CreateEmitter(cfg OutputConfig, pipelineName string, steps []pipeline.Step,
 		}
 
 	default: // "auto"
-		return createAutoEmitter(cfg, pipelineName, steps, m)
+		return createAutoEmitter(cfg, pipelineID, pipelineName, steps, m)
 	}
 }
 
 // createAutoEmitter selects BubbleTea TUI when connected to a TTY,
 // plain text otherwise.
-func createAutoEmitter(cfg OutputConfig, pipelineName string, steps []pipeline.Step, m *manifest.Manifest) EmitterResult {
+func createAutoEmitter(cfg OutputConfig, pipelineID, pipelineName string, steps []pipeline.Step, m *manifest.Manifest) EmitterResult {
 	termInfo := display.NewTerminalInfo()
 	isTTY := termInfo.IsTTY() && termInfo.SupportsANSI()
 
 	if isTTY {
-		btpd := display.NewBubbleTeaProgressDisplay(pipelineName, pipelineName, len(steps), nil, cfg.Verbose)
+		btpd := display.NewBubbleTeaProgressDisplay(pipelineID, pipelineName, len(steps), nil, cfg.Verbose)
 
 		// Register steps for tracking
 		for _, step := range steps {

--- a/cmd/wave/commands/output_test.go
+++ b/cmd/wave/commands/output_test.go
@@ -38,7 +38,7 @@ func TestValidateOutputFormat(t *testing.T) {
 
 func TestCreateEmitter_JSONFormat(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatJSON, Verbose: false}
-	result := CreateEmitter(cfg, "test", nil, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", nil, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter, "json format should return an emitter")
@@ -47,7 +47,7 @@ func TestCreateEmitter_JSONFormat(t *testing.T) {
 
 func TestCreateEmitter_TextFormat(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatText, Verbose: false}
-	result := CreateEmitter(cfg, "test", nil, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", nil, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -59,7 +59,7 @@ func TestCreateEmitter_TextFormat(t *testing.T) {
 
 func TestCreateEmitter_TextFormatVerbose(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatText, Verbose: true}
-	result := CreateEmitter(cfg, "test", nil, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", nil, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -71,7 +71,7 @@ func TestCreateEmitter_TextFormatVerbose(t *testing.T) {
 
 func TestCreateEmitter_QuietFormat(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatQuiet, Verbose: false}
-	result := CreateEmitter(cfg, "test", nil, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", nil, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -87,7 +87,7 @@ func TestCreateEmitter_AutoFormatWithSteps(t *testing.T) {
 		{ID: "step1", Persona: "navigator"},
 		{ID: "step2", Persona: "craftsman"},
 	}
-	result := CreateEmitter(cfg, "test-pipeline", steps, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test-pipeline", "test-pipeline", steps, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -101,7 +101,7 @@ func TestCreateEmitter_AutoFormatForceTTY(t *testing.T) {
 	steps := []pipeline.Step{
 		{ID: "step1", Persona: "navigator"},
 	}
-	result := CreateEmitter(cfg, "test", steps, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", steps, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -117,7 +117,7 @@ func TestCreateEmitter_AutoFormatForceNonTTY(t *testing.T) {
 	steps := []pipeline.Step{
 		{ID: "step1", Persona: "navigator"},
 	}
-	result := CreateEmitter(cfg, "test", steps, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", steps, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -128,7 +128,7 @@ func TestCreateEmitter_AutoFormatForceNonTTY(t *testing.T) {
 
 func TestCreateEmitter_NilSteps(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatText, Verbose: false}
-	result := CreateEmitter(cfg, "test", nil, &manifest.Manifest{})
+	result := CreateEmitter(cfg, "test", "test", nil, &manifest.Manifest{})
 	defer result.Cleanup()
 
 	assert.NotNil(t, result.Emitter)
@@ -143,7 +143,7 @@ func TestOutputFormatConstants(t *testing.T) {
 
 func TestCreateEmitter_TextFormatUsesThrottle(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatText, Verbose: false}
-	result := CreateEmitter(cfg, "test-pipeline", []pipeline.Step{}, nil)
+	result := CreateEmitter(cfg, "test-pipeline", "test-pipeline", []pipeline.Step{}, nil)
 	defer result.Cleanup()
 
 	if _, ok := result.Progress.(*display.ThrottledProgressEmitter); !ok {
@@ -153,7 +153,7 @@ func TestCreateEmitter_TextFormatUsesThrottle(t *testing.T) {
 
 func TestCreateEmitter_QuietFormatUsesThrottle(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatQuiet, Verbose: false}
-	result := CreateEmitter(cfg, "test-pipeline", []pipeline.Step{}, nil)
+	result := CreateEmitter(cfg, "test-pipeline", "test-pipeline", []pipeline.Step{}, nil)
 	defer result.Cleanup()
 
 	if _, ok := result.Progress.(*display.ThrottledProgressEmitter); !ok {
@@ -163,7 +163,7 @@ func TestCreateEmitter_QuietFormatUsesThrottle(t *testing.T) {
 
 func TestCreateEmitter_JSONFormatNoThrottle(t *testing.T) {
 	cfg := OutputConfig{Format: OutputFormatJSON, Verbose: false}
-	result := CreateEmitter(cfg, "test-pipeline", []pipeline.Step{}, nil)
+	result := CreateEmitter(cfg, "test-pipeline", "test-pipeline", []pipeline.Step{}, nil)
 	defer result.Cleanup()
 
 	if result.Progress != nil {

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -131,8 +131,11 @@ func runRun(opts RunOptions, debug bool) error {
 		runner = adapter.ResolveAdapter(adapterName)
 	}
 
+	// Generate run ID once — shared by display and executor
+	runID := pipeline.GenerateRunID(p.Metadata.Name, m.Runtime.PipelineIDHashLength)
+
 	// Initialize event emitter based on output format
-	result := CreateEmitter(opts.Output, p.Metadata.Name, p.Steps, &m)
+	result := CreateEmitter(opts.Output, runID, p.Metadata.Name, p.Steps, &m)
 	emitter := result.Emitter
 	progressDisplay := result.Progress
 	defer result.Cleanup()
@@ -176,6 +179,7 @@ func runRun(opts RunOptions, debug bool) error {
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(emitter),
 		pipeline.WithDebug(debug),
+		pipeline.WithRunID(runID),
 	}
 	if wsManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))

--- a/internal/display/bubbletea_model.go
+++ b/internal/display/bubbletea_model.go
@@ -110,8 +110,12 @@ func (m *ProgressModel) renderHeader() string {
 	pipelineStart := time.Unix(0, m.ctx.PipelineStartTime)
 	elapsed := time.Since(pipelineStart)
 
+	pipelineLabel := m.ctx.PipelineName
+	if m.ctx.PipelineID != "" && m.ctx.PipelineID != m.ctx.PipelineName {
+		pipelineLabel = m.ctx.PipelineID
+	}
 	projectLines := []string{
-		fmt.Sprintf("Pipeline: %s", m.ctx.PipelineName),
+		fmt.Sprintf("Pipeline: %s", pipelineLabel),
 		fmt.Sprintf("Config:   %s", m.ctx.ManifestPath),
 		fmt.Sprintf("Elapsed:  %s", formatElapsed(elapsed)),
 	}

--- a/internal/display/bubbletea_progress.go
+++ b/internal/display/bubbletea_progress.go
@@ -53,6 +53,7 @@ func NewBubbleTeaProgressDisplay(pipelineID, pipelineName string, totalSteps int
 	// Initial pipeline context
 	initialCtx := &PipelineContext{
 		PipelineName:      pipelineName,
+		PipelineID:        pipelineID,
 		OverallProgress:   0,
 		CurrentStepNum:    1,
 		TotalSteps:        totalSteps,
@@ -344,6 +345,7 @@ func (btpd *BubbleTeaProgressDisplay) toPipelineContext() *PipelineContext {
 
 	return &PipelineContext{
 		PipelineName:       btpd.pipelineName,
+		PipelineID:         btpd.pipelineID,
 		OverallProgress:    overallProgress,
 		CurrentStepNum:     currentStepIdx + 1, // 1-indexed for display
 		TotalSteps:         btpd.totalSteps,

--- a/internal/display/dashboard.go
+++ b/internal/display/dashboard.go
@@ -92,8 +92,12 @@ func (d *Dashboard) renderHeader(ctx *PipelineContext) string {
 
 	// Project info for right side
 	elapsed := float64(ctx.ElapsedTimeMs) / 1000.0
+	pipelineLabel := ctx.PipelineName
+	if ctx.PipelineID != "" && ctx.PipelineID != ctx.PipelineName {
+		pipelineLabel = ctx.PipelineID
+	}
 	projectInfo := []string{
-		fmt.Sprintf("%s", ctx.PipelineName),
+		pipelineLabel,
 		fmt.Sprintf("%.1fs • %s", elapsed, ctx.ManifestPath),
 		" Press: q=quit",
 	}

--- a/internal/display/progress.go
+++ b/internal/display/progress.go
@@ -476,6 +476,7 @@ func (pd *ProgressDisplay) toPipelineContext() *PipelineContext {
 
 	return &PipelineContext{
 		PipelineName:      pd.pipelineName,
+		PipelineID:        pd.pipelineID,
 		OverallProgress:   overallProgress,
 		CurrentStepNum:    pd.currentStepIdx + 1, // 1-indexed for display
 		TotalSteps:        pd.totalSteps,

--- a/internal/display/types.go
+++ b/internal/display/types.go
@@ -193,6 +193,7 @@ type PipelineContext struct {
 	// Project metadata
 	ManifestPath  string
 	PipelineName  string
+	PipelineID    string
 	WorkspacePath string
 
 	// Step tracking

--- a/internal/pipeline/executor_enhanced.go
+++ b/internal/pipeline/executor_enhanced.go
@@ -44,8 +44,10 @@ func (e *DefaultPipelineExecutor) ExecuteWithValidation(ctx context.Context, p *
 
 	// Initialize pipeline execution
 	pipelineName := p.Metadata.Name
-	hashLength := m.Runtime.PipelineIDHashLength
-	pipelineID := GenerateRunID(pipelineName, hashLength)
+	pipelineID := e.runID
+	if pipelineID == "" {
+		pipelineID = GenerateRunID(pipelineName, m.Runtime.PipelineIDHashLength)
+	}
 	execution := &PipelineExecution{
 		Pipeline:       p,
 		Manifest:       m,


### PR DESCRIPTION
## Summary

- Generate the run ID once in `run.go` and pass it to both the display layer (`CreateEmitter`) and executor (`WithRunID`)
- Both TUI (bubbletea) and text-mode (dashboard) headers now show the full run ID (e.g. `gh-issue-rewrite-301b03e5`) instead of just the pipeline name
- `CreateEmitter` accepts separate `pipelineID` and `pipelineName` parameters

## Before
```
Pipeline: gh-issue-rewrite
```

## After
```
Pipeline: gh-issue-rewrite-301b03e5
```

## Test plan
- [x] `go test -race ./...` passes
- [ ] Manual: run `wave run <pipeline>` and verify header shows run ID with hash