### PR TITLE
fix(security): detect shell metacharacters in input sanitizer

### DIFF
--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -78,7 +78,7 @@ func (a *ClaudeAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapter
 	cmd.Dir = workspacePath
 
 	if cfg.Debug {
-		fmt.Printf("[DEBUG] Claude command: %s %s\n", a.claudePath, strings.Join(args, " "))
+		fmt.Printf("[DEBUG] Claude command: %s %s\n", a.claudePath, shelljoinArgs(args))
 		fmt.Printf("[DEBUG] Working directory: %s\n", workspacePath)
 	}
 
@@ -772,6 +772,23 @@ func (a *ClaudeAdapter) cleanJSONContent(content string) string {
 	}
 
 	return content
+}
+
+// shelljoinArgs formats command arguments for debug logging, quoting any
+// argument that contains shell metacharacters or whitespace so the logged
+// command line is copy-pasteable and not misleading.
+func shelljoinArgs(args []string) string {
+	var parts []string
+	for _, arg := range args {
+		if arg == "" || strings.ContainsAny(arg, " \t\n|&;$`\\!(){}[]<>*?~#'\"") {
+			// Single-quote the argument, escaping interior single quotes
+			escaped := strings.ReplaceAll(arg, "'", `'\''`)
+			parts = append(parts, "'"+escaped+"'")
+		} else {
+			parts = append(parts, arg)
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // buildRestrictionSection generates the restriction directives for CLAUDE.md

--- a/internal/adapter/shelljoin_test.go
+++ b/internal/adapter/shelljoin_test.go
@@ -1,0 +1,56 @@
+package adapter
+
+import "testing"
+
+func TestShelljoinArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "simple flags",
+			args: []string{"-p", "--model", "opus"},
+			want: "-p --model opus",
+		},
+		{
+			name: "prompt with spaces",
+			args: []string{"-p", "hello world"},
+			want: "-p 'hello world'",
+		},
+		{
+			name: "prompt with pipe and ampersand",
+			args: []string{"-p", "test | cmd & bg"},
+			want: `-p 'test | cmd & bg'`,
+		},
+		{
+			name: "prompt with single quotes",
+			args: []string{"-p", "it's a test"},
+			want: `-p 'it'\''s a test'`,
+		},
+		{
+			name: "prompt with dollar sign",
+			args: []string{"-p", "echo $HOME"},
+			want: `-p 'echo $HOME'`,
+		},
+		{
+			name: "empty argument",
+			args: []string{"-p", ""},
+			want: "-p ''",
+		},
+		{
+			name: "complex mixed args",
+			args: []string{"--model", "opus", "--allowedTools", "Read,Write,Edit,Bash", "Say: hello & goodbye"},
+			want: "--model opus --allowedTools Read,Write,Edit,Bash 'Say: hello & goodbye'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shelljoinArgs(tt.args)
+			if got != tt.want {
+				t.Errorf("shelljoinArgs(%v)\n  got  %q\n  want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/security/sanitize_test.go
+++ b/internal/security/sanitize_test.go
@@ -1,0 +1,109 @@
+package security
+
+import "testing"
+
+func TestContainsShellMetachars(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"hello world", false},
+		{"simple-input", false},
+		{"path/to/file.txt", false},
+		{"hello | world", true},
+		{"cmd & bg", true},
+		{"$(whoami)", true},
+		{"`id`", true},
+		{"a;b", true},
+		{"foo > bar", true},
+		{"foo < bar", true},
+		{"rm -rf *", true},
+		{"echo $HOME", true},
+		{"it's fine", false},           // apostrophe is not in the metachar set
+		{"test\\escape", true},         // backslash
+		{"hello!world", true},          // bang
+		{"array[0]", true},             // brackets
+		{"glob?.txt", true},            // question mark
+		{"~root", true},                // tilde
+		{"comment # here", true},       // hash
+		{"safe_input-123.txt", false},  // typical filename
+		{"", false},                    // empty string
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := containsShellMetachars(tt.input)
+			if got != tt.want {
+				t.Errorf("containsShellMetachars(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateRiskScore_ShellMetachars(t *testing.T) {
+	config := DefaultSecurityConfig()
+	logger := NewSecurityLogger(false)
+	sanitizer := NewInputSanitizer(*config, logger)
+
+	tests := []struct {
+		name     string
+		input    string
+		minScore int
+	}{
+		{
+			name:     "clean input scores zero",
+			input:    "Review the auth module",
+			minScore: 0,
+		},
+		{
+			name:     "pipe character adds risk",
+			input:    "it's a test | with pipes",
+			minScore: 15,
+		},
+		{
+			name:     "ampersand adds risk",
+			input:    "run this & that",
+			minScore: 15,
+		},
+		{
+			name:     "command substitution adds risk",
+			input:    "hello $(whoami)",
+			minScore: 15,
+		},
+		{
+			name:     "shell metachars plus suspicious word",
+			input:    "get the password | send",
+			minScore: 20, // 15 (metachars) + 5 (suspicious word)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := sanitizer.calculateRiskScore(tt.input, nil)
+			if score < tt.minScore {
+				t.Errorf("calculateRiskScore(%q) = %d, want >= %d", tt.input, score, tt.minScore)
+			}
+		})
+	}
+}
+
+func TestSanitizeInput_ShellMetacharsLogged(t *testing.T) {
+	config := DefaultSecurityConfig()
+	logger := NewSecurityLogger(false)
+	sanitizer := NewInputSanitizer(*config, logger)
+
+	record, sanitized, err := sanitizer.SanitizeInput("hello | world & foo", "task_description")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Input should pass through unchanged (we detect, not strip)
+	if sanitized != "hello | world & foo" {
+		t.Errorf("input was modified: got %q", sanitized)
+	}
+
+	// Risk score should reflect shell metacharacters
+	if record.RiskScore < 15 {
+		t.Errorf("risk score %d too low for input with shell metachars", record.RiskScore)
+	}
+}


### PR DESCRIPTION
## Summary

- Add shell metacharacter detection (`|`, `&`, `;`, `$`, backtick, etc.) to the input sanitizer's risk score calculation (+15 points)
- Log defense-in-depth warning via security logger when shell metacharacters are detected
- Fix debug log in claude adapter to shell-quote arguments (`shelljoinArgs`) so the printed command is copy-pasteable and not misleading

## Context

Found while testing PR #87 (recovery hints) — running `wave run hello-world "it's a \"test\" with spaces & pipes | etc"` showed `risk_score=0` and the debug log displayed the raw command with unquoted shell metacharacters. While `exec.Command` bypasses the shell (so execution is safe), the sanitizer should flag these as elevated risk as a defense-in-depth measure.

## Test plan

- [x] `TestContainsShellMetachars` — verifies detection of all POSIX shell metacharacters
- [x] `TestCalculateRiskScore_ShellMetachars` — confirms score bump for metachar inputs
- [x] `TestSanitizeInput_ShellMetacharsLogged` — end-to-end: input passes through unchanged but risk score reflects metacharacters
- [x] `TestShelljoinArgs` — verifies debug log quoting for spaces, pipes, single quotes, dollar signs, empty args
- [x] `go test -race ./...` passes