### PR TITLE
feat(manifest): per-persona model and temperature tuning

### DIFF
--- a/wave.yaml
+++ b/wave.yaml
@@ -28,6 +28,8 @@ personas:
     auditor:
         adapter: claude
         description: Security review and quality assurance
+        model: opus
+        temperature: 0.1
         permissions:
             allowed_tools:
                 - Read
@@ -41,6 +43,8 @@ personas:
     craftsman:
         adapter: claude
         description: Code implementation and testing
+        model: opus
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -53,6 +57,8 @@ personas:
     debugger:
         adapter: claude
         description: Systematic issue diagnosis and root cause analysis
+        model: opus
+        temperature: 0.2
         permissions:
             allowed_tools:
                 - Read
@@ -69,6 +75,8 @@ personas:
     navigator:
         adapter: claude
         description: Read-only codebase exploration and analysis
+        model: sonnet
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -85,6 +93,8 @@ personas:
     philosopher:
         adapter: claude
         description: Architecture design and specification
+        model: opus
+        temperature: 0.7
         permissions:
             allowed_tools:
                 - Read
@@ -95,6 +105,8 @@ personas:
     planner:
         adapter: claude
         description: Task breakdown and project planning
+        model: sonnet
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -108,6 +120,8 @@ personas:
     summarizer:
         adapter: claude
         description: Context compaction for relay handoffs
+        model: sonnet
+        temperature: 0.2
         permissions:
             allowed_tools:
                 - Read
@@ -118,6 +132,8 @@ personas:
     github-analyst:
         adapter: claude
         description: GitHub issue analysis and quality assessment
+        model: sonnet
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -127,6 +143,8 @@ personas:
     github-enhancer:
         adapter: claude
         description: GitHub issue enhancement and improvement
+        model: sonnet
+        temperature: 0.5
         permissions:
             allowed_tools:
                 - Read
@@ -138,6 +156,8 @@ personas:
     implementer:
         adapter: claude
         description: Code execution and artifact generation for pipeline steps
+        model: opus
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -153,6 +173,8 @@ personas:
     reviewer:
         adapter: claude
         description: Quality review, validation, and assessment
+        model: sonnet
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read
@@ -170,6 +192,8 @@ personas:
     researcher:
         adapter: claude
         description: Web research and information synthesis
+        model: sonnet
+        temperature: 0.5
         permissions:
             allowed_tools:
                 - Read
@@ -188,6 +212,8 @@ personas:
     github-commenter:
         adapter: claude
         description: Post comments on GitHub issues
+        model: sonnet
+        temperature: 0.3
         permissions:
             allowed_tools:
                 - Read


### PR DESCRIPTION
## Summary

- Add `model` and `temperature` fields to all 13 personas in `wave.yaml`
- Opus for heavy-lift roles (craftsman, implementer, debugger, auditor, philosopher)
- Sonnet for read-only/lightweight roles (navigator, planner, summarizer, reviewer, researcher, github-*)
- Temperature calibrated per role intent:

| Persona | Model | Temp | Rationale |
|---------|-------|------|-----------|
| auditor | opus | 0.1 | Strict, deterministic validation |
| debugger | opus | 0.2 | Methodical diagnosis |
| summarizer | sonnet | 0.2 | Faithful compaction |
| navigator | sonnet | 0.3 | Factual exploration |
| planner | sonnet | 0.3 | Structured breakdown |
| craftsman | opus | 0.3 | Precise code generation |
| implementer | opus | 0.3 | Precise code execution |
| reviewer | sonnet | 0.3 | Consistent quality checks |
| github-analyst | sonnet | 0.3 | Factual assessment |
| github-commenter | sonnet | 0.3 | Clear communication |
| github-enhancer | sonnet | 0.5 | Creative improvement |
| researcher | sonnet | 0.5 | Exploratory synthesis |
| philosopher | opus | 0.7 | Creative architecture design |

## Test plan

- [x] `go test -race ./internal/manifest/... ./internal/pipeline/...` passes
- [ ] Manual: verify model/temperature are passed through to adapter subprocess args