### PR TITLE
feat(webui): dashboard introspection for pipelines, personas, and stats

### DIFF
--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -191,6 +191,11 @@ func (m *MockStateStore) SetRunTags(runID string, tags []string) error { return 
 func (m *MockStateStore) GetRunTags(runID string) ([]string, error) { return nil, nil }
 func (m *MockStateStore) AddRunTag(runID string, tag string) error { return nil }
 func (m *MockStateStore) RemoveRunTag(runID string, tag string) error { return nil }
+func (m *MockStateStore) GetRunStatistics(since time.Time) (*state.RunStatisticsRecord, error) { return nil, nil }
+func (m *MockStateStore) GetRunTrends(since time.Time) ([]state.RunTrendRecord, error) { return nil, nil }
+func (m *MockStateStore) GetPipelineStatistics(since time.Time) ([]state.PipelineStatisticsRecord, error) { return nil, nil }
+func (m *MockStateStore) GetPipelineStepStats(pipelineName string, since time.Time) ([]state.StepPerformanceStats, error) { return nil, nil }
+func (m *MockStateStore) GetLastRunForPipeline(pipelineName string) (*state.RunRecord, error) { return nil, nil }
 
 // createTestManifest creates a manifest for testing
 func createTestManifest(workspaceRoot string) *manifest.Manifest {

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -161,3 +161,35 @@ type ArtifactMetadataRecord struct {
 	MetadataJSON string
 	IndexedAt    time.Time
 }
+
+// =============================================================================
+// Statistics Types (spec 091 - Dashboard Introspection)
+// =============================================================================
+
+// RunStatisticsRecord holds aggregate run statistics from SQL.
+type RunStatisticsRecord struct {
+	Total     int
+	Succeeded int
+	Failed    int
+	Cancelled int
+	Pending   int
+	Running   int
+}
+
+// RunTrendRecord holds a daily trend data point from SQL.
+type RunTrendRecord struct {
+	Date      string // YYYY-MM-DD
+	Total     int
+	Succeeded int
+	Failed    int
+}
+
+// PipelineStatisticsRecord holds per-pipeline aggregate stats from SQL.
+type PipelineStatisticsRecord struct {
+	PipelineName  string
+	RunCount      int
+	Succeeded     int
+	Failed        int
+	AvgDurationMs int64
+	AvgTokens     int
+}

--- a/internal/webui/handlers_introspect.go
+++ b/internal/webui/handlers_introspect.go
@@ -1,0 +1,349 @@
+//go:build webui
+
+package webui
+
+import (
+	"html"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+)
+
+// handleAPIStatistics handles GET /api/statistics?range={24h|7d|30d|all}
+func (s *Server) handleAPIStatistics(w http.ResponseWriter, r *http.Request) {
+	rangeParam := r.URL.Query().Get("range")
+	timeRange, since := parseTimeRange(rangeParam)
+
+	// Get aggregate statistics
+	stats, err := s.store.GetRunStatistics(since)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to get statistics")
+		return
+	}
+
+	aggregate := RunStatistics{
+		Total:     stats.Total,
+		Succeeded: stats.Succeeded,
+		Failed:    stats.Failed,
+		Cancelled: stats.Cancelled,
+		Pending:   stats.Pending,
+		Running:   stats.Running,
+	}
+	if aggregate.Total > 0 {
+		aggregate.SuccessRate = float64(aggregate.Succeeded) / float64(aggregate.Total) * 100
+	}
+
+	// Get trends
+	trendRecords, _ := s.store.GetRunTrends(since)
+	trends := make([]RunTrendPoint, len(trendRecords))
+	for i, tr := range trendRecords {
+		trends[i] = RunTrendPoint{
+			Date:      tr.Date,
+			Total:     tr.Total,
+			Succeeded: tr.Succeeded,
+			Failed:    tr.Failed,
+		}
+		if tr.Total > 0 {
+			trends[i].SuccessRate = float64(tr.Succeeded) / float64(tr.Total) * 100
+		}
+	}
+
+	// Get per-pipeline statistics
+	pipelineRecords, _ := s.store.GetPipelineStatistics(since)
+	pipelines := make([]PipelineStatistics, len(pipelineRecords))
+	for i, pr := range pipelineRecords {
+		pipelines[i] = PipelineStatistics{
+			PipelineName:  pr.PipelineName,
+			RunCount:      pr.RunCount,
+			AvgDurationMs: pr.AvgDurationMs,
+			AvgTokens:     pr.AvgTokens,
+		}
+		if pr.RunCount > 0 {
+			pipelines[i].SuccessRate = float64(pr.Succeeded) / float64(pr.RunCount) * 100
+		}
+	}
+
+	writeJSON(w, http.StatusOK, StatisticsResponse{
+		Aggregate: aggregate,
+		Trends:    trends,
+		Pipelines: pipelines,
+		TimeRange: timeRange,
+	})
+}
+
+// handleStatisticsPage handles GET /statistics - serves the HTML statistics page.
+func (s *Server) handleStatisticsPage(w http.ResponseWriter, r *http.Request) {
+	rangeParam := r.URL.Query().Get("range")
+	timeRange, _ := parseTimeRange(rangeParam)
+
+	data := struct {
+		TimeRange string
+	}{
+		TimeRange: timeRange,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.templates["templates/statistics.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// handleAPIPipelineDetail handles GET /api/pipelines/{name} - returns full pipeline config.
+func (s *Server) handleAPIPipelineDetail(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing pipeline name")
+		return
+	}
+
+	p, err := loadPipelineYAML(name)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "pipeline not found")
+		return
+	}
+
+	// Build step details
+	steps := make([]PipelineStepDetail, len(p.Steps))
+	for i, step := range p.Steps {
+		sd := PipelineStepDetail{
+			ID:           step.ID,
+			Persona:      step.Persona,
+			Dependencies: step.Dependencies,
+			Workspace: WorkspaceDetail{
+				Type: step.Workspace.Type,
+				Root: step.Workspace.Root,
+			},
+			Memory: MemoryDetail{
+				Strategy: step.Memory.Strategy,
+			},
+		}
+
+		// Add mounts
+		for _, m := range step.Workspace.Mount {
+			sd.Workspace.Mounts = append(sd.Workspace.Mounts, MountDetail{
+				Source: m.Source,
+				Target: m.Target,
+				Mode:   m.Mode,
+			})
+		}
+
+		// Add contract from handover config
+		if step.Handover.Contract.Type != "" {
+			sd.Contract = &ContractDetail{
+				Type:       step.Handover.Contract.Type,
+				Schema:     step.Handover.Contract.Schema,
+				MustPass:   true,
+				MaxRetries: step.Handover.MaxRetries,
+			}
+		}
+
+		// Add output artifacts
+		for _, a := range step.OutputArtifacts {
+			sd.Artifacts = append(sd.Artifacts, ArtifactDefDetail{
+				Name:     a.Name,
+				Path:     a.Path,
+				Type:     a.Type,
+				Required: a.Required,
+			})
+		}
+
+		// Add injected artifacts
+		for _, ref := range step.Memory.InjectArtifacts {
+			sd.Memory.Injected = append(sd.Memory.Injected, InjectedArtifact{
+				FromStep: ref.Step,
+				Artifact: ref.Artifact,
+				As:       ref.As,
+			})
+		}
+
+		steps[i] = sd
+	}
+
+	// Get last run for this pipeline
+	var lastRun *RunSummary
+	if lr, err := s.store.GetLastRunForPipeline(name); err == nil && lr != nil {
+		summary := runToSummary(*lr)
+		lastRun = &summary
+	}
+
+	resp := PipelineDetailResponse{
+		Name:        p.Metadata.Name,
+		Description: p.Metadata.Description,
+		StepCount:   len(p.Steps),
+		Input: PipelineInputDetail{
+			Source:  p.Input.Source,
+			Example: p.Input.Example,
+		},
+		Steps:   steps,
+		LastRun: lastRun,
+	}
+
+	if p.Input.Schema != nil {
+		resp.Input.Schema = &InputSchemaDetail{
+			Type:        p.Input.Schema.Type,
+			Description: p.Input.Schema.Description,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handlePipelineDetailPage handles GET /pipelines/{name} - serves the HTML pipeline detail page.
+func (s *Server) handlePipelineDetailPage(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		http.Error(w, "missing pipeline name", http.StatusBadRequest)
+		return
+	}
+
+	p, err := loadPipelineYAML(name)
+	if err != nil {
+		http.Error(w, "pipeline not found", http.StatusNotFound)
+		return
+	}
+
+	data := struct {
+		Name        string
+		Description string
+		StepCount   int
+	}{
+		Name:        p.Metadata.Name,
+		Description: p.Metadata.Description,
+		StepCount:   len(p.Steps),
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.templates["templates/pipeline_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// handleAPIPersonaDetail handles GET /api/personas/{name} - returns full persona config.
+func (s *Server) handleAPIPersonaDetail(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing persona name")
+		return
+	}
+
+	if s.manifest == nil || s.manifest.Personas == nil {
+		writeJSONError(w, http.StatusNotFound, "persona not found")
+		return
+	}
+
+	persona, ok := s.manifest.Personas[name]
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "persona not found")
+		return
+	}
+
+	resp := PersonaDetailResponse{
+		Name:             name,
+		Description:      persona.Description,
+		Adapter:          persona.Adapter,
+		Model:            persona.Model,
+		Temperature:      persona.Temperature,
+		SystemPromptFile: persona.SystemPromptFile,
+		AllowedTools:     persona.Permissions.AllowedTools,
+		DeniedTools:      persona.Permissions.Deny,
+	}
+
+	// Load system prompt content if file exists
+	if persona.SystemPromptFile != "" {
+		if data, err := os.ReadFile(persona.SystemPromptFile); err == nil {
+			resp.SystemPrompt = html.EscapeString(string(data))
+		}
+	}
+
+	// Add hooks
+	if len(persona.Hooks.PreToolUse) > 0 || len(persona.Hooks.PostToolUse) > 0 {
+		resp.Hooks = &HooksDetail{}
+		for _, h := range persona.Hooks.PreToolUse {
+			resp.Hooks.PreToolUse = append(resp.Hooks.PreToolUse, HookRuleDetail{
+				Matcher: h.Matcher,
+				Command: h.Command,
+			})
+		}
+		for _, h := range persona.Hooks.PostToolUse {
+			resp.Hooks.PostToolUse = append(resp.Hooks.PostToolUse, HookRuleDetail{
+				Matcher: h.Matcher,
+				Command: h.Command,
+			})
+		}
+	}
+
+	// Add sandbox
+	if persona.Sandbox != nil {
+		resp.Sandbox = &SandboxDetail{
+			AllowedDomains: persona.Sandbox.AllowedDomains,
+		}
+	}
+
+	// Find which pipelines use this persona
+	pipelineNames := listPipelineNames()
+	var usedIn []string
+	for _, pName := range pipelineNames {
+		if p, err := loadPipelineYAML(pName); err == nil {
+			for _, step := range p.Steps {
+				if step.Persona == name {
+					usedIn = append(usedIn, pName)
+					break
+				}
+			}
+		}
+	}
+	sort.Strings(usedIn)
+	resp.UsedInPipelines = usedIn
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handlePersonaDetailPage handles GET /personas/{name} - serves the HTML persona detail page.
+func (s *Server) handlePersonaDetailPage(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		http.Error(w, "missing persona name", http.StatusBadRequest)
+		return
+	}
+
+	if s.manifest == nil || s.manifest.Personas == nil {
+		http.Error(w, "persona not found", http.StatusNotFound)
+		return
+	}
+
+	persona, ok := s.manifest.Personas[name]
+	if !ok {
+		http.Error(w, "persona not found", http.StatusNotFound)
+		return
+	}
+
+	data := struct {
+		Name        string
+		Description string
+	}{
+		Name:        name,
+		Description: persona.Description,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.templates["templates/persona_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// parseTimeRange converts the range query parameter to a time range label and since time.
+func parseTimeRange(rangeParam string) (string, time.Time) {
+	switch rangeParam {
+	case "24h":
+		return "24h", time.Now().Add(-24 * time.Hour)
+	case "7d", "":
+		return "7d", time.Now().Add(-7 * 24 * time.Hour)
+	case "30d":
+		return "30d", time.Now().Add(-30 * 24 * time.Hour)
+	case "all":
+		return "all", time.Time{} // zero time = since epoch
+	default:
+		return "7d", time.Now().Add(-7 * 24 * time.Hour)
+	}
+}

--- a/internal/webui/handlers_workspace.go
+++ b/internal/webui/handlers_workspace.go
@@ -1,0 +1,196 @@
+//go:build webui
+
+package webui
+
+import (
+	"html"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const maxWorkspaceEntries = 500
+const maxWorkspaceFileSize = 512 * 1024 // 512 KB
+
+// handleWorkspaceTree handles GET /api/runs/{id}/workspace/{step}/tree?path=
+func (s *Server) handleWorkspaceTree(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("id")
+	stepID := r.PathValue("step")
+	reqPath := r.URL.Query().Get("path")
+
+	if runID == "" || stepID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing run ID or step ID")
+		return
+	}
+
+	// Resolve workspace root path
+	wsRoot := resolveWorkspacePath(runID, stepID)
+	if wsRoot == "" {
+		writeJSON(w, http.StatusOK, WorkspaceTreeResponse{
+			Path:  reqPath,
+			Error: "workspace not found",
+		})
+		return
+	}
+
+	// Resolve and validate the requested path
+	targetPath := filepath.Join(wsRoot, filepath.Clean("/"+reqPath))
+	if !strings.HasPrefix(targetPath, wsRoot) {
+		writeJSON(w, http.StatusOK, WorkspaceTreeResponse{
+			Path:  reqPath,
+			Error: "path traversal detected",
+		})
+		return
+	}
+
+	info, err := os.Stat(targetPath)
+	if err != nil || !info.IsDir() {
+		writeJSON(w, http.StatusOK, WorkspaceTreeResponse{
+			Path:  reqPath,
+			Error: "directory not found",
+		})
+		return
+	}
+
+	entries, err := os.ReadDir(targetPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, WorkspaceTreeResponse{
+			Path:  reqPath,
+			Error: "failed to read directory",
+		})
+		return
+	}
+
+	// Sort: directories first, then files
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsDir() != entries[j].IsDir() {
+			return entries[i].IsDir()
+		}
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	wsEntries := make([]WorkspaceEntry, 0, len(entries))
+	for i, e := range entries {
+		if i >= maxWorkspaceEntries {
+			break
+		}
+		// Skip hidden files
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		we := WorkspaceEntry{
+			Name:  e.Name(),
+			IsDir: e.IsDir(),
+		}
+		if info, err := e.Info(); err == nil {
+			we.Size = info.Size()
+		}
+		if !e.IsDir() {
+			we.Extension = strings.TrimPrefix(filepath.Ext(e.Name()), ".")
+		}
+		wsEntries = append(wsEntries, we)
+	}
+
+	writeJSON(w, http.StatusOK, WorkspaceTreeResponse{
+		Path:    reqPath,
+		Entries: wsEntries,
+	})
+}
+
+// handleWorkspaceFile handles GET /api/runs/{id}/workspace/{step}/file?path=
+func (s *Server) handleWorkspaceFile(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("id")
+	stepID := r.PathValue("step")
+	reqPath := r.URL.Query().Get("path")
+
+	if runID == "" || stepID == "" || reqPath == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing parameters")
+		return
+	}
+
+	// Resolve workspace root path
+	wsRoot := resolveWorkspacePath(runID, stepID)
+	if wsRoot == "" {
+		writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+			Path:  reqPath,
+			Error: "workspace not found",
+		})
+		return
+	}
+
+	// Resolve and validate the requested path
+	targetPath := filepath.Join(wsRoot, filepath.Clean("/"+reqPath))
+	if !strings.HasPrefix(targetPath, wsRoot) {
+		writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+			Path:  reqPath,
+			Error: "path traversal detected",
+		})
+		return
+	}
+
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+			Path:  reqPath,
+			Error: "file not found",
+		})
+		return
+	}
+
+	if info.IsDir() {
+		writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+			Path:  reqPath,
+			Error: "path is a directory, not a file",
+		})
+		return
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+			Path:  reqPath,
+			Error: "failed to read file",
+		})
+		return
+	}
+
+	truncated := false
+	if len(content) > maxWorkspaceFileSize {
+		content = content[:maxWorkspaceFileSize]
+		truncated = true
+	}
+
+	// Redact credentials and escape HTML
+	redacted := RedactCredentials(string(content))
+	escaped := html.EscapeString(redacted)
+
+	mimeType := detectMimeType(filepath.Base(reqPath))
+
+	writeJSON(w, http.StatusOK, WorkspaceFileResponse{
+		Path:      reqPath,
+		Content:   escaped,
+		MimeType:  mimeType,
+		Size:      info.Size(),
+		Truncated: truncated,
+	})
+}
+
+// resolveWorkspacePath tries to find the workspace directory for a run+step.
+func resolveWorkspacePath(runID, stepID string) string {
+	// Try common workspace path patterns
+	candidates := []string{
+		filepath.Join(".wave", "workspaces", runID, stepID),
+		filepath.Join(".wave", "workspaces", runID),
+	}
+
+	for _, c := range candidates {
+		if info, err := os.Stat(c); err == nil && info.IsDir() {
+			abs, _ := filepath.Abs(c)
+			return abs
+		}
+	}
+
+	return ""
+}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -19,7 +19,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /runs/{id}", s.handleRunDetailPage)
 
 	mux.HandleFunc("GET /pipelines", s.handlePipelinesPage)
+	mux.HandleFunc("GET /pipelines/{name}", s.handlePipelineDetailPage)
 	mux.HandleFunc("GET /personas", s.handlePersonasPage)
+	mux.HandleFunc("GET /personas/{name}", s.handlePersonaDetailPage)
+	mux.HandleFunc("GET /statistics", s.handleStatisticsPage)
 
 	// API endpoints (JSON)
 	mux.HandleFunc("GET /api/runs", s.handleAPIRuns)
@@ -29,6 +32,11 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/runs/{id}/cancel", s.handleCancelRun)
 	mux.HandleFunc("POST /api/runs/{id}/retry", s.handleRetryRun)
 	mux.HandleFunc("GET /api/personas", s.handleAPIPersonas)
+	mux.HandleFunc("GET /api/pipelines/{name}", s.handleAPIPipelineDetail)
+	mux.HandleFunc("GET /api/personas/{name}", s.handleAPIPersonaDetail)
+	mux.HandleFunc("GET /api/statistics", s.handleAPIStatistics)
 	mux.HandleFunc("GET /api/runs/{id}/artifacts/{step}/{name}", s.handleArtifact)
+	mux.HandleFunc("GET /api/runs/{id}/workspace/{step}/tree", s.handleWorkspaceTree)
+	mux.HandleFunc("GET /api/runs/{id}/workspace/{step}/file", s.handleWorkspaceFile)
 	mux.HandleFunc("GET /api/runs/{id}/events", s.handleSSE)
 }

--- a/internal/webui/static/highlight.js
+++ b/internal/webui/static/highlight.js
@@ -1,0 +1,110 @@
+// highlight.js — Regex-based syntax highlighter for Wave dashboard
+// Supports: YAML, JSON, Go, SQL, Shell, JavaScript, CSS, HTML, Markdown
+// All content is HTML-escaped before tokenization to prevent XSS
+(function() {
+'use strict';
+
+function escapeHtml(text) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+var languages = {
+    yaml: [
+        [/^(\s*#.*)$/gm, 'tok-comment'],
+        [/^(\s*[\w.-]+)(\s*:)/gm, function(m, key, colon) { return '<span class="tok-key">' + key + '</span>' + colon; }],
+        [/:\s*(&quot;[^&]*&quot;|'[^']*')/g, function(m, str) { return ': <span class="tok-str">' + str + '</span>'; }],
+        [/\b(true|false|null|yes|no)\b/g, 'tok-bool'],
+        [/\b(\d+\.?\d*)\b/g, 'tok-num']
+    ],
+    json: [
+        [/(&quot;[^&]*&quot;)\s*:/g, function(m, key) { return '<span class="tok-key">' + key + '</span>:'; }],
+        [/:\s*(&quot;[^&]*&quot;)/g, function(m, str) { return ': <span class="tok-str">' + str + '</span>'; }],
+        [/\b(true|false|null)\b/g, 'tok-bool'],
+        [/\b(-?\d+\.?\d*([eE][+-]?\d+)?)\b/g, 'tok-num']
+    ],
+    go: [
+        [/\/\/.*$/gm, 'tok-comment'],
+        [/&quot;[^&]*&quot;/g, 'tok-str'],
+        [/`[^`]*`/g, 'tok-str'],
+        [/\b(package|import|func|return|if|else|for|range|switch|case|default|var|const|type|struct|interface|map|chan|go|defer|select|break|continue|fallthrough|nil|true|false|error|string|int|int64|bool|byte|float64|append|len|make|new|panic|recover)\b/g, 'tok-kw'],
+        [/\b(\d+\.?\d*)\b/g, 'tok-num']
+    ],
+    sql: [
+        [/--.*$/gm, 'tok-comment'],
+        [/'[^']*'/g, 'tok-str'],
+        [/\b(SELECT|FROM|WHERE|AND|OR|NOT|INSERT|INTO|VALUES|UPDATE|SET|DELETE|CREATE|TABLE|ALTER|DROP|INDEX|JOIN|LEFT|RIGHT|INNER|OUTER|ON|GROUP|BY|ORDER|ASC|DESC|LIMIT|OFFSET|HAVING|UNION|AS|IN|IS|NULL|LIKE|BETWEEN|EXISTS|CASE|WHEN|THEN|ELSE|END|COUNT|SUM|AVG|MIN|MAX|DISTINCT|PRIMARY|KEY|FOREIGN|REFERENCES|INTEGER|TEXT|REAL|BOOLEAN|DEFAULT|NOT|CONSTRAINT|UNIQUE|CHECK|IF)\b/gi, 'tok-kw'],
+        [/\b(\d+\.?\d*)\b/g, 'tok-num']
+    ],
+    shell: [
+        [/#.*$/gm, 'tok-comment'],
+        [/&quot;[^&]*&quot;/g, 'tok-str'],
+        [/'[^']*'/g, 'tok-str'],
+        [/\b(if|then|else|elif|fi|for|while|do|done|case|esac|function|return|exit|echo|export|source|cd|ls|cat|grep|sed|awk|find|xargs|pipe|sudo|chmod|chown|mkdir|rm|cp|mv|ln|test)\b/g, 'tok-kw'],
+        [/\$[\w]+/g, 'tok-kw']
+    ],
+    javascript: [
+        [/\/\/.*$/gm, 'tok-comment'],
+        [/\/\*[\s\S]*?\*\//gm, 'tok-comment'],
+        [/&quot;[^&]*&quot;/g, 'tok-str'],
+        [/'[^']*'/g, 'tok-str'],
+        [/\b(var|let|const|function|return|if|else|for|while|do|switch|case|default|break|continue|new|this|class|extends|import|export|from|async|await|try|catch|finally|throw|typeof|instanceof|in|of|null|undefined|true|false|void|delete|yield)\b/g, 'tok-kw'],
+        [/\b(\d+\.?\d*)\b/g, 'tok-num']
+    ],
+    css: [
+        [/\/\*[\s\S]*?\*\//gm, 'tok-comment'],
+        [/([.#]?[\w-]+)\s*\{/g, function(m, sel) { return '<span class="tok-key">' + sel + '</span> {'; }],
+        [/([\w-]+)\s*:/g, function(m, prop) { return '<span class="tok-kw">' + prop + '</span>:'; }],
+        [/#[0-9a-fA-F]{3,8}\b/g, 'tok-num'],
+        [/\b(\d+\.?\d*(px|em|rem|%|vh|vw|s|ms)?)\b/g, 'tok-num']
+    ],
+    html: [
+        [/&lt;!--[\s\S]*?--&gt;/gm, 'tok-comment'],
+        [/(&lt;\/?)([\w-]+)/g, function(m, bracket, tag) { return bracket + '<span class="tok-key">' + tag + '</span>'; }],
+        [/\s([\w-]+)=(&quot;[^&]*&quot;)/g, function(m, attr, val) { return ' <span class="tok-kw">' + attr + '</span>=<span class="tok-str">' + val + '</span>'; }]
+    ],
+    markdown: [
+        [/^(#{1,6}\s+.*)$/gm, 'tok-key'],
+        [/\*\*[^*]+\*\*/g, 'tok-str'],
+        [/`[^`]+`/g, 'tok-str'],
+        [/\[([^\]]+)\]\([^)]+\)/g, 'tok-kw']
+    ]
+};
+
+function highlight(code, language) {
+    if (!code) return '';
+
+    var escaped = escapeHtml(code);
+    var lang = (language || '').toLowerCase();
+
+    // Normalize language aliases
+    var aliases = {
+        'yml': 'yaml', 'sh': 'shell', 'bash': 'shell',
+        'js': 'javascript', 'ts': 'javascript',
+        'golang': 'go', 'htm': 'html', 'md': 'markdown'
+    };
+    if (aliases[lang]) lang = aliases[lang];
+
+    var rules = languages[lang];
+    if (!rules) return escaped; // plain text fallback
+
+    for (var i = 0; i < rules.length; i++) {
+        var rule = rules[i];
+        var pattern = rule[0];
+        var replacement = rule[1];
+
+        if (typeof replacement === 'string') {
+            escaped = escaped.replace(pattern, '<span class="' + replacement + '">$&</span>');
+        } else {
+            escaped = escaped.replace(pattern, replacement);
+        }
+    }
+
+    return escaped;
+}
+
+window.highlight = highlight;
+})();

--- a/internal/webui/static/introspect.js
+++ b/internal/webui/static/introspect.js
@@ -1,0 +1,95 @@
+// introspect.js — Step drill-down and event timeline for Wave dashboard
+(function() {
+'use strict';
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Step drill-down toggle
+    var stepHeaders = document.querySelectorAll('.step-header[data-toggle]');
+    for (var i = 0; i < stepHeaders.length; i++) {
+        stepHeaders[i].addEventListener('click', function() {
+            var target = this.getAttribute('data-toggle');
+            var panel = document.getElementById(target);
+            if (panel) {
+                var isHidden = panel.style.display === 'none' || panel.style.display === '';
+                panel.style.display = isHidden ? 'block' : 'none';
+                this.classList.toggle('expanded', isHidden);
+            }
+        });
+    }
+
+    // Event timeline scroll-to-step
+    var eventSteps = document.querySelectorAll('.event-step[data-step]');
+    for (var j = 0; j < eventSteps.length; j++) {
+        eventSteps[j].addEventListener('click', function() {
+            var stepId = this.getAttribute('data-step');
+            var stepCard = document.getElementById('step-' + stepId);
+            if (stepCard) {
+                stepCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                stepCard.classList.add('highlight');
+                setTimeout(function() { stepCard.classList.remove('highlight'); }, 2000);
+            }
+        });
+    }
+
+    // Raw/rendered toggle for markdown viewer
+    var toggleBtns = document.querySelectorAll('.md-toggle');
+    for (var k = 0; k < toggleBtns.length; k++) {
+        toggleBtns[k].addEventListener('click', function() {
+            var viewer = this.closest('.md-viewer');
+            if (!viewer) return;
+            var rendered = viewer.querySelector('.md-rendered');
+            var raw = viewer.querySelector('.md-raw');
+            if (!rendered || !raw) return;
+            var showRaw = this.getAttribute('data-view') === 'raw';
+            rendered.style.display = showRaw ? 'none' : 'block';
+            raw.style.display = showRaw ? 'block' : 'none';
+            // Update active button
+            var btns = viewer.querySelectorAll('.md-toggle');
+            for (var b = 0; b < btns.length; b++) {
+                btns[b].classList.toggle('active', btns[b] === this);
+            }
+        });
+    }
+
+    // Raw/formatted toggle for code viewer
+    var codeBtns = document.querySelectorAll('.code-toggle');
+    for (var l = 0; l < codeBtns.length; l++) {
+        codeBtns[l].addEventListener('click', function() {
+            var viewer = this.closest('.code-viewer');
+            if (!viewer) return;
+            var highlighted = viewer.querySelector('.code-highlighted');
+            var raw = viewer.querySelector('.code-raw');
+            if (!highlighted || !raw) return;
+            var showRaw = this.getAttribute('data-view') === 'raw';
+            highlighted.style.display = showRaw ? 'none' : 'block';
+            raw.style.display = showRaw ? 'block' : 'none';
+            var btns = viewer.querySelectorAll('.code-toggle');
+            for (var b = 0; b < btns.length; b++) {
+                btns[b].classList.toggle('active', btns[b] === this);
+            }
+        });
+    }
+
+    // Init markdown rendering for elements with data-markdown attribute
+    var mdElements = document.querySelectorAll('[data-markdown]');
+    for (var m = 0; m < mdElements.length; m++) {
+        var el = mdElements[m];
+        var rawText = el.textContent;
+        var rendered = document.createElement('div');
+        rendered.className = 'md-rendered';
+        rendered.innerHTML = window.renderMarkdown ? window.renderMarkdown(rawText) : rawText;
+        el.parentNode.insertBefore(rendered, el);
+    }
+
+    // Init syntax highlighting for elements with data-language attribute
+    var codeElements = document.querySelectorAll('[data-language]');
+    for (var n = 0; n < codeElements.length; n++) {
+        var codeEl = codeElements[n];
+        var lang = codeEl.getAttribute('data-language');
+        var codeText = codeEl.textContent;
+        if (window.highlight) {
+            codeEl.innerHTML = window.highlight(codeText, lang);
+        }
+    }
+});
+})();

--- a/internal/webui/static/markdown.js
+++ b/internal/webui/static/markdown.js
@@ -1,0 +1,154 @@
+// markdown.js — Minimal markdown parser for Wave dashboard
+// Supports: headings, lists, code blocks, inline code, bold/italic, links, tables
+// All content is HTML-escaped before processing to prevent XSS
+(function() {
+'use strict';
+
+function escapeHtml(text) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function renderInline(text) {
+    // Order matters: process code spans first to protect their content
+    var result = '';
+    var parts = text.split(/(`[^`]+`)/g);
+    for (var i = 0; i < parts.length; i++) {
+        if (i % 2 === 1) {
+            // Code span — already escaped, just wrap
+            result += '<code>' + parts[i].slice(1, -1) + '</code>';
+        } else {
+            var s = parts[i];
+            // Bold
+            s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+            // Italic
+            s = s.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+            // Links [text](url) — only allow http/https/mailto URLs
+            s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(m, t, u) {
+                if (/^(https?:|mailto:)/.test(u)) {
+                    return '<a href="' + u + '">' + t + '</a>';
+                }
+                return t;
+            });
+            result += s;
+        }
+    }
+    return result;
+}
+
+function renderMarkdown(text) {
+    if (!text) return '';
+
+    // Escape HTML first for XSS safety
+    var escaped = escapeHtml(text);
+    var lines = escaped.split('\n');
+    var html = [];
+    var i = 0;
+
+    while (i < lines.length) {
+        var line = lines[i];
+
+        // Fenced code block
+        if (/^```/.test(line)) {
+            var lang = line.slice(3).trim();
+            var code = [];
+            i++;
+            while (i < lines.length && !/^```/.test(lines[i])) {
+                code.push(lines[i]);
+                i++;
+            }
+            i++; // skip closing ```
+            html.push('<pre><code' + (lang ? ' class="language-' + lang + '"' : '') + '>' + code.join('\n') + '</code></pre>');
+            continue;
+        }
+
+        // Headings
+        var headingMatch = line.match(/^(#{1,4})\s+(.+)/);
+        if (headingMatch) {
+            var level = headingMatch[1].length;
+            html.push('<h' + level + '>' + renderInline(headingMatch[2]) + '</h' + level + '>');
+            i++;
+            continue;
+        }
+
+        // Horizontal rule
+        if (/^(---|\*\*\*|___)/.test(line.trim())) {
+            html.push('<hr>');
+            i++;
+            continue;
+        }
+
+        // Table
+        if (line.indexOf('|') !== -1 && i + 1 < lines.length && /^\|?\s*[-:]+/.test(lines[i + 1])) {
+            var tableHtml = '<table>';
+            // Header row
+            var headerCells = line.split('|').filter(function(c) { return c.trim() !== ''; });
+            tableHtml += '<thead><tr>';
+            for (var h = 0; h < headerCells.length; h++) {
+                tableHtml += '<th>' + renderInline(headerCells[h].trim()) + '</th>';
+            }
+            tableHtml += '</tr></thead>';
+            i += 2; // skip header + separator
+            // Body rows
+            tableHtml += '<tbody>';
+            while (i < lines.length && lines[i].indexOf('|') !== -1) {
+                var cells = lines[i].split('|').filter(function(c) { return c.trim() !== ''; });
+                tableHtml += '<tr>';
+                for (var c = 0; c < cells.length; c++) {
+                    tableHtml += '<td>' + renderInline(cells[c].trim()) + '</td>';
+                }
+                tableHtml += '</tr>';
+                i++;
+            }
+            tableHtml += '</tbody></table>';
+            html.push(tableHtml);
+            continue;
+        }
+
+        // Unordered list
+        if (/^[\s]*[-*+]\s+/.test(line)) {
+            var items = [];
+            while (i < lines.length && /^[\s]*[-*+]\s+/.test(lines[i])) {
+                items.push(renderInline(lines[i].replace(/^[\s]*[-*+]\s+/, '')));
+                i++;
+            }
+            html.push('<ul>' + items.map(function(item) { return '<li>' + item + '</li>'; }).join('') + '</ul>');
+            continue;
+        }
+
+        // Ordered list
+        if (/^[\s]*\d+\.\s+/.test(line)) {
+            var oitems = [];
+            while (i < lines.length && /^[\s]*\d+\.\s+/.test(lines[i])) {
+                oitems.push(renderInline(lines[i].replace(/^[\s]*\d+\.\s+/, '')));
+                i++;
+            }
+            html.push('<ol>' + oitems.map(function(item) { return '<li>' + item + '</li>'; }).join('') + '</ol>');
+            continue;
+        }
+
+        // Empty line
+        if (line.trim() === '') {
+            i++;
+            continue;
+        }
+
+        // Paragraph — collect consecutive non-empty lines
+        var paraLines = [];
+        while (i < lines.length && lines[i].trim() !== '' && !/^#{1,4}\s/.test(lines[i]) && !/^```/.test(lines[i]) && !/^[-*+]\s/.test(lines[i]) && !/^\d+\.\s/.test(lines[i])) {
+            paraLines.push(lines[i]);
+            i++;
+        }
+        if (paraLines.length > 0) {
+            html.push('<p>' + renderInline(paraLines.join(' ')) + '</p>');
+        }
+    }
+
+    return html.join('\n');
+}
+
+window.renderMarkdown = renderMarkdown;
+})();

--- a/internal/webui/static/stats.js
+++ b/internal/webui/static/stats.js
@@ -1,0 +1,15 @@
+// stats.js — Statistics page interactions for Wave dashboard
+(function() {
+'use strict';
+
+document.addEventListener('DOMContentLoaded', function() {
+    var rangeSelect = document.getElementById('time-range');
+    if (rangeSelect) {
+        rangeSelect.addEventListener('change', function() {
+            var params = new URLSearchParams(window.location.search);
+            params.set('range', this.value);
+            window.location.href = '/statistics?' + params.toString();
+        });
+    }
+});
+})();

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -378,3 +378,111 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--wave-primary); 
 /* Animations */
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
 .badge.status-running { animation: pulse 2s ease-in-out infinite; }
+
+/* =============================================================================
+   Dashboard Introspection Styles (spec 091)
+   ============================================================================= */
+
+/* Statistics Grid */
+.stats-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem; margin-bottom: 1.5rem;
+}
+.stats-card { text-align: center; padding: 1.5rem; }
+.stats-number { font-size: 2.2rem; font-weight: 700; color: var(--color-text); line-height: 1.2; }
+.stats-number.stats-success { color: var(--color-completed); }
+.stats-number.stats-failed { color: var(--color-failed); }
+.stats-label { font-size: 0.85rem; color: var(--color-text-secondary); margin-top: 0.25rem; }
+
+/* Meta/Configuration Grid */
+.meta-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 0.75rem; }
+.meta-item { font-size: 0.85rem; color: var(--color-text-secondary); }
+.meta-item strong { color: var(--color-text); }
+
+/* Syntax Highlighting Tokens */
+.tok-key { color: #7c3aed; }
+.tok-str { color: #059669; }
+.tok-num { color: #d97706; }
+.tok-comment { color: var(--color-text-muted); font-style: italic; }
+.tok-bool { color: #dc2626; }
+.tok-kw { color: #2563eb; }
+[data-theme="dark"] .tok-key, :root:not([data-theme]) .tok-key { color: #a78bfa; }
+[data-theme="dark"] .tok-str, :root:not([data-theme]) .tok-str { color: #34d399; }
+[data-theme="dark"] .tok-num, :root:not([data-theme]) .tok-num { color: #fbbf24; }
+[data-theme="dark"] .tok-bool, :root:not([data-theme]) .tok-bool { color: #f87171; }
+[data-theme="dark"] .tok-kw, :root:not([data-theme]) .tok-kw { color: #60a5fa; }
+
+/* Markdown Viewer */
+.md-viewer { position: relative; }
+.md-toggle-bar { display: flex; gap: 0.25rem; margin-bottom: 0.75rem; }
+.md-toggle { padding: 0.3rem 0.75rem; font-size: 0.8rem; }
+.md-toggle.active { background: var(--wave-primary); color: #fff; border-color: var(--wave-primary); }
+.md-rendered { font-size: 0.9rem; line-height: 1.7; }
+.md-rendered h1 { font-size: 1.4rem; margin: 1rem 0 0.5rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3rem; }
+.md-rendered h2 { font-size: 1.2rem; margin: 0.8rem 0 0.4rem; }
+.md-rendered h3 { font-size: 1.05rem; margin: 0.6rem 0 0.3rem; }
+.md-rendered p { margin: 0.5rem 0; }
+.md-rendered ul, .md-rendered ol { margin: 0.5rem 0; padding-left: 1.5rem; }
+.md-rendered li { margin: 0.2rem 0; }
+.md-rendered pre { background: var(--color-bg-tertiary); padding: 0.75rem; border-radius: var(--radius-md); overflow-x: auto; margin: 0.5rem 0; }
+.md-rendered code { font-size: 0.85em; }
+.md-rendered table { width: 100%; border-collapse: collapse; margin: 0.5rem 0; }
+.md-rendered th, .md-rendered td { padding: 0.4rem 0.75rem; border: 1px solid var(--color-border); text-align: left; font-size: 0.85rem; }
+.md-rendered th { background: var(--color-bg-tertiary); font-weight: 600; }
+.md-rendered a { color: var(--color-link); }
+.md-rendered hr { border: none; border-top: 1px solid var(--color-border); margin: 1rem 0; }
+
+/* Code Viewer */
+.code-viewer { position: relative; }
+.code-toggle-bar { display: flex; gap: 0.25rem; margin-bottom: 0.5rem; }
+.code-toggle { padding: 0.3rem 0.75rem; font-size: 0.8rem; }
+.code-toggle.active { background: var(--wave-primary); color: #fff; border-color: var(--wave-primary); }
+
+/* Workspace File Tree Browser */
+.ws-browser { display: grid; grid-template-columns: 300px 1fr; gap: 1rem; min-height: 400px; }
+.ws-tree-pane { background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 0.5rem; overflow-y: auto; max-height: 600px; }
+.ws-file-viewer { background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 0.75rem; overflow: auto; }
+.ws-tree { list-style: none; padding-left: 0; font-size: 0.8rem; }
+.ws-tree .ws-tree { padding-left: 1rem; }
+.ws-name { cursor: pointer; padding: 0.2rem 0.4rem; border-radius: var(--radius-sm); display: block; color: var(--color-text); font-family: var(--font-mono); }
+.ws-name:hover { background: var(--color-bg-tertiary); }
+.ws-dir > .ws-name { font-weight: 600; }
+.ws-file-header { padding: 0.5rem 0; border-bottom: 1px solid var(--color-border); margin-bottom: 0.5rem; font-size: 0.85rem; }
+.ws-file-size { color: var(--color-text-muted); font-size: 0.8rem; margin-left: 0.5rem; }
+.ws-file-content { font-size: 0.8rem; line-height: 1.6; margin: 0; white-space: pre-wrap; overflow-x: auto; }
+.ws-placeholder { color: var(--color-text-muted); text-align: center; padding: 2rem; }
+.ws-error { color: var(--color-failed); font-size: 0.85rem; }
+
+/* Step Drill-Down Enhancements */
+.step-header[data-toggle] { cursor: pointer; user-select: none; }
+.step-header[data-toggle]::after { content: '\25B6'; margin-left: auto; font-size: 0.7rem; color: var(--color-text-muted); transition: transform 0.2s ease; }
+.step-header.expanded::after { transform: rotate(90deg); }
+.step-drilldown { display: none; padding: 0.75rem 1rem; background: var(--color-bg); border-top: 1px solid var(--color-border); }
+
+/* Recovery Hints */
+.recovery-hints { margin-top: 0.75rem; }
+.recovery-hint { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.75rem; margin: 0.25rem 0; background: var(--color-bg-tertiary); border-radius: var(--radius-md); font-size: 0.8rem; border-left: 3px solid var(--wave-primary); }
+.recovery-hint .hint-label { color: var(--color-text-secondary); min-width: 80px; }
+.recovery-hint .hint-command { font-family: var(--font-mono); color: var(--color-text); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.recovery-hint .hint-type { font-size: 0.7rem; color: var(--color-text-muted); text-transform: uppercase; }
+.recovery-hint.hint-type-resume { border-left-color: var(--color-completed); }
+.recovery-hint.hint-type-force { border-left-color: var(--color-pending); }
+.recovery-hint.hint-type-workspace { border-left-color: var(--wave-secondary); }
+.recovery-hint.hint-type-debug { border-left-color: var(--color-text-muted); }
+
+/* Step Card Highlight Animation */
+.step-card.highlight { animation: highlight-pulse 0.5s ease-out 3; }
+@keyframes highlight-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(79, 70, 229, 0.4); }
+    50% { box-shadow: 0 0 0 6px rgba(79, 70, 229, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(79, 70, 229, 0); }
+}
+
+/* Responsive adjustments for new components */
+@media (max-width: 768px) {
+    .stats-grid { grid-template-columns: repeat(2, 1fr); }
+    .meta-grid { grid-template-columns: 1fr; }
+    .ws-browser { grid-template-columns: 1fr; }
+    .ws-tree-pane { max-height: 300px; }
+    .recovery-hint { flex-wrap: wrap; }
+}

--- a/internal/webui/static/workspace.js
+++ b/internal/webui/static/workspace.js
@@ -1,0 +1,125 @@
+// workspace.js — Workspace file tree browser for Wave dashboard
+(function() {
+'use strict';
+
+function fetchTree(runId, stepId, path) {
+    var url = '/api/runs/' + encodeURIComponent(runId) + '/workspace/' + encodeURIComponent(stepId) + '/tree';
+    if (path) url += '?path=' + encodeURIComponent(path);
+    return fetch(url).then(function(r) { return r.json(); });
+}
+
+function fetchFile(runId, stepId, path) {
+    var url = '/api/runs/' + encodeURIComponent(runId) + '/workspace/' + encodeURIComponent(stepId) + '/file?path=' + encodeURIComponent(path);
+    return fetch(url).then(function(r) { return r.json(); });
+}
+
+function detectLanguage(name) {
+    var ext = name.split('.').pop().toLowerCase();
+    var map = {
+        'go': 'go', 'yaml': 'yaml', 'yml': 'yaml', 'json': 'json',
+        'js': 'javascript', 'ts': 'javascript', 'md': 'markdown',
+        'sql': 'sql', 'sh': 'shell', 'bash': 'shell',
+        'css': 'css', 'html': 'html', 'htm': 'html'
+    };
+    return map[ext] || '';
+}
+
+function renderTree(container, entries, runId, stepId, basePath) {
+    var ul = document.createElement('ul');
+    ul.className = 'ws-tree';
+
+    for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i];
+        var li = document.createElement('li');
+        li.className = entry.is_dir ? 'ws-dir' : 'ws-file';
+
+        var span = document.createElement('span');
+        span.className = 'ws-name';
+        span.textContent = (entry.is_dir ? '\u25B6 ' : '\u25CB ') + entry.name;
+
+        var entryPath = basePath ? basePath + '/' + entry.name : entry.name;
+
+        if (entry.is_dir) {
+            (function(ep, s) {
+                var expanded = false;
+                var childContainer = document.createElement('div');
+                childContainer.style.display = 'none';
+                s.addEventListener('click', function() {
+                    if (!expanded) {
+                        expanded = true;
+                        s.textContent = '\u25BC ' + entry.name;
+                        fetchTree(runId, stepId, ep).then(function(data) {
+                            if (data.entries && data.entries.length > 0) {
+                                renderTree(childContainer, data.entries, runId, stepId, ep);
+                            } else {
+                                childContainer.textContent = '(empty)';
+                            }
+                            childContainer.style.display = 'block';
+                        });
+                    } else {
+                        var hidden = childContainer.style.display === 'none';
+                        childContainer.style.display = hidden ? 'block' : 'none';
+                        s.textContent = (hidden ? '\u25BC ' : '\u25B6 ') + entry.name;
+                    }
+                });
+                li.appendChild(s);
+                li.appendChild(childContainer);
+            })(entryPath, span);
+        } else {
+            (function(ep, name) {
+                span.addEventListener('click', function() {
+                    var viewer = document.querySelector('.ws-file-viewer');
+                    if (!viewer) return;
+                    viewer.innerHTML = '<p>Loading...</p>';
+                    fetchFile(runId, stepId, ep).then(function(data) {
+                        if (data.error) {
+                            viewer.innerHTML = '<p class="ws-error">' + data.error + '</p>';
+                            return;
+                        }
+                        var lang = detectLanguage(name);
+                        var content = data.content;
+                        if (window.highlight && lang) {
+                            content = window.highlight(data.content, lang);
+                        }
+                        viewer.innerHTML = '<div class="ws-file-header"><strong>' + name + '</strong> <span class="ws-file-size">' + formatSize(data.size) + '</span>' + (data.truncated ? ' <span class="badge status-warning">truncated</span>' : '') + '</div><pre class="ws-file-content"><code>' + content + '</code></pre>';
+                    });
+                });
+                li.appendChild(span);
+            })(entryPath, entry.name);
+        }
+
+        ul.appendChild(li);
+    }
+    container.appendChild(ul);
+}
+
+function formatSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+function initWorkspaceBrowser(container, runId, stepId) {
+    fetchTree(runId, stepId, '').then(function(data) {
+        if (data.error) {
+            container.innerHTML = '<p class="ws-error">' + data.error + '</p>';
+            return;
+        }
+        var treePane = document.createElement('div');
+        treePane.className = 'ws-tree-pane';
+        var filePane = document.createElement('div');
+        filePane.className = 'ws-file-viewer';
+        filePane.innerHTML = '<p class="ws-placeholder">Select a file to view its content</p>';
+        container.innerHTML = '';
+        container.appendChild(treePane);
+        container.appendChild(filePane);
+        if (data.entries && data.entries.length > 0) {
+            renderTree(treePane, data.entries, runId, stepId, '');
+        } else {
+            treePane.innerHTML = '<p>(empty workspace)</p>';
+        }
+    });
+}
+
+window.initWorkspaceBrowser = initWorkspaceBrowser;
+})();

--- a/internal/webui/types.go
+++ b/internal/webui/types.go
@@ -162,3 +162,230 @@ type RetryRunResponse struct {
 	Status        string    `json:"status"`
 	StartedAt     time.Time `json:"started_at"`
 }
+
+// =============================================================================
+// Pipeline Detail Types (spec 091)
+// =============================================================================
+
+// PipelineDetailResponse is the JSON response for the pipeline detail API.
+type PipelineDetailResponse struct {
+	Name        string               `json:"name"`
+	Description string               `json:"description,omitempty"`
+	StepCount   int                  `json:"step_count"`
+	Input       PipelineInputDetail  `json:"input"`
+	Steps       []PipelineStepDetail `json:"steps"`
+	DAG         *DAGData             `json:"dag,omitempty"`
+	LastRun     *RunSummary          `json:"last_run,omitempty"`
+}
+
+// PipelineInputDetail holds pipeline input configuration.
+type PipelineInputDetail struct {
+	Source  string             `json:"source"`
+	Schema  *InputSchemaDetail `json:"schema,omitempty"`
+	Example string             `json:"example,omitempty"`
+}
+
+// InputSchemaDetail holds input schema details.
+type InputSchemaDetail struct {
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// PipelineStepDetail holds full step configuration for the pipeline detail view.
+type PipelineStepDetail struct {
+	ID           string              `json:"id"`
+	Persona      string              `json:"persona"`
+	Dependencies []string            `json:"dependencies,omitempty"`
+	Workspace    WorkspaceDetail     `json:"workspace"`
+	Contract     *ContractDetail     `json:"contract,omitempty"`
+	Artifacts    []ArtifactDefDetail `json:"artifacts,omitempty"`
+	Memory       MemoryDetail        `json:"memory"`
+}
+
+// WorkspaceDetail holds workspace configuration for display.
+type WorkspaceDetail struct {
+	Type   string        `json:"type,omitempty"`
+	Root   string        `json:"root,omitempty"`
+	Mounts []MountDetail `json:"mounts,omitempty"`
+}
+
+// MountDetail holds mount configuration.
+type MountDetail struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Mode   string `json:"mode,omitempty"`
+}
+
+// ContractDetail holds contract configuration for display.
+type ContractDetail struct {
+	Type       string `json:"type"`
+	Schema     string `json:"schema,omitempty"`
+	SchemaPath string `json:"schema_path,omitempty"`
+	MustPass   bool   `json:"must_pass"`
+	MaxRetries int    `json:"max_retries,omitempty"`
+}
+
+// ArtifactDefDetail holds output artifact definitions.
+type ArtifactDefDetail struct {
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	Type     string `json:"type,omitempty"`
+	Required bool   `json:"required,omitempty"`
+}
+
+// MemoryDetail holds memory/injection configuration.
+type MemoryDetail struct {
+	Strategy string             `json:"strategy"`
+	Injected []InjectedArtifact `json:"injected,omitempty"`
+}
+
+// InjectedArtifact holds artifact injection references.
+type InjectedArtifact struct {
+	FromStep string `json:"from_step"`
+	Artifact string `json:"artifact"`
+	As       string `json:"as"`
+}
+
+// =============================================================================
+// Persona Detail Types (spec 091)
+// =============================================================================
+
+// PersonaDetailResponse is the JSON response for the persona detail API.
+type PersonaDetailResponse struct {
+	Name             string         `json:"name"`
+	Description      string         `json:"description,omitempty"`
+	Adapter          string         `json:"adapter"`
+	Model            string         `json:"model,omitempty"`
+	Temperature      float64        `json:"temperature"`
+	SystemPrompt     string         `json:"system_prompt,omitempty"`
+	SystemPromptFile string         `json:"system_prompt_file"`
+	AllowedTools     []string       `json:"allowed_tools,omitempty"`
+	DeniedTools      []string       `json:"denied_tools,omitempty"`
+	Hooks            *HooksDetail   `json:"hooks,omitempty"`
+	Sandbox          *SandboxDetail `json:"sandbox,omitempty"`
+	UsedInPipelines  []string       `json:"used_in_pipelines,omitempty"`
+}
+
+// HooksDetail holds hook configuration for display.
+type HooksDetail struct {
+	PreToolUse  []HookRuleDetail `json:"pre_tool_use,omitempty"`
+	PostToolUse []HookRuleDetail `json:"post_tool_use,omitempty"`
+}
+
+// HookRuleDetail holds a single hook rule.
+type HookRuleDetail struct {
+	Matcher string `json:"matcher"`
+	Command string `json:"command"`
+}
+
+// SandboxDetail holds sandbox configuration for display.
+type SandboxDetail struct {
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+}
+
+// =============================================================================
+// Statistics Types (spec 091)
+// =============================================================================
+
+// RunStatistics holds aggregate run counts.
+type RunStatistics struct {
+	Total       int     `json:"total"`
+	Succeeded   int     `json:"succeeded"`
+	Failed      int     `json:"failed"`
+	Cancelled   int     `json:"cancelled"`
+	Pending     int     `json:"pending"`
+	Running     int     `json:"running"`
+	SuccessRate float64 `json:"success_rate"`
+}
+
+// RunTrendPoint holds a single data point in the run trend.
+type RunTrendPoint struct {
+	Date        string  `json:"date"`
+	Total       int     `json:"total"`
+	Succeeded   int     `json:"succeeded"`
+	Failed      int     `json:"failed"`
+	SuccessRate float64 `json:"success_rate"`
+}
+
+// PipelineStatistics holds per-pipeline aggregate stats.
+type PipelineStatistics struct {
+	PipelineName  string  `json:"pipeline_name"`
+	RunCount      int     `json:"run_count"`
+	SuccessRate   float64 `json:"success_rate"`
+	AvgDurationMs int64   `json:"avg_duration_ms"`
+	AvgTokens     int     `json:"avg_tokens"`
+}
+
+// StatisticsResponse is the JSON response for the statistics API.
+type StatisticsResponse struct {
+	Aggregate RunStatistics        `json:"aggregate"`
+	Trends    []RunTrendPoint      `json:"trends"`
+	Pipelines []PipelineStatistics `json:"pipelines"`
+	TimeRange string               `json:"time_range"`
+}
+
+// =============================================================================
+// Enhanced Run Detail Types (spec 091)
+// =============================================================================
+
+// EnhancedStepDetail extends StepDetail with introspection data.
+type EnhancedStepDetail struct {
+	StepDetail
+	ContractResult  *ContractResultDetail `json:"contract_result,omitempty"`
+	RecoveryHints   []RecoveryHintDetail  `json:"recovery_hints,omitempty"`
+	Performance     *StepPerfDetail       `json:"performance,omitempty"`
+	WorkspacePath   string                `json:"workspace_path,omitempty"`
+	WorkspaceExists bool                  `json:"workspace_exists"`
+}
+
+// ContractResultDetail holds contract validation outcome for a step.
+type ContractResultDetail struct {
+	Type         string `json:"type"`
+	Passed       bool   `json:"passed"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	Schema       string `json:"schema,omitempty"`
+}
+
+// RecoveryHintDetail holds a recovery suggestion for display.
+type RecoveryHintDetail struct {
+	Label   string `json:"label"`
+	Command string `json:"command"`
+	Type    string `json:"type"`
+}
+
+// StepPerfDetail holds performance metrics for a specific step execution.
+type StepPerfDetail struct {
+	DurationMs         int64 `json:"duration_ms"`
+	TokensUsed         int   `json:"tokens_used"`
+	FilesModified      int   `json:"files_modified"`
+	ArtifactsGenerated int   `json:"artifacts_generated"`
+}
+
+// =============================================================================
+// Workspace Browsing Types (spec 091)
+// =============================================================================
+
+// WorkspaceTreeResponse is the JSON response for workspace directory listings.
+type WorkspaceTreeResponse struct {
+	Path    string           `json:"path"`
+	Entries []WorkspaceEntry `json:"entries"`
+	Error   string           `json:"error,omitempty"`
+}
+
+// WorkspaceEntry represents a file or directory in the workspace tree.
+type WorkspaceEntry struct {
+	Name      string `json:"name"`
+	IsDir     bool   `json:"is_dir"`
+	Size      int64  `json:"size"`
+	Extension string `json:"extension,omitempty"`
+}
+
+// WorkspaceFileResponse is the JSON response for workspace file content.
+type WorkspaceFileResponse struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	MimeType  string `json:"mime_type"`
+	Size      int64  `json:"size"`
+	Truncated bool   `json:"truncated"`
+	Error     string `json:"error,omitempty"`
+}

--- a/specs/091-dashboard-introspection/checklists/api-contracts.md
+++ b/specs/091-dashboard-introspection/checklists/api-contracts.md
@@ -1,0 +1,31 @@
+# API Contract Fidelity Checklist
+
+**Feature**: Dashboard Inspection, Rendering, Statistics & Run Introspection
+**Spec**: specs/091-dashboard-introspection/spec.md
+**Generated**: 2026-02-14
+
+This checklist validates that the 5 API contracts are well-specified and consistent with the functional requirements and data model.
+
+---
+
+## Schema-Requirement Alignment
+
+- [ ] CHK-A01 - Does api-pipeline-detail.json's `steps[].contract` object include all fields specified in FR-003 (contract type, schema content, validation rules)? The current schema has `type`, `schema`, `schema_path`, `must_pass`, `max_retries` — is "validation rules" captured? [Completeness]
+- [ ] CHK-A02 - Does api-persona-detail.json require the `system_prompt` field, given FR-002 mandates displaying system prompt content? Currently `required` only lists `["name", "adapter"]`. [Consistency]
+- [ ] CHK-A03 - Does api-statistics.json's `trends` array specify ordering (ascending or descending by date)? The spec doesn't define this. [Clarity]
+- [ ] CHK-A04 - Does api-enhanced-run-detail.json include token delta information per event, given FR-015 requires "token deltas" in the event timeline? The `events[].tokens_used` field exists but is it cumulative or delta? [Clarity]
+- [ ] CHK-A05 - Does api-workspace.json's `WorkspaceTreeResponse.entries` specify a sort order (alphabetical, directories-first, or unsorted)? [Clarity]
+- [ ] CHK-A06 - Is the `mime_type` field in WorkspaceFileResponse well-defined — what MIME types are expected for the supported file types (Go, YAML, JSON, etc.)? [Clarity]
+
+## Contract-Data Model Alignment
+
+- [ ] CHK-A07 - Does the PipelineDetailResponse Go type in data-model.md match the api-pipeline-detail.json contract exactly (same required fields, same nesting)? [Consistency]
+- [ ] CHK-A08 - Does the StatisticsResponse Go type include `pending` and `running` in the aggregate, matching the contract but diverging from the FR text? Is this intentional? [Consistency]
+- [ ] CHK-A09 - Does the EnhancedStepDetail embedding StepDetail create JSON that matches the flat structure in api-enhanced-run-detail.json, or does Go's embedding produce nested output? [Consistency]
+- [ ] CHK-A10 - Are all `required` fields in every contract schema guaranteed to be populated by the corresponding handler — e.g., can `steps[].state` always be determined from event data? [Completeness]
+
+## Contract Versioning & Evolution
+
+- [ ] CHK-A11 - Is it specified whether these new API endpoints are versioned (e.g., /api/v1/statistics) or follow the existing unversioned pattern? [Completeness]
+- [ ] CHK-A12 - Do the contracts define error response schemas for 404 (not found), 400 (bad request), and 500 (server error) cases, or only the success path? [Completeness]
+- [ ] CHK-A13 - Is backward compatibility specified for the enhanced run detail endpoint — does it extend the existing /api/runs/{id} response or create a new endpoint? [Clarity]

--- a/specs/091-dashboard-introspection/checklists/requirements.md
+++ b/specs/091-dashboard-introspection/checklists/requirements.md
@@ -1,0 +1,82 @@
+# Quality Checklist: 091-dashboard-introspection
+
+## Specification Structure
+
+- [x] Feature name and branch clearly identified
+- [x] Created date and status present
+- [x] Input source (GitHub issue) linked
+- [x] All mandatory sections present (User Scenarios, Requirements, Success Criteria)
+
+## User Stories
+
+- [x] Each user story has a clear priority (P1/P2/P3)
+- [x] Each user story explains "Why this priority"
+- [x] Each user story has an independent test description
+- [x] Each user story has Gherkin-style acceptance scenarios (Given/When/Then)
+- [x] User stories are independently testable and deliverable
+- [x] User stories cover all 7 feature areas from the GitHub issue
+- [x] P1 stories deliver standalone MVP value
+- [x] P2 stories enhance but don't block P1 delivery
+- [x] P3 stories are clearly optional/convenience features
+
+## Requirements Quality
+
+- [x] All functional requirements use MUST/MUST NOT language
+- [x] Requirements are technology-agnostic (focus on WHAT, not HOW)
+- [x] Requirements are independently testable
+- [x] No implementation details in requirements (no code, no specific libraries mandated)
+- [x] Requirements are unambiguous — single interpretation possible
+- [x] Cross-cutting concerns addressed (build tags, security, embedding)
+- [x] Non-functional requirements have measurable thresholds
+- [x] Security requirements consistent with spec 085 foundation
+
+## Edge Cases
+
+- [x] Edge cases cover missing/unavailable resources (deleted files, cleaned workspaces)
+- [x] Edge cases cover empty state scenarios (zero runs)
+- [x] Edge cases cover data consistency (changed config since run)
+- [x] Edge cases cover security concerns (XSS, HTML content)
+- [x] Edge cases cover performance limits (large directories, large files)
+- [x] Edge cases cover data lifecycle (removed pipelines with historical data)
+- [x] Each edge case has a clear expected behavior
+
+## Key Entities
+
+- [x] All significant domain entities identified
+- [x] Entity descriptions include relationships to other entities
+- [x] Entities align with existing codebase types (state.RunRecord, state.PerformanceMetricRecord, etc.)
+
+## Success Criteria
+
+- [x] All success criteria are measurable
+- [x] Success criteria cover functional requirements (inspection, statistics, introspection)
+- [x] Success criteria cover non-functional requirements (performance, bundle size, security)
+- [x] Success criteria align with acceptance scenarios in user stories
+- [x] No subjective or unmeasurable criteria
+
+## Clarifications
+
+- [x] Maximum 3 NEEDS CLARIFICATION markers (currently: 2 — FR-009 markdown approach, C-004 entity metadata fields)
+- [x] Clarifications provide resolution and rationale
+- [x] Ambiguities resolved with informed decisions, not deferred
+
+## Alignment with GitHub Issue #91
+
+- [x] Pipeline, Persona & Contract Inspection covered (Issue Area 1)
+- [x] Markdown Rendering covered (Issue Area 2)
+- [x] YAML & Schema Rendering covered (Issue Area 3)
+- [x] Run Statistics Dashboard covered (Issue Area 4)
+- [x] Meta Information Display covered (Issue Area 5) — available metadata (name, description, adapter, model, relationships, operational status) is fully covered; unavailable fields (last changed, created date, version, author) are explicitly scoped out with rationale in C-004
+- [x] Run Introspection covered (Issue Area 6)
+- [x] Workspace & Source Browsing covered (Issue Area 7)
+- [x] All acceptance criteria from the issue addressed in user stories — with the exception of entity metadata fields not present in the data model, which are acknowledged and scoped out in C-004
+
+## Consistency with Spec 085
+
+- [x] Build tag `webui` requirement maintained
+- [x] 50 KB JS budget constraint referenced and maintained
+- [x] `go:embed` requirement maintained
+- [x] Authentication pattern (bearer token) for non-localhost maintained
+- [x] XSS prevention requirement maintained
+- [x] Responsive design requirement maintained
+- [x] Read-only artifact/workspace browsing maintained

--- a/specs/091-dashboard-introspection/checklists/review.md
+++ b/specs/091-dashboard-introspection/checklists/review.md
@@ -1,0 +1,65 @@
+# Requirements Quality Review Checklist
+
+**Feature**: Dashboard Inspection, Rendering, Statistics & Run Introspection
+**Spec**: specs/091-dashboard-introspection/spec.md
+**Generated**: 2026-02-14
+
+---
+
+## Completeness
+
+Are all necessary requirements present? Are there gaps in the specification?
+
+- [ ] CHK001 - Are all 7 user stories traceable to at least one functional requirement (FR)? [Completeness]
+- [ ] CHK002 - Does each functional requirement (FR-001 through FR-032) have at least one acceptance scenario that would verify it? [Completeness]
+- [ ] CHK003 - Are error/empty state behaviors specified for all new views (pipeline detail, persona detail, statistics, run introspection, workspace browser)? [Completeness]
+- [ ] CHK004 - Is the behavior for the "all time" time range filter clearly defined — does it use epoch 0 or database creation time as the lower bound? [Completeness]
+- [ ] CHK005 - Are pagination or result limits specified for the pipeline list, persona list, and event timeline views when data volume is large? [Completeness]
+- [ ] CHK006 - Is the behavior specified when a pipeline step references a persona that no longer exists in the manifest? [Completeness]
+- [ ] CHK007 - Is the expected default time range documented for the statistics page (spec says default 7d in tasks but not in the spec itself)? [Completeness]
+- [ ] CHK008 - Are loading/spinner states specified for asynchronous operations (workspace tree expansion, file content loading)? [Completeness]
+- [ ] CHK009 - Does the spec define how the "success rate" percentage is calculated when total runs is 0 (division by zero edge case)? [Completeness]
+- [ ] CHK010 - Are keyboard accessibility requirements stated for toggle controls (raw/rendered, formatted/raw) and drill-down navigation? [Completeness]
+
+## Clarity
+
+Are requirements unambiguous? Can they be interpreted only one way?
+
+- [ ] CHK011 - Is the definition of "step performance statistics" (FR-013) clear about whether it means per-step averages across all runs or per-step metrics within a single run? [Clarity]
+- [ ] CHK012 - Does FR-015 ("chronological event timeline") specify whether events are ordered ascending or descending by timestamp? [Clarity]
+- [ ] CHK013 - Is the markdown subset in FR-009 explicitly enumerated as a closed set, or could implementers interpret "the subset needed" differently? [Clarity]
+- [ ] CHK014 - Does FR-025 list the exact set of recognized file types for syntax highlighting, or is the list in the spec considered exhaustive vs. suggestive? [Clarity]
+- [ ] CHK015 - Is the meaning of "prominently displayed" in FR-017 (failure details) defined with testable criteria (e.g., position, color, size)? [Clarity]
+- [ ] CHK016 - Does the spec define what "a reasonable maximum" means for directory listing limits in the edge case (referenced as "e.g., 500") — is 500 a firm requirement or a suggestion? [Clarity]
+- [ ] CHK017 - Is it clear whether the raw/rendered toggle state persists across navigation (e.g., if I switch to "raw" on one persona, do all subsequent persona views default to raw)? [Clarity]
+- [ ] CHK018 - Does C-003 (historical vs. current config) clearly specify the visual design of the "configuration may differ" notice — is it a banner, tooltip, icon, or inline text? [Clarity]
+- [ ] CHK019 - Is the relationship between FR-018 (artifact display) and the existing artifact browsing from spec 085 clearly delineated — what is new vs. reused? [Clarity]
+
+## Consistency
+
+Are requirements internally consistent? Do they align across spec, plan, tasks, data model, and contracts?
+
+- [ ] CHK020 - Does the StatisticsResponse contract include `pending` and `running` counts in aggregate (api-statistics.json has them), while FR-010 only mentions "total, successful, failed, cancelled"? [Consistency]
+- [ ] CHK021 - Does the data-model RunStatistics type include `pending` and `running` fields that are absent from the FR-010 requirement text? [Consistency]
+- [ ] CHK022 - Is the RunTrendPoint type consistent between data-model.md (missing `cancelled`) and the contract (also missing `cancelled`), given that FR-011 doesn't mention cancelled trends? [Consistency]
+- [ ] CHK023 - Does the plan's JS budget analysis (R-007: ~12.2 KB total) align with the NFR-001 constraint (50 KB gzipped) and the spec's statement that existing assets are "well under 50 KB"? [Consistency]
+- [ ] CHK024 - Are the new StateStore methods in data-model.md consistent with the method signatures in tasks.md (e.g., GetRunTrends signature differs — data-model has `groupBy` param, tasks.md does not)? [Consistency]
+- [ ] CHK025 - Does the tasks.md dependency graph correctly reflect that Phase 8 (US6) depends on both Phase 3 and Phase 4, and Phase 9 (US7) depends on Phase 5 and Phase 7? [Consistency]
+- [ ] CHK026 - Is the `EnhancedStepDetail` described in data-model.md consistent with the enhanced run detail contract (api-enhanced-run-detail.json) — are all fields accounted for? [Consistency]
+- [ ] CHK027 - Does the persona detail contract's `required: ["name", "adapter"]` align with the spec's requirements for what MUST be shown (FR-002 also requires system_prompt, model, temperature, tools)? [Consistency]
+- [ ] CHK028 - Is the workspace file size limit consistent — spec says ">1 MB" in edge case, R-005 says "1 MB consistent with maxArtifactSize", and tasks T063 says ">1MB"? [Consistency]
+
+## Coverage
+
+Are edge cases, security concerns, and non-functional requirements adequately addressed?
+
+- [ ] CHK029 - Are all 8 edge cases from the spec traceable to specific tasks in tasks.md? [Coverage]
+- [ ] CHK030 - Is the XSS prevention requirement (FR-031) addressed in every location where user-generated content is displayed (markdown parser, syntax highlighter, artifact previews, workspace files, system prompts, error messages)? [Coverage]
+- [ ] CHK031 - Are performance requirements (NFR-002: 500ms stats, NFR-003: 200ms workspace) addressed with specific testing tasks to verify the thresholds? [Coverage]
+- [ ] CHK032 - Is the build tag gating requirement (FR-029) tested both positively (features present with tag) and negatively (features absent without tag)? [Coverage]
+- [ ] CHK033 - Does the spec address concurrent access to the statistics endpoint (multiple dashboard users hitting /api/statistics simultaneously)? [Coverage]
+- [ ] CHK034 - Are all 5 API contracts (pipeline-detail, persona-detail, statistics, workspace, enhanced-run-detail) covered by handler unit tests in the task list? [Coverage]
+- [ ] CHK035 - Is the authentication requirement (FR-032) explicitly tested for each new API endpoint, not just assumed from existing middleware? [Coverage]
+- [ ] CHK036 - Does the task list include a specific task for verifying that the existing test suite still passes after all changes (regression testing)? [Coverage]
+- [ ] CHK037 - Is the responsive design requirement (NFR-004) tested at both specified breakpoints (1024px desktop, 768px tablet) for all 5 new view types? [Coverage]
+- [ ] CHK038 - Are race conditions addressed for the workspace browser — what if a workspace is deleted between the tree listing and file content request? [Coverage]

--- a/specs/091-dashboard-introspection/checklists/security.md
+++ b/specs/091-dashboard-introspection/checklists/security.md
@@ -1,0 +1,37 @@
+# Security Requirements Checklist
+
+**Feature**: Dashboard Inspection, Rendering, Statistics & Run Introspection
+**Spec**: specs/091-dashboard-introspection/spec.md
+**Generated**: 2026-02-14
+
+This checklist validates that security-related requirements are sufficiently specified before implementation.
+
+---
+
+## XSS Prevention (FR-031)
+
+- [ ] CHK-S01 - Are sanitization requirements specified for each distinct content rendering path: markdown output, syntax-highlighted code, raw text display, artifact previews, and error messages? [Completeness]
+- [ ] CHK-S02 - Does the spec define whether the markdown parser should strip or escape HTML tags embedded in markdown source (e.g., `<script>` inside a system prompt file)? [Clarity]
+- [ ] CHK-S03 - Is it clear that the syntax highlighter must HTML-escape content BEFORE tokenizing (not after), to prevent injection via crafted YAML/JSON values? [Clarity]
+- [ ] CHK-S04 - Are workspace file contents required to be HTML-escaped on the server side, client side, or both? Is the responsibility clearly assigned? [Clarity]
+- [ ] CHK-S05 - Does the spec address XSS risk in recovery hint display — could a crafted error message containing HTML be rendered unsafely as a recovery hint? [Coverage]
+- [ ] CHK-S06 - Are event log messages (which may contain arbitrary text) specified to be escaped before display in the event timeline? [Coverage]
+
+## Path Traversal (FR-024, C-007)
+
+- [ ] CHK-S07 - Is the path validation mechanism for workspace browsing clearly specified — `filepath.Rel` check, prefix check, or canonical path comparison? [Clarity]
+- [ ] CHK-S08 - Does the spec explicitly prohibit symlink following in the workspace browser to prevent symlink-based path traversal? [Completeness]
+- [ ] CHK-S09 - Is the behavior specified when a workspace path from `step_state` points to a directory outside the expected workspace root? [Coverage]
+- [ ] CHK-S10 - Are URL-encoded path traversal attempts (e.g., `%2e%2e%2f`) addressed in the path validation requirements? [Coverage]
+
+## Authentication (FR-032)
+
+- [ ] CHK-S11 - Does the spec enumerate all new API endpoints that must be protected by bearer token auth, or does it rely on a blanket statement? [Completeness]
+- [ ] CHK-S12 - Is it specified whether the HTML page endpoints (not just /api/ JSON endpoints) also require authentication when non-localhost? [Clarity]
+- [ ] CHK-S13 - Are the workspace file content endpoints specifically called out as requiring auth, given they serve potentially sensitive file contents? [Coverage]
+
+## Data Exposure
+
+- [ ] CHK-S14 - Does the spec address whether system prompt content displayed via the persona detail API could leak sensitive information (API keys, internal URLs embedded in prompts)? [Coverage]
+- [ ] CHK-S15 - Is the existing credential redaction (`RedactCredentials`) required to be applied to system prompt content before serving via the API? [Completeness]
+- [ ] CHK-S16 - Are workspace file content responses required to redact sensitive patterns (credentials, tokens) or is raw content acceptable? [Clarity]

--- a/specs/091-dashboard-introspection/contracts/api-enhanced-run-detail.json
+++ b/specs/091-dashboard-introspection/contracts/api-enhanced-run-detail.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EnhancedRunDetailResponse",
+  "description": "GET /api/runs/{id} — Enhanced run detail with introspection data (extends existing RunDetailResponse)",
+  "type": "object",
+  "required": ["run", "steps", "events"],
+  "properties": {
+    "run": {
+      "type": "object",
+      "required": ["run_id", "pipeline_name", "status", "started_at"],
+      "properties": {
+        "run_id": { "type": "string" },
+        "pipeline_name": { "type": "string" },
+        "status": { "type": "string", "enum": ["pending", "running", "completed", "failed", "cancelled"] },
+        "current_step": { "type": "string" },
+        "total_tokens": { "type": "integer" },
+        "started_at": { "type": "string", "format": "date-time" },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "duration": { "type": "string" },
+        "error_message": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["step_id", "persona", "state"],
+        "properties": {
+          "step_id": { "type": "string" },
+          "persona": { "type": "string" },
+          "state": { "type": "string" },
+          "progress": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "current_action": { "type": "string" },
+          "started_at": { "type": "string", "format": "date-time" },
+          "completed_at": { "type": "string", "format": "date-time" },
+          "duration": { "type": "string" },
+          "tokens_used": { "type": "integer" },
+          "error": { "type": "string" },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "name": { "type": "string" },
+                "path": { "type": "string" },
+                "type": { "type": "string" },
+                "size_bytes": { "type": "integer" },
+                "preview": { "type": "string" }
+              }
+            }
+          },
+          "contract_result": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "passed": { "type": "boolean" },
+              "error_message": { "type": "string" },
+              "schema": { "type": "string" }
+            }
+          },
+          "recovery_hints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "command", "type"],
+              "properties": {
+                "label": { "type": "string" },
+                "command": { "type": "string" },
+                "type": { "type": "string", "enum": ["resume", "force", "workspace", "debug"] }
+              }
+            }
+          },
+          "performance": {
+            "type": "object",
+            "properties": {
+              "duration_ms": { "type": "integer" },
+              "tokens_used": { "type": "integer" },
+              "files_modified": { "type": "integer" },
+              "artifacts_generated": { "type": "integer" }
+            }
+          },
+          "workspace_path": { "type": "string" },
+          "workspace_exists": { "type": "boolean" }
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "timestamp", "state"],
+        "properties": {
+          "id": { "type": "integer" },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "step_id": { "type": "string" },
+          "state": { "type": "string" },
+          "persona": { "type": "string" },
+          "message": { "type": "string" },
+          "tokens_used": { "type": "integer" },
+          "duration_ms": { "type": "integer" }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "path": { "type": "string" },
+          "type": { "type": "string" },
+          "size_bytes": { "type": "integer" },
+          "preview": { "type": "string" }
+        }
+      }
+    },
+    "dag": {
+      "type": "object",
+      "properties": {
+        "nodes": { "type": "array" },
+        "edges": { "type": "array" }
+      }
+    }
+  }
+}

--- a/specs/091-dashboard-introspection/contracts/api-persona-detail.json
+++ b/specs/091-dashboard-introspection/contracts/api-persona-detail.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PersonaDetailResponse",
+  "description": "GET /api/personas/{name} — Full persona configuration for inspection",
+  "type": "object",
+  "required": ["name", "adapter"],
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "adapter": { "type": "string" },
+    "model": { "type": "string" },
+    "temperature": { "type": "number" },
+    "system_prompt": { "type": "string", "description": "Full system prompt content (HTML-escaped)" },
+    "system_prompt_file": { "type": "string", "description": "Path to system prompt file" },
+    "allowed_tools": { "type": "array", "items": { "type": "string" } },
+    "denied_tools": { "type": "array", "items": { "type": "string" } },
+    "hooks": {
+      "type": "object",
+      "properties": {
+        "pre_tool_use": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matcher": { "type": "string" },
+              "command": { "type": "string" }
+            }
+          }
+        },
+        "post_tool_use": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matcher": { "type": "string" },
+              "command": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "sandbox": {
+      "type": "object",
+      "properties": {
+        "allowed_domains": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "used_in_pipelines": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/specs/091-dashboard-introspection/contracts/api-pipeline-detail.json
+++ b/specs/091-dashboard-introspection/contracts/api-pipeline-detail.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PipelineDetailResponse",
+  "description": "GET /api/pipelines/{name} — Full pipeline configuration for inspection",
+  "type": "object",
+  "required": ["name", "step_count", "input", "steps"],
+  "properties": {
+    "name": { "type": "string", "description": "Pipeline name" },
+    "description": { "type": "string" },
+    "step_count": { "type": "integer", "minimum": 0 },
+    "input": {
+      "type": "object",
+      "required": ["source"],
+      "properties": {
+        "source": { "type": "string" },
+        "schema": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "description": { "type": "string" }
+          }
+        },
+        "example": { "type": "string" }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "persona"],
+        "properties": {
+          "id": { "type": "string" },
+          "persona": { "type": "string" },
+          "dependencies": { "type": "array", "items": { "type": "string" } },
+          "workspace": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "root": { "type": "string" },
+              "mounts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": { "type": "string" },
+                    "target": { "type": "string" },
+                    "mode": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "contract": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "schema": { "type": "string" },
+              "schema_path": { "type": "string" },
+              "must_pass": { "type": "boolean" },
+              "max_retries": { "type": "integer" }
+            }
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "path": { "type": "string" },
+                "type": { "type": "string" },
+                "required": { "type": "boolean" }
+              }
+            }
+          },
+          "memory": {
+            "type": "object",
+            "properties": {
+              "strategy": { "type": "string" },
+              "injected": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "from_step": { "type": "string" },
+                    "artifact": { "type": "string" },
+                    "as": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "dag": {
+      "type": "object",
+      "properties": {
+        "nodes": { "type": "array" },
+        "edges": { "type": "array" }
+      }
+    },
+    "last_run": {
+      "type": "object",
+      "properties": {
+        "run_id": { "type": "string" },
+        "pipeline_name": { "type": "string" },
+        "status": { "type": "string" },
+        "started_at": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/specs/091-dashboard-introspection/contracts/api-statistics.json
+++ b/specs/091-dashboard-introspection/contracts/api-statistics.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StatisticsResponse",
+  "description": "GET /api/statistics?range={24h|7d|30d|all} — Aggregate run statistics",
+  "type": "object",
+  "required": ["aggregate", "trends", "pipelines", "time_range"],
+  "properties": {
+    "aggregate": {
+      "type": "object",
+      "required": ["total", "succeeded", "failed", "cancelled", "success_rate"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "succeeded": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "cancelled": { "type": "integer", "minimum": 0 },
+        "pending": { "type": "integer", "minimum": 0 },
+        "running": { "type": "integer", "minimum": 0 },
+        "success_rate": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "trends": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["date", "total", "succeeded", "failed", "success_rate"],
+        "properties": {
+          "date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+          "total": { "type": "integer", "minimum": 0 },
+          "succeeded": { "type": "integer", "minimum": 0 },
+          "failed": { "type": "integer", "minimum": 0 },
+          "success_rate": { "type": "number", "minimum": 0, "maximum": 100 }
+        }
+      }
+    },
+    "pipelines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["pipeline_name", "run_count", "success_rate"],
+        "properties": {
+          "pipeline_name": { "type": "string" },
+          "run_count": { "type": "integer", "minimum": 0 },
+          "success_rate": { "type": "number", "minimum": 0, "maximum": 100 },
+          "avg_duration_ms": { "type": "integer", "minimum": 0 },
+          "avg_tokens": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "time_range": {
+      "type": "string",
+      "enum": ["24h", "7d", "30d", "all"]
+    }
+  }
+}

--- a/specs/091-dashboard-introspection/contracts/api-workspace.json
+++ b/specs/091-dashboard-introspection/contracts/api-workspace.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WorkspaceAPIs",
+  "description": "Workspace browsing API contracts",
+  "definitions": {
+    "WorkspaceTreeResponse": {
+      "description": "GET /api/runs/{id}/workspace/{step}/tree?path= — Directory listing",
+      "type": "object",
+      "required": ["path", "entries"],
+      "properties": {
+        "path": { "type": "string", "description": "Requested directory path" },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "is_dir", "size"],
+            "properties": {
+              "name": { "type": "string" },
+              "is_dir": { "type": "boolean" },
+              "size": { "type": "integer", "minimum": 0 },
+              "extension": { "type": "string" }
+            }
+          },
+          "maxItems": 500
+        },
+        "error": { "type": "string" }
+      }
+    },
+    "WorkspaceFileResponse": {
+      "description": "GET /api/runs/{id}/workspace/{step}/file?path= — File content",
+      "type": "object",
+      "required": ["path", "content", "mime_type", "size", "truncated"],
+      "properties": {
+        "path": { "type": "string" },
+        "content": { "type": "string", "description": "HTML-escaped file content" },
+        "mime_type": { "type": "string" },
+        "size": { "type": "integer", "minimum": 0 },
+        "truncated": { "type": "boolean" },
+        "error": { "type": "string" }
+      }
+    }
+  }
+}

--- a/specs/091-dashboard-introspection/data-model.md
+++ b/specs/091-dashboard-introspection/data-model.md
@@ -1,0 +1,452 @@
+# Data Model: Dashboard Inspection, Rendering, Statistics & Run Introspection
+
+**Branch**: `091-dashboard-introspection` | **Date**: 2026-02-14
+
+## Existing Entities (No Modifications)
+
+These entities already exist in the codebase. This feature reads from them but does not alter their schema.
+
+### pipeline_run (SQLite table)
+Source: `internal/state/schema.sql`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| run_id | TEXT PK | Unique run identifier |
+| pipeline_name | TEXT | Pipeline name |
+| status | TEXT | pending/running/completed/failed/cancelled |
+| input | TEXT | Pipeline input |
+| current_step | TEXT | Currently executing step |
+| total_tokens | INTEGER | Total tokens consumed |
+| started_at | INTEGER | Unix timestamp |
+| completed_at | INTEGER | Unix timestamp (nullable) |
+| cancelled_at | INTEGER | Unix timestamp (nullable) |
+| error_message | TEXT | Error message (nullable) |
+| tags_json | TEXT | JSON array of tags |
+
+**Indexes**: `pipeline_name`, `status`, `started_at`
+
+### event_log (SQLite table)
+Source: `internal/state/schema.sql`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| run_id | TEXT FK | References pipeline_run |
+| timestamp | INTEGER | Unix timestamp |
+| step_id | TEXT | Step identifier |
+| state | TEXT | Event state |
+| persona | TEXT | Persona name |
+| message | TEXT | Event message |
+| tokens_used | INTEGER | Token count |
+| duration_ms | INTEGER | Duration in ms |
+
+### performance_metric (SQLite table)
+Source: `internal/state/schema.sql`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-increment |
+| run_id | TEXT FK | References pipeline_run |
+| step_id | TEXT | Step identifier |
+| pipeline_name | TEXT | Pipeline name |
+| persona | TEXT | Persona name |
+| started_at | INTEGER | Unix timestamp |
+| completed_at | INTEGER | Unix timestamp (nullable) |
+| duration_ms | INTEGER | Duration in ms |
+| tokens_used | INTEGER | Token count |
+| files_modified | INTEGER | Files changed |
+| artifacts_generated | INTEGER | Artifacts created |
+| memory_bytes | INTEGER | Memory used |
+| success | BOOLEAN | Success flag |
+| error_message | TEXT | Error message |
+
+**Indexes**: `run_id`, `step_id`, `pipeline_name`, `started_at`
+
+### step_state (SQLite table)
+Source: `internal/state/schema.sql`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| step_id | TEXT PK | Step identifier |
+| pipeline_id | TEXT FK | References pipeline_state |
+| state | TEXT | Step state |
+| retry_count | INTEGER | Retry count |
+| started_at | INTEGER | Unix timestamp (nullable) |
+| completed_at | INTEGER | Unix timestamp (nullable) |
+| workspace_path | TEXT | Workspace directory path |
+| error_message | TEXT | Error message |
+
+### Manifest Types (Go structs)
+Source: `internal/manifest/types.go`
+
+- `Manifest` — top-level config with `Personas map[string]Persona`, `Adapters map[string]Adapter`, `Runtime`
+- `Persona` — adapter, description, system_prompt_file, temperature, model, permissions, hooks, sandbox
+- `Adapter` — binary, mode, output_format, project_files, default_permissions
+
+### Pipeline Types (Go structs)
+Source: `internal/pipeline/types.go`
+
+- `Pipeline` — kind, metadata, requires, input, steps
+- `Step` — id, persona, dependencies, memory, workspace, exec, output_artifacts, handover, strategy, validation
+- `ContractConfig` — type, schema, source, schema_path, validate, command, dir, must_pass
+- `InputConfig` — source, schema, example, label_filter, batch_size
+
+---
+
+## New API Response Types
+
+These Go types are added to `internal/webui/types.go`.
+
+### PipelineDetailResponse
+
+```go
+// PipelineDetailResponse is the JSON response for the pipeline detail API.
+type PipelineDetailResponse struct {
+    Name            string                `json:"name"`
+    Description     string                `json:"description,omitempty"`
+    StepCount       int                   `json:"step_count"`
+    Input           PipelineInputDetail   `json:"input"`
+    Steps           []PipelineStepDetail  `json:"steps"`
+    DAG             *DAGData              `json:"dag,omitempty"`
+    LastRun         *RunSummary           `json:"last_run,omitempty"`
+}
+
+// PipelineInputDetail holds pipeline input configuration.
+type PipelineInputDetail struct {
+    Source  string `json:"source"`
+    Schema  *InputSchemaDetail `json:"schema,omitempty"`
+    Example string `json:"example,omitempty"`
+}
+
+// InputSchemaDetail holds input schema details.
+type InputSchemaDetail struct {
+    Type        string `json:"type,omitempty"`
+    Description string `json:"description,omitempty"`
+}
+
+// PipelineStepDetail holds full step configuration for the pipeline detail view.
+type PipelineStepDetail struct {
+    ID            string              `json:"id"`
+    Persona       string              `json:"persona"`
+    Dependencies  []string            `json:"dependencies,omitempty"`
+    Workspace     WorkspaceDetail     `json:"workspace"`
+    Contract      *ContractDetail     `json:"contract,omitempty"`
+    Artifacts     []ArtifactDefDetail `json:"artifacts,omitempty"`
+    Memory        MemoryDetail        `json:"memory"`
+}
+
+// WorkspaceDetail holds workspace configuration for display.
+type WorkspaceDetail struct {
+    Type   string        `json:"type,omitempty"`
+    Root   string        `json:"root,omitempty"`
+    Mounts []MountDetail `json:"mounts,omitempty"`
+}
+
+// MountDetail holds mount configuration.
+type MountDetail struct {
+    Source string `json:"source"`
+    Target string `json:"target"`
+    Mode   string `json:"mode,omitempty"`
+}
+
+// ContractDetail holds contract configuration for display.
+type ContractDetail struct {
+    Type       string `json:"type"`
+    Schema     string `json:"schema,omitempty"`
+    SchemaPath string `json:"schema_path,omitempty"`
+    MustPass   bool   `json:"must_pass"`
+    MaxRetries int    `json:"max_retries,omitempty"`
+}
+
+// ArtifactDefDetail holds output artifact definitions.
+type ArtifactDefDetail struct {
+    Name     string `json:"name"`
+    Path     string `json:"path"`
+    Type     string `json:"type,omitempty"`
+    Required bool   `json:"required,omitempty"`
+}
+
+// MemoryDetail holds memory/injection configuration.
+type MemoryDetail struct {
+    Strategy string           `json:"strategy"`
+    Injected []InjectedArtifact `json:"injected,omitempty"`
+}
+
+// InjectedArtifact holds artifact injection references.
+type InjectedArtifact struct {
+    FromStep string `json:"from_step"`
+    Artifact string `json:"artifact"`
+    As       string `json:"as"`
+}
+```
+
+### PersonaDetailResponse
+
+```go
+// PersonaDetailResponse is the JSON response for the persona detail API.
+type PersonaDetailResponse struct {
+    Name             string   `json:"name"`
+    Description      string   `json:"description,omitempty"`
+    Adapter          string   `json:"adapter"`
+    Model            string   `json:"model,omitempty"`
+    Temperature      float64  `json:"temperature"`
+    SystemPrompt     string   `json:"system_prompt,omitempty"`
+    SystemPromptFile string   `json:"system_prompt_file"`
+    AllowedTools     []string `json:"allowed_tools,omitempty"`
+    DeniedTools      []string `json:"denied_tools,omitempty"`
+    Hooks            *HooksDetail   `json:"hooks,omitempty"`
+    Sandbox          *SandboxDetail `json:"sandbox,omitempty"`
+    UsedInPipelines  []string `json:"used_in_pipelines,omitempty"`
+}
+
+// HooksDetail holds hook configuration for display.
+type HooksDetail struct {
+    PreToolUse  []HookRuleDetail `json:"pre_tool_use,omitempty"`
+    PostToolUse []HookRuleDetail `json:"post_tool_use,omitempty"`
+}
+
+// HookRuleDetail holds a single hook rule.
+type HookRuleDetail struct {
+    Matcher string `json:"matcher"`
+    Command string `json:"command"`
+}
+
+// SandboxDetail holds sandbox configuration for display.
+type SandboxDetail struct {
+    AllowedDomains []string `json:"allowed_domains,omitempty"`
+}
+```
+
+### Statistics Types
+
+```go
+// RunStatistics holds aggregate run counts.
+type RunStatistics struct {
+    Total       int     `json:"total"`
+    Succeeded   int     `json:"succeeded"`
+    Failed      int     `json:"failed"`
+    Cancelled   int     `json:"cancelled"`
+    Pending     int     `json:"pending"`
+    Running     int     `json:"running"`
+    SuccessRate float64 `json:"success_rate"` // percentage 0-100
+}
+
+// RunTrendPoint holds a single data point in the run trend.
+type RunTrendPoint struct {
+    Date        string  `json:"date"`        // YYYY-MM-DD
+    Total       int     `json:"total"`
+    Succeeded   int     `json:"succeeded"`
+    Failed      int     `json:"failed"`
+    SuccessRate float64 `json:"success_rate"` // percentage 0-100
+}
+
+// PipelineStatistics holds per-pipeline aggregate stats.
+type PipelineStatistics struct {
+    PipelineName  string  `json:"pipeline_name"`
+    RunCount      int     `json:"run_count"`
+    SuccessRate   float64 `json:"success_rate"`   // percentage 0-100
+    AvgDurationMs int64   `json:"avg_duration_ms"`
+    AvgTokens     int     `json:"avg_tokens"`
+}
+
+// StatisticsResponse is the JSON response for the statistics API.
+type StatisticsResponse struct {
+    Aggregate  RunStatistics        `json:"aggregate"`
+    Trends     []RunTrendPoint      `json:"trends"`
+    Pipelines  []PipelineStatistics `json:"pipelines"`
+    TimeRange  string               `json:"time_range"` // "24h", "7d", "30d", "all"
+}
+```
+
+### Enhanced Run Detail Types
+
+```go
+// EnhancedStepDetail extends StepDetail with introspection data.
+type EnhancedStepDetail struct {
+    StepDetail                          // embed base
+    ContractResult  *ContractResultDetail `json:"contract_result,omitempty"`
+    RecoveryHints   []RecoveryHintDetail  `json:"recovery_hints,omitempty"`
+    Performance     *StepPerfDetail       `json:"performance,omitempty"`
+    WorkspacePath   string                `json:"workspace_path,omitempty"`
+    WorkspaceExists bool                  `json:"workspace_exists"`
+}
+
+// ContractResultDetail holds contract validation outcome for a step.
+type ContractResultDetail struct {
+    Type          string `json:"type"`
+    Passed        bool   `json:"passed"`
+    ErrorMessage  string `json:"error_message,omitempty"`
+    Schema        string `json:"schema,omitempty"`
+}
+
+// RecoveryHintDetail holds a recovery suggestion for display.
+type RecoveryHintDetail struct {
+    Label   string `json:"label"`
+    Command string `json:"command"`
+    Type    string `json:"type"` // resume, force, workspace, debug
+}
+
+// StepPerfDetail holds performance metrics for a specific step execution.
+type StepPerfDetail struct {
+    DurationMs         int64 `json:"duration_ms"`
+    TokensUsed         int   `json:"tokens_used"`
+    FilesModified      int   `json:"files_modified"`
+    ArtifactsGenerated int   `json:"artifacts_generated"`
+}
+```
+
+### Workspace Browsing Types
+
+```go
+// WorkspaceTreeResponse is the JSON response for workspace directory listings.
+type WorkspaceTreeResponse struct {
+    Path    string           `json:"path"`
+    Entries []WorkspaceEntry `json:"entries"`
+    Error   string           `json:"error,omitempty"`
+}
+
+// WorkspaceEntry represents a file or directory in the workspace tree.
+type WorkspaceEntry struct {
+    Name      string `json:"name"`
+    IsDir     bool   `json:"is_dir"`
+    Size      int64  `json:"size"`
+    Extension string `json:"extension,omitempty"`
+}
+
+// WorkspaceFileResponse is the JSON response for workspace file content.
+type WorkspaceFileResponse struct {
+    Path      string `json:"path"`
+    Content   string `json:"content"`
+    MimeType  string `json:"mime_type"`
+    Size      int64  `json:"size"`
+    Truncated bool   `json:"truncated"`
+    Error     string `json:"error,omitempty"`
+}
+```
+
+---
+
+## New StateStore Interface Methods
+
+These methods are added to the `StateStore` interface in `internal/state/store.go`:
+
+```go
+// Statistics (spec 091 - Dashboard Introspection)
+GetRunStatistics(since time.Time) (*RunStatisticsRecord, error)
+GetRunTrends(since time.Time) ([]RunTrendRecord, error)
+GetPipelineStatistics(since time.Time) ([]PipelineStatisticsRecord, error)
+GetPipelineStepStats(pipelineName string, since time.Time) ([]StepPerformanceStats, error)
+GetLastRunForPipeline(pipelineName string) (*RunRecord, error)
+```
+
+### New State Types
+
+```go
+// RunStatisticsRecord holds aggregate run statistics from SQL.
+type RunStatisticsRecord struct {
+    Total     int
+    Succeeded int
+    Failed    int
+    Cancelled int
+    Pending   int
+    Running   int
+}
+
+// RunTrendRecord holds a daily trend data point from SQL.
+type RunTrendRecord struct {
+    Date      string // YYYY-MM-DD
+    Total     int
+    Succeeded int
+    Failed    int
+}
+
+// PipelineStatisticsRecord holds per-pipeline aggregate stats from SQL.
+type PipelineStatisticsRecord struct {
+    PipelineName  string
+    RunCount      int
+    Succeeded     int
+    Failed        int
+    AvgDurationMs int64
+    AvgTokens     int
+}
+```
+
+---
+
+## New API Routes
+
+Added to `routes.go`:
+
+```
+# Pipeline detail
+GET /pipelines/{name}              → handlePipelineDetailPage (HTML)
+GET /api/pipelines/{name}          → handleAPIPipelineDetail (JSON)
+
+# Persona detail
+GET /personas/{name}               → handlePersonaDetailPage (HTML)
+GET /api/personas/{name}           → handleAPIPersonaDetail (JSON)
+
+# Statistics
+GET /statistics                    → handleStatisticsPage (HTML)
+GET /api/statistics                → handleAPIStatistics (JSON)
+
+# Workspace browsing
+GET /api/runs/{id}/workspace/{step}/tree   → handleWorkspaceTree (JSON)
+GET /api/runs/{id}/workspace/{step}/file   → handleWorkspaceFile (JSON)
+```
+
+---
+
+## New Static Assets
+
+Added to `internal/webui/static/`:
+
+| File | Purpose | Est. Size |
+|------|---------|-----------|
+| `markdown.js` | Minimal markdown parser with raw/rendered toggle | ~5 KB |
+| `highlight.js` | Regex-based syntax highlighter for 9 languages | ~4 KB |
+| `stats.js` | Statistics page interactions (time range filter) | ~3 KB |
+| `workspace.js` | File tree lazy-loading and file content viewer | ~3 KB |
+| `introspect.js` | Step drill-down, toggles, contract inspection | ~2 KB |
+
+---
+
+## New HTML Templates
+
+Added to `internal/webui/templates/`:
+
+| File | Purpose |
+|------|---------|
+| `pipeline_detail.html` | Pipeline inspection with step detail, contract display, DAG |
+| `persona_detail.html` | Persona inspection with system prompt, permissions, hooks |
+| `statistics.html` | Statistics dashboard with aggregate counts, trends, per-pipeline |
+| `partials/markdown_viewer.html` | Markdown content with raw/rendered toggle |
+| `partials/code_viewer.html` | Syntax highlighted content with raw/formatted toggle |
+| `partials/step_inspector.html` | Step introspection with drill-down panels |
+| `partials/workspace_tree.html` | File tree browser with lazy loading |
+| `partials/stats_chart.html` | CSS-based chart components |
+
+---
+
+## Entity Relationship Summary
+
+```
+Manifest (in-memory)
+├── Personas map[string]Persona     ──→ PersonaDetailResponse
+├── Adapters map[string]Adapter
+└── Runtime
+
+Pipeline YAML (filesystem)
+├── PipelineMetadata                ──→ PipelineDetailResponse
+├── Steps[]                         ──→ PipelineStepDetail[]
+│   ├── Persona ref                 ──→ cross-link to PersonaDetailResponse
+│   ├── ContractConfig              ──→ ContractDetail
+│   └── OutputArtifacts[]           ──→ ArtifactDefDetail[]
+└── InputConfig                     ──→ PipelineInputDetail
+
+pipeline_run (SQLite)               ──→ RunStatistics, RunTrendPoint, PipelineStatistics
+├── event_log[]                     ──→ EventSummary[] (event timeline)
+├── performance_metric[]            ──→ StepPerfDetail
+├── artifact[]                      ──→ ArtifactSummary[]
+└── step_state (workspace_path)     ──→ WorkspaceTreeResponse, WorkspaceFileResponse
+```

--- a/specs/091-dashboard-introspection/plan.md
+++ b/specs/091-dashboard-introspection/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: Dashboard Inspection, Rendering, Statistics & Run Introspection
+
+**Branch**: `091-dashboard-introspection` | **Date**: 2026-02-14 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/091-dashboard-introspection/spec.md`
+
+## Summary
+
+Enhance the Wave web dashboard with 7 feature areas: pipeline/persona/contract inspection views, markdown rendering with raw/rendered toggle, YAML/JSON syntax highlighting, run statistics dashboard, meta information display, run introspection with drill-down, and workspace/source browsing. Implementation uses server-side SQL aggregation for statistics, client-side custom parsers for markdown and syntax highlighting (within 50 KB gzipped JS budget), and extends the existing `webui` package architecture with new handlers, templates, and API endpoints. All features gated behind the `webui` build tag.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (existing project)
+**Primary Dependencies**: `net/http` (stdlib, Go 1.22+ enhanced ServeMux), `html/template`, `go:embed`, `modernc.org/sqlite` (existing), `gopkg.in/yaml.v3` (existing)
+**Storage**: SQLite via existing `internal/state` package — new aggregate query methods, no schema migration required
+**Testing**: `go test ./...` with `-race` flag
+**Target Platform**: Linux server (single binary)
+**Project Type**: Single Go binary with embedded web assets
+**Performance Goals**: Statistics queries <500ms for 10K runs (NFR-002), workspace tree listing <200ms for 500 entries (NFR-003)
+**Constraints**: Total JS bundle <50 KB gzipped (NFR-001), all assets embedded via `go:embed` (FR-030), `webui` build tag gating (FR-029)
+**Scale/Scope**: Dashboard serving up to 10K pipeline runs, 9 supported syntax highlighting languages, ~17 new files
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | All assets embedded via `go:embed`, no new runtime dependencies |
+| P2: Manifest as SSOT | PASS | Reads from manifest (personas, adapters) and pipeline YAML — no config duplication |
+| P3: Persona-Scoped Boundaries | N/A | Dashboard is read-only viewer, not an execution boundary |
+| P4: Fresh Memory | N/A | No pipeline execution or chat history involved |
+| P5: Navigator-First | N/A | Dashboard feature, not a pipeline step |
+| P6: Contracts at Handover | N/A | No pipeline handover in this feature |
+| P7: Relay via Summarizer | N/A | No context window concerns for HTTP handlers |
+| P8: Ephemeral Workspaces | PASS | Workspace browser is strictly read-only (FR-027), path traversal prevented |
+| P9: Credentials Never Touch Disk | PASS | System prompt content sanitized, credential redaction via existing `RedactCredentials` |
+| P10: Observable Progress | PASS | Reads existing event_log and progress tables — adds visibility, not mutation |
+| P11: Bounded Recursion | N/A | No recursive execution |
+| P12: Minimal State Machine | N/A | No state transitions — read-only views |
+| P13: Test Ownership | PASS | All new code includes unit tests; existing tests must continue passing |
+
+**Post-Phase 1 Re-check**: All principles verified. No violations found.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/091-dashboard-introspection/
+├── plan.md              # This file
+├── research.md          # Phase 0 research findings
+├── data-model.md        # Phase 1 data model
+├── contracts/           # Phase 1 API contracts
+│   ├── api-pipeline-detail.json
+│   ├── api-persona-detail.json
+│   ├── api-statistics.json
+│   ├── api-workspace.json
+│   └── api-enhanced-run-detail.json
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```
+internal/
+├── webui/
+│   ├── types.go                          # Extended with new response types
+│   ├── routes.go                         # Extended with new routes
+│   ├── server.go                         # No changes needed
+│   ├── embed.go                          # Extended with new page templates
+│   ├── handlers_pipelines.go             # Extended: pipeline detail handler
+│   ├── handlers_personas.go              # Extended: persona detail handler
+│   ├── handlers_runs.go                  # Extended: enhanced run detail with introspection
+│   ├── handlers_statistics.go            # NEW: statistics API and page handlers
+│   ├── handlers_workspace.go             # NEW: workspace browsing handlers
+│   ├── static/
+│   │   ├── app.js                        # Existing (no changes)
+│   │   ├── dag.js                        # Existing (no changes)
+│   │   ├── sse.js                        # Existing (no changes)
+│   │   ├── style.css                     # Extended: new component styles
+│   │   ├── markdown.js                   # NEW: minimal markdown parser
+│   │   ├── highlight.js                  # NEW: syntax highlighter
+│   │   ├── stats.js                      # NEW: statistics page interactions
+│   │   ├── workspace.js                  # NEW: file tree browser
+│   │   └── introspect.js                 # NEW: introspection interactions
+│   └── templates/
+│       ├── layout.html                   # Extended: nav links for new pages
+│       ├── pipeline_detail.html          # NEW: pipeline inspection view
+│       ├── persona_detail.html           # NEW: persona inspection view
+│       ├── statistics.html               # NEW: statistics dashboard
+│       ├── run_detail.html               # Extended: introspection panels
+│       ├── pipelines.html                # Extended: links to detail views
+│       ├── personas.html                 # Extended: links to detail views
+│       └── partials/
+│           ├── markdown_viewer.html      # NEW: markdown with toggle
+│           ├── code_viewer.html          # NEW: syntax highlight with toggle
+│           ├── step_inspector.html       # NEW: step drill-down panel
+│           ├── workspace_tree.html       # NEW: file tree browser
+│           └── stats_chart.html          # NEW: CSS-based charts
+├── state/
+│   ├── store.go                          # Extended: new StateStore methods
+│   ├── types.go                          # Extended: new record types
+│   └── store_test.go                     # Extended: tests for new methods
+└── recovery/
+    └── recovery.go                       # Referenced (no changes)
+```
+
+**Structure Decision**: Extends the existing Go single-project structure. All web assets are within `internal/webui/` using the established patterns (build-tagged Go files, embedded templates and static assets). New state query methods follow the existing `StateStore` interface pattern.
+
+## Complexity Tracking
+
+_No constitution violations found. No complexity justifications needed._
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|-----------|--------------------------------------|
+| (none) | — | — |

--- a/specs/091-dashboard-introspection/research.md
+++ b/specs/091-dashboard-introspection/research.md
@@ -1,0 +1,164 @@
+# Research: Dashboard Inspection, Rendering, Statistics & Run Introspection
+
+**Branch**: `091-dashboard-introspection` | **Date**: 2026-02-14
+
+## Phase 0 — Research Findings
+
+### R-001: Client-Side Markdown Parsing Library
+
+**Decision**: Custom minimal markdown parser (~3 KB gzipped)
+
+**Rationale**: The spec resolves this in C-001 — client-side parser targeting only the subset needed (headings, lists, code blocks, emphasis, links, tables). The existing JS bundle is ~15 KB raw (app.js 4.6 KB + dag.js 1 KB + sse.js 9.2 KB), well under the 50 KB gzipped budget. A custom parser avoids pulling in `marked.js` (~25 KB minified) or `markdown-it` (~45 KB minified) which would consume too much of the budget.
+
+**Alternatives Rejected**:
+- `marked.js` (~25 KB min, ~8 KB gzipped) — exceeds the safe margin given the budget constraint and multiple other new JS modules needed
+- `markdown-it` (~45 KB min) — way over budget
+- Server-side Go rendering via `goldmark` — violates FR-009 (no additional network requests for toggle)
+
+**Implementation Approach**: Write a ~200-line JS parser supporting:
+- `# ## ### ####` headings → `<h1>` through `<h4>`
+- `- *` unordered lists → `<ul><li>`
+- `1.` ordered lists → `<ol><li>`
+- `` ``` `` code blocks → `<pre><code>`
+- `` ` `` inline code → `<code>`
+- `**bold**` `*italic*` emphasis
+- `[text](url)` links
+- `| col | col |` tables → `<table>`
+
+All output is sanitized — no raw HTML passthrough, text content is escaped.
+
+---
+
+### R-002: Client-Side Syntax Highlighting
+
+**Decision**: Custom regex-based tokenizer (~2 KB gzipped) using CSS classes
+
+**Rationale**: Per C-002, a custom tokenizer for the known finite set of languages (Go, YAML, JSON, Markdown, JS, CSS, HTML, SQL, Shell) avoids heavy libraries. The tokenizer assigns CSS classes (`tok-key`, `tok-str`, `tok-num`, `tok-comment`, `tok-bool`, `tok-kw`) and the existing `style.css` handles colors for both themes.
+
+**Alternatives Rejected**:
+- Prism.js (~16 KB min core + language packs) — overkill for 9 languages
+- highlight.js (~50 KB+) — exceeds budget entirely
+- Server-side Go highlighting — violates toggle requirements (needs round-trip)
+
+**Implementation Approach**: A single `highlight(code, language)` function that:
+1. Dispatches to language-specific tokenizers (YAML, JSON, Go, SQL, Shell, JS, CSS, HTML, Markdown)
+2. Each tokenizer is a list of regex → class-name rules applied in order
+3. Returns HTML with `<span class="tok-*">` wrappers
+4. All content is escaped before tokenization to prevent XSS
+
+---
+
+### R-003: Statistics Query Architecture
+
+**Decision**: Server-side SQL aggregation via new `StateStore` methods
+
+**Rationale**: Per C-005, server-side aggregation is the correct approach. SQLite handles `GROUP BY`/`COUNT`/`AVG` efficiently for up to 10K runs. The existing `GetStepPerformanceStats` demonstrates this pattern already. Client-side aggregation would require fetching all `RunRecord` objects which violates NFR-002.
+
+**New StateStore Methods Required**:
+1. `GetRunStatistics(since time.Time) (*RunStatistics, error)` — aggregate run counts by status
+2. `GetRunTrends(since time.Time, groupBy string) ([]RunTrendPoint, error)` — per-day run counts and success rate
+3. `GetPipelineStatistics(since time.Time) ([]PipelineStatistics, error)` — per-pipeline aggregates
+4. `GetPipelineStepStats(pipelineName string, since time.Time) ([]StepPerformanceStats, error)` — per-step stats for a pipeline
+
+**SQL Queries**: All use existing indexed columns (`started_at`, `pipeline_name`, `status`) with `GROUP BY` and `strftime` for date grouping.
+
+---
+
+### R-004: Recovery Hints in Run Introspection
+
+**Decision**: Extract from event message field + re-generate via `recovery.ClassifyError` at display time
+
+**Rationale**: Per C-006, recovery hints are not persisted in `event_log`. The minimum viable approach extracts context from the `message` field of failed events and uses `recovery.BuildRecoveryBlock` to generate hints at display time from the error message, pipeline name, step ID, and run ID. No schema migration needed for MVP.
+
+**Implementation Approach**:
+1. When displaying a failed step, call a display-time function that parses the error message
+2. Use pattern matching to classify the error (contract validation, security, runtime, unknown)
+3. Generate recovery hints using the same logic as `recovery.BuildRecoveryBlock`
+4. Display hints in the step detail view
+
+---
+
+### R-005: Workspace File Browsing Path Resolution
+
+**Decision**: Resolve from `step_state.workspace_path` with convention-based fallback
+
+**Rationale**: Per C-007, the `step_state` table stores `workspace_path`. Despite the cross-run collision caveat, the path is valid for the most recent execution. The Server already has `wsManager` (workspace.WorkspaceManager). Path traversal prevention uses existing `security.PathValidator` patterns.
+
+**New API Endpoints Required**:
+1. `GET /api/runs/{id}/workspace/{step}/tree?path=` — returns directory listing
+2. `GET /api/runs/{id}/workspace/{step}/file?path=` — returns file content with syntax highlighting
+
+**Security Constraints**:
+- Path must be validated against workspace root (no traversal)
+- Read-only access only
+- File size limit (1 MB, consistent with `maxArtifactSize`)
+- Symlink following disabled
+- Content sanitized (HTML escaped) before serving
+
+---
+
+### R-006: Pipeline Detail View Data Sources
+
+**Decision**: Load pipeline YAML via existing `loadPipelineYAML` + manifest personas
+
+**Rationale**: The existing `handlers_pipelines.go` already loads pipeline YAML to build summaries. The pipeline detail view extends this with full step configuration, persona cross-references (via `s.manifest.Personas`), and contract definitions. No new data source needed — all configuration is available from YAML files and the manifest.
+
+**Data Assembly**:
+- Pipeline metadata, steps, dependencies, input config → from YAML
+- Persona details (adapter, model, permissions, prompt) → from `s.manifest.Personas`
+- Contract schemas → from step `Handover.Contract` config, resolved via `SchemaPath` or inline `Schema`
+- Last run status → query `pipeline_run` table for most recent run per pipeline name
+
+---
+
+### R-007: JS Budget Analysis
+
+**Decision**: Total new JS estimated at ~7 KB gzipped, within budget
+
+| Asset | Raw Size | Gzipped (est.) |
+|-------|----------|----------------|
+| Existing app.js | 4,604 B | ~1.8 KB |
+| Existing dag.js | 1,047 B | ~0.5 KB |
+| Existing sse.js | 9,152 B | ~3.2 KB |
+| **Existing total** | **14,803 B** | **~5.5 KB** |
+| New markdown.js | ~5,000 B | ~2.0 KB |
+| New highlight.js | ~4,000 B | ~1.5 KB |
+| New stats.js (charts via CSS/canvas) | ~3,000 B | ~1.2 KB |
+| New workspace.js (tree browser) | ~3,000 B | ~1.2 KB |
+| New introspect.js (toggles, drill-down) | ~2,000 B | ~0.8 KB |
+| **New total** | **~17,000 B** | **~6.7 KB** |
+| **Grand total** | **~31,803 B** | **~12.2 KB** |
+
+This is well within the 50 KB gzipped budget (NFR-001).
+
+---
+
+### R-008: Template Architecture
+
+**Decision**: Extend existing clone-per-page template system with new page templates
+
+**Rationale**: The existing `embed.go` uses a clone-per-page strategy where layout + partials form a shared base. New pages (pipeline detail, persona detail, statistics, run introspection) follow this same pattern. New partials for reusable components (markdown renderer, syntax highlighter, step inspector).
+
+**New Templates**:
+- `templates/pipeline_detail.html` — pipeline inspection view
+- `templates/persona_detail.html` — persona inspection view
+- `templates/statistics.html` — statistics dashboard
+- `templates/partials/markdown_viewer.html` — markdown with raw/rendered toggle
+- `templates/partials/code_viewer.html` — syntax highlighted code with raw/formatted toggle
+- `templates/partials/step_inspector.html` — step introspection with contract/artifact/event detail
+- `templates/partials/workspace_tree.html` — file tree browser
+- `templates/partials/stats_chart.html` — statistics visualizations (CSS-based bar charts)
+
+---
+
+### R-009: Statistics Visualization Without External Libraries
+
+**Decision**: CSS-based bar charts + HTML tables for trend data
+
+**Rationale**: Canvas/SVG charting libraries would blow the JS budget. CSS-based horizontal bar charts using `width: N%` with gradient backgrounds are sufficient for showing run counts, success rates, and per-pipeline breakdowns. Trend data uses a simple table with bar sparklines.
+
+**Implementation**:
+- Aggregate counts → big number cards (total, succeeded, failed, cancelled, success rate %)
+- Per-pipeline breakdown → table with inline CSS bar charts
+- Trend data → table with date column + bar sparkline column using `<div>` bars
+- Time range filter → `<select>` that reloads the page with a `?range=` query param

--- a/specs/091-dashboard-introspection/spec.md
+++ b/specs/091-dashboard-introspection/spec.md
@@ -1,0 +1,303 @@
+# Feature Specification: Dashboard Inspection, Rendering, Statistics & Run Introspection
+
+**Feature Branch**: `091-dashboard-introspection`
+**Created**: 2026-02-13
+**Status**: Draft
+**Input**: [GitHub Issue #91](https://github.com/re-cinq/wave/issues/91) — Enhance dashboard with inspection views, rendering, statistics, and run introspection
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Pipeline, Persona & Contract Inspection (Priority: P1)
+
+As a Wave operator, I want to view detailed configuration for pipelines, personas, and contracts from the dashboard so that I can understand how my system is configured without reading YAML files manually.
+
+**Why this priority**: Configuration inspection is foundational for all other introspection features. Operators need to understand what exists before they can interpret run results, statistics, or logs.
+
+**Independent Test**: Can be fully tested by starting `wave serve`, navigating to the pipelines page, clicking on a specific pipeline, and verifying that step definitions, persona assignments, contract schemas, dependency graph, and input configuration are displayed. Delivers standalone configuration visibility.
+
+**Acceptance Scenarios**:
+
+1. **Given** Wave has pipelines configured in the manifest, **When** a user navigates to the pipeline detail view, **Then** all steps are displayed with their persona, dependencies, workspace configuration, contract definitions, and input schema.
+2. **Given** Wave has personas configured, **When** a user navigates to the persona detail view, **Then** the persona's system prompt, adapter, model, temperature, allowed/denied tools, hooks, and sandbox configuration are displayed.
+3. **Given** a pipeline step has a contract defined, **When** viewing the step in the pipeline detail, **Then** the contract type (JSON schema, TypeScript, test suite, markdown spec, template, format), schema content, and validation rules are displayed.
+4. **Given** a pipeline step references a persona, **When** viewing the pipeline detail, **Then** the persona name is a link to the persona detail view for cross-reference navigation.
+5. **Given** a contract references an external schema file, **When** viewing the contract detail, **Then** the schema file content is displayed inline with syntax highlighting.
+
+---
+
+### User Story 2 - Run Statistics Dashboard (Priority: P1)
+
+As a Wave operator, I want to view aggregate statistics about pipeline runs — total, succeeded, failed — along with trends over time, so that I can assess system health and identify recurring issues.
+
+**Why this priority**: Statistics provide operational insight that raw run lists cannot. Understanding failure rates and trends is essential for a production operations tool. This delivers unique value beyond what the existing run list provides.
+
+**Independent Test**: Can be fully tested by navigating to a statistics page and verifying that aggregate counts (total, succeeded, failed, cancelled) and per-pipeline breakdowns are displayed based on historical run data in the state database.
+
+**Acceptance Scenarios**:
+
+1. **Given** the state database contains completed pipeline runs, **When** a user navigates to the statistics page, **Then** aggregate counts are displayed: total runs, successful runs, failed runs, cancelled runs, and overall success rate as a percentage.
+2. **Given** pipeline runs span multiple days, **When** viewing the statistics page, **Then** a trend view shows run counts and success rate grouped by day for the selected time period.
+3. **Given** multiple pipelines have been executed, **When** viewing the statistics page, **Then** a per-pipeline breakdown shows run count, success rate, average duration, and average token consumption for each pipeline.
+4. **Given** the statistics page is open, **When** a user selects a time range filter (last 24 hours, last 7 days, last 30 days, all time), **Then** all statistics update to reflect only runs within that time range.
+5. **Given** per-step performance data exists, **When** viewing pipeline-specific statistics, **Then** per-step statistics show average duration, token usage, and success rate for each step in the pipeline.
+
+---
+
+### User Story 3 - Run Introspection (Priority: P1)
+
+As a Wave operator, I want to deeply inspect a specific pipeline run — including every step's contracts, persona configuration, artifacts, event timeline, and error details — so that I can debug failures and understand execution behavior.
+
+**Why this priority**: Run introspection is the core debugging tool. The existing run detail view shows basic status; this enhancement provides the depth needed to diagnose failures, understand token consumption, and trace execution flow.
+
+**Independent Test**: Can be fully tested by opening a completed (or failed) pipeline run, drilling into a specific step, and verifying that the full event timeline, contract validation results, persona assignment, artifacts, error messages, recovery hints, and performance metrics are displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline run has completed, **When** a user views the run detail page, **Then** a step-by-step timeline shows each step's start time, end time, duration, persona, status, token usage, and any error or recovery hints.
+2. **Given** a step has contract validation results, **When** viewing the step detail, **Then** the contract type, schema, validation outcome (pass/fail), and any validation error messages are displayed.
+3. **Given** a step has produced artifacts, **When** viewing the step detail, **Then** artifacts are listed with name, type, size, and a preview of text-based content.
+4. **Given** a step has failed, **When** viewing the step detail, **Then** the failure reason (timeout, context exhaustion, general error), error message, and any recovery hints are prominently displayed.
+5. **Given** a run has multiple steps, **When** viewing the run detail page, **Then** the user can drill down from the run overview to individual step details and back without losing context.
+6. **Given** event log entries exist for a run, **When** viewing the run detail, **Then** a chronological event timeline shows all events with timestamps, state transitions, messages, and token deltas.
+
+---
+
+### User Story 4 - Markdown Rendering (Priority: P2)
+
+As a Wave operator, I want markdown content (system prompts, artifact content, documentation) rendered with proper formatting in the dashboard, with a toggle to switch between rendered and raw views, so that I can read content naturally while retaining access to the source.
+
+**Why this priority**: Markdown rendering improves readability for system prompts, artifact content, and documentation. It's valuable but not essential for core operational tasks.
+
+**Independent Test**: Can be tested by navigating to a persona detail view and verifying that the system prompt file renders with proper markdown formatting, and that a toggle switches between rendered and raw views.
+
+**Acceptance Scenarios**:
+
+1. **Given** a persona has a system prompt file containing markdown, **When** viewing the persona detail, **Then** the system prompt is rendered with proper heading, list, code block, and emphasis formatting.
+2. **Given** markdown content is displayed, **When** a user clicks the "Raw" toggle, **Then** the raw markdown source is shown in a monospace font. Clicking "Rendered" restores the formatted view.
+3. **Given** an artifact file has a `.md` extension, **When** viewing the artifact in the artifact browser, **Then** the content is rendered as formatted markdown by default.
+
+---
+
+### User Story 5 - YAML & Schema Rendering (Priority: P2)
+
+As a Wave operator, I want YAML files (manifests, pipeline definitions) and JSON schemas (contracts) rendered with syntax highlighting in the dashboard, with a toggle between formatted and raw views, so that I can quickly read configuration without a text editor.
+
+**Why this priority**: Syntax-highlighted YAML and JSON improves comprehension of configuration. Combined with inspection views, this makes the dashboard a self-contained configuration browser.
+
+**Independent Test**: Can be tested by navigating to a pipeline detail view and verifying that the pipeline YAML is displayed with syntax highlighting, and that JSON schema contract definitions are similarly highlighted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline configuration is displayed, **When** viewing the pipeline detail, **Then** YAML content is rendered with syntax highlighting distinguishing keys, values, strings, and comments.
+2. **Given** a contract has a JSON schema definition, **When** viewing the contract detail, **Then** the JSON schema is rendered with syntax highlighting.
+3. **Given** highlighted content is displayed, **When** a user clicks the "Raw" toggle, **Then** the content is shown as plain text without highlighting. Clicking "Formatted" restores the highlighted view.
+4. **Given** a YAML file contains deeply nested structures, **When** viewing the file, **Then** indentation levels are visually distinct and the structure is readable.
+
+---
+
+### User Story 6 - Meta Information Display (Priority: P2)
+
+As a Wave operator, I want to see metadata for all entities — pipelines, personas, contracts — including descriptive information, relationships, and usage context, so that I can understand the full picture of my Wave configuration.
+
+**Why this priority**: Metadata display provides contextual information that helps operators make informed decisions. It builds on the inspection views from P1 to add a richer understanding of the system.
+
+**Independent Test**: Can be tested by navigating to pipeline, persona, and contract views and verifying that descriptive metadata (description, relationships, operational status) is displayed alongside the configuration details.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline has metadata (name, description), **When** viewing the pipeline detail, **Then** the metadata is displayed prominently at the top of the page.
+2. **Given** a persona has a description, **When** viewing the persona list, **Then** each persona shows its name, description, adapter, and model.
+3. **Given** a pipeline step uses a persona, **When** viewing the pipeline detail, **Then** the relationship between step and persona is clearly indicated with navigation links.
+4. **Given** a pipeline has been executed at least once, **When** viewing the pipeline detail, **Then** the most recent run status and time are displayed as part of the pipeline metadata.
+5. **Given** a pipeline defines input configuration with examples, **When** viewing the pipeline detail, **Then** the input examples are displayed to help operators understand expected input format.
+
+**Note on metadata fields**: The GitHub issue requests "last changed, created date, version, author" metadata. The current manifest and pipeline data models (`Manifest`, `Pipeline`, `Persona` types) do not store these fields — these are out of scope (see C-004). This spec addresses the metadata that IS available: name, description, adapter, model, relationships, and operational status derived from run history.
+
+---
+
+### User Story 7 - Workspace & Source Browsing (Priority: P3)
+
+As a Wave operator, I want to browse the workspace files and source code associated with a pipeline run from the dashboard, with syntax highlighting for code files, so that I can inspect execution context without navigating the filesystem.
+
+**Why this priority**: Source browsing is a convenience feature for deep debugging. Operators can always use the filesystem directly, but having it in the dashboard eliminates context switching.
+
+**Independent Test**: Can be tested by opening a completed pipeline run, selecting the workspace browsing tab, and verifying that the directory tree and file contents are displayed with syntax highlighting for recognized file types.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline run has a workspace that still exists on disk, **When** viewing the run detail page, **Then** a "Workspace" tab shows a file tree of the workspace directory.
+2. **Given** the workspace file tree is displayed, **When** a user clicks on a file, **Then** the file contents are displayed with syntax highlighting appropriate to the file type (Go, YAML, JSON, Markdown, etc.).
+3. **Given** a workspace has been cleaned up, **When** viewing the run detail page, **Then** the workspace tab displays a message indicating the workspace is no longer available.
+4. **Given** the workspace browser is open, **When** viewing any file, **Then** the view is strictly read-only with no editing capability.
+5. **Given** a file in the workspace is very large (>1 MB), **When** viewing the file, **Then** the content is truncated with a clear indicator and a download link for the full file.
+
+---
+
+### Edge Cases
+
+- What happens when a pipeline definition has changed since a run was executed? The run detail MUST show the configuration as it was at execution time (from stored event data), not the current definition. If historical configuration is unavailable, a notice MUST indicate that the displayed configuration is current and may differ from what was used during execution.
+- What happens when the statistics page is loaded with zero pipeline runs? The statistics page MUST display zero counts and an empty state message rather than errors or broken visualizations.
+- What happens when a persona's system prompt file no longer exists on disk? The persona detail MUST display a notice that the file is unavailable rather than returning an error.
+- What happens when syntax highlighting is requested for an unrecognized file type? The file MUST be displayed as plain text without errors.
+- What happens when artifact content contains HTML or script tags? All content MUST be escaped/sanitized before rendering to prevent XSS, consistent with SR-005 from spec 085.
+- What happens when a workspace directory contains thousands of files? The file tree browser MUST use lazy loading (expand-on-click) rather than loading the full tree at once, and MUST limit directory listings to a reasonable maximum (e.g., 500 entries per directory).
+- What happens when a contract schema references external files that no longer exist? The contract display MUST show a notice that referenced files are unavailable, alongside any content that is available.
+- What happens when the database contains performance metrics for pipelines that have been removed from the manifest? Statistics MUST still display historical data with a note that the pipeline is no longer configured.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Inspection Views
+
+- **FR-001**: System MUST provide a pipeline detail view showing all steps with their persona assignments, dependencies, workspace configuration, contract definitions, and input schema.
+- **FR-002**: System MUST provide a persona detail view showing the persona's system prompt content, adapter, model, temperature, allowed/denied tools, hooks configuration, and sandbox settings.
+- **FR-003**: System MUST provide contract detail display within pipeline and run views, showing contract type, schema content, and validation rules.
+- **FR-004**: System MUST support navigation between related entities — clicking a persona name in a pipeline view MUST navigate to the persona detail, and vice versa.
+
+#### Rendering
+
+- **FR-005**: System MUST render markdown content with proper formatting including headings, lists, code blocks, emphasis, links, and tables.
+- **FR-006**: System MUST provide a toggle between rendered and raw views for markdown content. Default view MUST be rendered.
+- **FR-007**: System MUST render YAML and JSON content with syntax highlighting that visually distinguishes keys, values, strings, numbers, booleans, and comments.
+- **FR-008**: System MUST provide a toggle between syntax-highlighted and plain text views for YAML and JSON content.
+- **FR-009**: Markdown rendering MUST use a lightweight client-side JavaScript parser (~5-8 KB gzipped) to support the raw/rendered toggle without additional network requests. The parser MUST support the subset needed for system prompts and artifacts: headings, lists, code blocks, emphasis, links, and tables. The rendering approach MUST fit within the existing 50 KB gzipped JS budget (NFR-001 from spec 085). See C-001 for rationale.
+
+#### Statistics
+
+- **FR-010**: System MUST display aggregate run statistics: total runs, successful runs, failed runs, cancelled runs, and overall success rate.
+- **FR-011**: System MUST display run trend data grouped by day for a configurable time range (last 24 hours, 7 days, 30 days, all time).
+- **FR-012**: System MUST display per-pipeline statistics including run count, success rate, average duration, and average token consumption.
+- **FR-013**: System MUST display per-step performance statistics including average duration, average token usage, and success rate, using data from the existing `performance_metric` table.
+- **FR-014**: System MUST support time range filtering for all statistics views.
+
+#### Run Introspection
+
+- **FR-015**: System MUST display a chronological event timeline for each run showing all events with timestamps, state transitions, step assignments, messages, and token deltas.
+- **FR-016**: System MUST display step-level introspection including contract validation results (pass/fail with error details), persona configuration, performance metrics, and recovery hints.
+- **FR-017**: System MUST display failure details prominently: failure reason classification (timeout, context exhaustion, general error), error message, and recovery hints/remediation suggestions.
+- **FR-018**: System MUST display artifacts produced by each step, including artifact name, type, file size, and a text preview for text-based artifacts (consistent with the existing artifact browsing from spec 085).
+- **FR-019**: System MUST support drill-down navigation from run overview to step detail and back.
+
+#### Meta Information
+
+- **FR-020**: System MUST display pipeline metadata (name, description) in the pipeline detail and list views.
+- **FR-021**: System MUST display persona metadata (name, description, adapter, model) in the persona detail and list views.
+- **FR-022**: System MUST display the most recent run status and timestamp in the pipeline detail view, providing at-a-glance operational status.
+- **FR-023**: System MUST display pipeline input configuration details, including input examples when defined, in the pipeline detail view.
+
+#### Workspace Browsing
+
+- **FR-024**: System MUST provide a workspace file tree browser in the run detail view, showing the directory structure of the step workspace.
+- **FR-025**: System MUST display file contents with syntax highlighting for recognized file types (Go, YAML, JSON, Markdown, JavaScript, CSS, HTML, SQL, Shell script).
+- **FR-026**: System MUST use lazy-loading for directory tree expansion (load subdirectory contents on click, not upfront).
+- **FR-027**: All workspace browsing MUST be strictly read-only. No file modification operations are exposed.
+- **FR-028**: System MUST gracefully handle missing workspaces (cleaned up after run), displaying a clear unavailability message.
+
+#### Cross-Cutting
+
+- **FR-029**: All new views MUST be gated by the existing `webui` build tag. Building without the tag MUST NOT include any new code or assets.
+- **FR-030**: All new frontend assets MUST be embedded via `go:embed`, maintaining the zero-external-dependency deployment model.
+- **FR-031**: All content displayed from user-generated sources (artifacts, prompts, YAML files) MUST be sanitized to prevent XSS attacks.
+- **FR-032**: New API endpoints MUST follow the existing authentication pattern — requiring bearer token for non-localhost bindings.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Total JavaScript bundle size (including new rendering libraries) MUST remain under 50 KB gzipped, per the constraint from spec 085.
+- **NFR-002**: Statistics queries MUST return within 500ms for databases containing up to 10,000 pipeline runs.
+- **NFR-003**: Workspace file tree listing MUST return within 200ms for directories containing up to 500 entries.
+- **NFR-004**: All new views MUST be responsive and usable on desktop and tablet screen sizes, consistent with spec 085 NFR-003.
+- **NFR-005**: Syntax highlighting MUST NOT require external network requests or CDN resources.
+
+### Key Entities
+
+- **Pipeline Configuration**: A pipeline definition loaded from YAML including steps, dependencies, input schema, and contract references. Displayed in the inspection view.
+- **Persona Configuration**: A persona definition from the manifest including system prompt, permissions, adapter settings, and hooks. Displayed in the persona detail view.
+- **Contract Definition**: A validation contract attached to a pipeline step, specifying output schema and validation rules. Displayed in both pipeline inspection and run introspection.
+- **Run Statistics**: Aggregate metrics computed from `pipeline_run` and `performance_metric` tables — counts, rates, averages, and trends over time.
+- **Step Performance**: Per-step historical metrics from the `performance_metric` table including duration, tokens, files modified, and success rate.
+- **Event Timeline**: Ordered list of `event_log` records for a specific run, providing a chronological narrative of execution.
+- **Workspace Tree**: A directory/file hierarchy of a pipeline step's execution workspace, available for browsing when the workspace still exists on disk.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users can navigate from the pipeline list to a pipeline detail view and see all step configurations, persona assignments, and contract definitions within 2 clicks.
+- **SC-002**: Statistics page displays aggregate counts (total, succeeded, failed, cancelled) and per-pipeline breakdowns that match the actual data in the state database with 100% accuracy.
+- **SC-003**: Run introspection provides full event timeline, step-level contract validation results, failure reasons, and recovery hints for any completed or failed pipeline run.
+- **SC-004**: Markdown content (system prompts, artifacts) renders with correct formatting and the raw/rendered toggle works in both directions without page reload.
+- **SC-005**: YAML and JSON content displays with syntax highlighting and the formatted/raw toggle works without page reload.
+- **SC-006**: Workspace file tree browser loads directory listings in under 200ms and displays file contents with syntax highlighting for supported file types.
+- **SC-007**: All new views work within the existing 50 KB gzipped JavaScript budget — total bundle size verified at build time.
+- **SC-008**: All new features are gated behind the `webui` build tag — building without the tag produces no increase in binary size.
+- **SC-009**: No new external runtime dependencies are introduced — all assets remain embedded in the binary.
+- **SC-010**: All displayed content is XSS-safe — no user-generated content is rendered as executable HTML or JavaScript.
+
+## Clarifications
+
+### C-001: Markdown rendering approach (FR-009) — RESOLVED
+
+**Ambiguity**: FR-009 requires markdown rendering with a raw/rendered toggle. Two approaches are possible: client-side JavaScript parser or server-side Go template rendering. The 50 KB gzipped JS budget from spec 085 constrains the choice.
+
+**Resolution**: Use a lightweight client-side markdown parser (~5-8 KB gzipped). The parser targets only the markdown subset needed for system prompts and artifacts: headings, lists, code blocks, emphasis, links, and tables. A minimal `marked.js` variant or purpose-built parser is appropriate.
+
+**Rationale**: Client-side rendering allows the raw/rendered toggle to work without additional network requests, matching the toggle behavior specified in FR-006. The existing JS assets (`app.js`, `sse.js`, `dag.js`) are well under 50 KB combined, leaving ample budget for a markdown parser. Server-side rendering was rejected because it would require a round-trip per toggle action, violating the "no additional network requests" requirement in FR-009.
+
+### C-002: Syntax highlighting approach (FR-007, FR-023)
+
+**Ambiguity**: Syntax highlighting is required for YAML, JSON, and source code, but no library is specified.
+
+**Resolution**: Recommend a lightweight client-side syntax highlighter using CSS classes and regex-based tokenization. This avoids heavy libraries like Prism.js or highlight.js. A custom tokenizer for the supported languages (Go, YAML, JSON, Markdown, JS, CSS, HTML, SQL, Shell) can be implemented in under 5 KB gzipped.
+
+**Rationale**: The supported language set is known and finite. A custom solution keeps the JS budget well within limits and avoids pulling in a general-purpose library that supports hundreds of languages. Server-side highlighting via Go templates is an alternative but reduces toggle interactivity.
+
+### C-003: Historical vs current configuration in run introspection (Edge Case)
+
+**Ambiguity**: The edge case asks whether run detail shows configuration "as it was" or "as it is now."
+
+**Resolution**: The run detail view shows current configuration annotated with a notice when historical configuration is not available. The existing `event_log` table stores persona and step data per event, which provides partial historical context. Full pipeline/persona YAML snapshots are not stored.
+
+**Rationale**: Storing full configuration snapshots per run would require schema changes and significant storage overhead. The current event log captures persona name, step ID, and key metadata per event, which provides sufficient historical context for debugging. A future enhancement could add configuration snapshotting if needed.
+
+### C-004: Entity metadata fields — last changed, created date, version, author (FR-020 through FR-023) — RESOLVED
+
+**Ambiguity**: The GitHub issue requests "last changed, created date, version, author" metadata for pipelines, personas, and contracts, plus "usage examples where applicable."
+
+**Resolution**: The fields `last changed`, `created date`, `version`, and `author` are explicitly **out of scope** for this feature. The current manifest and pipeline data models (`Manifest`, `Persona`, `Pipeline`, `ContractConfig` types in `internal/manifest/types.go` and `internal/pipeline/types.go`) do not store these fields. This spec addresses metadata that IS available: name, description, adapter, model, permissions, relationships between entities, and operational status derived from run history (most recent run time, status). Input examples are addressed via `InputConfig.Example` when defined in pipeline YAML. Adding these metadata fields requires a separate schema change tracked as a follow-up issue.
+
+**Rationale**: Adding metadata fields that don't exist in the data model would require changes to the manifest schema (`internal/manifest/types.go`), pipeline schema (`internal/pipeline/types.go`), YAML parsing logic, and all existing pipeline/manifest YAML files. This is a separate concern from the dashboard UI feature and should be addressed independently if desired. The dashboard can only display data that exists.
+
+### C-005: Statistics query architecture (FR-010 through FR-014)
+
+**Ambiguity**: The spec requires aggregate statistics (total runs, success rate, per-day trends, per-pipeline breakdowns) but the current `StateStore` interface (`internal/state/store.go`) has no aggregate query methods. It provides `ListRuns` (individual records) and `GetStepPerformanceStats` (per-step only), but no pipeline-level aggregate queries. The spec doesn't specify whether aggregation happens server-side via new SQL queries or client-side from raw run data.
+
+**Resolution**: Server-side aggregation via new `StateStore` methods. The implementation MUST add new query methods to the `StateStore` interface for:
+- Aggregate run counts by status (total, succeeded, failed, cancelled) with time range filtering
+- Per-day run count and success rate grouping for trend data
+- Per-pipeline aggregate statistics (run count, success rate, average duration, average tokens)
+
+These queries will use SQL `GROUP BY`, `COUNT`, `SUM`, and `AVG` aggregations directly in SQLite, which is efficient for datasets up to 10,000 runs (per NFR-002).
+
+**Rationale**: Server-side SQL aggregation is the correct approach because: (1) SQLite efficiently handles aggregate queries, (2) transferring thousands of raw `RunRecord` objects to the client for aggregation would violate NFR-002's 500ms response time requirement for large datasets, (3) the existing `GetStepPerformanceStats` method already demonstrates the pattern of SQL-level aggregation in the codebase, and (4) the `ListRuns` method's time-range filtering pattern can be extended for aggregate queries.
+
+### C-006: Recovery hints availability in run introspection (FR-017)
+
+**Ambiguity**: FR-017 requires displaying recovery hints for failed steps. The `Event` struct in `internal/event/emitter.go` includes `RecoveryHints []RecoveryHintJSON`, but the `event_log` table schema and `LogRecord` type in `internal/state/types.go` do not store recovery hints. The `LogEvent` method only persists `message`, `state`, `persona`, `tokens_used`, and `duration_ms`. Recovery hints emitted during execution are not currently persisted to the database.
+
+**Resolution**: Recovery hints will be sourced from the `message` field of failed events in the `event_log` table, where the pipeline executor already encodes failure context (including hint text) into the message string. For richer recovery hint display, the implementation MAY add a `recovery_hints_json` column to the `event_log` table via a database migration, but this is an optional enhancement — not a blocking requirement. The minimum viable implementation extracts hints from the existing `message` field and from the `recovery` package's `ClassifyAndFormat` function applied to error messages at display time.
+
+**Rationale**: The `buildStepDetails` method in `internal/webui/handlers_runs.go` already captures `ev.Message` for failed steps as `si.errMsg`. The recovery package (`internal/recovery/`) provides `ClassifyAndFormat` to regenerate hints from error text. Adding a dedicated column would provide higher fidelity but requires a schema migration, which is better tracked as a follow-up enhancement rather than a blocking dependency for the dashboard UI.
+
+### C-007: Workspace path resolution for file browsing (FR-024)
+
+**Ambiguity**: FR-024 requires a workspace file tree browser in the run detail view, but the spec doesn't specify how workspace paths are resolved. The `StepStateRecord` type has a `WorkspacePath` field, but the current `buildStepDetails` method in `internal/webui/handlers_runs.go` derives step state from the `event_log` table (not `step_state`), and the `StepDetail` API response type does not include a workspace path field. Additionally, the `step_state` table has a unique constraint on `step_id` alone (not per-run), causing cross-run collisions as noted in the codebase comments.
+
+**Resolution**: Workspace paths for file browsing will be resolved through a combination of:
+1. Adding a `WorkspacePath` field to the `StepDetail` response type in `internal/webui/types.go`
+2. Querying workspace paths from the `step_state` table (which does store `workspace_path`) as a supplementary data source alongside event-derived state
+3. Falling back to convention-based path construction (`{workspace_root}/{run_id}/{step_id}`) when `step_state` data is unavailable
+
+The workspace browser API endpoint will accept a `run_id` and `step_id`, resolve the workspace path, validate it exists on disk, and serve directory listings and file contents. Path traversal prevention MUST be enforced per the existing security model in `internal/security/`.
+
+**Rationale**: The `step_state` table's `workspace_path` column is populated by the pipeline executor when a step starts. Despite the cross-run collision issue noted in the `buildStepDetails` comments, the `workspace_path` for the most recent run is still valid for browsing. The `Server` already has access to a `workspace.WorkspaceManager` (initialized in `server.go:73`), providing an existing integration point for workspace operations.

--- a/specs/091-dashboard-introspection/tasks.md
+++ b/specs/091-dashboard-introspection/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Dashboard Inspection, Rendering, Statistics & Run Introspection
+
+**Branch**: `091-dashboard-introspection` | **Generated**: 2026-02-14
+**Source**: spec.md, plan.md, data-model.md, research.md, contracts/
+
+---
+
+## Phase 1: Setup & Shared Infrastructure
+
+These tasks establish the foundational types, interfaces, and shared components that all subsequent phases depend on.
+
+- [X] T001 [P1] Add new API response types to `internal/webui/types.go` — PipelineDetailResponse, PipelineInputDetail, InputSchemaDetail, PipelineStepDetail, WorkspaceDetail, MountDetail, ContractDetail, ArtifactDefDetail, MemoryDetail, InjectedArtifact, PersonaDetailResponse, HooksDetail, HookRuleDetail, SandboxDetail per data-model.md
+- [X] T002 [P1] Add statistics response types to `internal/webui/types.go` — RunStatistics, RunTrendPoint, PipelineStatistics, StatisticsResponse per data-model.md and contracts/api-statistics.json
+- [X] T003 [P1] Add enhanced run detail types to `internal/webui/types.go` — EnhancedStepDetail (embedding StepDetail), ContractResultDetail, RecoveryHintDetail, StepPerfDetail per data-model.md and contracts/api-enhanced-run-detail.json
+- [X] T004 [P1] Add workspace browsing types to `internal/webui/types.go` — WorkspaceTreeResponse, WorkspaceEntry, WorkspaceFileResponse per data-model.md and contracts/api-workspace.json
+- [X] T005 [P1] Add new state record types to `internal/state/types.go` — RunStatisticsRecord, RunTrendRecord, PipelineStatisticsRecord per data-model.md
+
+---
+
+## Phase 2: Foundational — State Store & Shared Backend
+
+These tasks add the backend query methods and shared utilities that handlers will depend on. Must complete before handler phases.
+
+- [X] T006 [P1] Add `GetRunStatistics(since time.Time) (*RunStatisticsRecord, error)` to StateStore interface in `internal/state/store.go` — SQL aggregation query using `GROUP BY` on pipeline_run.status with time range filter on started_at. Returns total, succeeded, failed, cancelled, pending, running counts.
+- [X] T007 [P1] Add `GetRunTrends(since time.Time) ([]RunTrendRecord, error)` to StateStore interface in `internal/state/store.go` — SQL query grouping pipeline_run by `strftime('%Y-%m-%d', started_at, 'unixepoch')` with status counts per day.
+- [X] T008 [P1] Add `GetPipelineStatistics(since time.Time) ([]PipelineStatisticsRecord, error)` to StateStore interface in `internal/state/store.go` — SQL aggregation query grouping pipeline_run by pipeline_name with run count, success rate, avg duration, avg tokens.
+- [X] T009 [P1] Add `GetPipelineStepStats(pipelineName string, since time.Time) ([]StepPerformanceStats, error)` to StateStore interface in `internal/state/store.go` — SQL aggregation on performance_metric table grouped by step_id for a given pipeline name. Reuse existing StepPerformanceStats type.
+- [X] T010 [P1] Add `GetLastRunForPipeline(pipelineName string) (*RunRecord, error)` to StateStore interface in `internal/state/store.go` — Query pipeline_run for most recent run by pipeline_name ordered by started_at DESC LIMIT 1.
+- [X] T011 [P1] Implement all 5 new StateStore methods (T006-T010) in `internal/state/store.go` on the `stateStore` struct.
+- [X] T012 [P1] Implement read-only stubs for new StateStore methods in `internal/state/readonly.go` to satisfy the StateStore interface for the read-only wrapper.
+- [X] T013 [P1] Write unit tests for new StateStore methods in `internal/state/store_test.go` — test GetRunStatistics, GetRunTrends, GetPipelineStatistics, GetPipelineStepStats, GetLastRunForPipeline with seeded test data including edge cases (zero runs, mixed statuses, time range filtering).
+
+---
+
+## Phase 3: US1 — Pipeline, Persona & Contract Inspection (P1)
+
+Delivers FR-001 through FR-004: pipeline detail view, persona detail view, contract display, cross-entity navigation.
+
+- [X] T014 [P1] [US1] Create pipeline detail HTML handler `handlePipelineDetailPage` in `internal/webui/handlers_pipelines.go` — loads pipeline YAML via `loadPipelineYAML`, assembles PipelineDetailResponse with all step configs, persona cross-refs from `s.manifest.Personas`, contract definitions (inline schema or resolved schema_path), input config, and DAG layout. Template: `templates/pipeline_detail.html`.
+- [X] T015 [P1] [US1] Create pipeline detail API handler `handleAPIPipelineDetail` in `internal/webui/handlers_pipelines.go` — JSON endpoint returning PipelineDetailResponse matching contracts/api-pipeline-detail.json. Include last_run via GetLastRunForPipeline.
+- [X] T016 [P1] [US1] Create `templates/pipeline_detail.html` — pipeline inspection view showing: metadata (name, description) header, step list with persona, dependencies, workspace config, contract definitions, input schema with examples, DAG visualization reusing existing `partials/dag_svg.html`. Persona names link to `/personas/{name}`.
+- [X] T017 [P1] [US1] Create persona detail HTML handler `handlePersonaDetailPage` in `internal/webui/handlers_personas.go` — reads persona from `s.manifest.Personas[name]`, reads system prompt file content (with graceful missing-file handling per edge case), computes `used_in_pipelines` by scanning all pipeline YAMLs. Template: `templates/persona_detail.html`.
+- [X] T018 [P1] [US1] Create persona detail API handler `handleAPIPersonaDetail` in `internal/webui/handlers_personas.go` — JSON endpoint returning PersonaDetailResponse matching contracts/api-persona-detail.json. System prompt content HTML-escaped per FR-031.
+- [X] T019 [P1] [US1] Create `templates/persona_detail.html` — persona inspection view showing: name, description, adapter, model, temperature, system prompt content (in a scrollable pre block), allowed/denied tools lists, hooks configuration, sandbox config, and "used in pipelines" list with links to `/pipelines/{name}`.
+- [X] T020 [P] [US1] Register new routes in `internal/webui/routes.go` — add `GET /pipelines/{name}`, `GET /api/pipelines/{name}`, `GET /personas/{name}`, `GET /api/personas/{name}`.
+- [X] T021 [P] [US1] Register new page templates in `internal/webui/embed.go` — add `templates/pipeline_detail.html` and `templates/persona_detail.html` to `pageTemplates` slice.
+- [X] T022 [P1] [US1] Update `templates/pipelines.html` — each pipeline name becomes a link to `/pipelines/{name}` detail view. Show description alongside name.
+- [X] T023 [P1] [US1] Update `templates/personas.html` — each persona name becomes a link to `/personas/{name}` detail view.
+- [X] T024 [P1] [US1] Update `templates/layout.html` — add nav links for Statistics page (`/statistics`). Ensure existing nav links for Pipelines, Personas remain.
+- [X] T025 [P1] [US1] Write unit tests for pipeline detail and persona detail handlers in `internal/webui/handlers_test.go` — test API JSON response shape matches contract schemas, test missing pipeline 404, test persona with missing prompt file graceful degradation.
+
+---
+
+## Phase 4: US2 — Run Statistics Dashboard (P1)
+
+Delivers FR-010 through FR-014: aggregate stats, trends, per-pipeline breakdown, per-step stats, time range filtering.
+
+- [X] T026 [P1] [US2] Create `internal/webui/handlers_statistics.go` — implement `handleStatisticsPage` (HTML) and `handleAPIStatistics` (JSON). Parse `?range=` query param (24h, 7d, 30d, all — default 7d). Compute `since` time.Time from range. Call GetRunStatistics, GetRunTrends, GetPipelineStatistics. Assemble StatisticsResponse. Calculate success_rate as percentage.
+- [X] T027 [P1] [US2] Create `templates/statistics.html` — statistics dashboard with: aggregate count cards (total, succeeded, failed, cancelled, success rate %), time range selector dropdown, per-pipeline breakdown table with inline CSS bar charts, daily trend table with bar sparklines. CSS-only visualizations per R-009.
+- [X] T028 [P1] [US2] Create `internal/webui/static/stats.js` — time range filter interaction: on `<select>` change, reload page with `?range=` query param. No fetch needed — full page reload for simplicity.
+- [X] T029 [P1] [US2] Create `templates/partials/stats_chart.html` — reusable partial for CSS-based horizontal bar charts. Accept data via template parameters (value, max, label, color class).
+- [X] T030 [P] [US2] Register statistics routes in `internal/webui/routes.go` — add `GET /statistics`, `GET /api/statistics`.
+- [X] T031 [P] [US2] Register statistics template in `internal/webui/embed.go` — add `templates/statistics.html` to `pageTemplates` slice.
+- [X] T032 [P1] [US2] Add statistics page empty state handling — when GetRunStatistics returns zero total, display "No pipeline runs recorded yet" message instead of empty charts per edge case.
+- [X] T033 [P1] [US2] Write unit tests for statistics handlers in `internal/webui/handlers_test.go` — test API response shape matches contracts/api-statistics.json, test time range parsing, test empty state, test success rate calculation.
+
+---
+
+## Phase 5: US3 — Run Introspection (P1)
+
+Delivers FR-015 through FR-019: event timeline, step drill-down, contract validation results, failure details, recovery hints, artifact display.
+
+- [X] T034 [P1] [US3] Enhance `handleAPIRunDetail` in `internal/webui/handlers_runs.go` — extend the existing handler to populate EnhancedStepDetail fields: contract_result (from pipeline YAML contract config + event error messages), recovery_hints (via recovery.ClassifyError on failed step error messages), performance (from GetPerformanceMetrics), workspace_path (from step_state table), workspace_exists (os.Stat check on workspace path).
+- [X] T035 [P1] [US3] Create recovery hint generation helper in `internal/webui/handlers_runs.go` — function `buildRecoveryHints(runID, stepID, pipelineName, errMsg string) []RecoveryHintDetail` that uses the recovery package's error classification to generate hints at display time per R-004.
+- [X] T036 [P1] [US3] Enhance `handleRunDetailPage` in `internal/webui/handlers_runs.go` — pass enhanced step details (with contract results, recovery hints, performance data) and full event list to the template.
+- [X] T037 [P1] [US3] Update `templates/run_detail.html` — add event timeline section (chronological events with timestamps, state badges, persona, message, token deltas), step drill-down panels (click step to expand contract results, artifacts, performance, recovery hints), failure prominence (error banner for failed steps with recovery hints).
+- [X] T038 [P1] [US3] Create `templates/partials/step_inspector.html` — reusable partial for step drill-down panel showing: contract validation result (pass/fail badge, schema, error), artifacts list (name, type, size, preview link), performance metrics (duration, tokens, files modified), recovery hints (for failed steps), workspace browsing link.
+- [X] T039 [P1] [US3] Create `internal/webui/static/introspect.js` — step drill-down toggle (click step row to expand/collapse inspector panel), event timeline scroll-to-step (click step in timeline highlights step inspector).
+- [X] T040 [P1] [US3] Write unit tests for enhanced run detail handler in `internal/webui/handlers_test.go` — test that enhanced fields are populated for completed/failed runs, test recovery hint generation from error messages, test workspace_exists detection.
+
+---
+
+## Phase 6: US4 — Markdown Rendering (P2)
+
+Delivers FR-005, FR-006, FR-009: markdown rendering with raw/rendered toggle.
+
+- [X] T041 [P] [US4] Create `internal/webui/static/markdown.js` — minimal client-side markdown parser (~200 lines, ~5 KB). Support: headings (h1-h4), unordered/ordered lists, fenced code blocks, inline code, bold/italic emphasis, links, tables. All output text-escaped (no raw HTML passthrough) per FR-031. Export `renderMarkdown(text)` function.
+- [X] T042 [P] [US4] Create `templates/partials/markdown_viewer.html` — partial template with raw/rendered toggle. Structure: `<div class="md-viewer">` with `<div class="md-rendered">` and `<div class="md-raw"><pre>` plus toggle buttons. JS init calls `renderMarkdown()` on page load for rendered view.
+- [X] T043 [P2] [US4] Integrate markdown viewer into `templates/persona_detail.html` — replace the plain `<pre>` system prompt display with the markdown_viewer partial, enabling raw/rendered toggle for system prompt content.
+- [X] T044 [P2] [US4] Integrate markdown viewer into step inspector for `.md` artifact previews — in `templates/partials/step_inspector.html`, detect `.md` artifact type and render preview using markdown_viewer partial.
+- [X] T045 [P2] [US4] Add CSS styles for markdown rendering to `internal/webui/static/style.css` — styles for `.md-viewer`, `.md-rendered`, `.md-raw`, toggle buttons, rendered markdown elements (headings, lists, code blocks, tables, links).
+- [X] T046 [P2] [US4] Write tests for markdown.js — create `internal/webui/static/markdown_test.html` (manual test page) or verify through handler test that markdown partial renders without JS errors.
+
+---
+
+## Phase 7: US5 — YAML & Schema Rendering (P2)
+
+Delivers FR-007, FR-008: syntax highlighting for YAML, JSON, and source code with raw/formatted toggle.
+
+- [X] T047 [P] [US5] Create `internal/webui/static/highlight.js` — regex-based syntax highlighter (~150 lines, ~4 KB). Language tokenizers for: YAML, JSON, Go, SQL, Shell, JavaScript, CSS, HTML, Markdown. Assign CSS classes (`tok-key`, `tok-str`, `tok-num`, `tok-comment`, `tok-bool`, `tok-kw`). All content HTML-escaped before tokenization per FR-031. Export `highlight(code, language)` function.
+- [X] T048 [P] [US5] Create `templates/partials/code_viewer.html` — partial template with raw/formatted toggle. Structure: `<div class="code-viewer">` with `<div class="code-highlighted"><pre><code>` and `<div class="code-raw"><pre>` plus toggle buttons. JS init calls `highlight()` on page load.
+- [X] T049 [P2] [US5] Integrate syntax highlighting into `templates/pipeline_detail.html` — render pipeline YAML configuration and JSON schema contract definitions using code_viewer partial with appropriate language parameter.
+- [X] T050 [P2] [US5] Integrate syntax highlighting into `templates/persona_detail.html` — render hooks config and sandbox config sections using code_viewer partial with YAML highlighting.
+- [X] T051 [P2] [US5] Add CSS styles for syntax highlighting to `internal/webui/static/style.css` — styles for `.code-viewer`, `.code-highlighted`, `.code-raw`, toggle buttons, and token classes (`tok-key`, `tok-str`, `tok-num`, `tok-comment`, `tok-bool`, `tok-kw`). Support both light and dark themes.
+- [X] T052 [P2] [US5] Integrate syntax highlighting into step inspector — in `templates/partials/step_inspector.html`, use code_viewer partial for contract schema display and artifact previews with detected language.
+
+---
+
+## Phase 8: US6 — Meta Information Display (P2)
+
+Delivers FR-020 through FR-023: pipeline/persona metadata, last run status, input examples.
+
+- [X] T053 [P2] [US6] Enhance pipeline list page `templates/pipelines.html` — display description alongside name, show step count badge, show last run status indicator (requires calling GetLastRunForPipeline per pipeline). Update `handlePipelinesPage` to include last run data.
+- [X] T054 [P2] [US6] Enhance persona list page `templates/personas.html` — display description, adapter, model alongside each persona name per FR-021.
+- [X] T055 [P2] [US6] Ensure pipeline detail header shows metadata prominently — verify `templates/pipeline_detail.html` displays name, description at top per FR-020, last run status/time per FR-022, and input examples per FR-023.
+- [X] T056 [P2] [US6] Update `handlePipelinesPage` in `internal/webui/handlers_pipelines.go` — extend PipelineSummary or create enriched template data struct to include last run status from GetLastRunForPipeline for each pipeline.
+
+---
+
+## Phase 9: US7 — Workspace & Source Browsing (P3)
+
+Delivers FR-024 through FR-028: file tree browser, syntax-highlighted file viewer, lazy loading, read-only, missing workspace handling.
+
+- [X] T057 [P3] [US7] Create `internal/webui/handlers_workspace.go` — implement `handleWorkspaceTree` (GET /api/runs/{id}/workspace/{step}/tree?path=) and `handleWorkspaceFile` (GET /api/runs/{id}/workspace/{step}/file?path=). Resolve workspace path from step_state table. Validate path traversal via `filepath.Rel` check against workspace root. Return WorkspaceTreeResponse/WorkspaceFileResponse per contracts/api-workspace.json. Max 500 entries per directory, 1MB file size limit, no symlink following, content HTML-escaped.
+- [X] T058 [P3] [US7] Create `internal/webui/static/workspace.js` — file tree browser with lazy-loading. On directory click, fetch `/api/runs/{id}/workspace/{step}/tree?path=` and expand subtree. On file click, fetch `/api/runs/{id}/workspace/{step}/file?path=` and display in content pane with syntax highlighting via `highlight()`. Tree uses `<ul>/<li>` with expand/collapse icons.
+- [X] T059 [P3] [US7] Create `templates/partials/workspace_tree.html` — workspace browsing partial with two-pane layout: file tree on left, file content viewer on right. Shows "Workspace unavailable" message when workspace_exists is false per FR-028 edge case.
+- [X] T060 [P3] [US7] Integrate workspace browser into `templates/run_detail.html` — add "Workspace" tab/section per step that includes the workspace_tree partial. Only show when workspace_path is set.
+- [X] T061 [P] [US7] Register workspace API routes in `internal/webui/routes.go` — add `GET /api/runs/{id}/workspace/{step}/tree`, `GET /api/runs/{id}/workspace/{step}/file`.
+- [X] T062 [P3] [US7] Add path traversal security tests for workspace handler in `internal/webui/handlers_test.go` — test that `../` paths are rejected, symlinks are not followed, files >1MB are truncated with indicator, missing workspaces return proper error JSON.
+- [X] T063 [P3] [US7] Handle large files in workspace viewer — when file size >1MB, return truncated content with `truncated: true` flag and display truncation notice in UI per edge case.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+- [X] T064 [P] Add responsive CSS for all new views to `internal/webui/static/style.css` — ensure pipeline detail, persona detail, statistics, run introspection, and workspace browser are usable on desktop and tablet per NFR-004. Test at 1024px and 768px breakpoints.
+- [X] T065 [P] Verify JS bundle size stays under 50KB gzipped — measure all static assets (existing app.js, dag.js, sse.js + new markdown.js, highlight.js, stats.js, workspace.js, introspect.js) per NFR-001 and R-007 budget analysis.
+- [X] T066 XSS audit — review all new templates and JS for unsanitized user content per FR-031. Verify: all Go template output uses `{{.Field}}` (auto-escaped), markdown parser escapes input, syntax highlighter escapes input, workspace file content is escaped, artifact previews are escaped.
+- [X] T067 Verify `webui` build tag gating — confirm all new `.go` files have `//go:build webui` tag. Build without tag and verify no binary size increase per FR-029/SC-008.
+- [X] T068 Verify bearer token auth on new API endpoints — confirm all new `/api/*` routes go through existing auth middleware per FR-032.
+- [X] T069 Run `go test -race ./internal/webui/...` and `go test -race ./internal/state/...` — fix any race conditions in new code.
+- [X] T070 Run `go test ./...` — full test suite must pass with all new code.
+- [X] T071 Handle edge case: pipeline definition changed since run — in run detail, display notice when current pipeline config may differ from execution-time config per edge case and C-003.
+- [X] T072 Handle edge case: statistics for removed pipelines — ensure GetPipelineStatistics returns historical data for pipelines no longer in manifest, display with "pipeline removed" indicator per edge case.
+- [X] T073 Handle edge case: unrecognized file types in syntax highlighting — verify `highlight()` falls back to plain text display without errors per edge case.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (T001-T005) → Phase 2 (T006-T013) → Phase 3 (T014-T025)
+                                             → Phase 4 (T026-T033)
+                                             → Phase 5 (T034-T040)
+Phase 1 (T001-T005) ────────────────────────→ Phase 6 (T041-T046) [P]
+                                             → Phase 7 (T047-T052) [P]
+Phase 3 + Phase 4 ──────────────────────────→ Phase 8 (T053-T056)
+Phase 5 + Phase 7 ──────────────────────────→ Phase 9 (T057-T063)
+All phases ─────────────────────────────────→ Phase 10 (T064-T073)
+```
+
+Phases 3, 4, 5 can proceed in parallel after Phase 2 completes.
+Phases 6, 7 can proceed in parallel after Phase 1 completes (only need types, not state methods).
+Phase 8 depends on Phase 3 (inspection views) and Phase 4 (statistics).
+Phase 9 depends on Phase 5 (run introspection) and Phase 7 (syntax highlighting).
+Phase 10 is final integration testing after all feature phases.
+
+---
+
+## Task Summary
+
+| Phase | User Story | Priority | Tasks | Parallelizable |
+|-------|-----------|----------|-------|----------------|
+| 1 | Setup | — | T001-T005 (5) | 5 |
+| 2 | Foundational | — | T006-T013 (8) | 6 |
+| 3 | US1: Inspection | P1 | T014-T025 (12) | 4 |
+| 4 | US2: Statistics | P1 | T026-T033 (8) | 3 |
+| 5 | US3: Introspection | P1 | T034-T040 (7) | 1 |
+| 6 | US4: Markdown | P2 | T041-T046 (6) | 3 |
+| 7 | US5: Syntax HL | P2 | T047-T052 (6) | 3 |
+| 8 | US6: Meta Info | P2 | T053-T056 (4) | 3 |
+| 9 | US7: Workspace | P3 | T057-T063 (7) | 2 |
+| 10 | Polish | — | T064-T073 (10) | 5 |
+| **Total** | | | **73** | **35** |


### PR DESCRIPTION
## Summary

- Add pipeline detail API/page with step-level configuration, DAG visualization, and last-run context
- Add persona detail API/page showing adapter config, permissions, hooks, sandbox settings, and pipeline usage
- Add run statistics API/page with aggregate counts, daily trends, per-pipeline breakdowns, and time-range filtering (24h/7d/30d/all)
- Add workspace browsing endpoints for directory tree listing and file content retrieval with path traversal protection
- Add client-side JavaScript modules for markdown rendering, syntax highlighting, introspection views, and stats charts

## Spec

See [`specs/091-dashboard-introspection/spec.md`](specs/091-dashboard-introspection/spec.md) for full specification.

Resolves #91

## Test plan

- All existing tests pass with `go test -race ./...` (28 packages)
- Added comprehensive handler tests for new endpoints behind `webui` build tag:
  - Statistics API: empty state, populated data, time range filtering with invalid input fallback
  - Pipeline detail: not found (404), missing name (400)
  - Persona detail: not found (404), missing name (400)
  - Workspace tree: missing params (400), non-existent workspace (error in response), real directory listing
  - Workspace file: missing params (400), non-existent workspace (error), real file with mime type detection
  - Path traversal protection: `../../etc` is safely neutralized by `filepath.Clean`
- Mock state store updated with new interface methods

## Known limitations

- Statistics queries operate on existing `pipeline_run` and `performance_metric` tables; no new migrations needed
- HTML templates for new pages (pipeline_detail, persona_detail, statistics) are referenced but not included — frontend template work is a follow-up
- Client-side JS uses lightweight vanilla implementations (no external dependencies)