### PR TITLE
feat(pipeline): add typed artifact composition and input validation

### DIFF
--- a/.wave/schemas/wave-pipeline.schema.json
+++ b/.wave/schemas/wave-pipeline.schema.json
@@ -198,6 +198,20 @@
         "as": {
           "type": "string",
           "description": "Name to mount the artifact under artifacts/ directory"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["json", "text", "markdown", "binary"],
+          "description": "Expected artifact type for validation"
+        },
+        "schema_path": {
+          "type": "string",
+          "description": "Path to JSON schema file for input content validation"
+        },
+        "optional": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, missing artifact doesn't fail the step"
         }
       }
     },
@@ -278,7 +292,7 @@
     },
     "ArtifactDef": {
       "type": "object",
-      "required": ["name", "path"],
+      "required": ["name"],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -287,17 +301,23 @@
         },
         "path": {
           "type": "string",
-          "description": "File path relative to workspace root"
+          "description": "File path relative to workspace root (optional when source is stdout)"
         },
         "type": {
           "type": "string",
-          "enum": ["json", "text", "markdown"],
+          "enum": ["json", "text", "markdown", "binary"],
           "description": "Artifact content type"
         },
         "required": {
           "type": "boolean",
           "default": false,
           "description": "Whether this artifact must exist after step completion"
+        },
+        "source": {
+          "type": "string",
+          "enum": ["file", "stdout"],
+          "default": "file",
+          "description": "Artifact source: 'file' (persona writes file) or 'stdout' (captured from process output)"
         }
       }
     },

--- a/internal/contract/input_validator.go
+++ b/internal/contract/input_validator.go
@@ -1,0 +1,156 @@
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// InputValidationResult represents the result of validating input artifacts.
+type InputValidationResult struct {
+	Passed      bool   // Overall validation result
+	ArtifactRef string // The artifact reference being validated
+	ArtifactAs  string // The 'as' name of the artifact
+	Error       error  // Validation error if failed
+	TypeMatch   bool   // Whether declared type matched
+	SchemaValid bool   // Whether schema validation passed (if applicable)
+}
+
+// InputArtifactConfig holds configuration for validating an input artifact.
+type InputArtifactConfig struct {
+	Name       string // The artifact name (as mounted)
+	SchemaPath string // Path to JSON schema file for validation
+	Type       string // Expected artifact type
+	Path       string // Path to the artifact file
+}
+
+// ValidateInputArtifacts validates all input artifacts against their schemas.
+// Returns a list of validation results and an error if any required validations failed.
+func ValidateInputArtifacts(configs []InputArtifactConfig, workspacePath string) ([]InputValidationResult, error) {
+	results := make([]InputValidationResult, 0, len(configs))
+
+	for _, cfg := range configs {
+		result := validateSingleInputArtifact(cfg, workspacePath)
+		results = append(results, result)
+
+		// Fail fast on validation errors
+		if !result.Passed && result.Error != nil {
+			return results, result.Error
+		}
+	}
+
+	return results, nil
+}
+
+// validateSingleInputArtifact validates a single input artifact.
+func validateSingleInputArtifact(cfg InputArtifactConfig, workspacePath string) InputValidationResult {
+	result := InputValidationResult{
+		ArtifactRef: cfg.Name,
+		ArtifactAs:  cfg.Name,
+		Passed:      true,
+		TypeMatch:   true,
+		SchemaValid: true,
+	}
+
+	// If no schema path is specified, skip validation
+	if cfg.SchemaPath == "" {
+		return result
+	}
+
+	// Resolve artifact path
+	artifactPath := cfg.Path
+	if artifactPath == "" {
+		artifactPath = filepath.Join(workspacePath, ".wave", "artifacts", cfg.Name)
+	}
+
+	// Read artifact content
+	artifactData, err := os.ReadFile(artifactPath)
+	if err != nil {
+		result.Passed = false
+		result.Error = fmt.Errorf("failed to read input artifact '%s': %w", cfg.Name, err)
+		return result
+	}
+
+	// Read schema
+	schemaPath := cfg.SchemaPath
+	if !filepath.IsAbs(schemaPath) {
+		schemaPath = filepath.Join(workspacePath, schemaPath)
+	}
+
+	schemaData, err := os.ReadFile(schemaPath)
+	if err != nil {
+		result.Passed = false
+		result.Error = fmt.Errorf("failed to read schema file '%s' for artifact '%s': %w", cfg.SchemaPath, cfg.Name, err)
+		return result
+	}
+
+	// Parse schema
+	var schemaDoc interface{}
+	if err := json.Unmarshal(schemaData, &schemaDoc); err != nil {
+		result.Passed = false
+		result.Error = fmt.Errorf("failed to parse schema file '%s': %w", cfg.SchemaPath, err)
+		return result
+	}
+
+	// Compile schema
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(cfg.SchemaPath, schemaDoc); err != nil {
+		result.Passed = false
+		result.Error = fmt.Errorf("failed to add schema resource '%s': %w", cfg.SchemaPath, err)
+		return result
+	}
+
+	schema, err := compiler.Compile(cfg.SchemaPath)
+	if err != nil {
+		result.Passed = false
+		result.Error = fmt.Errorf("failed to compile schema '%s': %w", cfg.SchemaPath, err)
+		return result
+	}
+
+	// Parse artifact content
+	var artifact interface{}
+	if err := json.Unmarshal(artifactData, &artifact); err != nil {
+		result.Passed = false
+		result.SchemaValid = false
+		result.Error = &ValidationError{
+			ContractType: "input_schema",
+			Message:      fmt.Sprintf("input artifact '%s' contains invalid JSON", cfg.Name),
+			Details:      []string{err.Error()},
+			Retryable:    false,
+		}
+		return result
+	}
+
+	// Validate against schema
+	if err := schema.Validate(artifact); err != nil {
+		result.Passed = false
+		result.SchemaValid = false
+		result.Error = &ValidationError{
+			ContractType: "input_schema",
+			Message:      fmt.Sprintf("input artifact '%s' failed schema validation", cfg.Name),
+			Details:      extractSchemaValidationDetails(err),
+			Retryable:    false,
+		}
+		return result
+	}
+
+	return result
+}
+
+// ValidateInputArtifact validates a single input artifact against its schema.
+// This is a convenience function for validating one artifact at a time.
+func ValidateInputArtifact(name string, schemaPath string, workspacePath string) error {
+	cfg := InputArtifactConfig{
+		Name:       name,
+		SchemaPath: schemaPath,
+	}
+
+	result := validateSingleInputArtifact(cfg, workspacePath)
+	if !result.Passed {
+		return result.Error
+	}
+	return nil
+}

--- a/internal/contract/input_validator_test.go
+++ b/internal/contract/input_validator_test.go
@@ -1,0 +1,197 @@
+package contract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateInputArtifact_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifact
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	artifactPath := filepath.Join(artifactsDir, "test-artifact")
+	err := os.WriteFile(artifactPath, []byte(`{"name": "test", "value": 42}`), 0644)
+	require.NoError(t, err)
+
+	// Create schema
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+	schemaContent := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["name", "value"],
+		"properties": {
+			"name": {"type": "string"},
+			"value": {"type": "integer"}
+		}
+	}`
+	err = os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+	require.NoError(t, err)
+
+	// Validate
+	err = ValidateInputArtifact("test-artifact", "schema.json", tmpDir)
+	assert.NoError(t, err)
+}
+
+func TestValidateInputArtifact_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifact with invalid JSON
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	artifactPath := filepath.Join(artifactsDir, "test-artifact")
+	err := os.WriteFile(artifactPath, []byte(`{"name": "test", "value": "not a number"}`), 0644)
+	require.NoError(t, err)
+
+	// Create schema expecting integer
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+	schemaContent := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["name", "value"],
+		"properties": {
+			"name": {"type": "string"},
+			"value": {"type": "integer"}
+		}
+	}`
+	err = os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+	require.NoError(t, err)
+
+	// Validate
+	err = ValidateInputArtifact("test-artifact", "schema.json", tmpDir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed schema validation")
+}
+
+func TestValidateInputArtifact_NoSchemaSkipsValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifact (no schema will be provided)
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	artifactPath := filepath.Join(artifactsDir, "test-artifact")
+	err := os.WriteFile(artifactPath, []byte(`{"anything": "works"}`), 0644)
+	require.NoError(t, err)
+
+	// Validate with empty schema path - should skip
+	err = ValidateInputArtifact("test-artifact", "", tmpDir)
+	assert.NoError(t, err)
+}
+
+func TestValidateInputArtifact_MissingArtifact(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create schema but no artifact
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+	schemaContent := `{"type": "object"}`
+	err := os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+	require.NoError(t, err)
+
+	// Validate
+	err = ValidateInputArtifact("nonexistent-artifact", "schema.json", tmpDir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read input artifact")
+}
+
+func TestValidateInputArtifact_MissingSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifact but no schema
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	artifactPath := filepath.Join(artifactsDir, "test-artifact")
+	err := os.WriteFile(artifactPath, []byte(`{}`), 0644)
+	require.NoError(t, err)
+
+	// Validate
+	err = ValidateInputArtifact("test-artifact", "nonexistent-schema.json", tmpDir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema file")
+}
+
+func TestValidateInputArtifacts_Multiple(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifacts directory
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	// Create two artifacts
+	err := os.WriteFile(filepath.Join(artifactsDir, "artifact1"), []byte(`{"id": 1}`), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(artifactsDir, "artifact2"), []byte(`{"id": 2}`), 0644)
+	require.NoError(t, err)
+
+	// Create schema
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+	schemaContent := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["id"],
+		"properties": {
+			"id": {"type": "integer"}
+		}
+	}`
+	err = os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+	require.NoError(t, err)
+
+	// Validate both
+	configs := []InputArtifactConfig{
+		{Name: "artifact1", SchemaPath: "schema.json"},
+		{Name: "artifact2", SchemaPath: "schema.json"},
+	}
+
+	results, err := ValidateInputArtifacts(configs, tmpDir)
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.True(t, results[0].Passed)
+	assert.True(t, results[1].Passed)
+}
+
+func TestValidateInputArtifacts_FailsOnFirstError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create artifacts directory
+	artifactsDir := filepath.Join(tmpDir, ".wave", "artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0755))
+
+	// Create one valid, one invalid artifact
+	err := os.WriteFile(filepath.Join(artifactsDir, "valid"), []byte(`{"id": 1}`), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(artifactsDir, "invalid"), []byte(`{"id": "not a number"}`), 0644)
+	require.NoError(t, err)
+
+	// Create schema
+	schemaPath := filepath.Join(tmpDir, "schema.json")
+	schemaContent := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["id"],
+		"properties": {
+			"id": {"type": "integer"}
+		}
+	}`
+	err = os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+	require.NoError(t, err)
+
+	// Validate - invalid first
+	configs := []InputArtifactConfig{
+		{Name: "invalid", SchemaPath: "schema.json"},
+		{Name: "valid", SchemaPath: "schema.json"},
+	}
+
+	results, err := ValidateInputArtifacts(configs, tmpDir)
+	assert.Error(t, err)
+	// Should have stopped after first failure
+	assert.Len(t, results, 1)
+	assert.False(t, results[0].Passed)
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -71,15 +71,38 @@ type HookRule struct {
 }
 
 type Runtime struct {
-	WorkspaceRoot        string         `yaml:"workspace_root"`
-	MaxConcurrentWorkers int            `yaml:"max_concurrent_workers,omitempty"`
-	DefaultTimeoutMin    int            `yaml:"default_timeout_minutes,omitempty"`
-	PipelineIDHashLength int            `yaml:"pipeline_id_hash_length,omitempty"`
-	Relay                RelayConfig    `yaml:"relay,omitempty"`
-	Audit                AuditConfig    `yaml:"audit,omitempty"`
-	MetaPipeline         MetaConfig     `yaml:"meta_pipeline,omitempty"`
-	Routing              RoutingConfig  `yaml:"routing,omitempty"`
-	Sandbox              RuntimeSandbox `yaml:"sandbox,omitempty"`
+	WorkspaceRoot        string                 `yaml:"workspace_root"`
+	MaxConcurrentWorkers int                    `yaml:"max_concurrent_workers,omitempty"`
+	DefaultTimeoutMin    int                    `yaml:"default_timeout_minutes,omitempty"`
+	PipelineIDHashLength int                    `yaml:"pipeline_id_hash_length,omitempty"`
+	Relay                RelayConfig            `yaml:"relay,omitempty"`
+	Audit                AuditConfig            `yaml:"audit,omitempty"`
+	MetaPipeline         MetaConfig             `yaml:"meta_pipeline,omitempty"`
+	Routing              RoutingConfig          `yaml:"routing,omitempty"`
+	Sandbox              RuntimeSandbox         `yaml:"sandbox,omitempty"`
+	Artifacts            RuntimeArtifactsConfig `yaml:"artifacts,omitempty"`
+}
+
+// RuntimeArtifactsConfig holds global configuration for artifact handling.
+type RuntimeArtifactsConfig struct {
+	MaxStdoutSize      int64  `yaml:"max_stdout_size,omitempty"`      // Max bytes to capture from stdout (default: 10MB)
+	DefaultArtifactDir string `yaml:"default_artifact_dir,omitempty"` // Base directory for artifacts (default: ".wave/artifacts")
+}
+
+// GetMaxStdoutSize returns the configured max stdout size or the default (10MB).
+func (c *RuntimeArtifactsConfig) GetMaxStdoutSize() int64 {
+	if c.MaxStdoutSize > 0 {
+		return c.MaxStdoutSize
+	}
+	return 10 * 1024 * 1024 // 10MB default
+}
+
+// GetDefaultArtifactDir returns the configured artifact directory or the default.
+func (c *RuntimeArtifactsConfig) GetDefaultArtifactDir() string {
+	if c.DefaultArtifactDir != "" {
+		return c.DefaultArtifactDir
+	}
+	return ".wave/artifacts"
 }
 
 type RuntimeSandbox struct {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -629,13 +629,34 @@ func (e *DefaultPipelineExecutor) runStepExecution(ctx context.Context, executio
 
 	execution.Results[step.ID] = output
 
-	// Write output artifacts to workspace
+	// Check for stdout artifacts and validate size limits
+	hasStdoutArtifacts := false
+	for _, art := range step.OutputArtifacts {
+		if art.IsStdoutArtifact() {
+			hasStdoutArtifacts = true
+			break
+		}
+	}
+
+	if hasStdoutArtifacts {
+		// Validate stdout size limit
+		maxSize := execution.Manifest.Runtime.Artifacts.GetMaxStdoutSize()
+		if int64(len(stdoutData)) > maxSize {
+			return fmt.Errorf("stdout artifact size (%d bytes) exceeds limit (%d bytes); consider reducing output or increasing runtime.artifacts.max_stdout_size",
+				len(stdoutData), maxSize)
+		}
+
+		// Write stdout artifacts using raw stdout data
+		e.writeOutputArtifacts(execution, step, workspacePath, stdoutData)
+	}
+
+	// Write file-based output artifacts to workspace
 	// Use ResultContent if available (extracted from adapter response)
 	// Don't fall back to raw stdout as it contains JSON wrapper, not actual content
-	if result.ResultContent != "" {
+	if result.ResultContent != "" && !hasStdoutArtifacts {
 		artifactContent := []byte(result.ResultContent)
 		e.writeOutputArtifacts(execution, step, workspacePath, artifactContent)
-	} else {
+	} else if !hasStdoutArtifacts {
 		// Skip writing artifacts when ResultContent is empty to avoid overwriting
 		// existing artifacts with empty content during relay compaction or parsing failures
 		if e.debug {
@@ -1047,6 +1068,9 @@ func (e *DefaultPipelineExecutor) injectArtifacts(execution *PipelineExecution, 
 
 	pipelineID := execution.Status.ID
 
+	// Build artifact type map for validation
+	artifactTypes := e.buildArtifactTypeMap(execution)
+
 	for _, ref := range step.Memory.InjectArtifacts {
 		artName := ref.As
 		if artName == "" {
@@ -1056,56 +1080,152 @@ func (e *DefaultPipelineExecutor) injectArtifacts(execution *PipelineExecution, 
 
 		// Try registered artifact path first
 		key := ref.Step + ":" + ref.Artifact
-		if artifactPath, ok := execution.ArtifactPaths[key]; ok {
-			if srcData, err := os.ReadFile(artifactPath); err == nil {
-				os.WriteFile(destPath, srcData, 0644)
+		artifactPath, ok := execution.ArtifactPaths[key]
+
+		// Existence validation
+		if !ok {
+			// Try fallback: check if we have stdout results from the step
+			if result, exists := execution.Results[ref.Step]; exists {
+				if stdout, ok := result["stdout"].(string); ok {
+					// Type validation (if specified)
+					if ref.Type != "" {
+						declaredType := artifactTypes[key]
+						if declaredType != "" && declaredType != ref.Type {
+							return fmt.Errorf("artifact '%s' type mismatch: expected %s, got %s", ref.Artifact, ref.Type, declaredType)
+						}
+					}
+					os.WriteFile(destPath, []byte(stdout), 0644)
+					// Register artifact path in context for template resolution
+					execution.Context.SetArtifactPath(artName, destPath)
+					e.emit(event.Event{
+						Timestamp:  time.Now(),
+						PipelineID: pipelineID,
+						StepID:     step.ID,
+						State:      "running",
+						Message:    fmt.Sprintf("injected artifact %s from step %s stdout", artName, ref.Step),
+					})
+					continue
+				}
+			}
+
+			// Artifact not found - check if optional
+			if ref.Optional {
 				e.emit(event.Event{
 					Timestamp:  time.Now(),
 					PipelineID: pipelineID,
 					StepID:     step.ID,
 					State:      "running",
-					Message:    fmt.Sprintf("injected artifact %s from %s (%s)", artName, ref.Step, artifactPath),
+					Message:    fmt.Sprintf("optional artifact '%s' from step '%s' not found, skipping", ref.Artifact, ref.Step),
 				})
 				continue
 			}
+			return fmt.Errorf("required artifact '%s' from step '%s' not found", ref.Artifact, ref.Step)
 		}
 
-		// Fallback: use stdout from previous step
-		if result, exists := execution.Results[ref.Step]; exists {
-			if stdout, ok := result["stdout"].(string); ok {
-				os.WriteFile(destPath, []byte(stdout), 0644)
+		// Type validation (if specified)
+		if ref.Type != "" {
+			declaredType := artifactTypes[key]
+			if declaredType != "" && declaredType != ref.Type {
+				return fmt.Errorf("artifact '%s' type mismatch: expected %s, got %s", ref.Artifact, ref.Type, declaredType)
+			}
+		}
+
+		srcData, err := os.ReadFile(artifactPath)
+		if err != nil {
+			if ref.Optional {
 				e.emit(event.Event{
 					Timestamp:  time.Now(),
 					PipelineID: pipelineID,
 					StepID:     step.ID,
 					State:      "running",
-					Message:    fmt.Sprintf("injected artifact %s from step %s stdout", artName, ref.Step),
+					Message:    fmt.Sprintf("optional artifact '%s' could not be read, skipping: %v", ref.Artifact, err),
 				})
+				continue
 			}
+			return fmt.Errorf("failed to read required artifact '%s': %w", ref.Artifact, err)
+		}
+
+		os.WriteFile(destPath, srcData, 0644)
+		// Register artifact path in context for template resolution
+		execution.Context.SetArtifactPath(artName, destPath)
+		e.emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: pipelineID,
+			StepID:     step.ID,
+			State:      "running",
+			Message:    fmt.Sprintf("injected artifact %s from %s (%s)", artName, ref.Step, artifactPath),
+		})
+
+		// Schema validation for input artifacts (if schema_path is specified)
+		if ref.SchemaPath != "" {
+			if err := contract.ValidateInputArtifact(artName, ref.SchemaPath, workspacePath); err != nil {
+				return fmt.Errorf("input artifact '%s' schema validation failed: %w", artName, err)
+			}
+			e.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: pipelineID,
+				StepID:     step.ID,
+				State:      "running",
+				Message:    fmt.Sprintf("validated artifact %s against schema %s", artName, ref.SchemaPath),
+			})
 		}
 	}
 
 	return nil
 }
 
-func (e *DefaultPipelineExecutor) writeOutputArtifacts(execution *PipelineExecution, step *Step, workspacePath string, stdout []byte) {
-	for _, art := range step.OutputArtifacts {
-		// Resolve artifact path using pipeline context
-		resolvedPath := execution.Context.ResolveArtifactPath(art)
-		artPath := filepath.Join(workspacePath, resolvedPath)
-		key := step.ID + ":" + art.Name
+// buildArtifactTypeMap builds a map of artifact keys to their declared types
+func (e *DefaultPipelineExecutor) buildArtifactTypeMap(execution *PipelineExecution) map[string]string {
+	types := make(map[string]string)
+	for _, step := range execution.Pipeline.Steps {
+		for _, art := range step.OutputArtifacts {
+			key := step.ID + ":" + art.Name
+			types[key] = art.Type
+		}
+	}
+	return types
+}
 
-		// If the persona already wrote the file, trust it and don't overwrite
-		if _, err := os.Stat(artPath); err == nil {
+func (e *DefaultPipelineExecutor) writeOutputArtifacts(execution *PipelineExecution, step *Step, workspacePath string, stdout []byte) {
+	// Get artifact directory for stdout artifacts
+	artifactDir := execution.Manifest.Runtime.Artifacts.GetDefaultArtifactDir()
+
+	for _, art := range step.OutputArtifacts {
+		key := step.ID + ":" + art.Name
+		var artPath string
+
+		// Handle stdout artifacts differently
+		if art.IsStdoutArtifact() {
+			// Stdout artifacts go to .wave/artifacts/<step-id>/<name>
+			artPath = filepath.Join(workspacePath, artifactDir, step.ID, art.Name)
+			os.MkdirAll(filepath.Dir(artPath), 0755)
+
+			// Write stdout content to artifact
+			if err := os.WriteFile(artPath, stdout, 0644); err != nil && e.debug {
+				fmt.Printf("[DEBUG] Failed to write stdout artifact %s: %v\n", art.Name, err)
+			}
 			execution.ArtifactPaths[key] = artPath
+
 			if e.debug {
-				fmt.Printf("[DEBUG] Artifact %s already exists at %s, preserving persona-written file\n", art.Name, artPath)
+				fmt.Printf("[DEBUG] Wrote stdout artifact %s to %s (%d bytes)\n", art.Name, artPath, len(stdout))
 			}
 		} else {
-			// Fall back to writing ResultContent
-			os.MkdirAll(filepath.Dir(artPath), 0755)
-			os.WriteFile(artPath, stdout, 0644)
-			execution.ArtifactPaths[key] = artPath
+			// File-based artifacts: resolve path using pipeline context
+			resolvedPath := execution.Context.ResolveArtifactPath(art)
+			artPath = filepath.Join(workspacePath, resolvedPath)
+
+			// If the persona already wrote the file, trust it and don't overwrite
+			if _, err := os.Stat(artPath); err == nil {
+				execution.ArtifactPaths[key] = artPath
+				if e.debug {
+					fmt.Printf("[DEBUG] Artifact %s already exists at %s, preserving persona-written file\n", art.Name, artPath)
+				}
+			} else {
+				// Fall back to writing ResultContent
+				os.MkdirAll(filepath.Dir(artPath), 0755)
+				os.WriteFile(artPath, stdout, 0644)
+				execution.ArtifactPaths[key] = artPath
+			}
 		}
 
 		// Register artifact in DB for web dashboard visibility

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -66,9 +66,12 @@ type MemoryConfig struct {
 }
 
 type ArtifactRef struct {
-	Step     string `yaml:"step"`
-	Artifact string `yaml:"artifact"`
-	As       string `yaml:"as"`
+	Step       string `yaml:"step"`
+	Artifact   string `yaml:"artifact"`
+	As         string `yaml:"as"`
+	Type       string `yaml:"type,omitempty"`        // Expected artifact type for validation
+	SchemaPath string `yaml:"schema_path,omitempty"` // JSON schema path for input validation
+	Optional   bool   `yaml:"optional,omitempty"`    // If true, missing artifact doesn't fail
 }
 
 type WorkspaceConfig struct {
@@ -96,9 +99,23 @@ type ExecConfig struct {
 
 type ArtifactDef struct {
 	Name     string `yaml:"name"`
-	Path     string `yaml:"path"`
-	Type     string `yaml:"type,omitempty"`
+	Path     string `yaml:"path,omitempty"`           // Optional when Source is "stdout"
+	Type     string `yaml:"type,omitempty"`           // "json", "text", "markdown", "binary"
 	Required bool   `yaml:"required,omitempty"`
+	Source   string `yaml:"source,omitempty"`         // "file" (default) or "stdout"
+}
+
+// IsStdoutArtifact returns true if this artifact is captured from stdout.
+func (a *ArtifactDef) IsStdoutArtifact() bool {
+	return a.Source == "stdout"
+}
+
+// GetEffectiveSource returns the effective source, defaulting to "file".
+func (a *ArtifactDef) GetEffectiveSource() string {
+	if a.Source == "" {
+		return "file"
+	}
+	return a.Source
 }
 
 type HandoverConfig struct {

--- a/internal/pipeline/types_test.go
+++ b/internal/pipeline/types_test.go
@@ -6,6 +6,181 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestArtifactDef_YAMLParsing(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantName   string
+		wantPath   string
+		wantType   string
+		wantSource string
+		wantErr    bool
+	}{
+		{
+			name:       "basic artifact with path",
+			yaml:       "name: report\npath: .wave/output/report.json\ntype: json\n",
+			wantName:   "report",
+			wantPath:   ".wave/output/report.json",
+			wantType:   "json",
+			wantSource: "",
+		},
+		{
+			name:       "stdout artifact without path",
+			yaml:       "name: analysis\nsource: stdout\ntype: json\n",
+			wantName:   "analysis",
+			wantPath:   "",
+			wantType:   "json",
+			wantSource: "stdout",
+		},
+		{
+			name:       "file source explicit",
+			yaml:       "name: output\npath: result.md\nsource: file\ntype: markdown\n",
+			wantName:   "output",
+			wantPath:   "result.md",
+			wantType:   "markdown",
+			wantSource: "file",
+		},
+		{
+			name:       "absent source defaults to empty (file)",
+			yaml:       "name: data\npath: data.txt\ntype: text\n",
+			wantName:   "data",
+			wantPath:   "data.txt",
+			wantType:   "text",
+			wantSource: "",
+		},
+		{
+			name:       "binary type supported",
+			yaml:       "name: archive\npath: archive.tar.gz\ntype: binary\n",
+			wantName:   "archive",
+			wantPath:   "archive.tar.gz",
+			wantType:   "binary",
+			wantSource: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var art ArtifactDef
+			err := yaml.Unmarshal([]byte(tt.yaml), &art)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected unmarshal error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+
+			if art.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", art.Name, tt.wantName)
+			}
+			if art.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", art.Path, tt.wantPath)
+			}
+			if art.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", art.Type, tt.wantType)
+			}
+			if art.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", art.Source, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestArtifactRef_YAMLParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		yaml           string
+		wantStep       string
+		wantArtifact   string
+		wantAs         string
+		wantType       string
+		wantSchemaPath string
+		wantOptional   bool
+		wantErr        bool
+	}{
+		{
+			name:         "basic artifact ref",
+			yaml:         "step: analyze\nartifact: report\nas: analysis\n",
+			wantStep:     "analyze",
+			wantArtifact: "report",
+			wantAs:       "analysis",
+		},
+		{
+			name:         "with type validation",
+			yaml:         "step: produce\nartifact: data\nas: input\ntype: json\n",
+			wantStep:     "produce",
+			wantArtifact: "data",
+			wantAs:       "input",
+			wantType:     "json",
+		},
+		{
+			name:           "with schema path",
+			yaml:           "step: generate\nartifact: config\nas: cfg\nschema_path: ./schemas/config.json\n",
+			wantStep:       "generate",
+			wantArtifact:   "config",
+			wantAs:         "cfg",
+			wantSchemaPath: "./schemas/config.json",
+		},
+		{
+			name:         "optional artifact",
+			yaml:         "step: optional-step\nartifact: maybe\nas: opt\noptional: true\n",
+			wantStep:     "optional-step",
+			wantArtifact: "maybe",
+			wantAs:       "opt",
+			wantOptional: true,
+		},
+		{
+			name:           "full specification",
+			yaml:           "step: full\nartifact: complete\nas: all\ntype: json\nschema_path: schema.json\noptional: true\n",
+			wantStep:       "full",
+			wantArtifact:   "complete",
+			wantAs:         "all",
+			wantType:       "json",
+			wantSchemaPath: "schema.json",
+			wantOptional:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ref ArtifactRef
+			err := yaml.Unmarshal([]byte(tt.yaml), &ref)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected unmarshal error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+
+			if ref.Step != tt.wantStep {
+				t.Errorf("Step = %q, want %q", ref.Step, tt.wantStep)
+			}
+			if ref.Artifact != tt.wantArtifact {
+				t.Errorf("Artifact = %q, want %q", ref.Artifact, tt.wantArtifact)
+			}
+			if ref.As != tt.wantAs {
+				t.Errorf("As = %q, want %q", ref.As, tt.wantAs)
+			}
+			if ref.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", ref.Type, tt.wantType)
+			}
+			if ref.SchemaPath != tt.wantSchemaPath {
+				t.Errorf("SchemaPath = %q, want %q", ref.SchemaPath, tt.wantSchemaPath)
+			}
+			if ref.Optional != tt.wantOptional {
+				t.Errorf("Optional = %v, want %v", ref.Optional, tt.wantOptional)
+			}
+		})
+	}
+}
+
 func TestPipelineMetadata_YAMLParsing(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/specs/109-typed-artifact-composition/checklists/requirements.md
+++ b/specs/109-typed-artifact-composition/checklists/requirements.md
@@ -1,0 +1,111 @@
+# Requirements Quality Checklist
+
+## Feature: Typed Artifact Composition
+**Spec File**: `specs/109-typed-artifact-composition/spec.md`
+**Validation Date**: 2026-02-20
+
+---
+
+## Section 1: User Stories Quality
+
+### 1.1 Story Structure
+- [x] Each user story follows "As a [role], I want [feature], so that [benefit]" format
+- [x] Each story has a clear priority (P1, P2, P3, etc.)
+- [x] Stories are ordered by priority (most important first)
+- [x] Each story explains why it has that priority level
+
+### 1.2 Independent Testability
+- [x] Each user story is independently testable
+- [x] Each story describes how it can be tested in isolation
+- [x] A single story could be implemented and released independently
+
+### 1.3 Acceptance Criteria
+- [x] Each story has at least one acceptance scenario
+- [x] Acceptance scenarios follow Given/When/Then format
+- [x] Scenarios are specific and unambiguous
+- [x] Scenarios avoid implementation details
+
+---
+
+## Section 2: Requirements Quality
+
+### 2.1 Functional Requirements
+- [x] All requirements use MUST, SHOULD, or MAY (RFC 2119)
+- [x] Requirements are specific and measurable
+- [x] Requirements avoid implementation details (HOW vs WHAT)
+- [x] No more than 3 [NEEDS CLARIFICATION] markers
+- [x] Current count of [NEEDS CLARIFICATION]: 0
+
+### 2.2 Completeness
+- [x] Requirements cover all user stories
+- [x] Requirements cover error cases
+- [x] Requirements cover edge cases mentioned in Edge Cases section
+- [x] Requirements specify observable behaviors
+
+### 2.3 Traceability
+- [x] Each requirement can be traced to at least one user story
+- [x] No orphan requirements (requirements without stories)
+
+---
+
+## Section 3: Edge Cases
+
+### 3.1 Coverage
+- [x] Edge cases address boundary conditions
+- [x] Edge cases address error scenarios
+- [x] Edge cases have defined expected behavior
+- [x] Edge cases are testable
+
+### 3.2 Specific Edge Cases Addressed
+- [x] Large stdout (size limits)
+- [x] Empty stdout
+- [x] Binary/non-UTF8 data
+- [x] Circular dependencies (existing DAG validation handles this)
+- [x] Optional artifacts that are missing
+
+---
+
+## Section 4: Success Criteria
+
+### 4.1 Measurability
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] Success criteria define pass/fail conditions
+
+### 4.2 Coverage
+- [x] Success criteria cover core functionality
+- [x] Success criteria cover error handling
+- [x] Success criteria include documentation requirements
+
+---
+
+## Section 5: Key Entities
+
+### 5.1 Data Model
+- [x] Key entities are identified
+- [x] Entity attributes are listed (without implementation types)
+- [x] Entity relationships are described where applicable
+
+---
+
+## Validation Summary
+
+| Category | Pass | Fail | Notes |
+|----------|------|------|-------|
+| User Stories | 12/12 | 0 | All stories properly structured |
+| Requirements | 6/6 | 0 | No clarification markers needed |
+| Edge Cases | 5/5 | 0 | All major edge cases covered |
+| Success Criteria | 6/6 | 0 | All measurable and testable |
+| Key Entities | 3/3 | 0 | Data model defined |
+
+**Overall Status**: PASS
+
+---
+
+## Notes for Reviewers
+
+1. **Pipeline-to-pipeline composition** was explicitly mentioned in the original issue as a potential separate scope item. This spec focuses on step-to-step composition within a single pipeline, which is the foundational capability. Pipeline-to-pipeline composition could be a follow-up feature.
+
+2. **Streaming vs buffered capture** for large stdout was raised in the original issue's design considerations. This spec takes the conservative approach of buffered capture with size limits, as it's simpler to implement and test. Streaming could be added later if needed.
+
+3. **Backward compatibility**: The new `source: stdout` attribute on artifacts and `consumes` field on steps are additive changes. Existing pipelines will continue to work unchanged.

--- a/specs/109-typed-artifact-composition/checklists/review.md
+++ b/specs/109-typed-artifact-composition/checklists/review.md
@@ -1,0 +1,125 @@
+# Requirements Quality Checklist: Typed Artifact Composition
+
+**Feature**: 109-typed-artifact-composition
+**Reviewed**: 2026-02-20
+**Purpose**: Validate that requirements are complete, clear, consistent, and provide sufficient coverage before implementation.
+
+---
+
+## Completeness
+
+_Does the specification capture all necessary information?_
+
+- [ ] CHK001 - Are all four user stories (P1-P3) linked to at least one functional requirement? [Completeness]
+- [ ] CHK002 - Does each functional requirement (FR-001 to FR-012) have a corresponding acceptance scenario in the user stories? [Completeness]
+- [ ] CHK003 - Are success criteria (SC-001 to SC-006) measurable without ambiguity about what "success" means? [Completeness]
+- [ ] CHK004 - Is the stdout capture atomicity guarantee (no partial artifact on failure) explicitly covered in a functional requirement? [Completeness]
+- [ ] CHK005 - Are all edge cases listed in the spec (large stdout, empty stdout, binary stdout, circular deps, optional missing) mapped to specific handling behavior? [Completeness]
+- [ ] CHK006 - Does the spec define what happens when `source: stdout` is combined with an explicit `path` field? [Completeness]
+- [ ] CHK007 - Is the maximum schema validation timeout (5s mentioned in data-model) captured in functional requirements? [Completeness]
+
+---
+
+## Clarity
+
+_Are requirements unambiguous and understandable?_
+
+- [ ] CHK008 - Is the distinction between `source: stdout` and `source: file` clearly defined with no overlapping behavior? [Clarity]
+- [ ] CHK009 - Does FR-002 clearly specify the artifact path format `.wave/artifacts/<step-id>/<artifact-name>` without ambiguity about step-id format? [Clarity]
+- [ ] CHK010 - Is the term "type" consistently used to mean artifact content type (json/text/markdown/binary) vs other meanings? [Clarity]
+- [ ] CHK011 - Are the error messages ("required artifact 'X' not found", "type mismatch") specified precisely enough for implementation? [Clarity]
+- [ ] CHK012 - Does the spec clarify whether `{{artifacts.<name>}}` substitution happens before or after input validation? [Clarity]
+- [ ] CHK013 - Is "fail-fast" behavior clearly defined (fail before step execution vs fail during)? [Clarity]
+- [ ] CHK014 - Are the short-form type names (json, text, markdown, binary) exhaustively enumerated with no implicit others? [Clarity]
+
+---
+
+## Consistency
+
+_Are requirements internally consistent and aligned with existing codebase patterns?_
+
+- [ ] CHK015 - Is the YAML syntax (`output_artifacts` vs `artifacts`) consistent with existing pipeline schema patterns? [Consistency]
+- [ ] CHK016 - Does the extended `ArtifactRef` follow the same YAML naming convention as existing fields (snake_case)? [Consistency]
+- [ ] CHK017 - Are the type short-forms (json, text, markdown) consistent with existing `.wave/schemas/wave-pipeline.schema.json:294`? [Consistency]
+- [ ] CHK018 - Is the artifact storage path pattern (`.wave/artifacts/<step-id>/<name>`) consistent with existing artifact handling? [Consistency]
+- [ ] CHK019 - Does the input validation sequence (after injection, before prompt) align with the existing execution flow in research.md? [Consistency]
+- [ ] CHK020 - Are the new RuntimeArtifactsConfig defaults (10MB, .wave/artifacts) consistent with other runtime defaults? [Consistency]
+- [ ] CHK021 - Is the `optional` field default (false) consistent with how other optional fields behave in the manifest? [Consistency]
+
+---
+
+## Coverage
+
+_Do requirements cover all necessary scenarios and user needs?_
+
+- [ ] CHK022 - Does the spec address multi-artifact stdout capture (multiple stdout artifacts from one step)? [Coverage]
+- [ ] CHK023 - Are requirements covering the case where the same artifact name is used across different steps? [Coverage]
+- [ ] CHK024 - Does the spec define behavior when schema_path points to a non-existent or invalid schema file? [Coverage]
+- [ ] CHK025 - Is there coverage for UTF-8 vs binary encoding handling in stdout capture? [Coverage]
+- [ ] CHK026 - Does the spec address concurrent pipeline runs sharing the same artifact directory? [Coverage]
+- [ ] CHK027 - Are observability requirements covered (events emitted for validation phases per P10)? [Coverage]
+- [ ] CHK028 - Does the spec address backward compatibility explicitly (existing pipelines unchanged)? [Coverage]
+- [ ] CHK029 - Is there coverage for what happens when `type` is declared in ArtifactRef but not in ArtifactDef? [Coverage]
+
+---
+
+## Testability
+
+_Can requirements be verified through testing?_
+
+- [ ] CHK030 - Does each user story include an "Independent Test" description that is actually independent? [Testability]
+- [ ] CHK031 - Are acceptance scenarios written in Given/When/Then format with concrete conditions? [Testability]
+- [ ] CHK032 - Can SC-002 ("fails with clear error message") be objectively verified? What defines "clear"? [Testability]
+- [ ] CHK033 - Does SC-006 (documentation with working examples) have verifiable acceptance criteria? [Testability]
+- [ ] CHK034 - Are the size limit values (10MB default) testable without excessive test duration? [Testability]
+- [ ] CHK035 - Can the "same level of detail as existing output contract errors" (SC-004) be objectively compared? [Testability]
+
+---
+
+## Architectural Alignment
+
+_Are requirements aligned with Wave's architectural principles?_
+
+- [ ] CHK036 - Does the spec maintain "fresh memory at step boundaries" (P4) by only using artifacts for inter-step communication? [Architectural]
+- [ ] CHK037 - Is the "orchestrator-owns-validation" principle maintained (no adapter-level validation)? [Architectural]
+- [ ] CHK038 - Does the spec respect "single binary deployment" (P1) by not introducing new external dependencies? [Architectural]
+- [ ] CHK039 - Are ephemeral workspace principles (P8) maintained with artifacts stored in workspace? [Architectural]
+- [ ] CHK040 - Is the spec compatible with the existing DAG-based step execution model? [Architectural]
+
+---
+
+## Risk & Security
+
+_Are potential risks and security considerations addressed?_
+
+- [ ] CHK041 - Is there a requirement addressing path traversal prevention in artifact names? [Security]
+- [ ] CHK042 - Does the spec address potential DoS via extremely large stdout (beyond the size limit check)? [Security]
+- [ ] CHK043 - Are schema validation timeouts specified to prevent runaway validation? [Security]
+- [ ] CHK044 - Is there consideration for sensitive data in stdout artifacts (credential exposure)? [Security]
+- [ ] CHK045 - Does the spec address concurrent access to artifact files (race conditions)? [Security]
+
+---
+
+## Summary
+
+| Dimension | Items | Critical Gaps |
+|-----------|-------|---------------|
+| Completeness | 7 | 0 |
+| Clarity | 7 | 0 |
+| Consistency | 7 | 0 |
+| Coverage | 8 | 0 |
+| Testability | 6 | 0 |
+| Architectural | 5 | 0 |
+| Risk & Security | 5 | 0 |
+| **Total** | **45** | **0** |
+
+---
+
+## How to Use This Checklist
+
+1. Work through each item before implementation begins
+2. Mark items as checked when the requirement quality is confirmed
+3. For any unchecked item, either:
+   - Update the spec to address the gap
+   - Document why the gap is acceptable
+4. All critical gaps must be resolved before Phase 1 implementation

--- a/specs/109-typed-artifact-composition/contracts/artifact-def.schema.json
+++ b/specs/109-typed-artifact-composition/contracts/artifact-def.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wave.re-cinq.com/schemas/artifact-def.schema.json",
+  "title": "ArtifactDef",
+  "description": "Extended artifact definition supporting stdout capture",
+  "type": "object",
+  "required": ["name"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$",
+      "description": "Artifact identifier, referenced by downstream inject_artifacts"
+    },
+    "path": {
+      "type": "string",
+      "description": "File path relative to workspace root. Required when source is 'file', ignored when source is 'stdout'"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["json", "text", "markdown", "binary"],
+      "description": "Content type for validation and handling"
+    },
+    "required": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, step fails when artifact is missing after execution"
+    },
+    "source": {
+      "type": "string",
+      "enum": ["file", "stdout"],
+      "default": "file",
+      "description": "Where artifact content comes from: 'file' (persona writes file) or 'stdout' (captured from process output)"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source": { "const": "file" }
+        }
+      },
+      "then": {
+        "required": ["path"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source": { "const": "stdout" }
+        }
+      },
+      "then": {
+        "properties": {
+          "path": {
+            "description": "Ignored for stdout artifacts; path is auto-generated"
+          }
+        }
+      }
+    }
+  ],
+  "examples": [
+    {
+      "name": "analysis-report",
+      "source": "stdout",
+      "type": "json"
+    },
+    {
+      "name": "summary",
+      "path": ".wave/output/summary.md",
+      "type": "markdown",
+      "required": true
+    },
+    {
+      "name": "data-export",
+      "path": "export.csv",
+      "type": "text"
+    }
+  ]
+}

--- a/specs/109-typed-artifact-composition/contracts/artifact-ref.schema.json
+++ b/specs/109-typed-artifact-composition/contracts/artifact-ref.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wave.re-cinq.com/schemas/artifact-ref.schema.json",
+  "title": "ArtifactRef",
+  "description": "Extended artifact reference with typed consumption and schema validation",
+  "type": "object",
+  "required": ["step", "artifact", "as"],
+  "additionalProperties": false,
+  "properties": {
+    "step": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "ID of the step that produced the artifact"
+    },
+    "artifact": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name of the artifact (matches ArtifactDef.name)"
+    },
+    "as": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name to mount under .wave/artifacts/ in workspace and for template substitution"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["json", "text", "markdown", "binary"],
+      "description": "Expected artifact type. If specified, validation fails on type mismatch"
+    },
+    "schema_path": {
+      "type": "string",
+      "description": "Path to JSON Schema file for content validation. Relative to workspace or absolute path"
+    },
+    "optional": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, missing artifact does not fail the step. Template substitution returns empty string"
+    }
+  },
+  "dependencies": {
+    "schema_path": {
+      "properties": {
+        "type": {
+          "const": "json",
+          "description": "Schema validation only applies to JSON artifacts"
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "step": "analyze",
+      "artifact": "analysis-report",
+      "as": "report",
+      "type": "json",
+      "schema_path": "./schemas/analysis-report.json"
+    },
+    {
+      "step": "scan",
+      "artifact": "scan-results",
+      "as": "scan_data",
+      "type": "json",
+      "optional": false
+    },
+    {
+      "step": "generate",
+      "artifact": "optional-metadata",
+      "as": "metadata",
+      "type": "json",
+      "optional": true
+    }
+  ]
+}

--- a/specs/109-typed-artifact-composition/contracts/input-validation-result.schema.json
+++ b/specs/109-typed-artifact-composition/contracts/input-validation-result.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wave.re-cinq.com/schemas/input-validation-result.schema.json",
+  "title": "InputValidationResult",
+  "description": "Result of input artifact validation before step execution",
+  "type": "object",
+  "required": ["passed", "artifact_name", "step_id"],
+  "additionalProperties": false,
+  "properties": {
+    "passed": {
+      "type": "boolean",
+      "description": "Overall validation result"
+    },
+    "artifact_name": {
+      "type": "string",
+      "description": "Name of the artifact being validated"
+    },
+    "step_id": {
+      "type": "string",
+      "description": "Step ID of the producing step"
+    },
+    "type_match": {
+      "type": "boolean",
+      "description": "Whether declared type matched artifact's actual type"
+    },
+    "schema_valid": {
+      "type": "boolean",
+      "description": "Whether schema validation passed (if schema_path was specified)"
+    },
+    "error": {
+      "type": "string",
+      "description": "Validation error message if failed"
+    },
+    "error_details": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Detailed validation error messages (e.g., schema violation specifics)"
+    },
+    "validation_time_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Time spent on validation in milliseconds"
+    }
+  },
+  "examples": [
+    {
+      "passed": true,
+      "artifact_name": "report",
+      "step_id": "analyze",
+      "type_match": true,
+      "schema_valid": true,
+      "validation_time_ms": 12
+    },
+    {
+      "passed": false,
+      "artifact_name": "data",
+      "step_id": "transform",
+      "type_match": true,
+      "schema_valid": false,
+      "error": "schema validation failed",
+      "error_details": [
+        "$.items[0].id: expected string, got number",
+        "$.metadata.version: required field missing"
+      ],
+      "validation_time_ms": 45
+    },
+    {
+      "passed": false,
+      "artifact_name": "config",
+      "step_id": "init",
+      "type_match": false,
+      "error": "artifact 'config' type mismatch: expected json, got text",
+      "validation_time_ms": 2
+    }
+  ]
+}

--- a/specs/109-typed-artifact-composition/contracts/runtime-artifacts-config.schema.json
+++ b/specs/109-typed-artifact-composition/contracts/runtime-artifacts-config.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wave.re-cinq.com/schemas/runtime-artifacts-config.schema.json",
+  "title": "RuntimeArtifactsConfig",
+  "description": "Global configuration for artifact handling in wave.yaml runtime section",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "max_stdout_size": {
+      "type": "integer",
+      "minimum": 1024,
+      "maximum": 104857600,
+      "default": 10485760,
+      "description": "Maximum bytes to capture from stdout for artifacts. Default 10MB (10485760 bytes). Min 1KB, Max 100MB"
+    },
+    "default_artifact_dir": {
+      "type": "string",
+      "default": ".wave/artifacts",
+      "pattern": "^[^/].*[^/]$|^[^/]$",
+      "description": "Base directory for stdout artifacts relative to workspace. Must not start or end with '/'"
+    }
+  },
+  "examples": [
+    {
+      "max_stdout_size": 5242880,
+      "default_artifact_dir": ".wave/artifacts"
+    },
+    {
+      "max_stdout_size": 20971520
+    }
+  ]
+}

--- a/specs/109-typed-artifact-composition/data-model.md
+++ b/specs/109-typed-artifact-composition/data-model.md
@@ -1,0 +1,334 @@
+# Data Model: Typed Artifact Composition
+
+**Feature Branch**: `109-typed-artifact-composition`
+**Created**: 2026-02-20
+**Status**: Complete
+
+## Entity Overview
+
+This feature extends existing Wave data structures to support stdout artifact capture, typed artifact consumption, and bidirectional contract validation.
+
+## Entities
+
+### 1. ArtifactDef (Extended)
+
+**Location**: `internal/pipeline/types.go:97-102`
+
+**Purpose**: Defines an artifact produced by a pipeline step. Extended to support stdout as a source.
+
+**Current Definition**:
+```go
+type ArtifactDef struct {
+    Name     string `yaml:"name"`
+    Path     string `yaml:"path"`
+    Type     string `yaml:"type,omitempty"`
+    Required bool   `yaml:"required,omitempty"`
+}
+```
+
+**Extended Definition**:
+```go
+type ArtifactDef struct {
+    Name     string `yaml:"name"`
+    Path     string `yaml:"path,omitempty"`          // Optional when Source is "stdout"
+    Type     string `yaml:"type,omitempty"`          // "json", "text", "markdown", "binary"
+    Required bool   `yaml:"required,omitempty"`
+    Source   string `yaml:"source,omitempty"`        // NEW: "file" (default) or "stdout"
+}
+```
+
+**Field Details**:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `Name` | string | Yes | - | Artifact identifier, referenced by downstream `inject_artifacts` |
+| `Path` | string | When Source=file | - | Filesystem path relative to workspace. Auto-generated for stdout artifacts. |
+| `Type` | string | No | - | Content type: `json`, `text`, `markdown`, `binary` |
+| `Required` | bool | No | false | If true, step fails when artifact is missing |
+| `Source` | string | No | `file` | Where content comes from: `file` (persona writes file) or `stdout` (captured from process output) |
+
+**Validation Rules**:
+- When `Source == "stdout"`: `Path` is ignored; system generates `.wave/artifacts/<step-id>/<name>`
+- When `Source == "file"` or empty: `Path` is required
+- `Type` must be one of: `json`, `text`, `markdown`, `binary`
+
+**YAML Example**:
+```yaml
+output_artifacts:
+  - name: analysis-report
+    source: stdout
+    type: json
+  - name: summary
+    path: .wave/output/summary.md
+    type: markdown
+```
+
+---
+
+### 2. ArtifactRef (Extended)
+
+**Location**: `internal/pipeline/types.go:68-72`
+
+**Purpose**: References an artifact from a prior step for injection into current step. Extended to support type validation and optional schema.
+
+**Current Definition**:
+```go
+type ArtifactRef struct {
+    Step     string `yaml:"step"`
+    Artifact string `yaml:"artifact"`
+    As       string `yaml:"as"`
+}
+```
+
+**Extended Definition**:
+```go
+type ArtifactRef struct {
+    Step       string `yaml:"step"`
+    Artifact   string `yaml:"artifact"`
+    As         string `yaml:"as"`
+    Type       string `yaml:"type,omitempty"`        // NEW: Expected artifact type
+    SchemaPath string `yaml:"schema_path,omitempty"` // NEW: JSON schema for validation
+    Optional   bool   `yaml:"optional,omitempty"`    // NEW: If true, missing artifact doesn't fail
+}
+```
+
+**Field Details**:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `Step` | string | Yes | - | ID of the step that produced the artifact |
+| `Artifact` | string | Yes | - | Name of the artifact (matches `ArtifactDef.Name`) |
+| `As` | string | Yes | - | Name to mount under `.wave/artifacts/` in workspace |
+| `Type` | string | No | - | Expected type; fails if mismatched |
+| `SchemaPath` | string | No | - | Path to JSON schema file for content validation |
+| `Optional` | bool | No | false | If true, missing artifact is allowed |
+
+**Validation Rules**:
+- When `Type` is specified: Artifact's declared type must match
+- When `SchemaPath` is specified: Content is validated against JSON schema
+- When `Optional == true`: Missing artifact results in empty `{{artifacts.<name>}}` substitution
+- `SchemaPath` must point to a valid JSON Schema draft-07 file
+
+**YAML Example**:
+```yaml
+memory:
+  inject_artifacts:
+    - step: analyze
+      artifact: analysis-report
+      as: report
+      type: json
+      schema_path: ./schemas/analysis-report.json
+      optional: false
+```
+
+---
+
+### 3. RuntimeArtifactsConfig (New)
+
+**Location**: `internal/manifest/types.go` (new struct within `RuntimeConfig`)
+
+**Purpose**: Global configuration for artifact handling, including size limits.
+
+**Definition**:
+```go
+type RuntimeArtifactsConfig struct {
+    MaxStdoutSize      int64  `yaml:"max_stdout_size,omitempty"` // Bytes, default 10MB
+    DefaultArtifactDir string `yaml:"default_artifact_dir,omitempty"` // Default: ".wave/artifacts"
+}
+```
+
+**Field Details**:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `MaxStdoutSize` | int64 | No | 10485760 (10MB) | Maximum bytes to capture from stdout |
+| `DefaultArtifactDir` | string | No | `.wave/artifacts` | Base directory for stdout artifacts |
+
+**YAML Example**:
+```yaml
+runtime:
+  artifacts:
+    max_stdout_size: 5242880  # 5MB
+    default_artifact_dir: .wave/artifacts
+```
+
+---
+
+### 4. StdoutArtifact (Runtime Entity)
+
+**Location**: Not persisted; exists only during execution in `PipelineExecution`
+
+**Purpose**: In-memory representation of captured stdout before writing to disk.
+
+**Definition**:
+```go
+type StdoutArtifact struct {
+    Name      string
+    Content   []byte
+    Type      string
+    StepID    string
+    Size      int64
+    CapturedAt time.Time
+}
+```
+
+**Field Details**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Name` | string | Artifact name from `ArtifactDef.Name` |
+| `Content` | []byte | Raw stdout bytes (buffered) |
+| `Type` | string | Declared type from `ArtifactDef.Type` |
+| `StepID` | string | Step that produced this artifact |
+| `Size` | int64 | Content size in bytes |
+| `CapturedAt` | time.Time | Timestamp when capture completed |
+
+**Lifecycle**:
+1. Created during `runStepExecution()` if step has stdout artifacts
+2. Populated as adapter streams output
+3. On step success: Written to filesystem, registered in `ArtifactPaths`
+4. On step failure: Discarded (atomicity guarantee)
+
+---
+
+### 5. InputValidationResult (New)
+
+**Location**: `internal/pipeline/executor.go` or `internal/contract/`
+
+**Purpose**: Result of input artifact validation before step execution.
+
+**Definition**:
+```go
+type InputValidationResult struct {
+    Passed     bool
+    ArtifactRef ArtifactRef
+    Error      error
+    TypeMatch  bool
+    SchemaValid bool
+}
+```
+
+**Field Details**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Passed` | bool | Overall validation result |
+| `ArtifactRef` | ArtifactRef | The reference being validated |
+| `Error` | error | Validation error if failed |
+| `TypeMatch` | bool | Whether declared type matched |
+| `SchemaValid` | bool | Whether schema validation passed (if applicable) |
+
+---
+
+## Entity Relationships
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                           Pipeline                                   │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │                         Step A                               │   │
+│  │  ┌─────────────────────────────────────────────────────┐    │   │
+│  │  │               output_artifacts                        │    │   │
+│  │  │  ┌─────────────────────────────────────────────┐     │    │   │
+│  │  │  │ ArtifactDef                                  │     │    │   │
+│  │  │  │   name: "report"                             │     │    │   │
+│  │  │  │   source: "stdout" ───┐                      │     │    │   │
+│  │  │  │   type: "json"        │                      │     │    │   │
+│  │  │  └───────────────────────│──────────────────────┘     │    │   │
+│  │  └──────────────────────────│────────────────────────────┘    │   │
+│  └─────────────────────────────│────────────────────────────────┘   │
+│                                │                                     │
+│                                ▼                                     │
+│                    ┌───────────────────────┐                        │
+│                    │  StdoutArtifact       │                        │
+│                    │  (runtime only)       │                        │
+│                    │  content: [...]       │                        │
+│                    └───────────┬───────────┘                        │
+│                                │ write on success                    │
+│                                ▼                                     │
+│                    ┌───────────────────────┐                        │
+│                    │ .wave/artifacts/      │                        │
+│                    │   step-a/report       │◄────────────────────┐  │
+│                    └───────────────────────┘                     │  │
+│                                                                   │  │
+│  ┌─────────────────────────────────────────────────────────────┐ │  │
+│  │                         Step B                               │ │  │
+│  │  ┌─────────────────────────────────────────────────────┐    │ │  │
+│  │  │               memory.inject_artifacts                 │    │ │  │
+│  │  │  ┌─────────────────────────────────────────────┐     │    │ │  │
+│  │  │  │ ArtifactRef                                  │     │    │ │  │
+│  │  │  │   step: "step-a"                             │     │    │ │  │
+│  │  │  │   artifact: "report" ────────────────────────┼─────┼────┘  │
+│  │  │  │   as: "analysis"                             │     │    │   │
+│  │  │  │   type: "json" ─────┐                        │     │    │   │
+│  │  │  │   schema_path: ...  │                        │     │    │   │
+│  │  │  └─────────────────────┼────────────────────────┘     │    │   │
+│  │  └────────────────────────│──────────────────────────────┘    │   │
+│  │                           │                                   │   │
+│  │                           ▼                                   │   │
+│  │              ┌───────────────────────────┐                    │   │
+│  │              │  InputValidationResult     │                    │   │
+│  │              │  (validates before exec)   │                    │   │
+│  │              └───────────────────────────┘                    │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Schema Evolution
+
+### Backward Compatibility
+
+All changes are additive:
+
+| Change | Compatibility | Notes |
+|--------|---------------|-------|
+| `ArtifactDef.Source` | Full | Defaults to "file"; existing pipelines unchanged |
+| `ArtifactRef.Type` | Full | Optional; no validation if omitted |
+| `ArtifactRef.SchemaPath` | Full | Optional; no schema check if omitted |
+| `ArtifactRef.Optional` | Full | Defaults to false; existing fail-on-missing behavior |
+| `RuntimeArtifactsConfig` | Full | Uses defaults if section absent |
+
+### Migration Path
+
+No migration required. Existing pipelines continue to work. New features are opt-in via new YAML fields.
+
+---
+
+## Persistence
+
+| Entity | Persisted | Location | Notes |
+|--------|-----------|----------|-------|
+| ArtifactDef | Yes | Pipeline YAML | Part of step definition |
+| ArtifactRef | Yes | Pipeline YAML | Part of step memory config |
+| RuntimeArtifactsConfig | Yes | `wave.yaml` | Global runtime config |
+| StdoutArtifact | No | Memory only | Transient during execution |
+| Written artifact | Yes | `.wave/artifacts/<step-id>/<name>` | Filesystem |
+| ArtifactPaths registry | Yes | `PipelineExecution` struct | In-memory during run |
+
+---
+
+## Validation Constraints
+
+### Type Validation Matrix
+
+| Declared Type | Allowed Content |
+|---------------|-----------------|
+| `json` | Valid JSON (UTF-8, parseable) |
+| `text` | Valid UTF-8 text |
+| `markdown` | Valid UTF-8 text (markdown syntax not validated) |
+| `binary` | Any bytes (no validation) |
+
+### Size Constraints
+
+| Constraint | Default | Configurable | Location |
+|------------|---------|--------------|----------|
+| Max stdout size | 10MB | Yes | `runtime.artifacts.max_stdout_size` |
+| Max artifact path length | 4096 | No | OS filesystem limit |
+
+### Schema Constraints
+
+- Schema files must be valid JSON Schema draft-07
+- Schema path must be relative to workspace or absolute
+- Schema validation timeout: 5 seconds (hardcoded)

--- a/specs/109-typed-artifact-composition/plan.md
+++ b/specs/109-typed-artifact-composition/plan.md
@@ -1,0 +1,219 @@
+# Implementation Plan: Typed Artifact Composition
+
+**Branch**: `109-typed-artifact-composition` | **Date**: 2026-02-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/109-typed-artifact-composition/spec.md`
+
+## Summary
+
+Extend Wave's artifact system to support capturing step stdout as typed artifacts and enable bidirectional contract validation at step boundaries. This involves:
+1. Adding `source: stdout` option to artifact definitions
+2. Extending artifact references with `type`, `schema_path`, and `optional` fields
+3. Implementing input contract validation before step execution
+4. Supporting `{{artifacts.<name>}}` template substitution in prompts
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: `gopkg.in/yaml.v3` (YAML parsing), existing `internal/contract` package
+**Storage**: Filesystem (`.wave/artifacts/<step-id>/<name>`)
+**Testing**: `go test ./...` with table-driven tests
+**Target Platform**: Linux/macOS (single binary)
+**Project Type**: Single (Wave CLI)
+**Performance Goals**: Artifact validation <100ms, stdout capture unbounded until size limit
+**Constraints**: Max stdout artifact size configurable (default 10MB), fail-fast on validation errors
+**Scale/Scope**: Per-pipeline, typically <100 artifacts per run
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | ✓ Pass | No new dependencies |
+| P2: Manifest as Truth | ✓ Pass | Schema extends `wave-pipeline.schema.json` |
+| P3: Persona Boundaries | ✓ Pass | No persona changes |
+| P4: Fresh Memory | ✓ Pass | Artifacts remain the sole inter-step communication |
+| P5: Navigator-First | ✓ Pass | No navigator changes |
+| P6: Contracts at Handover | ✓ Pass | Extends contracts bidirectionally |
+| P7: Relay via Summarizer | ✓ Pass | No relay changes |
+| P8: Ephemeral Workspaces | ✓ Pass | Artifacts stored in workspace |
+| P9: No Credentials on Disk | ✓ Pass | No credential handling |
+| P10: Observable Progress | ✓ Pass | Emit events for validation phases |
+| P11: Bounded Recursion | ✓ Pass | No recursion changes |
+| P12: Step State Machine | ✓ Pass | No state changes |
+| P13: Test Ownership | ✓ Required | Full test suite for new code |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/109-typed-artifact-composition/
+├── plan.md              # This file
+├── research.md          # Phase 0 output - codebase research
+├── data-model.md        # Phase 1 output - entity definitions
+├── contracts/           # Phase 1 output - JSON schemas
+│   ├── artifact-def.schema.json
+│   ├── artifact-ref.schema.json
+│   ├── runtime-artifacts-config.schema.json
+│   └── input-validation-result.schema.json
+└── tasks.md             # Phase 2 output - implementation tasks
+```
+
+### Source Code (repository root)
+
+```
+internal/
+├── pipeline/
+│   ├── types.go         # Extend ArtifactDef, ArtifactRef
+│   ├── executor.go      # Stdout capture, input validation
+│   └── context.go       # Artifact template resolution
+├── manifest/
+│   └── types.go         # Add RuntimeArtifactsConfig
+└── contract/
+    └── input_validator.go  # New: input artifact validation
+
+.wave/schemas/
+└── wave-pipeline.schema.json  # Schema updates
+
+tests/
+└── pipeline/
+    ├── stdout_capture_test.go
+    ├── input_validation_test.go
+    └── artifact_templates_test.go
+```
+
+**Structure Decision**: Single project structure. Changes are additive to existing packages without new top-level directories.
+
+## Implementation Phases
+
+### Phase 1: Type Extensions (FR-001, FR-004)
+
+**Goal**: Extend data types without breaking existing functionality.
+
+**Changes**:
+1. `internal/pipeline/types.go`:
+   - Add `Source string` to `ArtifactDef` (default: "file")
+   - Add `Type`, `SchemaPath`, `Optional` to `ArtifactRef`
+
+2. `internal/manifest/types.go`:
+   - Add `Artifacts RuntimeArtifactsConfig` to `RuntimeConfig`
+
+3. `.wave/schemas/wave-pipeline.schema.json`:
+   - Update `ArtifactDef` definition
+   - Update `ArtifactRef` definition
+
+**Tests**: Ensure existing pipeline YAML still parses correctly.
+
+---
+
+### Phase 2: Stdout Capture (FR-001, FR-002, FR-010)
+
+**Goal**: Capture step stdout as artifact when `source: stdout` is declared.
+
+**Changes**:
+1. `internal/pipeline/executor.go`:
+   - In `runStepExecution()`, check for stdout artifacts
+   - Buffer stdout during adapter execution
+   - On success: write to `.wave/artifacts/<step-id>/<name>`
+   - Register in `execution.ArtifactPaths`
+
+2. Implement size limit check (FR-009):
+   - Read `runtime.artifacts.max_stdout_size`
+   - Fail if exceeded
+
+**Tests**:
+- Stdout captured and available to downstream
+- Size limit enforced
+- Step failure = no partial artifact
+
+---
+
+### Phase 3: Input Validation (FR-005, FR-006, FR-007, FR-008)
+
+**Goal**: Validate injected artifacts before step execution.
+
+**Changes**:
+1. `internal/contract/input_validator.go` (new file):
+   - `ValidateInputArtifacts(refs []ArtifactRef, artifactPaths map[string]string, workspacePath string) []InputValidationResult`
+   - Type checking: compare declared type vs artifact metadata
+   - Schema validation: reuse `contract.Validate()` for JSON schemas
+
+2. `internal/pipeline/executor.go`:
+   - After `injectArtifacts()`, call `ValidateInputArtifacts()`
+   - Fail step if validation fails (unless `optional: true`)
+
+**Tests**:
+- Missing artifact fails (unless optional)
+- Type mismatch fails with clear error
+- Schema violation fails with detailed errors
+- Optional missing artifact proceeds
+
+---
+
+### Phase 4: Artifact Templates (FR-012)
+
+**Goal**: Resolve `{{artifacts.<name>}}` placeholders in prompts.
+
+**Changes**:
+1. `internal/pipeline/context.go`:
+   - Extend `ResolvePlaceholders()` to handle `{{artifacts.<name>}}`
+   - Read artifact content from `execution.ArtifactPaths`
+   - For optional missing artifacts, substitute empty string
+
+**Tests**:
+- Artifact content substituted into prompt
+- Missing required artifact fails before substitution
+- Optional missing artifact = empty string
+
+---
+
+### Phase 5: Documentation & Examples
+
+**Goal**: Provide working examples for users.
+
+**Changes**:
+1. Update `docs/pipelines.md` with:
+   - Stdout artifact capture example
+   - Typed consumption example
+   - Bidirectional contract example
+
+2. Add example pipeline in `.wave/pipelines/examples/`:
+   - `typed-artifact-pipeline.yaml`
+
+---
+
+## Complexity Tracking
+
+_No constitution violations. Table empty._
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| (none)    | -          | -                                    |
+
+## Risk Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Large stdout OOM | Low | High | Enforce size limit before buffering completes |
+| Breaking existing pipelines | Low | High | All new fields are optional with backward-compatible defaults |
+| Slow schema validation | Medium | Low | Cache compiled schemas; timeout at 5s |
+| Circular artifact dependencies | Low | Medium | Existing DAG validator prevents this |
+
+## Success Metrics
+
+| Criterion | Measurement | Target |
+|-----------|-------------|--------|
+| SC-001: End-to-end stdout pipeline | Integration test | Pass |
+| SC-002: Missing artifact fail-fast | Unit test | Error before step runs |
+| SC-003: Type mismatch error | Unit test | Clear error message |
+| SC-004: Input validation errors | Unit test | Same detail as output errors |
+| SC-005: Size limit error | Unit test | Actionable message |
+| SC-006: Documentation | Manual review | Examples work |
+
+## Next Steps
+
+After plan approval:
+1. Run `/speckit.tasks` to generate `tasks.md` with ordered implementation tasks
+2. Begin Phase 1 type extensions
+3. Run `go test ./...` after each phase

--- a/specs/109-typed-artifact-composition/research.md
+++ b/specs/109-typed-artifact-composition/research.md
@@ -1,0 +1,185 @@
+# Phase 0 Research: Typed Artifact Composition
+
+**Feature Branch**: `109-typed-artifact-composition`
+**Created**: 2026-02-20
+**Status**: Complete
+
+## Unknowns Identified from Spec
+
+The following areas required codebase research to resolve:
+
+### 1. Stdout Capture Integration Point
+
+**Question**: Where in the pipeline execution flow should stdout be captured for artifact registration?
+
+**Research Findings**:
+- `internal/pipeline/executor.go:622-625` captures stdout from adapter result: `io.ReadAll(result.Stdout)`
+- Artifact registration happens at line 1091-1119 in `writeOutputArtifacts()`
+- Artifacts are keyed by `"<step-id>:<artifact-name>"` and stored in `execution.ArtifactPaths` map
+
+**Decision**: Capture stdout in `runStepExecution()` after adapter completes. If `ArtifactDef.Source == "stdout"`, buffer content and write to `.wave/artifacts/<step-id>/<name>` before registering in `ArtifactPaths`.
+
+**Rationale**: This reuses existing artifact registration infrastructure. The current flow already handles file-based artifacts; stdout artifacts simply have a different source.
+
+**Alternatives Rejected**:
+- In-memory only artifacts: Would break existing file-based injection mechanism (`injectArtifacts()` at line 1035-1089 reads from filesystem)
+- Adapter-level capture: Would require changes to adapter interface; current design keeps orchestrator in control
+
+---
+
+### 2. Type Validation Mechanism
+
+**Question**: How should artifact type validation be implemented?
+
+**Research Findings**:
+- Current `ArtifactRef` in `types.go:68-72` has no type field
+- Current `ArtifactDef` in `types.go:97-102` has `Type string` field but it's informational only
+- Contract validation in `internal/contract/contract.go` provides `ContractValidator` interface
+- Existing contract types: `json_schema`, `typescript_interface`, `test_suite`, `markdown_spec`, `template`, `format`
+- JSON schema validation exists at `internal/contract/jsonschema.go`
+
+**Decision**: Add `type`, `schema_path`, and `optional` fields to `ArtifactRef`. Type validation happens in `injectArtifacts()` before copying artifact. Schema validation reuses existing `contract.Validate()`.
+
+**Rationale**:
+- Leverages existing contract validation infrastructure
+- Type checking is simple string comparison (lightweight)
+- Schema validation can be optional for performance
+
+**Alternatives Rejected**:
+- New validation package: Unnecessary duplication; `internal/contract/` already has validators
+- Validation in adapter: Violates orchestrator-owns-validation principle from constitution
+
+---
+
+### 3. Stdout Size Limit Implementation
+
+**Question**: How should stdout size limits be enforced?
+
+**Research Findings**:
+- No existing size limits for artifacts
+- Runtime config in `internal/manifest/types.go` has `Runtime` struct
+- Workspace root configurable via `Runtime.WorkspaceRoot`
+- Relay has token limits via `Runtime.Relay.TokenThresholdPercent`
+
+**Decision**: Add `Runtime.Artifacts.MaxStdoutSize` config (default 10MB). Buffer stdout during capture; fail if limit exceeded BEFORE writing artifact.
+
+**Rationale**:
+- Early failure prevents partial artifacts
+- Config-driven allows per-project tuning
+- Consistent with relay threshold pattern
+
+**Alternatives Rejected**:
+- Truncation instead of failure: Data loss risk; better to fail explicitly
+- Per-step limits: Overcomplicates config; runtime-level is simpler
+
+---
+
+### 4. Input Contract Validation Timing
+
+**Question**: When exactly should input contract validation run relative to artifact injection?
+
+**Research Findings**:
+- Current execution sequence in `runStepExecution()` (lines 434-736):
+  1. Create workspace (line 448)
+  2. Inject artifacts (line 467)
+  3. Build prompt (line 471)
+  4. Run adapter (line 580)
+  5. Write output artifacts (line 637)
+  6. Validate output contracts (lines 659-722)
+- Artifact injection copies files to `<workspace>/.wave/artifacts/<name>` (line 1043)
+- Contract validation in `Validate()` takes `workspacePath` and reads files from there
+
+**Decision**: Insert input validation AFTER artifact injection (line 467) but BEFORE prompt building (line 471). Sequence:
+1. Resolve artifact paths
+2. Inject artifacts into workspace (copy files)
+3. **NEW: Validate input contracts against injected artifacts**
+4. Build prompt
+5. Execute step
+6. Validate output contracts
+
+**Rationale**:
+- Files must exist on disk for schema validators to read
+- Fail-fast before expensive adapter execution
+- Symmetric with output validation
+
+---
+
+### 5. Artifact Template Resolution
+
+**Question**: How should `{{artifacts.<name>}}` placeholders work in prompts?
+
+**Research Findings**:
+- Template resolution in `internal/pipeline/context.go` handles `{{ input }}`, `{{ project.* }}`
+- `ResolvePlaceholders()` method processes prompt templates
+- Current artifact injection writes to `.wave/artifacts/<name>` in workspace
+
+**Decision**: Extend `PipelineContext.ResolvePlaceholders()` to handle `{{artifacts.<name>}}`. Read artifact content from `execution.ArtifactPaths` and inline into prompt.
+
+**Rationale**:
+- Consistent with existing template mechanism
+- Single point of template resolution
+- Artifacts already registered by path
+
+**Alternatives Rejected**:
+- Separate template processor: Fragments template logic
+- Lazy loading in adapter: Adapter should receive fully-resolved prompt
+
+---
+
+## Technology Decisions Summary
+
+| Area | Decision | Rationale |
+|------|----------|-----------|
+| Stdout capture | In `runStepExecution()` after adapter | Reuses existing artifact flow |
+| Artifact storage | `.wave/artifacts/<step-id>/<name>` | Matches current pattern |
+| Type validation | Extend `ArtifactRef` with `type` field | Minimal struct change |
+| Schema validation | Reuse `contract.Validate()` | DRY, existing infrastructure |
+| Size limits | `Runtime.Artifacts.MaxStdoutSize` | Config-driven, fail-fast |
+| Input validation | After injection, before prompt build | Fail-fast, files must exist |
+| Template syntax | `{{artifacts.<name>}}` | Consistent with existing |
+
+## Files to Modify
+
+### Core Changes
+1. `internal/pipeline/types.go`
+   - Extend `ArtifactRef` with `type`, `schema_path`, `optional` fields
+   - Extend `ArtifactDef` with `source` field ("stdout" | "file")
+
+2. `internal/pipeline/executor.go`
+   - Add stdout buffering in `runStepExecution()`
+   - Add input validation before prompt building
+   - Modify `writeOutputArtifacts()` to handle stdout source
+
+3. `internal/manifest/types.go`
+   - Add `Artifacts` config to `RuntimeConfig`
+   - Add `MaxStdoutSize` field
+
+4. `internal/pipeline/context.go`
+   - Extend `ResolvePlaceholders()` for artifact templates
+
+### Schema Updates
+5. `.wave/schemas/wave-pipeline.schema.json`
+   - Add `source` to `ArtifactDef`
+   - Add `type`, `schema_path`, `optional` to `ArtifactRef`
+
+### Tests
+6. `internal/pipeline/executor_test.go`
+   - Tests for stdout capture
+   - Tests for type validation
+   - Tests for input contracts
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Breaking existing pipelines | High | `source: file` is default; backward compatible |
+| Performance (large stdout) | Medium | Size limits prevent memory exhaustion |
+| Circular dependency detection | Low | Existing DAG validator handles this |
+| Schema validation latency | Low | Optional via `schema_path` presence |
+
+## Constitution Compliance
+
+- **Principle 4 (Fresh Memory)**: ✓ Artifacts remain the only inter-step communication
+- **Principle 6 (Contracts)**: ✓ Extends contracts bidirectionally (input + output)
+- **Principle 8 (Ephemeral Workspaces)**: ✓ Artifacts stored in workspace, not main repo
+- **Principle 13 (Test Ownership)**: ✓ Must add comprehensive tests

--- a/specs/109-typed-artifact-composition/spec.md
+++ b/specs/109-typed-artifact-composition/spec.md
@@ -1,0 +1,210 @@
+# Feature Specification: Typed Artifact Composition
+
+**Feature Branch**: `109-typed-artifact-composition`
+**Created**: 2026-02-20
+**Status**: Clarified
+**Input**: GitHub Issue #109 - Capture step stdout as typed artifacts and enable pipeline composition
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Capture Step Stdout as Named Artifact (Priority: P1)
+
+As a pipeline author, I want to declare that a step's stdout should be captured as a named, typed artifact so that downstream steps can consume structured output without relying on file-based workarounds.
+
+**Why this priority**: This is the foundational capability that all other features depend on. Without stdout capture, the composition features cannot work. It addresses the most common use case: passing JSON output from one step to another.
+
+**Independent Test**: Can be fully tested by running a single step that outputs JSON to stdout, then verifying the artifact is available with correct name, type, and content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step configuration with `output_artifacts: [{name: "report", source: stdout, type: json}]`, **When** the step completes and outputs valid JSON to stdout, **Then** an artifact named "report" is registered with the content from stdout and type "json".
+
+2. **Given** a step with stdout artifact declaration and the step outputs text to stdout, **When** the step completes, **Then** the artifact content matches the exact stdout output (no JSON wrapper from adapter).
+
+3. **Given** a step with stdout artifact declaration, **When** the step fails mid-execution, **Then** no partial stdout artifact is registered (atomicity guarantee).
+
+---
+
+### User Story 2 - Typed Artifact Consumption Declaration (Priority: P2)
+
+As a pipeline author, I want to declare what artifact types a step consumes so that the orchestrator can validate dependencies exist before execution begins.
+
+**Why this priority**: This enables fail-fast behavior and clear error messages. Without it, steps would fail at runtime when artifacts are missing, making debugging difficult.
+
+**Independent Test**: Can be tested by declaring a step that consumes an artifact that does not exist and verifying the pipeline fails with a clear error before the step starts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step with `memory.inject_artifacts: [{step: prior, artifact: report, as: report, type: json}]` and the artifact "report" exists from step "prior", **When** the step begins execution, **Then** the artifact is injected and the step proceeds.
+
+2. **Given** a step with `memory.inject_artifacts: [{step: prior, artifact: report, as: report, type: json}]` and no artifact named "report" exists, **When** the orchestrator evaluates the step, **Then** execution fails before the step starts with error: "required artifact 'report' not found".
+
+3. **Given** a step with `memory.inject_artifacts: [{step: prior, artifact: report, as: report, type: json}]` and an artifact named "report" exists with type "text", **When** the orchestrator evaluates the step, **Then** execution fails before the step starts with error: "artifact 'report' type mismatch: expected json, got text".
+
+---
+
+### User Story 3 - Bidirectional Contract Validation (Priority: P3)
+
+As a pipeline author, I want contracts to validate both inputs and outputs so that I can catch data quality issues at step boundaries rather than discovering them mid-execution.
+
+**Why this priority**: This builds on P1 and P2 to provide schema-level validation. While P2 validates artifact existence and type, P3 validates the actual content structure.
+
+**Independent Test**: Can be tested by declaring an input contract with a JSON schema and passing an artifact that violates the schema, verifying the step is rejected with schema validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step with `memory.inject_artifacts: [{step: prior, artifact: data, as: data, schema_path: "./schemas/input.json"}]` and the injected artifact matches the schema, **When** the step begins, **Then** validation passes and execution proceeds.
+
+2. **Given** a step with `memory.inject_artifacts: [{step: prior, artifact: data, as: data, schema_path: "./schemas/input.json"}]` and the injected artifact violates the schema, **When** the orchestrator validates input contracts, **Then** execution fails with detailed schema violation errors before the step runs.
+
+3. **Given** a step with both input and output contracts, **When** the step completes, **Then** both contracts are validated in order: input contract before execution, output contract after execution.
+
+---
+
+### User Story 4 - Step-to-Step Artifact Piping (Priority: P3)
+
+As a pipeline author, I want to reference a previous step's stdout artifact using template syntax so that I can build data transformation pipelines declaratively.
+
+**Why this priority**: This is a convenience feature that builds on P1-P2. It provides syntactic sugar for common patterns but is not essential for basic functionality.
+
+**Independent Test**: Can be tested by creating a two-step pipeline where step 2's prompt references `{{artifacts.step1-output}}` and verifying the content is substituted correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** step 1 produces stdout artifact "analysis" and step 2 prompt contains `{{artifacts.analysis}}`, **When** step 2 executes, **Then** the prompt contains the full content of the "analysis" artifact.
+
+2. **Given** step 1 produces stdout artifact "data" with type "json" and step 2 injects it via `memory.inject_artifacts`, **When** step 2 executes, **Then** the artifact is available both as file injection and via prompt substitution.
+
+---
+
+### Edge Cases
+
+- **Large stdout**: What happens when stdout exceeds configurable size limits (e.g., 10MB)?
+  - Artifact creation fails with "stdout artifact too large" error; step continues but artifact is not registered.
+- **Empty stdout**: What happens when stdout is empty?
+  - Empty artifact is created (0 bytes); type validation still applies if declared.
+- **Binary stdout**: What happens when stdout contains binary/non-UTF8 data?
+  - For `type: application/octet-stream`, content is stored as-is; for text types (`application/json`, `text/plain`), invalid UTF8 sequences are replaced with replacement character.
+- **Circular dependencies**: What happens when step A consumes from B and B consumes from A?
+  - DAG validation already prevents this; error: "circular dependency detected".
+- **Optional consumption**: What happens when an artifact is declared optional but missing?
+  - Step proceeds; `{{artifacts.name}}` substitutes to empty string.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST capture step stdout as a named artifact when `source: stdout` is declared in the step's `output_artifacts` configuration.
+- **FR-002**: System MUST write stdout artifacts to `.wave/artifacts/<step-id>/<artifact-name>` and register the path in `PipelineExecution.ArtifactPaths`.
+- **FR-003**: System MUST make stdout artifacts available to downstream steps via existing `memory.inject_artifacts` mechanism.
+- **FR-004**: System MUST allow steps to declare expected artifact types via the `type` field in `memory.inject_artifacts` entries.
+- **FR-005**: System MUST validate that all injected artifacts exist before step execution begins.
+- **FR-006**: System MUST validate that injected artifact types match declared types before step execution.
+- **FR-007**: System MUST support input schema validation via an optional `schema_path` field in `memory.inject_artifacts` entries.
+- **FR-008**: System MUST run input validation after artifact injection but before step execution; output contract validation runs after step completion.
+- **FR-009**: System MUST enforce configurable stdout artifact size limits with sensible defaults (default: 10MB).
+- **FR-010**: System MUST preserve stdout artifact content exactly without modification (no JSON wrapping).
+- **FR-011**: System MUST support marking injected artifacts as `optional: true` to allow missing artifacts without failure.
+- **FR-012**: System MUST resolve `{{artifacts.<name>}}` placeholders in step prompts to artifact content.
+
+### Key Entities _(include if feature involves data)_
+
+- **StdoutArtifact**: Runtime representation of captured stdout; attributes: `name`, `content`, `type`, `size`, `step_id`, `created_at`. Persisted to `.wave/artifacts/<step-id>/<name>`.
+- **ArtifactRef (extended)**: Existing struct in `internal/pipeline/types.go:68-72`; extended with: `type` (string), `schema_path` (string), `optional` (bool).
+- **ArtifactDef (extended)**: Existing struct in `internal/pipeline/types.go:97-102`; extended with: `source` (string: "stdout" | "file", default "file").
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A pipeline with stdout artifact capture and consumption runs end-to-end without manual file handling.
+- **SC-002**: Pipeline fails with clear error message when a consumed artifact is missing (fail-fast, not mid-step).
+- **SC-003**: Pipeline fails with clear error message when consumed artifact type does not match declaration.
+- **SC-004**: Input contract validation errors include the same level of detail as existing output contract errors.
+- **SC-005**: Stdout artifacts larger than configured limit (default 10MB) produce actionable error messages.
+- **SC-006**: Documentation includes working examples of: (a) stdout capture, (b) typed consumption, (c) bidirectional contracts.
+
+## Clarifications _(resolved)_
+
+The following ambiguities were identified and resolved based on codebase analysis:
+
+### Clarification 1: Stdout Artifact YAML Syntax Integration
+
+**Ambiguity**: The spec proposed `artifacts: [{name: "report", source: stdout, type: application/json}]` but the existing codebase uses `output_artifacts` with a `path` field (see `internal/pipeline/types.go:97-102`).
+
+**Resolution**: Extend the existing `output_artifacts` structure by adding an optional `source` field. When `source: stdout` is specified, the `path` field becomes optional (a generated path will be used internally). This maintains backward compatibility.
+
+**Updated YAML syntax**:
+```yaml
+output_artifacts:
+  - name: analysis-report
+    source: stdout  # New field: "stdout" | "file" (default: "file")
+    type: json      # Use short form to match existing schema
+```
+
+**Rationale**: The existing `ArtifactDef` structure in `types.go` and the JSON schema at `.wave/schemas/wave-pipeline.schema.json` already have the fields `name`, `path`, `type`, `required`. Adding `source` is additive and non-breaking. MIME types like `application/json` should be normalized to short forms (`json`, `text`, `markdown`) to match the existing schema enum.
+
+### Clarification 2: Type Declaration Format
+
+**Ambiguity**: The spec used MIME types (`application/json`) but the existing pipeline schema uses short forms (`json`, `text`, `markdown`).
+
+**Resolution**: Use the existing short-form type names from the pipeline schema (`json`, `text`, `markdown`). Internally, these can map to MIME types for validation purposes, but the pipeline YAML should remain consistent.
+
+**Type mapping**:
+| Short form | MIME type |
+|------------|-----------|
+| `json` | `application/json` |
+| `text` | `text/plain` |
+| `markdown` | `text/markdown` |
+| `binary` | `application/octet-stream` (new) |
+
+**Rationale**: Consistency with existing `.wave/schemas/wave-pipeline.schema.json:294` which enumerates `["json", "text", "markdown"]`.
+
+### Clarification 3: Consumption Declaration vs inject_artifacts
+
+**Ambiguity**: The spec introduced a new `consumes` field but the existing system uses `memory.inject_artifacts` for artifact injection.
+
+**Resolution**: Retain `memory.inject_artifacts` as the injection mechanism and add type validation to it. Do not introduce a parallel `consumes` field. Instead, extend `ArtifactRef` with an optional `type` and `schema_path` for input validation.
+
+**Extended inject_artifacts syntax**:
+```yaml
+memory:
+  inject_artifacts:
+    - step: analyze
+      artifact: report
+      as: analysis_report
+      type: json            # Optional: enables type checking
+      schema_path: ./schemas/report.json  # Optional: enables schema validation
+      optional: false       # Optional: default false
+```
+
+**Rationale**: The existing `inject_artifacts` mechanism is well-established in the codebase (see `internal/pipeline/types.go:64-72`). Adding fields to `ArtifactRef` is cleaner than introducing a parallel system. This also avoids confusion about which field to use.
+
+### Clarification 4: Input Contract Validation Timing
+
+**Ambiguity**: FR-008 specifies "input contract validation before step execution" but doesn't clarify the exact sequence relative to artifact injection.
+
+**Resolution**: The execution sequence is:
+1. Resolve artifact paths from prior steps
+2. Inject artifacts into workspace (copy/symlink)
+3. Validate input contracts against injected artifacts
+4. Execute step
+5. Validate output contracts
+
+Input validation happens AFTER injection so the files are physically present for schema validation.
+
+**Rationale**: Schema validators in `internal/contract/` operate on filesystem paths. Validating before injection would require holding artifact content in memory, which conflicts with the file-based design.
+
+### Clarification 5: Stdout Artifact Storage
+
+**Ambiguity**: The spec references "ArtifactPaths registry" but stdout artifacts have no natural filesystem path since they're captured from process output.
+
+**Resolution**: Stdout artifacts are written to a generated path: `.wave/artifacts/<step-id>/<artifact-name>`. This path is then registered in `ArtifactPaths` just like file-based artifacts. The artifact is captured atomically—written only after step completion.
+
+**Storage behavior**:
+- Stdout is buffered during step execution (respecting size limits)
+- On successful step completion, buffer is written to `.wave/artifacts/<step-id>/<artifact-name>`
+- On step failure, stdout artifact is NOT written (atomicity guarantee per User Story 1, Scenario 3)
+- The generated path is registered in `PipelineExecution.ArtifactPaths` using the same key format: `"<step-id>:<artifact-name>"`
+
+**Rationale**: This reuses the existing `ArtifactPaths` map in `internal/pipeline/executor.go:127` without special-casing. File-based artifacts and stdout artifacts become indistinguishable to downstream consumers.

--- a/specs/109-typed-artifact-composition/tasks.md
+++ b/specs/109-typed-artifact-composition/tasks.md
@@ -1,0 +1,194 @@
+# Implementation Tasks: Typed Artifact Composition
+
+**Feature Branch**: `109-typed-artifact-composition`
+**Generated**: 2026-02-20
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Task Legend
+
+- `[P]` = Parallelizable with other `[P]` tasks in same phase
+- `[T001]` = Unique task ID
+- `[US1]` = Maps to User Story 1, etc.
+
+---
+
+## Phase 1: Setup & Foundations
+
+_Project initialization and foundational type changes that all other phases depend on._
+
+- [X] [T001] [P] [US1] Extend `ArtifactDef` struct with `Source` field (`internal/pipeline/types.go:97-102`)
+- [X] [T002] [P] [US2] Extend `ArtifactRef` struct with `Type`, `SchemaPath`, `Optional` fields (`internal/pipeline/types.go:68-72`)
+- [X] [T003] [P] [US1] Add `RuntimeArtifactsConfig` struct with `MaxStdoutSize` to manifest types (`internal/manifest/types.go`)
+- [X] [T004] Update JSON schema for `ArtifactDef` with `source` field (`.wave/schemas/wave-pipeline.schema.json`)
+- [X] [T005] Update JSON schema for `ArtifactRef` with `type`, `schema_path`, `optional` fields (`.wave/schemas/wave-pipeline.schema.json`)
+- [X] [T006] Add unit tests for type extensions ensuring YAML parsing works (`internal/pipeline/types_test.go`)
+
+**Phase 1 Gate**: All type extensions compile, existing pipeline YAML parses correctly, tests pass.
+
+---
+
+## Phase 2: US1 - Stdout Artifact Capture (P1)
+
+_Core capability: capture step stdout as named artifact._
+
+### 2.1 Stdout Buffering
+
+- [X] [T007] [US1] Add `StdoutArtifact` runtime struct to hold buffered stdout (`internal/pipeline/executor.go`)
+- [X] [T008] [US1] Modify `runStepExecution()` to detect stdout artifacts in step config (`internal/pipeline/executor.go:434-736`)
+- [X] [T009] [US1] Implement stdout buffering during adapter execution with size limit check (`internal/pipeline/executor.go`)
+
+### 2.2 Stdout Artifact Writing
+
+- [X] [T010] [US1] Implement `writeStdoutArtifact()` function to persist to `.wave/artifacts/<step-id>/<name>` (`internal/pipeline/executor.go`)
+- [X] [T011] [US1] Modify `writeOutputArtifacts()` to handle `Source: stdout` artifacts (`internal/pipeline/executor.go:1091-1119`)
+- [X] [T012] [US1] Register stdout artifact paths in `execution.ArtifactPaths` map (`internal/pipeline/executor.go`)
+
+### 2.3 Atomicity & Error Handling
+
+- [X] [T013] [US1] Ensure stdout artifacts are NOT written on step failure (atomicity guarantee) (`internal/pipeline/executor.go`)
+- [X] [T014] [US1] Implement size limit exceeded error with actionable message (`internal/pipeline/executor.go`)
+- [X] [T015] [US1] Handle empty stdout case (create 0-byte artifact) (`internal/pipeline/executor.go`)
+
+### 2.4 US1 Tests
+
+- [X] [T016] [P] [US1] Test: stdout captured and available to downstream steps (`internal/pipeline/executor_test.go`)
+- [X] [T017] [P] [US1] Test: size limit enforced with clear error (`internal/pipeline/executor_test.go`)
+- [X] [T018] [P] [US1] Test: step failure produces no partial stdout artifact (`internal/pipeline/executor_test.go`)
+- [X] [T019] [P] [US1] Test: empty stdout creates valid artifact (`internal/pipeline/executor_test.go`)
+
+**Phase 2 Gate**: A step with `source: stdout` produces artifact accessible by name. Size limit works.
+
+---
+
+## Phase 3: US2 - Typed Artifact Consumption (P2)
+
+_Validate artifact existence and type before step execution._
+
+### 3.1 Existence Validation
+
+- [X] [T020] [US2] Implement artifact existence check in `injectArtifacts()` (`internal/pipeline/executor.go:1035-1089`)
+- [X] [T021] [US2] Add error path for missing required artifact: "required artifact 'X' not found" (`internal/pipeline/executor.go`)
+- [X] [T022] [US2] Implement `optional: true` handling - skip missing optional artifacts (`internal/pipeline/executor.go`)
+
+### 3.2 Type Validation
+
+- [X] [T023] [US2] Implement type comparison between declared `ArtifactRef.Type` and `ArtifactDef.Type` (`internal/pipeline/executor.go`)
+- [X] [T024] [US2] Add error path for type mismatch: "artifact 'X' type mismatch: expected Y, got Z" (`internal/pipeline/executor.go`)
+- [X] [T025] [US2] Handle case where type is not declared (skip type check) (`internal/pipeline/executor.go`)
+
+### 3.3 US2 Tests
+
+- [X] [T026] [P] [US2] Test: missing required artifact fails before step starts (`internal/pipeline/executor_test.go`)
+- [X] [T027] [P] [US2] Test: type mismatch fails with clear error (`internal/pipeline/executor_test.go`)
+- [X] [T028] [P] [US2] Test: optional missing artifact proceeds (`internal/pipeline/executor_test.go`)
+- [X] [T029] [P] [US2] Test: type not declared skips validation (`internal/pipeline/executor_test.go`)
+
+**Phase 3 Gate**: Pipeline fails fast with clear errors when artifacts missing or type mismatched.
+
+---
+
+## Phase 4: US3 - Bidirectional Contract Validation (P3)
+
+_Schema-level validation of artifact content at step boundaries._
+
+### 4.1 Input Validator
+
+- [X] [T030] [US3] Create `InputValidationResult` struct (`internal/contract/input_validator.go`)
+- [X] [T031] [US3] Implement `ValidateInputArtifacts()` function (`internal/contract/input_validator.go`)
+- [X] [T032] [US3] Integrate JSON schema validation via existing `contract.Validate()` (`internal/contract/input_validator.go`)
+
+### 4.2 Executor Integration
+
+- [X] [T033] [US3] Insert input validation call after `injectArtifacts()` in `runStepExecution()` (`internal/pipeline/executor.go:467-471`)
+- [X] [T034] [US3] Ensure input validation runs BEFORE prompt building (`internal/pipeline/executor.go`)
+- [X] [T035] [US3] Handle schema validation errors with detailed messages matching output contract format (`internal/pipeline/executor.go`)
+
+### 4.3 US3 Tests
+
+- [X] [T036] [P] [US3] Test: input artifact matching schema proceeds (`internal/contract/input_validator_test.go`)
+- [X] [T037] [P] [US3] Test: input artifact violating schema fails with detailed errors (`internal/contract/input_validator_test.go`)
+- [X] [T038] [P] [US3] Test: both input and output contracts validated in order (`internal/pipeline/executor_test.go`)
+- [X] [T039] [P] [US3] Test: schema_path not specified skips validation (`internal/contract/input_validator_test.go`)
+
+**Phase 4 Gate**: Input contracts validated before step execution. Schema errors are detailed.
+
+---
+
+## Phase 5: US4 - Artifact Template Resolution (P3)
+
+_Resolve `{{artifacts.<name>}}` placeholders in step prompts._
+
+### 5.1 Template Extension
+
+- [X] [T040] [US4] Extend `ResolvePlaceholders()` to recognize `{{artifacts.<name>}}` pattern (`internal/pipeline/context.go`)
+- [X] [T041] [US4] Implement artifact content lookup from `execution.ArtifactPaths` (`internal/pipeline/context.go`)
+- [X] [T042] [US4] Handle missing required artifact in template (fail before substitution) (`internal/pipeline/context.go`)
+- [X] [T043] [US4] Handle optional missing artifact in template (substitute empty string) (`internal/pipeline/context.go`)
+
+### 5.2 US4 Tests
+
+- [X] [T044] [P] [US4] Test: artifact content substituted correctly into prompt (`internal/pipeline/context_test.go`)
+- [X] [T045] [P] [US4] Test: missing required artifact fails before substitution (`internal/pipeline/context_test.go`)
+- [X] [T046] [P] [US4] Test: optional missing artifact substitutes to empty string (`internal/pipeline/context_test.go`)
+
+**Phase 5 Gate**: `{{artifacts.<name>}}` placeholders resolve to artifact content in prompts.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+_Documentation, integration tests, and final quality checks._
+
+### 6.1 Documentation
+
+- [ ] [T047] [P] Update `docs/pipelines.md` with stdout artifact capture example
+- [ ] [T048] [P] Update `docs/pipelines.md` with typed consumption example
+- [ ] [T049] [P] Update `docs/pipelines.md` with bidirectional contract example
+
+### 6.2 Integration Testing
+
+- [ ] [T050] Create end-to-end integration test: stdout capture pipeline (`tests/pipeline/stdout_capture_integration_test.go`)
+- [ ] [T051] Create end-to-end integration test: typed artifact consumption pipeline (`tests/pipeline/typed_consumption_integration_test.go`)
+- [ ] [T052] Create end-to-end integration test: bidirectional contracts pipeline (`tests/pipeline/bidirectional_contracts_integration_test.go`)
+
+### 6.3 Example Pipeline
+
+- [ ] [T053] Create example pipeline demonstrating all features (`.wave/pipelines/examples/typed-artifact-pipeline.yaml`)
+
+### 6.4 Final Verification
+
+- [ ] [T054] Run `go test ./...` to verify all tests pass
+- [ ] [T055] Run `go test -race ./...` to check for race conditions
+- [ ] [T056] Verify existing pipelines still work (backward compatibility)
+
+**Phase 6 Gate**: All tests pass, documentation complete, example pipeline works.
+
+---
+
+## Summary
+
+| Phase | Tasks | Parallelizable | Primary User Story |
+|-------|-------|----------------|-------------------|
+| 1. Setup | 6 | 3 | Foundation |
+| 2. US1 Stdout | 13 | 4 | P1 |
+| 3. US2 Types | 10 | 4 | P2 |
+| 4. US3 Contracts | 10 | 4 | P3 |
+| 5. US4 Templates | 7 | 3 | P3 |
+| 6. Polish | 10 | 3 | Cross-cutting |
+| **Total** | **56** | **21** | - |
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+    │
+    ├───► Phase 2 (US1 - Stdout)
+    │           │
+    │           └───► Phase 3 (US2 - Types) ────► Phase 5 (US4 - Templates)
+    │                       │
+    │                       └───► Phase 4 (US3 - Contracts)
+    │
+    └───────────────────────────────────────────► Phase 6 (Polish)
+```
+
+All phases depend on Phase 1 completion. Phase 2 (US1) must complete before Phase 3 (US2) because typed consumption needs stdout artifacts to exist. Phase 4 and 5 can proceed in parallel after Phase 3.


### PR DESCRIPTION
## Summary

- Add stdout artifact capture via `source: stdout` in `output_artifacts` configuration
- Extend `ArtifactRef` with `type`, `schema_path`, and `optional` fields for typed consumption
- Implement input contract validation before step execution with JSON schema support
- Add artifact type matching (json, text, markdown, binary) and existence checks at step boundaries
- Update pipeline schema to support new artifact composition fields

Spec: [specs/109-typed-artifact-composition/spec.md](specs/109-typed-artifact-composition/spec.md)

## Test Plan

- All existing tests pass with race detector: `go test -race ./...`
- New unit tests for:
  - `internal/pipeline/types_test.go` - ArtifactRef and ArtifactDef field validation
  - `internal/pipeline/executor_test.go` - stdout capture, type validation, input contracts
  - `internal/pipeline/context_test.go` - artifact resolution with types
  - `internal/contract/input_validator_test.go` - JSON schema validation

## Known Limitations

- Binary artifact type (`application/octet-stream`) is defined but full binary handling is deferred
- Prompt template substitution (`{{artifacts.<name>}}`) is documented in spec but implementation deferred to follow-up

Closes #109