### PR TITLE
docs: restructure CLAUDE.md — reduce noise, add runtime documentation

### DIFF
--- a/specs/141-restructure-claudemd/plan.md
+++ b/specs/141-restructure-claudemd/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Restructure CLAUDE.md
+
+## Objective
+
+Restructure the project root `CLAUDE.md` (285 lines) to reduce noise by 30%+, surface critical directives early, and add missing documentation about Wave's core runtime behavior (pipeline steps, contracts, artifacts).
+
+## Approach
+
+This is a **documentation-only change** to a single file (`CLAUDE.md`). No Go code changes are required. The strategy is:
+
+1. **Audit** every section of the current CLAUDE.md against its value-to-length ratio
+2. **Promote** critical directives (constraints, security model, test ownership) to the top
+3. **Add** a concise "How Wave Works at Runtime" section covering pipelines, contracts, and artifacts
+4. **Condense** verbose recipe-style sections (Common Tasks, Database Migrations, Adding New X) into brief references to source files
+5. **Remove** information that duplicates what's in code comments or is trivially discoverable
+6. **Preserve** structural markers (`MANUAL ADDITIONS`) and auto-updated sections (`Recent Changes`)
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `CLAUDE.md` | modify | Restructure, trim, and add runtime documentation |
+
+No other files are created, modified, or deleted.
+
+## Section-by-Section Analysis
+
+### Current Structure (285 lines)
+
+| Section | Lines | Verdict |
+|---------|-------|---------|
+| Wave Development Guidelines (header + overview) | ~10 | **Keep** — condense slightly |
+| Architecture Principles | ~25 | **Keep** — high signal |
+| Development Guidelines > Code Standards | ~8 | **Keep** — condense to bullet list |
+| Development Guidelines > Critical Constraints | ~10 | **Promote** — move to top of file |
+| File Structure | ~20 | **Keep** — useful reference |
+| Key Implementation Patterns | ~15 | **Replace** — fold into new Runtime section |
+| Testing Requirements | ~8 | **Keep** — condense |
+| Test Ownership | ~12 | **Promote** — move to top alongside constraints |
+| Constitutional Compliance | ~8 | **Keep** — merge into constraints |
+| Security Considerations (~40 lines) | ~40 | **Condense** — remove sub-sections, keep essentials |
+| Common Tasks (~25 lines) | ~25 | **Remove** — reference `cmd/wave/commands/` and `internal/contract/` instead |
+| Performance Considerations | ~5 | **Remove** — generic, not actionable |
+| Database Migrations (~25 lines) | ~25 | **Condense** — single line referencing `docs/migrations.md` |
+| Testing (CLI commands) | ~12 | **Condense** — keep only `go test ./...` and `go test -race ./...` |
+| Code Style | ~6 | **Keep** — already concise |
+| Git Commits | ~6 | **Keep** — critical for AI agents |
+| Versioning (~20 lines) | ~20 | **Condense** — keep table, remove prose |
+| Debugging | ~5 | **Keep** — useful |
+| Recent Changes | ~5 | **Keep** — auto-updated |
+| Manual Additions | ~2 | **Keep** — structural markers |
+
+### Proposed New Structure (~190 lines target)
+
+```
+# Wave Development Guidelines
+  (2-sentence overview)
+
+## Critical Constraints               ← PROMOTED to top
+  (single static binary, test ownership, security first, constitutional compliance)
+
+## How Wave Works at Runtime           ← NEW section
+  Pipeline execution → workspace → persona → contract
+  Artifact injection for inter-step communication
+  Runtime CLAUDE.md assembly (base-protocol + persona + contract + restrictions)
+
+## Architecture
+  Active technologies, core components, security model
+
+## File Structure
+  (existing tree, trimmed)
+
+## Security
+  (condensed: key principles only, no sub-headed recipes)
+
+## Development
+  Code standards, testing (condensed CLI commands), code style
+
+## Git & Versioning
+  Commits, conventional prefixes, semver table
+
+## Debugging
+  (existing, compact)
+
+## Recent Changes
+  (preserved as-is)
+
+## Manual Additions
+  (preserved as-is)
+```
+
+## Architecture Decisions
+
+1. **No code changes**: The issue is about the project root CLAUDE.md, not the runtime-generated per-step CLAUDE.md. The runtime assembly in `internal/adapter/claude.go` is unaffected.
+
+2. **Critical directives first**: Agents need to see constraints, test ownership, and security rules immediately. Currently these are buried ~60 lines in.
+
+3. **New "How Wave Works at Runtime" section**: This addresses the missing core concepts (pipeline environments, contracts, artifacts). It will be ~20 lines of high-density content, not a tutorial.
+
+4. **Reference over duplication**: Instead of documenting migration CLI commands or "how to add a new contract type" in CLAUDE.md, reference the source files. This prevents staleness.
+
+5. **Preserve auto-updated sections**: The `Recent Changes` section and `MANUAL ADDITIONS` markers are maintained exactly as-is for pipeline compatibility.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Removing too much context causes agents to miss important patterns | Keep all critical constraints and security model intact; only remove recipe-style instructions |
+| New runtime section becomes stale as code evolves | Write it at the conceptual level (not implementation detail); reference source files for specifics |
+| Breaking pipeline-injected content in MANUAL ADDITIONS section | Preserve markers and any content between them exactly |
+| Tests referencing CLAUDE.md content | Check for any tests that parse CLAUDE.md content (unlikely but verify) |
+
+## Testing Strategy
+
+1. **Line count verification**: `wc -l CLAUDE.md` should show ≤200 lines (down from 285)
+2. **Content audit**: Verify all acceptance criteria sections are present
+3. **Test suite**: Run `go test ./...` to confirm no regressions
+4. **Marker preservation**: Verify `MANUAL ADDITIONS` markers are intact
+5. **Grep for removed content**: Confirm no critical directives were accidentally removed

--- a/specs/141-restructure-claudemd/spec.md
+++ b/specs/141-restructure-claudemd/spec.md
@@ -1,0 +1,80 @@
+# Restructure CLAUDE.md: reduce noise, add core pipeline/contract documentation
+
+**Feature Branch**: `141-restructure-claudemd`
+**Issue**: [#141](https://github.com/re-cinq/wave/issues/141)
+**Labels**: documentation, enhancement
+**Author**: nextlevelshit
+**Status**: Draft
+
+## Problem
+
+The project `CLAUDE.md` (285 lines) is a critical component of Wave's agent protocol — it configures every AI persona's behavior at runtime. However, the current file has grown too long and contains low-signal content that dilutes the important instructions. This makes it harder for agents to follow key directives and increases the risk of content becoming outdated.
+
+Additionally, core Wave functionality is not documented in CLAUDE.md, leaving agents without essential context about how the system works.
+
+## Current Issues
+
+- **Too much noise**: The file contains verbose sections that could be condensed without losing meaning
+- **Low signal-to-noise ratio**: Critical keywords and directives are buried in walls of text
+- **Staleness risk**: The structure makes it easy for sections to become outdated as Wave evolves
+- **Missing core concepts**: Key runtime behaviors are not explained, including:
+  - Pipeline step environments (ephemeral worktrees with isolated context)
+  - Contract injection and validation at step boundaries
+  - Artifact injection for inter-step communication
+  - Runtime prompt generation from manifest + persona + contract schemas
+
+## Acceptance Criteria
+
+- [ ] CLAUDE.md is shorter overall (target: reduce by 30%+ in line count, from 285 to ~200 or fewer)
+- [ ] Every section has a clear, scannable heading
+- [ ] Core pipeline/contract/artifact runtime behavior is documented
+- [ ] No duplicated information that could become stale — references to canonical sources where appropriate
+- [ ] Agent personas can discover critical directives within the first screen of content
+- [ ] Existing test suite passes (`go test ./...`) after any related code changes
+- [ ] MANUAL ADDITIONS markers are preserved for user-added content
+
+## Context
+
+### Runtime CLAUDE.md Assembly
+
+The project root `CLAUDE.md` is read by Claude Code as project instructions. It is NOT the same as the runtime-generated per-step CLAUDE.md. The runtime CLAUDE.md is assembled by `prepareWorkspace()` in `internal/adapter/claude.go:213-309` from:
+
+1. Base protocol preamble (`.wave/personas/base-protocol.md`)
+2. Persona system prompt
+3. Contract compliance section (auto-generated from step contract)
+4. Restriction section (derived from manifest permissions)
+
+The project root CLAUDE.md serves a different purpose: it provides development guidelines to agents working directly in the Wave codebase (not through pipeline steps).
+
+### Key Source Files
+
+- `CLAUDE.md` — the file to restructure (285 lines)
+- `internal/pipeline/executor.go` — pipeline execution, workspace creation, artifact injection, contract validation
+- `internal/pipeline/context.go` — template variable resolution, pipeline context
+- `internal/contract/contract.go` — contract validation types and interfaces
+- `internal/workspace/workspace.go` — ephemeral workspace management
+- `internal/adapter/claude.go` — runtime CLAUDE.md assembly, workspace preparation
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Restructured CLAUDE.md MUST be 30%+ shorter in line count than the current 285 lines
+- **FR-002**: Critical directives (constraints, test ownership, security model) MUST appear in the first ~50 lines
+- **FR-003**: New section documenting core runtime behavior MUST be added (pipeline steps, contracts, artifacts)
+- **FR-004**: Verbose recipe-style sections (Common Tasks, Database Migrations) MUST be condensed or reference source files
+- **FR-005**: `<!-- MANUAL ADDITIONS START -->` / `<!-- MANUAL ADDITIONS END -->` markers MUST be preserved
+- **FR-006**: Recent Changes section MUST be preserved (it is auto-updated by pipelines)
+- **FR-007**: Information that duplicates source code comments or is easily discoverable MUST be removed
+
+### Non-Functional Requirements
+
+- **NFR-001**: No Go code changes required — this is a documentation-only change
+- **NFR-002**: All existing tests MUST pass after the change
+- **NFR-003**: The restructured content MUST be readable without external context
+
+## Success Criteria
+
+- **SC-001**: CLAUDE.md line count drops from 285 to ≤200 lines
+- **SC-002**: A new developer-facing section about pipeline/contract/artifact runtime is present
+- **SC-003**: `go test ./...` passes with no regressions

--- a/specs/141-restructure-claudemd/tasks.md
+++ b/specs/141-restructure-claudemd/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Phase 1: Audit and Analysis
+
+- [X] Task 1.1: Record baseline line count of CLAUDE.md (285 lines)
+- [X] Task 1.2: Verify no tests reference CLAUDE.md content directly (grep for CLAUDE.md in test files)
+
+## Phase 2: Core Restructure
+
+- [X] Task 2.1: Create new "Critical Constraints" section at top of file by extracting and consolidating from "Critical Constraints", "Test Ownership", and "Constitutional Compliance" sections
+- [X] Task 2.2: Write new "How Wave Works at Runtime" section (~20 lines) covering pipeline execution, workspace isolation, contract validation, artifact injection, and runtime CLAUDE.md assembly [P]
+- [X] Task 2.3: Condense "Security Considerations" section — collapse four sub-sections (Input Validation, Permission Enforcement, Sandbox Isolation, Data Protection) into a single compact list [P]
+- [X] Task 2.4: Remove "Common Tasks" section entirely — replace with one-line reference to source directories [P]
+- [X] Task 2.5: Remove "Performance Considerations" section — generic and not actionable [P]
+- [X] Task 2.6: Condense "Database Migrations" section to single line referencing `docs/migrations.md` [P]
+- [X] Task 2.7: Condense "Testing" section — keep only essential commands (`go test ./...`, `go test -race ./...`) [P]
+- [X] Task 2.8: Condense "Versioning" section — keep the commit prefix table, remove surrounding prose [P]
+- [X] Task 2.9: Merge "Key Implementation Patterns" into the new runtime section (Task 2.2) [P]
+
+## Phase 3: Polish and Verify
+
+- [X] Task 3.1: Verify `<!-- MANUAL ADDITIONS START -->` and `<!-- MANUAL ADDITIONS END -->` markers are preserved with their content
+- [X] Task 3.2: Verify `Recent Changes` section is preserved as-is
+- [X] Task 3.3: Verify final line count is ≤200 lines (30%+ reduction from 285)
+- [X] Task 3.4: Verify all section headings are clear and scannable
+
+## Phase 4: Validation
+
+- [X] Task 4.1: Run `go test ./...` to confirm no test regressions
+- [X] Task 4.2: Run `wc -l CLAUDE.md` to confirm line count target met
+- [X] Task 4.3: Review final document for readability and completeness


### PR DESCRIPTION
## Summary

Restructures CLAUDE.md to reduce noise and improve signal-to-noise ratio for AI agents. No code changes — purely documentation.

Closes #141

## Changes

- **CLAUDE.md** — Major restructure (~40% line reduction):
  - Moved critical constraints to the top so agents see them first
  - Added "How Wave Works at Runtime" section documenting the pipeline step lifecycle (workspace creation → artifact injection → CLAUDE.md assembly → adapter execution → contract validation)
  - Condensed redundant sections (testing, code style, security, versioning) into scannable bullet points
  - Removed verbose how-to guides (migrations CLI, adding commands/contracts/security features) that duplicated `docs/` content
  - Replaced hyphens with em-dashes for consistent formatting
- **specs/141-restructure-claudemd/** — Added spec, plan, and task artifacts

## Test Plan

- [ ] `go test ./...` passes (no code changes, but verify CLAUDE.md parse isn't broken)
- [ ] Verify critical directives (constraints, git rules, manual additions) are preserved
- [ ] Confirm runtime documentation matches actual behavior in `internal/pipeline/executor.go`