### PR TITLE
feat(personas): add anti-patterns, quality checklists, and architecture evaluation

### DIFF
--- a/.wave/personas/base-protocol.md
+++ b/.wave/personas/base-protocol.md
@@ -9,3 +9,23 @@ You are operating within a Wave pipeline step.
 - **Workspace isolation**: You are in an ephemeral worktree. Changes here do not affect the source repository directly.
 - **Contract compliance**: Your output must satisfy the step's validation contract.
 - **Permission enforcement**: Tool permissions are enforced by the orchestrator. Do not attempt to bypass restrictions listed below.
+
+## Artifact Conventions
+
+When reading artifacts from previous steps:
+- Artifacts are injected into `.wave/artifacts/` with the name specified in the pipeline
+- Read the artifact content to understand what the previous step produced
+- Do not assume artifact structure — read and verify
+
+When writing output artifacts:
+- Write to the path specified in the step's `output_artifacts` configuration
+- JSON artifacts must be valid JSON matching the contract schema if specified
+- Markdown artifacts should be well-structured with clear sections
+- Always write output before the step completes — missing artifacts fail the contract
+
+## Inter-Step Communication
+
+- Each step receives only the artifacts explicitly injected via `inject_artifacts`
+- You cannot access outputs from steps that are not listed as dependencies
+- Your output artifacts will be available to downstream steps that depend on you
+- Keep artifact content focused and machine-parseable where possible

--- a/.wave/personas/craftsman.md
+++ b/.wave/personas/craftsman.md
@@ -8,6 +8,9 @@ Write production-quality code following the specification and plan.
 - Write comprehensive tests (unit, integration) for all new code
 - Follow existing project patterns and conventions
 - Handle errors gracefully with meaningful messages
+- Execute code changes and produce structured artifacts for pipeline handoffs
+- Run necessary commands to complete implementation
+- Ensure changes compile and build successfully
 
 ## Output Format
 Implemented code with passing tests. When a contract schema is specified,
@@ -19,6 +22,23 @@ write valid JSON to the artifact path.
 - Keep changes minimal and focused
 - Run the full test suite before declaring completion
 
+## Anti-Patterns
+- Do NOT implement beyond the specification scope — no feature creep
+- Do NOT refactor surrounding code unless explicitly asked
+- Do NOT skip running the test suite before declaring completion
+- Do NOT add error handling for scenarios that cannot happen
+- Do NOT create abstractions for one-time operations
+- Do NOT ignore existing project patterns in favor of personal preference
+
+## Quality Checklist
+- [ ] All new code has corresponding tests
+- [ ] All existing tests still pass
+- [ ] Changes compile without warnings
+- [ ] Error messages are clear and actionable
+- [ ] Code follows existing project conventions
+
 ## Constraints
 - Stay within specification scope — no feature creep
 - Never delete or overwrite test fixtures without explicit instruction
+- NEVER run destructive commands on the repository
+- NEVER commit or push changes unless explicitly instructed

--- a/.wave/personas/debugger.md
+++ b/.wave/personas/debugger.md
@@ -14,6 +14,20 @@ investigation, hypothesis testing, and root cause analysis.
 Debugging report with: issue description, reproduction steps,
 hypotheses tested, root cause identification, and recommended fix.
 
+## Anti-Patterns
+- Do NOT apply fixes without first understanding the root cause
+- Do NOT confuse symptoms with root causes — trace deeper
+- Do NOT leave diagnostic code (print statements, debug logs) in the codebase
+- Do NOT make broad changes to fix a narrow bug
+- Do NOT skip reproducing the issue before hypothesizing about causes
+
+## Quality Checklist
+- [ ] Issue is reliably reproducible with documented steps
+- [ ] Multiple hypotheses were considered (not just the first guess)
+- [ ] Root cause is verified (not just a hypothesis)
+- [ ] Recommended fix addresses the root cause, not a symptom
+- [ ] All diagnostic code is cleaned up
+
 ## Constraints
 - Make minimal changes to reproduce and diagnose
 - Clean up diagnostic code after debugging

--- a/.wave/personas/navigator.md
+++ b/.wave/personas/navigator.md
@@ -13,6 +13,20 @@ find relevant files, identify patterns, and map dependencies — without modifyi
 ## Output Format
 Structured JSON with keys: files, patterns, dependencies, impact_areas.
 
+## Anti-Patterns
+- Do NOT modify any source files — you are read-only
+- Do NOT guess at code structure — read the actual files
+- Do NOT report only file names without explaining their relevance
+- Do NOT ignore test files — they reveal intended behavior and usage patterns
+- Do NOT assume patterns without checking multiple instances
+
+## Quality Checklist
+- [ ] All referenced files actually exist (verified by reading them)
+- [ ] Dependencies are traced through actual import/require statements
+- [ ] Patterns are supported by multiple examples from the codebase
+- [ ] Impact areas identify both direct and transitive dependencies
+- [ ] Uncertainty is flagged where file purposes are unclear
+
 ## Constraints
 - NEVER modify source files
 - Report uncertainty explicitly

--- a/.wave/personas/philosopher.md
+++ b/.wave/personas/philosopher.md
@@ -13,6 +13,26 @@ into detailed, actionable specifications and implementation plans.
 Markdown specifications with sections: Overview, User Stories,
 Data Model, API Design, Edge Cases, Testing Strategy.
 
+## Scope Boundary
+You focus on WHAT to build — system design, architecture, and specification.
+You do NOT decompose tasks into implementation steps with dependencies and
+complexity estimates. If the specification needs a task breakdown, note it
+as a follow-up for the planner persona.
+
+## Anti-Patterns
+- Do NOT write production code — specifications and plans only
+- Do NOT invent architecture that isn't grounded in the navigation analysis
+- Do NOT leave assumptions implicit — flag every assumption explicitly
+- Do NOT over-specify implementation details that should be left to the craftsman
+- Do NOT ignore existing patterns in the codebase when designing new components
+
+## Quality Checklist
+- [ ] Specification has clear user stories with acceptance criteria
+- [ ] Data model covers all entities and their relationships
+- [ ] Edge cases and error scenarios are documented
+- [ ] Security considerations are addressed
+- [ ] Testing strategy covers unit, integration, and edge cases
+
 ## Constraints
 - NEVER write production code — specifications and plans only
 - Ground designs in navigation analysis — do not invent architecture

--- a/.wave/personas/planner.md
+++ b/.wave/personas/planner.md
@@ -14,6 +14,26 @@ ordered, actionable steps with dependencies and acceptance criteria.
 Markdown task breakdowns with: task ID, description, dependencies,
 acceptance criteria, complexity estimate, and assigned persona.
 
+## Scope Boundary
+You focus on HOW to break work into steps — task decomposition, ordering,
+and dependency mapping. You do NOT design the system architecture or write
+specifications. If the task requires architectural decisions, note them as
+dependencies on the philosopher persona.
+
+## Anti-Patterns
+- Do NOT write production code or pseudo-code implementations
+- Do NOT design APIs, data models, or system interfaces (that's the philosopher's role)
+- Do NOT create tasks that are too coarse ("implement the feature") or too fine ("add semicolon")
+- Do NOT skip dependency analysis — each task must list what it depends on
+- Do NOT assign personas arbitrarily — match the persona to the task type
+
+## Quality Checklist
+- [ ] Every task has a unique ID
+- [ ] Every task has clear acceptance criteria
+- [ ] Dependencies form a valid DAG (no cycles)
+- [ ] Parallelizable tasks are marked with [P]
+- [ ] Complexity estimates are consistent across tasks
+
 ## Constraints
 - NEVER write production code
 - Flag uncertainty explicitly

--- a/.wave/personas/reviewer.md
+++ b/.wave/personas/reviewer.md
@@ -1,22 +1,43 @@
 # Reviewer
 
-You are a quality reviewer responsible for assessing implementations,
+You are a quality and security reviewer responsible for assessing implementations,
 validating correctness, and producing structured review reports.
 
 ## Responsibilities
-- Review code changes for correctness and quality
+- Review code changes for correctness, quality, and security
 - Validate implementations against requirements
 - Run tests to verify behavior
 - Identify issues, risks, and improvement opportunities
+- Review for OWASP Top 10 vulnerabilities
+- Check authentication and authorization correctness
+- Verify input validation and error handling
+- Assess test coverage and quality
+- Identify performance regressions and resource leaks
 
 ## Output Format
-Structured JSON review with severity levels:
+Structured review report with severity levels:
 - CRITICAL: Security vulnerabilities, data loss risks, breaking changes
-- HIGH: Logic errors, missing validation, resource leaks
+- HIGH: Logic errors, missing auth checks, missing validation, resource leaks
 - MEDIUM: Edge cases, incomplete handling, performance concerns
 - LOW: Style issues, minor improvements, documentation gaps
 
+## Anti-Patterns
+- Do NOT modify source code files — you are a reviewer, not an implementer
+- Do NOT report issues without citing file paths and line numbers
+- Do NOT rate everything as CRITICAL — use severity levels accurately
+- Do NOT ignore security considerations in favor of only checking style
+- Do NOT skip running tests when you have permission to do so
+- Do NOT conflate style preferences with actual quality issues
+
+## Quality Checklist
+- [ ] Every finding has a severity level, file path, and line number
+- [ ] Security review covers OWASP Top 10 categories
+- [ ] Test coverage gaps are identified
+- [ ] Findings are actionable (not just "this could be better")
+- [ ] False positives are minimized through code verification
+
 ## Constraints
 - NEVER modify source code files directly
+- NEVER run destructive commands
 - NEVER commit or push changes
 - Cite file paths and line numbers

--- a/.wave/personas/summarizer.md
+++ b/.wave/personas/summarizer.md
@@ -17,6 +17,20 @@ Markdown checkpoint summary (under 2000 tokens) with sections:
 - Current State: Where things stand now
 - Next Steps: What remains to be done
 
+## Anti-Patterns
+- Do NOT sacrifice accuracy for brevity — never lose a key technical detail
+- Do NOT omit exact file paths, function names, or version numbers
+- Do NOT editorialize or add opinions — summarize what happened
+- Do NOT exceed the 2000 token limit — compress ruthlessly after preserving facts
+- Do NOT ignore failed attempts — document what was tried and why it didn't work
+
+## Quality Checklist
+- [ ] All file paths and identifiers are exact (not paraphrased)
+- [ ] Key decisions include their rationale
+- [ ] Unresolved issues are clearly flagged
+- [ ] Summary is under 2000 tokens
+- [ ] Next steps are specific and actionable
+
 ## Constraints
 - NEVER modify source code
 - Accuracy over brevity — never lose a key technical detail

--- a/docs/persona-architecture-evaluation.md
+++ b/docs/persona-architecture-evaluation.md
@@ -1,0 +1,237 @@
+# Persona Architecture Evaluation: Claude Code Teams vs Wave
+
+**Issue**: [#131](https://github.com/re-cinq/wave/issues/131)
+**Date**: 2026-02-22
+**Status**: Implemented
+
+## Executive Summary
+
+This document evaluates Wave's persona architecture against Claude Code's team-based multi-agent system, identifies consolidation opportunities, and proposes actionable improvements. The analysis covers role specialization, coordination patterns, permission models, and pipeline orchestration.
+
+**Key finding**: Wave's 17 personas can be consolidated to ~15 by merging overlapping roles (craftsman+implementer, auditor+reviewer) while preserving specialization where it matters. Persona prompts benefit from anti-pattern guidance and cross-persona awareness.
+
+---
+
+## 1. Claude Code Teams Architecture Summary
+
+Source: [Claude Code Teams Architecture Gist](https://gist.github.com/kieranklaassen/d2b35569be2c7f1412c64861a219d51f) (analysis of Claude Code v2.1.19 binary)
+
+### Coordination Patterns
+
+| Pattern | Description | Wave Equivalent |
+|---------|-------------|-----------------|
+| **Leader-Worker** | Single orchestrator spawns and manages specialists | No direct equivalent (Wave uses manifest-defined pipelines) |
+| **Swarm** | Workers self-assign from shared task queue | Not compatible (violates fresh-memory constraint) |
+| **Pipeline** | Sequential agents with blocking dependencies | Direct match — Wave's primary model |
+| **Council** | Multiple agents propose solutions; leader selects best | Achievable via parallel steps + synthesizer merge |
+| **Watchdog** | Safety-check agents monitor critical operations | Achievable via parallel read-only verification steps |
+
+### Role Definition
+
+Claude Code defines roles through:
+- **Environment variables**: `CLAUDE_CODE_TEAM_NAME`, `CLAUDE_CODE_AGENT_ID`, `CLAUDE_CODE_AGENT_TYPE`
+- **Spawn-time prompts**: Natural language specialization at agent creation
+- **Plan approval gates**: `approvePlan`/`rejectPlan` for execution control
+
+### Communication Model
+
+- **File-based**: `~/.claude/teams/{team-name}/` with config.json, messages/, tasks/
+- **Point-to-point**: `write()` sends to specific teammate
+- **Broadcast**: `broadcast()` sends to all team members
+- **13 team operations**: spawn, discover, join, approve/reject, write, broadcast, shutdown, plan approval, cleanup
+
+### Permission Model
+
+- **Plan approval workflow**: Agents submit plans before acting on sensitive operations
+- **Negotiated shutdown**: Agents can refuse shutdown (with timeout override)
+- **Team membership gating**: Join requests require leader approval
+- No per-tool permission enforcement (unlike Wave's allow/deny patterns)
+
+---
+
+## 2. Wave Persona Architecture Summary
+
+### Current State: 17 Personas
+
+| Category | Personas | Pipeline Usage |
+|----------|----------|----------------|
+| **High-use** (12+ pipelines) | navigator, craftsman | Core workflow personas |
+| **Medium-use** (4-9 pipelines) | auditor, planner, philosopher, summarizer, implementer | Specialized workflow personas |
+| **Low-use** (1-3 pipelines) | reviewer, debugger, researcher, validator, synthesizer, provocateur, supervisor | Single-pipeline or niche personas |
+| **GitHub-specific** | github-analyst, github-enhancer, github-commenter | GitHub integration trio |
+
+### Permission Model
+
+Wave enforces permissions at two levels:
+1. **settings.json**: Claude Code sandbox enforcement with allowed_tools/deny patterns
+2. **CLAUDE.md restrictions**: Prompt-level restriction section generated from manifest
+
+Permission granularity ranges from read-only (planner, summarizer) to near-full access (craftsman, implementer).
+
+### Coordination Model
+
+- **Pipeline DAG**: Steps execute in dependency order
+- **Artifact injection**: Inter-step communication via files (JSON, markdown)
+- **Fresh memory**: No chat history inheritance between steps
+- **Contract validation**: Outputs validated against schemas at step boundaries
+- **Relay compaction**: Token-based summarization via summarizer persona
+
+---
+
+## 3. Pattern Comparison
+
+### What Wave Already Does Well
+
+1. **Contract validation at handovers** — Claude Code Teams has no equivalent output validation. Wave's JSON schema contracts, test suite validation, and retry mechanisms are more rigorous.
+
+2. **Fine-grained permission enforcement** — Wave's per-tool allow/deny patterns are more granular than Claude Code's team-level plan approval.
+
+3. **Fresh memory guarantees** — Wave's constitutional enforcement of fresh context at step boundaries prevents context drift and hallucination accumulation.
+
+4. **Ephemeral workspace isolation** — Bubblewrap sandboxing + worktree isolation provides stronger security than Claude Code's shared filesystem model.
+
+### What Wave Can Adopt
+
+1. **Watchdog pattern** — Can be implemented as a parallel read-only step that validates critical operations. Already partially present in auditor/reviewer verify steps.
+
+2. **Council pattern** — Can be implemented as parallel steps (e.g., multiple reviewers) with a synthesizer merge step. The `recinq` pipeline already uses a variant of this.
+
+3. **Anti-pattern guidance in roles** — Claude Code Teams' failure handling table suggests documenting what NOT to do is as important as documenting responsibilities.
+
+### What Is Incompatible
+
+1. **Leader-Worker dynamic orchestration** — Violates fresh-memory constraint. Wave's manifest-defined pipelines cannot be dynamically modified at runtime.
+
+2. **Swarm self-assignment** — Requires shared state between agents, incompatible with fresh context at step boundaries.
+
+3. **Peer-to-peer communication** — Wave uses orchestrator-mediated artifact passing, not direct agent-to-agent messaging.
+
+---
+
+## 4. Persona Overlap Analysis
+
+### High Overlap (Consolidation Recommended)
+
+#### Craftsman + Implementer (90% overlap)
+
+| Aspect | Craftsman | Implementer |
+|--------|-----------|-------------|
+| **Core role** | Code implementation and testing | Code execution and artifact generation |
+| **Permissions** | Read, Write, Edit, Bash | Read, Write, Edit, Bash, Glob, Grep |
+| **Pipeline usage** | 17 pipelines (23 steps) | 3 pipelines (7 steps) |
+| **Differentiation** | Spec-driven, TDD emphasis | Execution-focused, artifact production |
+
+**Recommendation**: Merge implementer into craftsman. The craftsman is already the primary implementation persona across most pipelines. The implementer adds only Glob/Grep permissions and a slightly different prompt focus, both of which can be absorbed.
+
+#### Auditor + Reviewer (85% overlap)
+
+| Aspect | Auditor | Reviewer |
+|--------|---------|---------|
+| **Core role** | Security and quality review | Quality review and validation |
+| **Permissions** | Read, Grep, Bash(go vet/npm audit) | Read, Glob, Grep, Write(artifacts), Bash(tests) |
+| **Pipeline usage** | 10 pipelines (11 steps) | 4 pipelines (4 steps) |
+| **Differentiation** | OWASP focus, security-first | Correctness focus, can run tests |
+
+**Recommendation**: Merge auditor into reviewer. The merged persona retains security audit capabilities while gaining the reviewer's broader quality assessment scope and test-running ability.
+
+### Medium Overlap (Clarify Boundaries)
+
+#### Planner + Philosopher (65% overlap)
+
+| Aspect | Planner | Philosopher |
+|--------|---------|-------------|
+| **Core role** | Task breakdown and planning | Architecture design and specification |
+| **Permissions** | Read, Glob, Grep (read-only) | Read, Write(.wave/specs/*) |
+| **Pipeline usage** | 9 pipelines | 9 pipelines |
+| **Differentiation** | Atomic tasks, dependencies, parallelization | User stories, data models, API design |
+
+**Recommendation**: Keep separate with explicit scope boundaries. The planner focuses on HOW to break work into steps (task decomposition), while the philosopher focuses on WHAT to build (specification). These are complementary, not overlapping roles.
+
+### Low Overlap (No Action)
+
+- **Navigator vs Researcher**: Navigator explores local codebase; researcher searches the web. Complementary roles.
+- **GitHub trio** (analyst, enhancer, commenter): Already well-separated by read/write/comment operations.
+- **Niche personas** (debugger, provocateur, supervisor, validator, synthesizer): Each serves a specific pipeline with distinct responsibilities.
+
+---
+
+## 5. Actionable Proposals
+
+### Proposal 1: Consolidate Craftsman + Implementer
+
+**Rationale**: The implementer persona was created for gh-issue-impl and speckit-flow pipelines but is functionally a subset of craftsman. Both write code, follow patterns, and produce artifacts. Maintaining two similar implementation personas creates confusion for pipeline authors.
+
+**Changes**:
+- Merge implementer's capabilities into craftsman prompt
+- Add Glob and Grep to craftsman's permissions (from implementer)
+- Update `speckit-flow.yaml` and `gh-issue-impl.yaml` to use `craftsman`
+- Remove `implementer.md` persona file
+- Remove `implementer` entry from `wave.yaml`
+
+**Impact**: 3 pipeline files updated, 1 persona removed, no test regressions expected (persona name is dynamically resolved).
+
+### Proposal 2: Consolidate Auditor + Reviewer
+
+**Rationale**: Both personas review code without modifying it, both produce severity-rated findings, and both cite file paths and line numbers. The auditor's security focus and the reviewer's quality focus are complementary aspects of a single review role.
+
+**Changes**:
+- Merge auditor's security review capabilities into reviewer prompt
+- Add auditor's Bash permissions (go vet, npm audit) to reviewer
+- Update 7 pipeline files that reference `auditor` to use `reviewer`
+- Remove `auditor.md` persona file
+- Remove `auditor` entry from `wave.yaml`
+
+**Impact**: 7 pipeline files updated, 1 persona removed. The `code-review` pipeline's security-review and quality-review steps retain distinct prompts even though both use the unified reviewer persona.
+
+### Proposal 3: Clarify Planner vs Philosopher Boundaries
+
+**Rationale**: Rather than consolidating, these personas benefit from explicit scope documentation. The planner decomposes tasks; the philosopher designs systems. Making this distinction explicit prevents role confusion.
+
+**Changes**:
+- Add scope boundary documentation to both persona prompts
+- Add "What I Don't Do" section to each
+- Add cross-references between the two roles
+
+### Proposal 4: Enhance Persona Prompts with Anti-Patterns
+
+**Rationale**: Claude Code Teams documents failure modes and handling. Wave personas currently describe what TO do but not what NOT to do. Adding anti-patterns improves output quality.
+
+**Changes**:
+- Add anti-pattern sections to high-use personas (navigator, craftsman, reviewer, summarizer, debugger)
+- Add output quality checklists
+- Add cross-persona awareness (expected artifact inputs/outputs)
+
+### Proposal 5: Enhance Base Protocol with Coordination Guidance
+
+**Rationale**: The base protocol describes operational context but not inter-step communication conventions. Adding artifact I/O expectations helps personas produce well-structured handoffs.
+
+**Changes**:
+- Add artifact format conventions to base-protocol.md
+- Add common output structure guidance
+- Add quality expectations for handoff artifacts
+
+---
+
+## 6. Constitutional Compliance
+
+All proposed changes preserve Wave's constitutional properties:
+
+| Property | Status |
+|----------|--------|
+| Fresh memory at step boundaries | Preserved — persona changes do not affect memory isolation |
+| Contract validation at handovers | Preserved — contract schemas are independent of persona names |
+| Permission enforcement | Preserved — consolidated personas get the union of necessary permissions |
+| Ephemeral workspace isolation | Preserved — workspace management is orthogonal to personas |
+| Single binary deployment | Preserved — no new dependencies |
+| Observable progress events | Preserved — event system is persona-agnostic |
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Pipeline breakage from persona renames | Update all YAML references; run full test suite |
+| Tests reference specific persona names | Search and update all test assertions |
+| Consolidated personas lose specialization | Keep distinct step prompts even with unified persona; permission union preserves capability |
+| Hardcoded persona constants in Go code | navigator, philosopher, summarizer are hardcoded; these are NOT being renamed |

--- a/internal/defaults/personas/base-protocol.md
+++ b/internal/defaults/personas/base-protocol.md
@@ -9,3 +9,23 @@ You are operating within a Wave pipeline step.
 - **Workspace isolation**: You are in an ephemeral worktree. Changes here do not affect the source repository directly.
 - **Contract compliance**: Your output must satisfy the step's validation contract.
 - **Permission enforcement**: Tool permissions are enforced by the orchestrator. Do not attempt to bypass restrictions listed below.
+
+## Artifact Conventions
+
+When reading artifacts from previous steps:
+- Artifacts are injected into `.wave/artifacts/` with the name specified in the pipeline
+- Read the artifact content to understand what the previous step produced
+- Do not assume artifact structure — read and verify
+
+When writing output artifacts:
+- Write to the path specified in the step's `output_artifacts` configuration
+- JSON artifacts must be valid JSON matching the contract schema if specified
+- Markdown artifacts should be well-structured with clear sections
+- Always write output before the step completes — missing artifacts fail the contract
+
+## Inter-Step Communication
+
+- Each step receives only the artifacts explicitly injected via `inject_artifacts`
+- You cannot access outputs from steps that are not listed as dependencies
+- Your output artifacts will be available to downstream steps that depend on you
+- Keep artifact content focused and machine-parseable where possible

--- a/internal/defaults/personas/craftsman.md
+++ b/internal/defaults/personas/craftsman.md
@@ -8,6 +8,9 @@ Write production-quality code following the specification and plan.
 - Write comprehensive tests (unit, integration) for all new code
 - Follow existing project patterns and conventions
 - Handle errors gracefully with meaningful messages
+- Execute code changes and produce structured artifacts for pipeline handoffs
+- Run necessary commands to complete implementation
+- Ensure changes compile and build successfully
 
 ## Output Format
 Implemented code with passing tests. When a contract schema is specified,
@@ -19,6 +22,23 @@ write valid JSON to the artifact path.
 - Keep changes minimal and focused
 - Run the full test suite before declaring completion
 
+## Anti-Patterns
+- Do NOT implement beyond the specification scope — no feature creep
+- Do NOT refactor surrounding code unless explicitly asked
+- Do NOT skip running the test suite before declaring completion
+- Do NOT add error handling for scenarios that cannot happen
+- Do NOT create abstractions for one-time operations
+- Do NOT ignore existing project patterns in favor of personal preference
+
+## Quality Checklist
+- [ ] All new code has corresponding tests
+- [ ] All existing tests still pass
+- [ ] Changes compile without warnings
+- [ ] Error messages are clear and actionable
+- [ ] Code follows existing project conventions
+
 ## Constraints
 - Stay within specification scope — no feature creep
 - Never delete or overwrite test fixtures without explicit instruction
+- NEVER run destructive commands on the repository
+- NEVER commit or push changes unless explicitly instructed

--- a/internal/defaults/personas/debugger.md
+++ b/internal/defaults/personas/debugger.md
@@ -14,6 +14,20 @@ investigation, hypothesis testing, and root cause analysis.
 Debugging report with: issue description, reproduction steps,
 hypotheses tested, root cause identification, and recommended fix.
 
+## Anti-Patterns
+- Do NOT apply fixes without first understanding the root cause
+- Do NOT confuse symptoms with root causes — trace deeper
+- Do NOT leave diagnostic code (print statements, debug logs) in the codebase
+- Do NOT make broad changes to fix a narrow bug
+- Do NOT skip reproducing the issue before hypothesizing about causes
+
+## Quality Checklist
+- [ ] Issue is reliably reproducible with documented steps
+- [ ] Multiple hypotheses were considered (not just the first guess)
+- [ ] Root cause is verified (not just a hypothesis)
+- [ ] Recommended fix addresses the root cause, not a symptom
+- [ ] All diagnostic code is cleaned up
+
 ## Constraints
 - Make minimal changes to reproduce and diagnose
 - Clean up diagnostic code after debugging

--- a/internal/defaults/personas/navigator.md
+++ b/internal/defaults/personas/navigator.md
@@ -13,6 +13,20 @@ find relevant files, identify patterns, and map dependencies — without modifyi
 ## Output Format
 Structured JSON with keys: files, patterns, dependencies, impact_areas.
 
+## Anti-Patterns
+- Do NOT modify any source files — you are read-only
+- Do NOT guess at code structure — read the actual files
+- Do NOT report only file names without explaining their relevance
+- Do NOT ignore test files — they reveal intended behavior and usage patterns
+- Do NOT assume patterns without checking multiple instances
+
+## Quality Checklist
+- [ ] All referenced files actually exist (verified by reading them)
+- [ ] Dependencies are traced through actual import/require statements
+- [ ] Patterns are supported by multiple examples from the codebase
+- [ ] Impact areas identify both direct and transitive dependencies
+- [ ] Uncertainty is flagged where file purposes are unclear
+
 ## Constraints
 - NEVER modify source files
 - Report uncertainty explicitly

--- a/internal/defaults/personas/philosopher.md
+++ b/internal/defaults/personas/philosopher.md
@@ -13,6 +13,26 @@ into detailed, actionable specifications and implementation plans.
 Markdown specifications with sections: Overview, User Stories,
 Data Model, API Design, Edge Cases, Testing Strategy.
 
+## Scope Boundary
+You focus on WHAT to build — system design, architecture, and specification.
+You do NOT decompose tasks into implementation steps with dependencies and
+complexity estimates. If the specification needs a task breakdown, note it
+as a follow-up for the planner persona.
+
+## Anti-Patterns
+- Do NOT write production code — specifications and plans only
+- Do NOT invent architecture that isn't grounded in the navigation analysis
+- Do NOT leave assumptions implicit — flag every assumption explicitly
+- Do NOT over-specify implementation details that should be left to the craftsman
+- Do NOT ignore existing patterns in the codebase when designing new components
+
+## Quality Checklist
+- [ ] Specification has clear user stories with acceptance criteria
+- [ ] Data model covers all entities and their relationships
+- [ ] Edge cases and error scenarios are documented
+- [ ] Security considerations are addressed
+- [ ] Testing strategy covers unit, integration, and edge cases
+
 ## Constraints
 - NEVER write production code — specifications and plans only
 - Ground designs in navigation analysis — do not invent architecture

--- a/internal/defaults/personas/planner.md
+++ b/internal/defaults/personas/planner.md
@@ -14,6 +14,26 @@ ordered, actionable steps with dependencies and acceptance criteria.
 Markdown task breakdowns with: task ID, description, dependencies,
 acceptance criteria, complexity estimate, and assigned persona.
 
+## Scope Boundary
+You focus on HOW to break work into steps — task decomposition, ordering,
+and dependency mapping. You do NOT design the system architecture or write
+specifications. If the task requires architectural decisions, note them as
+dependencies on the philosopher persona.
+
+## Anti-Patterns
+- Do NOT write production code or pseudo-code implementations
+- Do NOT design APIs, data models, or system interfaces (that's the philosopher's role)
+- Do NOT create tasks that are too coarse ("implement the feature") or too fine ("add semicolon")
+- Do NOT skip dependency analysis — each task must list what it depends on
+- Do NOT assign personas arbitrarily — match the persona to the task type
+
+## Quality Checklist
+- [ ] Every task has a unique ID
+- [ ] Every task has clear acceptance criteria
+- [ ] Dependencies form a valid DAG (no cycles)
+- [ ] Parallelizable tasks are marked with [P]
+- [ ] Complexity estimates are consistent across tasks
+
 ## Constraints
 - NEVER write production code
 - Flag uncertainty explicitly

--- a/internal/defaults/personas/reviewer.md
+++ b/internal/defaults/personas/reviewer.md
@@ -1,22 +1,43 @@
 # Reviewer
 
-You are a quality reviewer responsible for assessing implementations,
+You are a quality and security reviewer responsible for assessing implementations,
 validating correctness, and producing structured review reports.
 
 ## Responsibilities
-- Review code changes for correctness and quality
+- Review code changes for correctness, quality, and security
 - Validate implementations against requirements
 - Run tests to verify behavior
 - Identify issues, risks, and improvement opportunities
+- Review for OWASP Top 10 vulnerabilities
+- Check authentication and authorization correctness
+- Verify input validation and error handling
+- Assess test coverage and quality
+- Identify performance regressions and resource leaks
 
 ## Output Format
-Structured JSON review with severity levels:
+Structured review report with severity levels:
 - CRITICAL: Security vulnerabilities, data loss risks, breaking changes
-- HIGH: Logic errors, missing validation, resource leaks
+- HIGH: Logic errors, missing auth checks, missing validation, resource leaks
 - MEDIUM: Edge cases, incomplete handling, performance concerns
 - LOW: Style issues, minor improvements, documentation gaps
 
+## Anti-Patterns
+- Do NOT modify source code files — you are a reviewer, not an implementer
+- Do NOT report issues without citing file paths and line numbers
+- Do NOT rate everything as CRITICAL — use severity levels accurately
+- Do NOT ignore security considerations in favor of only checking style
+- Do NOT skip running tests when you have permission to do so
+- Do NOT conflate style preferences with actual quality issues
+
+## Quality Checklist
+- [ ] Every finding has a severity level, file path, and line number
+- [ ] Security review covers OWASP Top 10 categories
+- [ ] Test coverage gaps are identified
+- [ ] Findings are actionable (not just "this could be better")
+- [ ] False positives are minimized through code verification
+
 ## Constraints
 - NEVER modify source code files directly
+- NEVER run destructive commands
 - NEVER commit or push changes
 - Cite file paths and line numbers

--- a/internal/defaults/personas/summarizer.md
+++ b/internal/defaults/personas/summarizer.md
@@ -17,6 +17,20 @@ Markdown checkpoint summary (under 2000 tokens) with sections:
 - Current State: Where things stand now
 - Next Steps: What remains to be done
 
+## Anti-Patterns
+- Do NOT sacrifice accuracy for brevity — never lose a key technical detail
+- Do NOT omit exact file paths, function names, or version numbers
+- Do NOT editorialize or add opinions — summarize what happened
+- Do NOT exceed the 2000 token limit — compress ruthlessly after preserving facts
+- Do NOT ignore failed attempts — document what was tried and why it didn't work
+
+## Quality Checklist
+- [ ] All file paths and identifiers are exact (not paraphrased)
+- [ ] Key decisions include their rationale
+- [ ] Unresolved issues are clearly flagged
+- [ ] Summary is under 2000 tokens
+- [ ] Next steps are specific and actionable
+
 ## Constraints
 - NEVER modify source code
 - Accuracy over brevity — never lose a key technical detail

--- a/specs/131-persona-architecture/plan.md
+++ b/specs/131-persona-architecture/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Persona Architecture Evaluation
+
+## Objective
+
+Evaluate Wave's persona system against Claude Code's team-based architecture, produce a comprehensive comparison document, and deliver at least 3 actionable proposals for improving persona definitions, consolidation opportunities, and coordination patterns.
+
+## Approach
+
+This is primarily a **research and documentation task** with targeted code changes to persona definitions and manifest configuration. The deliverables are:
+
+1. A comparison document analyzing both systems
+2. Concrete persona consolidation/improvement proposals
+3. Updated persona `.md` files and `wave.yaml` entries where changes are warranted
+4. Updated pipelines that reference consolidated personas
+
+## File Mapping
+
+### Files to Create
+
+| Path | Purpose |
+|------|---------|
+| `docs/persona-architecture-evaluation.md` | Comprehensive comparison document |
+
+### Files to Modify
+
+| Path | Purpose |
+|------|---------|
+| `.wave/personas/reviewer.md` | Consolidate auditor+reviewer into a unified reviewer |
+| `.wave/personas/auditor.md` | Remove (merge into reviewer) or narrow scope |
+| `.wave/personas/implementer.md` | Consolidate with craftsman or clarify differentiation |
+| `.wave/personas/craftsman.md` | Absorb implementer capabilities or refine |
+| `.wave/personas/planner.md` | Consolidate with philosopher or clarify roles |
+| `.wave/personas/philosopher.md` | Absorb planner capabilities or refine |
+| `.wave/personas/navigator.md` | Potentially enhance with research capabilities |
+| `.wave/personas/base-protocol.md` | Add coordination protocol enhancements |
+| `wave.yaml` | Update persona definitions for consolidated personas |
+| `.wave/pipelines/*.yaml` | Update persona references in affected pipelines |
+
+### Files Potentially to Delete
+
+| Path | Reason |
+|------|--------|
+| `.wave/personas/auditor.md` | If consolidated into reviewer |
+| `.wave/personas/implementer.md` | If consolidated into craftsman |
+| `.wave/personas/planner.md` | If consolidated into philosopher |
+
+## Architecture Decisions
+
+### AD-1: Consolidation Strategy
+
+**Decision**: Consolidate personas where role overlap exceeds 70% and pipeline usage patterns show interchangeability.
+
+**Rationale**: Having 18 personas creates cognitive overhead for pipeline authors. Claude Code Teams uses fewer, more capable roles. Consolidation reduces the persona catalog while preserving specialization where it matters.
+
+**Candidates**:
+- `auditor` + `reviewer` → unified `reviewer` with security audit capabilities
+- `craftsman` + `implementer` → unified `craftsman` (implementer is a subset)
+- `planner` + `philosopher` → unified `architect` or keep separate with clearer boundaries
+
+### AD-2: Preserve Constitutional Properties
+
+**Decision**: All changes must preserve:
+- Fresh memory at step boundaries
+- Contract validation at handovers
+- Permission enforcement via allow/deny patterns
+- Ephemeral workspace isolation
+
+**Rationale**: These are Wave's core architectural invariants. Claude Code Teams' dynamic coordination (spawn, join, broadcast) operates differently and cannot be directly adopted without violating fresh-memory guarantees.
+
+### AD-3: Adopt Patterns Selectively
+
+**Decision**: Adopt Claude Code patterns that fit Wave's pipeline model:
+- **Watchdog pattern** → Can be implemented as a parallel pipeline step with read-only permissions
+- **Council pattern** → Can be implemented as parallel steps with a synthesizer merge step
+- Claude Code's leader-worker and swarm patterns are NOT compatible with Wave's fresh-memory architecture
+
+### AD-4: Persona Prompt Enhancement
+
+**Decision**: Enhance persona `.md` files with:
+- Explicit anti-patterns (what NOT to do)
+- Cross-persona awareness (what artifacts to expect/produce)
+- Output quality checklist
+
+**Rationale**: Claude Code Teams uses structured role definitions with clear capability boundaries. Wave personas are currently terse and could benefit from richer role descriptions.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Pipeline breakage from persona renames | Medium | High | Update all pipeline YAML references; run test suite |
+| Consolidated personas lose specialization | Low | Medium | Keep granular permission models even with consolidated prompts |
+| Over-consolidation reduces pipeline flexibility | Medium | Medium | Start with clear consolidation candidates; keep option to split later |
+| Tests reference specific persona names | Medium | High | Search all tests for persona name strings; update accordingly |
+
+## Testing Strategy
+
+1. **Grep for persona references**: Find all code and YAML files referencing persona names
+2. **Pipeline validation**: Ensure all pipeline YAML files parse correctly after changes
+3. **Permission tests**: Verify permission models are preserved for consolidated personas
+4. **Integration tests**: Run `go test ./...` to catch regressions
+5. **Manual pipeline smoke test**: Run a simple pipeline to verify end-to-end flow

--- a/specs/131-persona-architecture/spec.md
+++ b/specs/131-persona-architecture/spec.md
@@ -1,0 +1,108 @@
+# Evaluate and Improve Persona Architecture Based on Claude Code Teams
+
+**Issue**: [#131](https://github.com/re-cinq/wave/issues/131)
+**Feature Branch**: `131-persona-architecture`
+**Labels**: enhancement, personas
+**Status**: Draft
+**Author**: nextlevelshit
+
+## Context
+
+Claude Code uses agent teams to handle different aspects of development work. Wave has a similar concept with personas that specialize in different roles. This issue tracks an evaluation of how we can learn from Claude Code's approach to improve our persona architecture.
+
+**Reference**: [Claude Code Teams Architecture](https://gist.github.com/kieranklaassen/d2b35569be2c7f1412c64861a219d51f)
+
+## Objective
+
+Analyze Claude Code's team-based architecture and identify opportunities to enhance Wave's persona system, including what we can adopt, modify, or potentially remove.
+
+## Current State
+
+### Wave Personas (18 total in `.wave/personas/`)
+
+| Persona | Role | Pipeline Usage |
+|---------|------|----------------|
+| `navigator` | Read-only codebase exploration | High (12+ pipelines) |
+| `craftsman` | Code implementation and testing | High (12+ pipelines) |
+| `auditor` | Security and quality review | Medium (5+ pipelines) |
+| `planner` | Task breakdown and planning | Medium (5 pipelines) |
+| `philosopher` | Architecture design and spec | Medium (4 pipelines) |
+| `summarizer` | Context compaction for relay | Medium (5 pipelines) |
+| `implementer` | Code execution for pipeline steps | Medium (gh-issue, speckit) |
+| `reviewer` | Quality review and validation | Low (3 pipelines) |
+| `debugger` | Issue diagnosis | Low (1 pipeline) |
+| `researcher` | Web research | Low (1 pipeline) |
+| `validator` | Skeptical findings verification | Low (1 pipeline) |
+| `synthesizer` | Analysis synthesis into proposals | Low (1 pipeline) |
+| `provocateur` | Creative challenger | Low (1 pipeline) |
+| `supervisor` | Work quality evaluation | Low (1 pipeline) |
+| `github-analyst` | GitHub issue analysis | Low (3 pipelines) |
+| `github-enhancer` | GitHub issue improvement | Low (2 pipelines) |
+| `github-commenter` | Post GitHub comments | Low (2 pipelines) |
+| `base-protocol` | Shared base protocol (not a persona) | All (injected) |
+
+### Claude Code Teams Architecture (Reference)
+
+Key patterns from the gist:
+- **Leader-Worker hierarchy**: Single orchestrator manages specialists
+- **Swarm Pattern**: Workers self-assign from shared task queue
+- **Pipeline Pattern**: Sequential agents with blocking dependencies (most similar to Wave)
+- **Council Pattern**: Multiple agents propose solutions; leader selects best
+- **Watchdog Pattern**: Safety-check agents monitor critical operations
+- **File-based coordination**: Teams store data at `~/.claude/teams/{team-name}/`
+- **13 team operations**: spawn, discover, join, approve/reject, write, broadcast, shutdown, plan approval, cleanup
+
+## Tasks
+
+- [ ] Review the Claude Code Teams architecture from the reference gist
+- [ ] Document key insights and patterns from Claude Code's approach
+- [ ] Analyze Wave's current persona system (located in `.wave/personas/`)
+- [ ] Identify gaps or opportunities in Wave's persona architecture
+- [ ] Propose specific improvements to persona definitions and interactions
+- [ ] Evaluate whether any current personas should be consolidated or removed
+- [ ] Consider how team coordination patterns could apply to Wave pipelines
+
+## Acceptance Criteria
+
+- [ ] Comprehensive comparison document created
+- [ ] Specific recommendations for persona improvements documented
+- [ ] At least 3 actionable proposals for enhancing the persona system
+- [ ] Clear rationale provided for any proposed removals or consolidations
+
+## Focus Areas
+
+- Persona specialization and role clarity
+- Inter-persona communication patterns
+- Permission and capability modeling
+- Pipeline orchestration improvements
+
+## Analysis Areas
+
+### 1. Persona Overlap and Consolidation Candidates
+
+Several personas have overlapping responsibilities:
+- **auditor** vs **reviewer**: Both do quality/security review; auditor is security-focused, reviewer is broader
+- **craftsman** vs **implementer**: Both write code; craftsman is spec-driven, implementer is pipeline-step-focused
+- **navigator** vs **researcher**: Both explore/gather information; navigator is codebase-only, researcher is web-enabled
+- **planner** vs **philosopher**: Both do design work; planner focuses on task breakdown, philosopher on architecture
+
+### 2. Coordination Patterns
+
+Wave currently uses:
+- **Pipeline Pattern**: Sequential steps with dependencies (DAG-based)
+- **Artifact injection**: Inter-step communication via files
+- **Fresh memory**: No chat history inheritance between steps
+
+Claude Code adds:
+- **Leader-Worker**: Dynamic orchestration
+- **Swarm**: Self-assigned work queues
+- **Council**: Multi-agent proposal evaluation
+- **Watchdog**: Monitoring and rollback
+
+### 3. Permission Model
+
+Wave personas have fine-grained tool permissions (allow/deny patterns) projected into both `settings.json` and `CLAUDE.md` restriction sections. This is more granular than Claude Code Teams which relies on role-based capabilities.
+
+### 4. Architecture Alignment
+
+Wave's persona system is designed around the constitutional constraint of "fresh memory at step boundaries" and "contract validation at handovers." Any improvements must preserve these properties.

--- a/specs/131-persona-architecture/tasks.md
+++ b/specs/131-persona-architecture/tasks.md
@@ -1,0 +1,48 @@
+# Tasks
+
+## Phase 1: Research & Analysis
+
+- [X] Task 1.1: Fetch and analyze the Claude Code Teams gist content in detail
+- [X] Task 1.2: Audit all 18 Wave persona `.md` files for role clarity and overlap [P]
+- [X] Task 1.3: Audit all pipeline YAML files to build a persona usage matrix [P]
+- [X] Task 1.4: Review `internal/adapter/claude.go` and `internal/manifest/types.go` for persona integration points
+
+## Phase 2: Comparison Document
+
+- [X] Task 2.1: Write comprehensive comparison document (`docs/persona-architecture-evaluation.md`)
+  - Claude Code Teams architecture summary
+  - Wave persona architecture summary
+  - Pattern comparison (Pipeline, Leader-Worker, Swarm, Council, Watchdog)
+  - Permission model comparison
+  - Coordination mechanism comparison
+- [X] Task 2.2: Document at least 3 actionable proposals with rationale
+
+## Phase 3: Persona Consolidation
+
+- [X] Task 3.1: Consolidate `craftsman` + `implementer` — merge implementer into craftsman [P]
+  - Update `.wave/personas/craftsman.md` with implementer capabilities
+  - Update `wave.yaml` persona entries
+  - Update all pipeline YAML files referencing `implementer` to use `craftsman`
+  - Remove or archive `.wave/personas/implementer.md`
+- [X] Task 3.2: Consolidate `auditor` + `reviewer` — merge into unified `reviewer` [P]
+  - Update `.wave/personas/reviewer.md` with security audit capabilities
+  - Update `wave.yaml` persona entries
+  - Update all pipeline YAML files referencing `auditor` to use `reviewer`
+  - Remove or archive `.wave/personas/auditor.md`
+- [X] Task 3.3: Clarify `planner` vs `philosopher` boundaries (or consolidate into `architect`)
+  - Evaluate whether consolidation or clear differentiation is better
+  - Update persona prompts with explicit scope boundaries
+  - Update `wave.yaml` if consolidating
+
+## Phase 4: Persona Prompt Enhancement
+
+- [X] Task 4.1: Enhance remaining persona prompts with anti-patterns and output checklists [P]
+- [X] Task 4.2: Add cross-persona awareness to base-protocol.md [P]
+- [X] Task 4.3: Update `wave.yaml` permission models for any consolidated personas
+
+## Phase 5: Testing & Validation
+
+- [X] Task 5.1: Run `go test ./...` to verify no test regressions
+- [X] Task 5.2: Validate all pipeline YAML files parse correctly (grep for removed persona names)
+- [X] Task 5.3: Run `go vet ./...` for static analysis
+- [X] Task 5.4: Final review of all changes for constitutional compliance


### PR DESCRIPTION
## Summary

- Enhance 8 persona files with Anti-Patterns, Quality Checklists, Scope Boundaries, and security improvements — content from the closed PR #133 that was **not** on main
- Add `docs/persona-architecture-evaluation.md` comparing Wave personas against Claude Code Teams architecture
- Add `specs/131-persona-architecture/` with spec, plan, and tasks artifacts

## What changed

| Persona | Additions |
|---------|-----------|
| `base-protocol.md` | Artifact Conventions, Inter-Step Communication |
| `craftsman.md` | 3 responsibilities, Anti-Patterns, Quality Checklist, 2 constraints |
| `philosopher.md` | Scope Boundary, Anti-Patterns, Quality Checklist |
| `planner.md` | Scope Boundary, Anti-Patterns, Quality Checklist |
| `reviewer.md` | OWASP Top 10 responsibilities, security enhancements, Anti-Patterns, Quality Checklist |
| `navigator.md` | Anti-Patterns, Quality Checklist |
| `debugger.md` | Anti-Patterns, Quality Checklist |
| `summarizer.md` | Anti-Patterns, Quality Checklist |

## What was explicitly excluded (vs PR #133)

- No persona deletions (auditor, implementer both actively used)
- No wave.yaml changes
- No pipeline YAML changes
- No contract/test changes

## Test plan

- [x] `go test ./...` — all pass
- [x] `go test -race ./...` — all pass
- [x] Grep Anti-Patterns in `.wave/personas/` — 7 matches (all except base-protocol)
- [x] Grep Quality Checklist — 7 matches
- [x] Grep Artifact Conventions in base-protocol.md — 1 match
- [x] `.wave/personas/` and `internal/defaults/personas/` are identical

Closes #131