### PR TITLE
fix(docs): add base URL for GitHub Pages subpath hosting

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,7 @@ export default withMermaid(
     title: 'Wave',
     titleTemplate: ':title · AI-as-Code for multi-agent pipelines',
     description: 'Define, version, and run AI workflows like you manage infrastructure.',
+    base: '/wave/',
 
     head: [
       ['meta', { name: 'keywords', content: 'AI, pipelines, orchestration, LLM, Claude, automation, YAML, DevOps' }],
@@ -13,11 +14,11 @@ export default withMermaid(
       ['meta', { property: 'og:title', content: 'Wave · AI-as-Code for multi-agent pipelines' }],
       ['meta', { property: 'og:description', content: 'Define, version, and run AI workflows like you manage infrastructure.' }],
       ['meta', { property: 'og:type', content: 'website' }],
-      ['meta', { property: 'og:image', content: '/og-image.png' }],
+      ['meta', { property: 'og:image', content: '/wave/og-image.png' }],
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
       ['meta', { name: 'twitter:title', content: 'Wave · AI-as-Code for multi-agent pipelines' }],
       ['meta', { name: 'twitter:description', content: 'Define, version, and run AI workflows like you manage infrastructure.' }],
-      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }]
+      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/wave/favicon.svg' }]
     ],
 
     themeConfig: {

--- a/specs/165-docs-css-base-url/plan.md
+++ b/specs/165-docs-css-base-url/plan.md
@@ -1,0 +1,36 @@
+# Implementation Plan: fix(docs) CSS Base URL
+
+## Objective
+
+Add the `base: '/wave/'` property to the VitePress configuration so that all generated asset paths (CSS, JS, images) include the `/wave/` subpath prefix required for GitHub Pages hosting under `re-cinq.github.io/wave/`.
+
+## Approach
+
+This is a trivial configuration fix. The primary change is adding `base: '/wave/'` to the `defineConfig()` call in `docs/.vitepress/config.ts`. VitePress automatically rewrites all internal links and asset URLs when `base` is set, so most paths will be handled automatically.
+
+However, the `head` array contains hardcoded absolute paths for the OG image and favicon that need manual updating since they are raw HTML meta/link tags injected directly into the page head — VitePress does not rewrite these automatically.
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/.vitepress/config.ts` | modify | Add `base: '/wave/'` to `defineConfig()`, update hardcoded paths in `head` array |
+
+## Architecture Decisions
+
+1. **Use VitePress `base` property** rather than modifying build scripts or the GitHub Actions workflow. This is the idiomatic VitePress approach for subpath deployment.
+2. **Update `head` paths manually** for OG image and favicon since VitePress does not auto-rewrite raw HTML injected via the `head` config array.
+3. **No workflow changes needed** — the existing `docs.yml` workflow uses `actions/configure-pages@v4` which handles GitHub Pages deployment correctly regardless of subpath. The VitePress `base` property is sufficient.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Local dev broken by base path | Low | VitePress `dev` server handles `base` correctly; `npm run dev` will still work |
+| Missed hardcoded paths elsewhere | Low | Grep for absolute `/` paths in docs config; VitePress handles internal links automatically |
+
+## Testing Strategy
+
+1. **Build verification**: Run `npm run build` in `docs/` to confirm VitePress builds successfully with the new `base` setting
+2. **Manual inspection**: Inspect the generated HTML in `docs/.vitepress/dist/` to verify asset paths include `/wave/` prefix
+3. **No Go tests affected**: This change is docs-only (TypeScript config) — `go test ./...` is not required

--- a/specs/165-docs-css-base-url/spec.md
+++ b/specs/165-docs-css-base-url/spec.md
@@ -1,0 +1,49 @@
+# fix(docs): CSS styles broken on GitHub Pages after repo URL change
+
+**Feature Branch**: `165-docs-css-base-url`
+**Issue**: [#165](https://github.com/re-cinq/wave/issues/165)
+**Labels**: bug, documentation, priority: medium
+**Author**: nextlevelshit
+**Status**: Draft
+
+## Summary
+
+The documentation site experienced styling problems after the repository transitioned to public status. The URL changed to re-cinq.github.io/wave/, and this new path structure prevents CSS stylesheets from loading properly.
+
+## Current Behavior
+
+- Documentation pages at the new URL load without functional CSS styling
+- GitHub Pages' folder structure prevents stylesheet paths from resolving correctly
+
+## Expected Behavior
+
+- All pages should display with proper styling applied
+- Visual elements including navigation, typography, and layout should render as designed
+
+## Root Cause
+
+The VitePress configuration at `docs/.vitepress/config.ts` is missing the `base: '/wave/'` property. When a GitHub Pages site is served under a subpath (e.g., `re-cinq.github.io/wave/`), VitePress needs this `base` setting to correctly prefix all asset URLs (CSS, JS, images) with the subpath. Without it, assets are requested from the root (`/assets/...`) instead of the correct subpath (`/wave/assets/...`), resulting in 404s.
+
+Additionally, the `head` config contains hardcoded absolute paths for OG image (`/og-image.png`) and favicon (`/favicon.svg`) that won't resolve under the `/wave/` subpath.
+
+## Acceptance Criteria
+
+- CSS renders correctly across all documentation pages
+- Base URL/path prefix configuration updated for public repository (`base: '/wave/'`)
+- Layout and navigation display as intended
+- OG image and favicon paths resolve correctly under `/wave/` subpath
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: VitePress config MUST include `base: '/wave/'` so all generated asset paths include the subpath prefix
+- **FR-002**: OG image meta tag MUST reference the correct path under `/wave/`
+- **FR-003**: Favicon link MUST reference the correct path under `/wave/`
+- **FR-004**: All documentation pages MUST load CSS and JS assets correctly when served at `re-cinq.github.io/wave/`
+
+## Success Criteria
+
+- **SC-001**: Visiting `https://re-cinq.github.io/wave/` renders the documentation with full CSS styling
+- **SC-002**: VitePress build completes without errors with the new base path
+- **SC-003**: Browser DevTools shows no 404 errors for CSS, JS, or image assets

--- a/specs/165-docs-css-base-url/tasks.md
+++ b/specs/165-docs-css-base-url/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## Phase 1: Core Fix
+
+- [X] Task 1.1: Add `base: '/wave/'` property to `defineConfig()` in `docs/.vitepress/config.ts`
+- [X] Task 1.2: Update OG image path in `head` array from `'/og-image.png'` to `'/wave/og-image.png'`
+- [X] Task 1.3: Update favicon href in `head` array from `'/favicon.svg'` to `'/wave/favicon.svg'`
+
+## Phase 2: Validation
+
+- [X] Task 2.1: Run VitePress build (`npm run build` in `docs/`) and verify it completes without errors
+- [X] Task 2.2: Inspect generated HTML in `docs/.vitepress/dist/index.html` to confirm CSS/JS paths include `/wave/` prefix
+
+## Phase 3: Polish
+
+- [X] Task 3.1: Commit changes with conventional commit message `fix(docs): add base URL for GitHub Pages subpath hosting`


### PR DESCRIPTION
## Summary

- Add `base: '/wave/'` to VitePress config for correct GitHub Pages subpath hosting
- Update OG image meta tag path to include `/wave/` prefix
- Update favicon href to include `/wave/` prefix
- Ensures CSS stylesheets and static assets load correctly at `re-cinq.github.io/wave/`

Closes #165

## Changes

- `docs/.vitepress/config.ts`: Added `base: '/wave/'` property to `defineConfig`, updated `og:image` content path from `/og-image.png` to `/wave/og-image.png`, updated favicon `href` from `/favicon.svg` to `/wave/favicon.svg`

## Test Plan

- Visit https://re-cinq.github.io/wave/ after merge and verify CSS renders correctly
- Confirm favicon and OG image load from correct paths
- Verify navigation and layout display as intended across all documentation pages