### PR TITLE
feat(init): dynamic persona discovery from embedded YAML configs

### DIFF
--- a/internal/defaults/embed_test.go
+++ b/internal/defaults/embed_test.go
@@ -222,3 +222,107 @@ func TestGetReleasePipelines_DisabledAndReleaseIncluded(t *testing.T) {
 		}
 	}
 }
+
+func TestGetPersonaConfigs_ReturnsAllPersonas(t *testing.T) {
+	configs, err := GetPersonaConfigs()
+	if err != nil {
+		t.Fatalf("GetPersonaConfigs() error: %v", err)
+	}
+
+	// Should have exactly 26 persona configs (all .md files minus base-protocol)
+	if len(configs) != 26 {
+		t.Errorf("expected 26 persona configs, got %d", len(configs))
+	}
+
+	// Verify a few known personas exist
+	expected := []string{"navigator", "craftsman", "summarizer", "implementer", "github-analyst", "gitea-analyst", "gitlab-analyst", "bitbucket-analyst"}
+	for _, name := range expected {
+		if _, ok := configs[name]; !ok {
+			t.Errorf("expected persona config %q not found", name)
+		}
+	}
+}
+
+func TestGetPersonaConfigs_HasRequiredFields(t *testing.T) {
+	configs, err := GetPersonaConfigs()
+	if err != nil {
+		t.Fatalf("GetPersonaConfigs() error: %v", err)
+	}
+
+	for name, cfg := range configs {
+		if cfg.Description == "" {
+			t.Errorf("persona %q has empty Description", name)
+		}
+		if cfg.Temperature < 0 || cfg.Temperature > 1.0 {
+			t.Errorf("persona %q has invalid Temperature %f (must be 0.0-1.0)", name, cfg.Temperature)
+		}
+		if len(cfg.Permissions.AllowedTools) == 0 {
+			t.Errorf("persona %q has no allowed_tools", name)
+		}
+		// Adapter and SystemPromptFile should NOT be set — they're injected at init time
+		if cfg.Adapter != "" {
+			t.Errorf("persona %q should not have adapter set in config (got %q)", name, cfg.Adapter)
+		}
+		if cfg.SystemPromptFile != "" {
+			t.Errorf("persona %q should not have system_prompt_file set in config (got %q)", name, cfg.SystemPromptFile)
+		}
+	}
+}
+
+func TestGetPersonaConfigs_ModelOverrides(t *testing.T) {
+	configs, err := GetPersonaConfigs()
+	if err != nil {
+		t.Fatalf("GetPersonaConfigs() error: %v", err)
+	}
+
+	// Only these personas should have model overrides
+	expectedModels := map[string]string{
+		"provocateur": "opus",
+		"validator":   "sonnet",
+		"synthesizer": "sonnet",
+	}
+
+	for name, cfg := range configs {
+		expected, hasExpected := expectedModels[name]
+		if hasExpected {
+			if cfg.Model != expected {
+				t.Errorf("persona %q should have model %q, got %q", name, expected, cfg.Model)
+			}
+		} else {
+			if cfg.Model != "" {
+				t.Errorf("persona %q should not have a model override, got %q", name, cfg.Model)
+			}
+		}
+	}
+}
+
+func TestGetPersonaConfigs_MatchesPersonaFiles(t *testing.T) {
+	configs, err := GetPersonaConfigs()
+	if err != nil {
+		t.Fatalf("GetPersonaConfigs() error: %v", err)
+	}
+
+	personas, err := GetPersonas()
+	if err != nil {
+		t.Fatalf("GetPersonas() error: %v", err)
+	}
+
+	// Every persona config should have a corresponding .md file
+	for name := range configs {
+		mdFile := name + ".md"
+		if _, ok := personas[mdFile]; !ok {
+			t.Errorf("persona config %q has no corresponding .md file", name)
+		}
+	}
+
+	// Every .md file (except base-protocol) should have a corresponding config
+	for mdFile := range personas {
+		if mdFile == "base-protocol.md" {
+			continue
+		}
+		name := strings.TrimSuffix(mdFile, ".md")
+		if _, ok := configs[name]; !ok {
+			t.Errorf("persona .md file %q has no corresponding .yaml config", mdFile)
+		}
+	}
+}

--- a/internal/defaults/personas/auditor.yaml
+++ b/internal/defaults/personas/auditor.yaml
@@ -1,0 +1,11 @@
+description: "Security review and quality assurance"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Grep
+    - "Bash(git log*)"
+    - "Bash(git status*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"

--- a/internal/defaults/personas/bitbucket-analyst.yaml
+++ b/internal/defaults/personas/bitbucket-analyst.yaml
@@ -1,0 +1,8 @@
+description: "Bitbucket issue analysis and scanning"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(bb *)"
+  deny: []

--- a/internal/defaults/personas/bitbucket-commenter.yaml
+++ b/internal/defaults/personas/bitbucket-commenter.yaml
@@ -1,0 +1,7 @@
+description: "Posts comments on Bitbucket issues"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - "Bash(bb *)"
+  deny: []

--- a/internal/defaults/personas/bitbucket-enhancer.yaml
+++ b/internal/defaults/personas/bitbucket-enhancer.yaml
@@ -1,0 +1,8 @@
+description: "Bitbucket issue enhancement and improvement"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(bb *)"
+  deny: []

--- a/internal/defaults/personas/craftsman.yaml
+++ b/internal/defaults/personas/craftsman.yaml
@@ -1,0 +1,10 @@
+description: "Code implementation and testing"
+temperature: 0.7
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - Edit
+    - Bash
+  deny:
+    - "Bash(rm -rf /*)"

--- a/internal/defaults/personas/debugger.yaml
+++ b/internal/defaults/personas/debugger.yaml
@@ -1,0 +1,12 @@
+description: "Systematic debugging and root cause analysis"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(git log*)"
+    - "Bash(git bisect*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"

--- a/internal/defaults/personas/gitea-analyst.yaml
+++ b/internal/defaults/personas/gitea-analyst.yaml
@@ -1,0 +1,8 @@
+description: "Gitea issue analysis and scanning"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(tea *)"
+  deny: []

--- a/internal/defaults/personas/gitea-commenter.yaml
+++ b/internal/defaults/personas/gitea-commenter.yaml
@@ -1,0 +1,7 @@
+description: "Posts comments on Gitea issues"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - "Bash(tea *)"
+  deny: []

--- a/internal/defaults/personas/gitea-enhancer.yaml
+++ b/internal/defaults/personas/gitea-enhancer.yaml
@@ -1,0 +1,8 @@
+description: "Gitea issue enhancement and improvement"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(tea *)"
+  deny: []

--- a/internal/defaults/personas/github-analyst.yaml
+++ b/internal/defaults/personas/github-analyst.yaml
@@ -1,0 +1,8 @@
+description: "GitHub issue analysis and scanning"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(gh *)"
+  deny: []

--- a/internal/defaults/personas/github-commenter.yaml
+++ b/internal/defaults/personas/github-commenter.yaml
@@ -1,0 +1,7 @@
+description: "Posts comments on GitHub issues"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - "Bash(gh *)"
+  deny: []

--- a/internal/defaults/personas/github-enhancer.yaml
+++ b/internal/defaults/personas/github-enhancer.yaml
@@ -1,0 +1,8 @@
+description: "GitHub issue enhancement and improvement"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(gh *)"
+  deny: []

--- a/internal/defaults/personas/gitlab-analyst.yaml
+++ b/internal/defaults/personas/gitlab-analyst.yaml
@@ -1,0 +1,8 @@
+description: "GitLab issue analysis and scanning"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(glab *)"
+  deny: []

--- a/internal/defaults/personas/gitlab-commenter.yaml
+++ b/internal/defaults/personas/gitlab-commenter.yaml
@@ -1,0 +1,7 @@
+description: "Posts comments on GitLab issues"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - "Bash(glab *)"
+  deny: []

--- a/internal/defaults/personas/gitlab-enhancer.yaml
+++ b/internal/defaults/personas/gitlab-enhancer.yaml
@@ -1,0 +1,8 @@
+description: "GitLab issue enhancement and improvement"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - "Bash(glab *)"
+  deny: []

--- a/internal/defaults/personas/implementer.yaml
+++ b/internal/defaults/personas/implementer.yaml
@@ -1,0 +1,10 @@
+description: "Execution specialist for code changes and structured output"
+temperature: 0.3
+permissions:
+  allowed_tools:
+    - Read
+    - Write
+    - Edit
+    - Bash
+  deny:
+    - "Bash(rm -rf /*)"

--- a/internal/defaults/personas/navigator.yaml
+++ b/internal/defaults/personas/navigator.yaml
@@ -1,0 +1,14 @@
+description: "Read-only codebase exploration and analysis"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(git log*)"
+    - "Bash(git status*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"
+    - "Bash(git commit*)"
+    - "Bash(git push*)"

--- a/internal/defaults/personas/philosopher.yaml
+++ b/internal/defaults/personas/philosopher.yaml
@@ -1,0 +1,8 @@
+description: "Architecture design and specification"
+temperature: 0.3
+permissions:
+  allowed_tools:
+    - Read
+    - "Write(.wave/specs/*)"
+  deny:
+    - "Bash(*)"

--- a/internal/defaults/personas/planner.yaml
+++ b/internal/defaults/personas/planner.yaml
@@ -1,0 +1,8 @@
+description: "Task breakdown and planning"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - "Write(.wave/plans/*)"
+  deny:
+    - "Bash(*)"

--- a/internal/defaults/personas/provocateur.yaml
+++ b/internal/defaults/personas/provocateur.yaml
@@ -1,0 +1,19 @@
+description: "Creative challenger for divergent thinking and complexity hunting"
+model: opus
+temperature: 0.8
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(wc *)"
+    - "Bash(git log*)"
+    - "Bash(git diff*)"
+    - "Bash(find*)"
+    - "Bash(ls*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"
+    - "Bash(git commit*)"
+    - "Bash(git push*)"
+    - "Bash(rm*)"

--- a/internal/defaults/personas/researcher.yaml
+++ b/internal/defaults/personas/researcher.yaml
@@ -1,0 +1,12 @@
+description: "Deep codebase research and analysis"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(gh *)"
+    - "Bash(git log*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"

--- a/internal/defaults/personas/reviewer.yaml
+++ b/internal/defaults/personas/reviewer.yaml
@@ -1,0 +1,12 @@
+description: "Code review and quality checks"
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(git diff*)"
+    - "Bash(git log*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"

--- a/internal/defaults/personas/summarizer.yaml
+++ b/internal/defaults/personas/summarizer.yaml
@@ -1,0 +1,8 @@
+description: "Context compaction for relay handoffs"
+temperature: 0.0
+permissions:
+  allowed_tools:
+    - Read
+  deny:
+    - "Write(*)"
+    - "Bash(*)"

--- a/internal/defaults/personas/supervisor.yaml
+++ b/internal/defaults/personas/supervisor.yaml
@@ -1,0 +1,13 @@
+description: "Work supervision and quality evaluation"
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(go test *)"
+    - "Bash(git log*)"
+    - "Bash(git notes*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"

--- a/internal/defaults/personas/synthesizer.yaml
+++ b/internal/defaults/personas/synthesizer.yaml
@@ -1,0 +1,11 @@
+description: "Structured synthesis of analysis findings into actionable JSON proposals"
+model: sonnet
+temperature: 0.2
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+  deny:
+    - "Edit(*)"
+    - "Bash(*)"

--- a/internal/defaults/personas/validator.yaml
+++ b/internal/defaults/personas/validator.yaml
@@ -1,0 +1,17 @@
+description: "Skeptical analysis and verification of findings against source code"
+model: sonnet
+temperature: 0.1
+permissions:
+  allowed_tools:
+    - Read
+    - Glob
+    - Grep
+    - "Bash(wc *)"
+    - "Bash(git log*)"
+    - "Bash(git diff*)"
+  deny:
+    - "Write(*)"
+    - "Edit(*)"
+    - "Bash(git commit*)"
+    - "Bash(git push*)"
+    - "Bash(rm*)"


### PR DESCRIPTION
## Summary

- Replace ~180-line hardcoded persona map in `createDefaultManifest()` with 26 embedded YAML config files that are auto-discovered at init time
- Extend transitive filtering to persona manifest entries — only personas referenced by selected pipelines (+ system personas) go into `wave.yaml`
- Adding a new persona now requires only two files (`.md` + `.yaml`) instead of editing Go source code

Closes #179
Supersedes #180

## Changes

| File | Action |
|------|--------|
| `internal/defaults/personas/*.yaml` (26 new) | Persona config data (description, temperature, permissions, optional model) |
| `internal/defaults/embed.go` | Add `personaConfigsFS` embed + `GetPersonaConfigs()` |
| `internal/defaults/embed_test.go` | Config parsing, field validation, model override, parity tests |
| `cmd/wave/commands/init.go` | Replace hardcoded map with `buildPersonaManifest()`, extend `filterTransitiveDeps()` |
| `cmd/wave/commands/init_test.go` | Transitive persona filtering + manifest-config match tests |

## Design decisions

- **`adapter`** omitted from YAML — injected from `--adapter` flag at init time
- **`system_prompt_file`** computed by convention (`.wave/personas/<name>.md`) — not stored in YAML
- **System personas** (`summarizer`, `navigator`, `philosopher`) always included regardless of pipeline refs
- **Persona .md files** still ALL copied to `.wave/personas/` (unchanged behavior)
- **Persona manifest entries** only include those transitively referenced by selected pipelines

## Test plan

- [x] `go test ./internal/defaults/...` — persona config parsing (4 new tests)
- [x] `go test ./cmd/wave/commands/...` — init filtering + manifest structure (2 new tests)
- [x] `go test -race ./...` — full suite passes
- [ ] Manual: `wave init` → verify `wave.yaml` personas match release pipeline deps
- [ ] Manual: `wave init --all` → all 26 personas in manifest
- [ ] Manual: `wave validate` passes after both modes