### PR TITLE
fix(adapter): strip Write/Edit tools, disallow TodoWrite, remove false JSON validation

### DIFF
--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -184,15 +184,10 @@ func (a *ClaudeAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapter
 	// produces false positives when personas write about "rate limiting" in their
 	// analysis (e.g. security reviews mentioning "No rate limiting on endpoints").
 
-	// Apply output validation and correction
-	correctedContent, err := a.validateAndCorrectOutput(parsed.ResultContent, cfg.OutputFormat)
-	if err != nil && cfg.Debug {
-		fmt.Printf("[DEBUG] Output validation/correction failed: %v\n", err)
-		fmt.Printf("[DEBUG] Using original content\n")
-		result.ResultContent = parsed.ResultContent
-	} else {
-		result.ResultContent = correctedContent
-	}
+	// The persona's text response (ResultContent) is always natural language,
+	// not the JSON artifact. Artifact validation is handled by the contract
+	// validator which reads the actual file. Skip format validation here.
+	result.ResultContent = parsed.ResultContent
 
 	if cfg.Debug {
 		fmt.Printf("[DEBUG] Claude exit code: %d\n", result.ExitCode)
@@ -216,7 +211,7 @@ func (a *ClaudeAdapter) prepareWorkspace(workspacePath string, cfg AdapterRunCon
 	// Build allowed tools list from config
 	allowedTools := cfg.AllowedTools
 	if len(allowedTools) == 0 {
-		allowedTools = []string{"Read", "Write", "Edit", "Bash", "Glob", "Grep"}
+		allowedTools = []string{"Read", "Bash", "Glob", "Grep"}
 	}
 
 	// Generate settings.json for this step's persona
@@ -388,6 +383,9 @@ func (a *ClaudeAdapter) buildArgs(cfg AdapterRunConfig) []string {
 		normalized := normalizeAllowedTools(cfg.AllowedTools)
 		args = append(args, "--allowedTools", strings.Join(normalized, ","))
 	}
+
+	// Prevent personas from wasting turns on TodoWrite
+	args = append(args, "--disallowedTools", "TodoWrite")
 
 	args = append(args, "--output-format", "stream-json")
 	args = append(args, "--verbose")
@@ -729,112 +727,6 @@ func ExtractJSONFromMarkdown(content string) string {
 	return jsonStr
 }
 
-// validateAndCorrectOutput validates and attempts to fix common output format issues
-func (a *ClaudeAdapter) validateAndCorrectOutput(content, outputFormat string) (string, error) {
-	if content == "" {
-		return "", fmt.Errorf("empty output content")
-	}
-
-	// Apply format-specific validation and correction
-	switch outputFormat {
-	case "json":
-		return a.validateAndCorrectJSON(content)
-	default:
-		// For non-JSON formats, return as-is
-		return content, nil
-	}
-}
-
-// validateAndCorrectJSON validates JSON output and applies automatic corrections
-func (a *ClaudeAdapter) validateAndCorrectJSON(content string) (string, error) {
-	// First, try to parse the content as-is
-	var js json.RawMessage
-	if json.Unmarshal([]byte(content), &js) == nil {
-		// Already valid JSON
-		return content, nil
-	}
-
-	// Try extracting JSON from markdown code blocks
-	if strings.Contains(content, "```") {
-		if extracted := ExtractJSONFromMarkdown(content); extracted != "" {
-			if json.Unmarshal([]byte(extracted), &js) == nil {
-				return extracted, nil
-			}
-		}
-	}
-
-	// Try basic JSON cleanup
-	cleaned := a.cleanJSONContent(content)
-	if cleaned != "" {
-		if json.Unmarshal([]byte(cleaned), &js) == nil {
-			return cleaned, nil
-		}
-	}
-
-	// If all corrections failed, return original with error
-	return content, fmt.Errorf("could not correct malformed JSON output")
-}
-
-// cleanJSONContent performs basic JSON cleanup operations
-func (a *ClaudeAdapter) cleanJSONContent(content string) string {
-	// Remove common non-JSON text patterns
-	lines := strings.Split(content, "\n")
-	var jsonLines []string
-	inJSON := false
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		// Skip empty lines
-		if trimmed == "" {
-			continue
-		}
-
-		// Skip lines that look like explanatory text
-		if strings.HasPrefix(trimmed, "Here") ||
-		   strings.HasPrefix(trimmed, "This") ||
-		   strings.HasPrefix(trimmed, "The") ||
-		   strings.Contains(strings.ToLower(trimmed), "explanation") ||
-		   strings.Contains(strings.ToLower(trimmed), "here is") {
-			continue
-		}
-
-		// Look for JSON start
-		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
-			inJSON = true
-		}
-
-		if inJSON {
-			jsonLines = append(jsonLines, line)
-		}
-
-		// Look for JSON end
-		if (strings.HasSuffix(trimmed, "}") || strings.HasSuffix(trimmed, "]")) && inJSON {
-			// Check if this completes the JSON
-			candidate := strings.Join(jsonLines, "\n")
-			var js json.RawMessage
-			if json.Unmarshal([]byte(candidate), &js) == nil {
-				return candidate
-			}
-		}
-	}
-
-	// If we collected JSON lines but validation failed, try the full content
-	if len(jsonLines) > 0 {
-		candidate := strings.Join(jsonLines, "\n")
-
-		// Try some common fixes
-		candidate = strings.TrimSpace(candidate)
-
-		// Remove trailing commas before closing braces/brackets
-		candidate = strings.ReplaceAll(candidate, ",}", "}")
-		candidate = strings.ReplaceAll(candidate, ",]", "]")
-
-		return candidate
-	}
-
-	return content
-}
 
 // shelljoinArgs formats command arguments for debug logging, quoting any
 // argument that contains shell metacharacters or whitespace so the logged
@@ -897,15 +789,18 @@ func buildRestrictionSection(cfg AdapterRunConfig) string {
 	return b.String()
 }
 
-// normalizeAllowedTools converts scoped Write entries to bare Write
-// since Claude Code doesn't support Write(path) specifiers.
+// normalizeAllowedTools strips Write and Edit entries (bare or scoped) since
+// these tools don't exist in headless Claude Code CLI. File writing is done
+// via Bash; CLAUDE.md restrictions control which paths are allowed.
 // It also deduplicates entries.
 func normalizeAllowedTools(tools []string) []string {
 	seen := make(map[string]bool)
 	var result []string
 	for _, tool := range tools {
-		if strings.HasPrefix(tool, "Write(") {
-			tool = "Write"
+		// Skip Write/Edit — these tools don't exist in headless Claude Code CLI.
+		if tool == "Write" || strings.HasPrefix(tool, "Write(") ||
+			tool == "Edit" || strings.HasPrefix(tool, "Edit(") {
+			continue
 		}
 		if !seen[tool] {
 			seen[tool] = true

--- a/internal/adapter/claude_test.go
+++ b/internal/adapter/claude_test.go
@@ -45,19 +45,19 @@ func TestNormalizeAllowedTools(t *testing.T) {
 		want  []string
 	}{
 		{
-			name:  "bare tools unchanged",
+			name:  "Write and Edit stripped from bare tools",
 			input: []string{"Read", "Write", "Edit", "Bash"},
-			want:  []string{"Read", "Write", "Edit", "Bash"},
+			want:  []string{"Read", "Bash"},
 		},
 		{
-			name:  "Write scoped entries normalized to bare Write",
+			name:  "scoped Write entries stripped entirely",
 			input: []string{"Read", "Write(.wave/output/*)", "Write(.wave/artifact.json)"},
-			want:  []string{"Read", "Write"},
+			want:  []string{"Read"},
 		},
 		{
-			name:  "deduplicates after normalization",
+			name:  "deduplicates after stripping",
 			input: []string{"Write(.wave/output/*)", "Write(.wave/artifact.json)", "Read"},
-			want:  []string{"Write", "Read"},
+			want:  []string{"Read"},
 		},
 		{
 			name:  "preserves Bash scoped entries",
@@ -65,9 +65,9 @@ func TestNormalizeAllowedTools(t *testing.T) {
 			want:  []string{"Bash(go test*)", "Bash(git log*)", "Read"},
 		},
 		{
-			name:  "mixed scoped and bare",
+			name:  "Write stripped from mixed tools",
 			input: []string{"Read", "Glob", "Grep", "WebSearch", "Write(.wave/output/*)", "Write"},
-			want:  []string{"Read", "Glob", "Grep", "WebSearch", "Write"},
+			want:  []string{"Read", "Glob", "Grep", "WebSearch"},
 		},
 		{
 			name:  "empty input",
@@ -75,9 +75,14 @@ func TestNormalizeAllowedTools(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name:  "bare Write preserved",
+			name:  "bare Write stripped",
 			input: []string{"Write"},
-			want:  []string{"Write"},
+			want:  nil,
+		},
+		{
+			name:  "Edit bare and scoped stripped",
+			input: []string{"Edit", "Edit(.wave/output/*)", "Read"},
+			want:  []string{"Read"},
 		},
 	}
 
@@ -105,7 +110,7 @@ func TestContractPromptInClaudeMD(t *testing.T) {
 		Persona:        "test",
 		WorkspacePath:  tmpDir,
 		Model:          "sonnet",
-		AllowedTools:   []string{"Read", "Write", "Bash"},
+		AllowedTools:   []string{"Read", "Bash"},
 		ContractPrompt: "## Contract Compliance\n\n- **Output file**: `artifact.json`\n- **Format**: Valid JSON only.\n",
 	}
 
@@ -175,13 +180,13 @@ func TestSettingsJSONFormat(t *testing.T) {
 		t.Fatal("settings.json missing 'permissions.allow' array")
 	}
 
-	// Verify Write(.wave/output/*) was normalized to Write
+// Verify Write(.wave/output/*) was stripped (Write doesn't exist in headless Claude Code)
 	allowStrs := make([]string, len(allow))
 	for i, v := range allow {
 		allowStrs[i] = v.(string)
 	}
 
-	expected := []string{"Read", "Write", "Glob"}
+	expected := []string{"Read", "Glob"}
 	if len(allowStrs) != len(expected) {
 		t.Fatalf("permissions.allow = %v, want %v", allowStrs, expected)
 	}
@@ -214,9 +219,44 @@ func TestBuildArgsNormalizesAllowedTools(t *testing.T) {
 		t.Fatal("--allowedTools not found in args")
 	}
 
-	expected := "Read,Write,Glob"
+	// Write entries should be stripped entirely
+	expected := "Read,Glob"
 	if allowedToolsArg != expected {
 		t.Errorf("--allowedTools = %q, want %q", allowedToolsArg, expected)
+	}
+
+	// Verify --disallowedTools TodoWrite is present
+	var disallowedToolsArg string
+	for i, arg := range args {
+		if arg == "--disallowedTools" && i+1 < len(args) {
+			disallowedToolsArg = args[i+1]
+			break
+		}
+	}
+	if disallowedToolsArg != "TodoWrite" {
+		t.Errorf("--disallowedTools = %q, want %q", disallowedToolsArg, "TodoWrite")
+	}
+}
+
+
+func TestBuildArgsDisallowsTodoWrite(t *testing.T) {
+	adapter := NewClaudeAdapter()
+
+	// Even with no explicit AllowedTools, --disallowedTools TodoWrite must be present
+	cfg := AdapterRunConfig{
+		Prompt: "test",
+	}
+	args := adapter.buildArgs(cfg)
+
+	var disallowedToolsArg string
+	for i, arg := range args {
+		if arg == "--disallowedTools" && i+1 < len(args) {
+			disallowedToolsArg = args[i+1]
+			break
+		}
+	}
+	if disallowedToolsArg != "TodoWrite" {
+		t.Errorf("--disallowedTools = %q, want %q", disallowedToolsArg, "TodoWrite")
 	}
 }
 
@@ -664,11 +704,11 @@ func TestSettingsJSONPerPersona(t *testing.T) {
 			wantSandbox:  false,
 		},
 		{
-			name:           "implementer: full access with sandbox",
+			name:           "implementer: full access with sandbox (Write/Edit stripped)",
 			persona:        "implementer",
 			allowedTools:   []string{"Read", "Write", "Edit", "Bash", "Glob", "Grep"},
 			allowedDomains: []string{"api.anthropic.com", "github.com", "proxy.golang.org"},
-			wantAllow:      []string{"Read", "Write", "Edit", "Bash", "Glob", "Grep"},
+			wantAllow:      []string{"Read", "Bash", "Glob", "Grep"},
 			wantSandbox:    true,
 			sandboxEnabled: true,
 		},

--- a/wave.yaml
+++ b/wave.yaml
@@ -15,8 +15,6 @@ adapters:
         default_permissions:
             allowed_tools:
                 - Read
-                - Write
-                - Edit
                 - Bash
             deny: []
         mode: headless


### PR DESCRIPTION
## Summary

Fixes three systematic issues observed in headless Claude Code runs (continuation of #202 / `fix/preflight-and-todowrite`):

- **Write/Edit tools don't exist in headless Claude Code CLI** (`-p` mode). Personas tried `Write`, got rejected, wasted a turn falling back to `Bash`. Now `normalizeAllowedTools` strips Write/Edit entries entirely from `--allowedTools` and `settings.json`
- **`validateAndCorrectOutput` ran on the wrong content** — parsed the persona's text response (markdown) as JSON instead of the actual artifact file, producing false `[DEBUG] Output validation/correction failed` warnings every step. Removed — the contract validator already handles artifact file validation
- **`TodoWrite` wasted turns** — base protocol says "Do not use TodoWrite" but it was still available. Now blocked via `--disallowedTools TodoWrite` at CLI level

## Test plan

- [x] `go test -race ./internal/adapter/...` — all adapter tests pass
- [x] `go test -race ./...` — full suite passes
- [ ] `wave run gh-rewrite --debug --verbose` — zero "No such tool: Write" errors, zero TodoWrite calls, zero false validation warnings