### PR TITLE
fix(pipelines): prevent batch fallback when specific issue not found

### DIFF
--- a/.wave/pipelines/bb-rewrite.yaml
+++ b/.wave/pipelines/bb-rewrite.yaml
@@ -41,6 +41,11 @@ steps:
             "https://api.bitbucket.org/2.0/repositories/WORKSPACE/REPO/issues?pagelen=10" \
             | jq '[.values[] | {id, title, content: .content.raw, kind, url: .links.html.href}]'
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, kind classification, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/.wave/pipelines/gh-rewrite.yaml
+++ b/.wave/pipelines/gh-rewrite.yaml
@@ -35,6 +35,11 @@ steps:
         - Single: gh issue view <NUM> --repo <REPO> --json number,title,body,labels,url
         - Batch: gh issue list --repo {{ input }} --limit 10 --json number,title,body,labels,url
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/.wave/pipelines/gl-rewrite.yaml
+++ b/.wave/pipelines/gl-rewrite.yaml
@@ -34,6 +34,11 @@ steps:
         - Single: glab issue view NUM --repo OWNER/REPO --output json
         - Batch: glab issue list --repo OWNER/REPO --per-page 10 --output json
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/.wave/pipelines/gt-rewrite.yaml
+++ b/.wave/pipelines/gt-rewrite.yaml
@@ -34,6 +34,11 @@ steps:
         - Single: tea issues view NUM --repo OWNER/REPO --json number,title,body,labels,url
         - Batch: tea issues list --repo OWNER/REPO --limit 10 --json number,title,body,labels,url
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/internal/defaults/pipelines/bb-rewrite.yaml
+++ b/internal/defaults/pipelines/bb-rewrite.yaml
@@ -41,6 +41,11 @@ steps:
             "https://api.bitbucket.org/2.0/repositories/WORKSPACE/REPO/issues?pagelen=10" \
             | jq '[.values[] | {id, title, content: .content.raw, kind, url: .links.html.href}]'
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, kind classification, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/internal/defaults/pipelines/gh-rewrite.yaml
+++ b/internal/defaults/pipelines/gh-rewrite.yaml
@@ -31,6 +31,11 @@ steps:
         - Single: gh issue view <NUM> --repo <REPO> --json number,title,body,labels,url
         - Batch: gh issue list --repo {{ input }} --limit 10 --json number,title,body,labels,url
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/internal/defaults/pipelines/gl-rewrite.yaml
+++ b/internal/defaults/pipelines/gl-rewrite.yaml
@@ -30,6 +30,11 @@ steps:
         - Single: glab issue view NUM --repo OWNER/REPO --output json
         - Batch: glab issue list --repo OWNER/REPO --per-page 10 --output json
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:

--- a/internal/defaults/pipelines/gt-rewrite.yaml
+++ b/internal/defaults/pipelines/gt-rewrite.yaml
@@ -30,6 +30,11 @@ steps:
         - Single: tea issues view NUM --repo OWNER/REPO --json number,title,body,labels,url
         - Batch: tea issues list --repo OWNER/REPO --limit 10 --json number,title,body,labels,url
 
+        IMPORTANT: If a specific issue number was parsed from the input but the fetch
+        fails (not found, permissions error), STOP. Output JSON with repository set
+        to <REPO>, issues_to_enhance as empty array, and total_to_enhance: 0.
+        Do NOT fall back to batch mode when a specific issue was requested.
+
         Step 3: Score each issue quality (0-100) on title clarity, description completeness, labels, and acceptance criteria.
 
         Step 4: For issues scoring below 70, create an enhancement plan with:


### PR DESCRIPTION
## Summary

- Adds an `IMPORTANT` guard to all 8 rewrite pipeline prompts (gh, gl, gt, bb — both `.wave/pipelines/` and `internal/defaults/pipelines/`)
- When a specific issue number is requested but the fetch fails (not found, permissions error), the persona now stops and outputs an empty result instead of silently falling back to batch mode and scanning unrelated issues

## Context

When running `wave run gh-rewrite "re-cinq/wave 99999"` with a non-existent issue number, the scan-and-score persona would fall back to batch mode and start scanning/enhancing random open issues — not the intended behavior.

Closes #225

## Test plan

- [x] `wave run gh-rewrite "re-cinq/wave 99999"` should output empty `issues_to_enhance` array instead of batch-scanning
- [ ] `wave run gh-rewrite "re-cinq/wave"` should still work in batch mode as before
- [x] `go test -race ./...` passes (verified)