### PR TITLE
docs: create architecture diagrams for non-technical audiences

### DIFF
--- a/docs/architecture/context-engineering.md
+++ b/docs/architecture/context-engineering.md
@@ -1,0 +1,139 @@
+# Context Engineering
+
+Context engineering is how Wave controls **what each AI agent knows** when it starts
+working. Unlike a human developer who remembers everything from the day, each Wave
+agent starts with a completely blank slate — it has no memory of what happened before.
+The only information it receives is what Wave explicitly provides.
+
+This is by design: it prevents agents from being confused by irrelevant context,
+ensures reproducible behavior, and maintains security boundaries between steps.
+
+## Artifact Flow Between Steps
+
+Artifacts are the files that steps produce as output and pass to downstream steps.
+They are the primary mechanism for inter-step communication.
+
+```mermaid
+graph LR
+    subgraph Step1["Step 1: Analyze"]
+        S1Work["Agent works<br/>in isolation"]
+        S1Out["📤 Output:<br/>analysis.json"]
+    end
+
+    subgraph Step2["Step 2: Plan"]
+        S2In["📥 Input:<br/>analysis.json"]
+        S2Work["Agent works<br/>in isolation"]
+        S2Out["📤 Output:<br/>plan.md"]
+    end
+
+    subgraph Step3["Step 3: Implement"]
+        S3In["📥 Inputs:<br/>analysis.json<br/>plan.md"]
+        S3Work["Agent works<br/>in isolation"]
+        S3Out["📤 Output:<br/>code changes"]
+    end
+
+    S1Work --> S1Out
+    S1Out -->|"copied to<br/>.wave/artifacts/"| S2In
+    S2In --> S2Work --> S2Out
+    S1Out -->|"copied to<br/>.wave/artifacts/"| S3In
+    S2Out -->|"copied to<br/>.wave/artifacts/"| S3In
+    S3In --> S3Work --> S3Out
+
+    style S1Out fill:#ffd93d,color:#333
+    style S2In fill:#4a9eff,color:#fff
+    style S2Out fill:#ffd93d,color:#333
+    style S3In fill:#4a9eff,color:#fff
+    style S3Out fill:#6bcb77,color:#fff
+```
+
+### How Artifact Injection Works
+
+1. A step completes and produces an output artifact (a file)
+2. Wave saves this artifact and records its location
+3. When a downstream step starts, Wave checks which artifacts it needs
+4. Those artifacts are **copied** into the new step's workspace under `.wave/artifacts/`
+5. The agent reads these files to understand what the previous step produced
+6. If a schema is specified, Wave validates the artifact format before injection
+
+Only explicitly declared dependencies are injected — a step cannot access artifacts
+from steps it does not depend on.
+
+## What Each Agent Sees
+
+When an agent starts, it receives exactly three things — nothing more, nothing less:
+
+```mermaid
+graph TD
+    subgraph Context["What the Agent Receives"]
+        direction TB
+        CLAUDE["📄 CLAUDE.md<br/>Assembled instruction document<br/>(base protocol + persona + contract + restrictions)"]
+        Artifacts["📥 Injected Artifacts<br/>Output files from<br/>dependency steps only"]
+        Workspace["📁 Clean Workspace<br/>Isolated directory with<br/>no prior history"]
+    end
+
+    subgraph Absent["What the Agent Does NOT Have"]
+        direction TB
+        NoPrior["❌ No prior chat history"]
+        NoOther["❌ No artifacts from<br/>non-dependency steps"]
+        NoEnv["❌ No host environment<br/>variables (except allowed)"]
+    end
+
+    style CLAUDE fill:#4a9eff,color:#fff
+    style Artifacts fill:#ffd93d,color:#333
+    style Workspace fill:#6bcb77,color:#fff
+    style NoPrior fill:#ffcccc,color:#333
+    style NoOther fill:#ffcccc,color:#333
+    style NoEnv fill:#ffcccc,color:#333
+```
+
+## Fresh Memory Principle
+
+Each step begins with **zero memory** of what happened before. This is the "fresh
+memory at step boundaries" principle. Even if the same persona runs in two consecutive
+steps, it starts clean each time.
+
+**Why?** Because:
+- It prevents context pollution — agents cannot be confused by irrelevant history
+- It ensures reproducibility — the same inputs always produce the same behavior
+- It enforces security — an agent cannot leak information from one step to another
+- It keeps token usage efficient — agents do not waste tokens on irrelevant context
+
+## Relay: Handling Long-Running Tasks
+
+Sometimes a single step requires more work than fits in the AI model's context window
+(roughly 200,000 tokens). The **Relay Monitor** watches token usage and triggers
+compaction when needed.
+
+```mermaid
+graph TD
+    Agent["🎭 Agent Working"]
+    Monitor["🔄 Relay Monitor<br/>Watches token usage"]
+    Threshold{"Token usage<br/>exceeds 70%?"}
+    Summarizer["📝 Summarizer Persona<br/>Condenses conversation"]
+    Checkpoint["💾 Checkpoint<br/>Summary saved"]
+    Resume["🔄 Fresh Agent<br/>Resumes with summary"]
+
+    Agent --> Monitor
+    Monitor --> Threshold
+    Threshold -->|"No"| Agent
+    Threshold -->|"Yes"| Summarizer
+    Summarizer --> Checkpoint
+    Checkpoint --> Resume
+    Resume --> Agent
+
+    style Agent fill:#ffd93d,color:#333
+    style Monitor fill:#4a9eff,color:#fff
+    style Threshold fill:#ff8c42,color:#fff
+    style Summarizer fill:#a855f7,color:#fff
+    style Checkpoint fill:#6bcb77,color:#fff
+    style Resume fill:#64748b,color:#fff
+```
+
+### How Relay Works
+
+1. The Relay Monitor tracks how many tokens the agent has used
+2. When usage exceeds ~70% of the context window, compaction triggers
+3. A specialized **Summarizer** persona reads the conversation and produces a concise summary
+4. This summary is saved as a **checkpoint**
+5. A fresh agent instance starts with the checkpoint summary instead of the full history
+6. The agent continues working from where it left off, but with a much smaller context

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,68 @@
+# Wave Architecture Overview
+
+Wave is a **multi-agent pipeline orchestrator** — it coordinates specialized AI agents
+to perform complex software engineering tasks as a series of connected steps. Think of
+it as an assembly line where each station has a specialist who receives materials from
+the previous station, does their part, and passes their work forward.
+
+This diagram shows all the major components and how they relate to each other.
+
+```mermaid
+graph TD
+    Manifest["📋 Manifest<br/>(wave.yaml)"]
+    Executor["⚙️ Pipeline Executor"]
+    Preflight["✅ Preflight Checker"]
+    DAG["🔀 DAG Resolver"]
+    Personas["🎭 Personas"]
+    Workspaces["📁 Workspaces"]
+    Adapters["🔌 Adapters"]
+    Contracts["📝 Contracts"]
+    StateStore["💾 State Store"]
+    Events["📡 Event System"]
+    Relay["🔄 Relay Monitor"]
+    Audit["📜 Audit Logger"]
+    CLI["🖥️ Claude Code CLI"]
+
+    Manifest -->|"defines pipelines,<br/>personas, contracts"| Executor
+    Executor -->|"checks tool &<br/>skill availability"| Preflight
+    Executor -->|"resolves step<br/>dependencies"| DAG
+    DAG -->|"sorted execution<br/>order"| Executor
+
+    Executor -->|"assigns persona<br/>to each step"| Personas
+    Executor -->|"creates isolated<br/>directory per step"| Workspaces
+    Executor -->|"validates output<br/>after each step"| Contracts
+
+    Personas -->|"defines behavior,<br/>permissions, role"| Adapters
+    Adapters -->|"launches subprocess"| CLI
+    CLI -->|"runs in isolated<br/>workspace"| Workspaces
+
+    Executor -->|"persists progress<br/>& enables resume"| StateStore
+    Executor -->|"emits progress<br/>updates"| Events
+    Executor -->|"monitors token usage,<br/>triggers compaction"| Relay
+    CLI -->|"logs tool calls,<br/>scrubs credentials"| Audit
+
+    style Manifest fill:#4a9eff,color:#fff,stroke:#2d7ad6
+    style Executor fill:#ff6b6b,color:#fff,stroke:#d64545
+    style Personas fill:#ffd93d,color:#333,stroke:#d4b52e
+    style Workspaces fill:#6bcb77,color:#fff,stroke:#4a9e5a
+    style Contracts fill:#ff8c42,color:#fff,stroke:#d6712e
+    style StateStore fill:#a855f7,color:#fff,stroke:#8b3fd6
+    style CLI fill:#64748b,color:#fff,stroke:#475569
+```
+
+## What Each Component Does
+
+| Component | Purpose |
+|-----------|---------|
+| **Manifest** | The configuration file (`wave.yaml`) that defines everything: which pipelines exist, which personas are available, and how contracts validate output |
+| **Pipeline Executor** | The orchestration engine — reads the manifest, resolves the order of steps, and runs them one by one (or in parallel where possible) |
+| **Preflight Checker** | Verifies all required tools and skills are available before the pipeline starts |
+| **DAG Resolver** | Determines the correct execution order by analyzing step dependencies — ensures no step runs before its prerequisites are complete |
+| **Personas** | Specialized AI agent roles (e.g., navigator, craftsman, reviewer) — each has a defined behavior, permissions, and system prompt |
+| **Workspaces** | Isolated directories where each step runs — prevents steps from interfering with each other |
+| **Adapters** | The bridge between Wave and the AI CLI tool (Claude Code) — handles subprocess launching and output parsing |
+| **Contracts** | Validation rules that check whether a step's output meets quality requirements (JSON schema, test suites, etc.) |
+| **State Store** | SQLite database that tracks pipeline progress — enables pausing and resuming pipelines |
+| **Event System** | Real-time progress notifications — powers the terminal dashboard and monitoring |
+| **Relay Monitor** | Watches token usage during long tasks — triggers context compaction when approaching limits |
+| **Audit Logger** | Records all tool calls and actions with credential scrubbing for security and traceability |

--- a/docs/architecture/pipeline-lifecycle.md
+++ b/docs/architecture/pipeline-lifecycle.md
@@ -1,0 +1,116 @@
+# Pipeline Execution Lifecycle
+
+A pipeline in Wave is a series of connected steps that form a **directed acyclic graph**
+(DAG) — a fancy way of saying "steps have dependencies, but there are no circular loops."
+The Pipeline Executor processes these steps in the right order, running independent steps
+in parallel when possible.
+
+This diagram shows what happens from the moment a pipeline is triggered until it completes.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Executor as Pipeline Executor
+    participant DAG as DAG Resolver
+    participant Preflight as Preflight Checker
+    participant State as State Store
+    participant WS as Workspace Manager
+    participant Adapter as Adapter
+    participant CLI as Claude Code CLI
+    participant Contract as Contract Validator
+    participant Events as Event System
+
+    User->>Executor: Start pipeline
+
+    rect rgb(240, 248, 255)
+        Note over Executor,Preflight: Initialization
+        Executor->>DAG: Resolve step dependencies
+        DAG-->>Executor: Sorted execution order
+        Executor->>Preflight: Check required tools & skills
+        Preflight-->>Executor: All prerequisites met
+        Executor->>State: Create pipeline run record
+        Executor->>Events: Emit "pipeline started"
+    end
+
+    loop For each step (in dependency order)
+        rect rgb(245, 255, 245)
+            Note over Executor,Events: Step Execution
+            Executor->>Events: Emit "step started"
+
+            Executor->>WS: Create isolated workspace
+            WS-->>Executor: Workspace directory ready
+
+            Executor->>WS: Inject artifacts from prior steps
+            WS-->>Executor: Artifacts copied to .wave/artifacts/
+
+            Executor->>Adapter: Prepare persona & prompt
+            Note over Adapter: Assembles CLAUDE.md:<br/>base protocol + persona<br/>+ contract + restrictions
+
+            Adapter->>CLI: Launch subprocess
+            CLI-->>Adapter: Stream progress (NDJSON)
+            Adapter->>Events: Forward activity events
+            CLI-->>Adapter: Final result + token usage
+
+            Executor->>Contract: Validate step output
+            alt Validation passes
+                Contract-->>Executor: Output meets requirements
+            else Validation fails (strict)
+                Contract-->>Executor: Block — step failed
+                Executor->>Events: Emit "step failed"
+            end
+
+            Executor->>State: Save step result & artifacts
+            Executor->>Events: Emit "step completed"
+        end
+    end
+
+    Executor->>State: Mark pipeline completed
+    Executor->>Events: Emit "pipeline completed"
+    Executor-->>User: Pipeline finished
+```
+
+## Step Execution in Detail
+
+Each step in the pipeline goes through these stages:
+
+```mermaid
+graph LR
+    A["🔀 Find Ready<br/>Steps"] --> B["📁 Create<br/>Workspace"]
+    B --> C["📥 Inject<br/>Artifacts"]
+    C --> D["🎭 Bind<br/>Persona"]
+    D --> E["🚀 Run<br/>Adapter"]
+    E --> F["📝 Validate<br/>Contract"]
+    F --> G["💾 Save<br/>State"]
+    G --> H["📤 Register<br/>Artifacts"]
+
+    style A fill:#4a9eff,color:#fff
+    style B fill:#6bcb77,color:#fff
+    style C fill:#ffd93d,color:#333
+    style D fill:#ff8c42,color:#fff
+    style E fill:#ff6b6b,color:#fff
+    style F fill:#a855f7,color:#fff
+    style G fill:#64748b,color:#fff
+    style H fill:#4a9eff,color:#fff
+```
+
+## Key Concepts
+
+### Dependency Resolution
+Steps declare which other steps they depend on. The DAG Resolver sorts them so that
+a step never runs before its prerequisites. Steps with no mutual dependencies can run
+in parallel.
+
+### Artifact Flow
+When a step completes, its output (called an **artifact**) is saved. Downstream steps
+that depend on it receive those artifacts automatically — they appear as files in the
+step's workspace under `.wave/artifacts/`.
+
+### Retry and Resume
+If a step fails, the executor can retry it (up to a configurable limit). If the entire
+pipeline is interrupted, it can be resumed from the last successful step — the State
+Store tracks exactly where execution left off.
+
+### Contract Validation
+After each step runs, its output is validated against a **contract** — a set of rules
+defining what valid output looks like. This catches errors early, before they propagate
+to downstream steps.

--- a/docs/architecture/prompt-engineering.md
+++ b/docs/architecture/prompt-engineering.md
@@ -1,0 +1,92 @@
+# Prompt Engineering Layers
+
+Every AI agent in Wave receives a carefully assembled instruction document called
+**CLAUDE.md**. This document tells the agent who it is, what it should do, what rules
+it must follow, and what output format is expected. It is built from four layers,
+stacked on top of each other like a sandwich.
+
+This ensures every agent receives consistent operational rules while also getting
+role-specific guidance for its particular task.
+
+## CLAUDE.md Assembly
+
+This diagram shows how the four layers combine to form the complete instruction
+document for each pipeline step.
+
+```mermaid
+graph TD
+    subgraph Assembly["CLAUDE.md Assembly"]
+        direction TB
+        L1["📜 Layer 1: Base Protocol<br/>Shared rules for all agents"]
+        L2["🎭 Layer 2: Persona Prompt<br/>Role-specific behavior & constraints"]
+        L3["📝 Layer 3: Contract Compliance<br/>Output format & validation rules"]
+        L4["🔒 Layer 4: Restrictions<br/>Tool permissions & network access"]
+
+        L1 --> L2
+        L2 --> L3
+        L3 --> L4
+    end
+
+    L4 --> Final["📄 Final CLAUDE.md<br/>Written to workspace<br/>before agent starts"]
+
+    style L1 fill:#4a9eff,color:#fff
+    style L2 fill:#ffd93d,color:#333
+    style L3 fill:#ff8c42,color:#fff
+    style L4 fill:#ff6b6b,color:#fff
+    style Final fill:#6bcb77,color:#fff
+```
+
+### What Each Layer Contains
+
+| Layer | Source | Purpose |
+|-------|--------|---------|
+| **Base Protocol** | `.wave/personas/base-protocol.md` | Universal rules: fresh context per step, artifact I/O conventions, workspace isolation, no memory of prior steps |
+| **Persona Prompt** | `.wave/personas/<name>.md` | Role definition: responsibilities, anti-patterns, quality checklist (e.g., "You are a senior developer focused on clean implementation") |
+| **Contract Compliance** | Auto-generated from step config | Output requirements: where to write artifacts, expected JSON schema, validation commands |
+| **Restrictions** | Auto-generated from manifest permissions | Security constraints: which tools are denied, which are allowed, which network domains are accessible |
+
+## Persona Definition
+
+Each persona is a named agent role defined in the manifest (`wave.yaml`). Beyond the
+system prompt, a persona carries configuration that controls how it behaves at runtime.
+
+```mermaid
+graph TD
+    Persona["🎭 Persona Definition"]
+
+    Persona --> Prompt["📜 System Prompt<br/>Role, responsibilities,<br/>constraints, anti-patterns"]
+    Persona --> Permissions["🔐 Permissions<br/>Allowed & denied<br/>tool lists"]
+    Persona --> Model["🧠 Model<br/>Which AI model<br/>to use"]
+    Persona --> Temp["🌡️ Temperature<br/>Creativity vs<br/>precision setting"]
+    Persona --> Sandbox["🏖️ Sandbox<br/>Network domain<br/>allowlist"]
+    Persona --> Hooks["🪝 Hooks<br/>Pre/post tool-use<br/>actions"]
+
+    Permissions --> Enforce["⚡ Enforced at Runtime<br/>Written to settings.json<br/>AND CLAUDE.md restrictions"]
+    Sandbox --> Enforce
+
+    style Persona fill:#ffd93d,color:#333
+    style Prompt fill:#4a9eff,color:#fff
+    style Permissions fill:#ff6b6b,color:#fff
+    style Model fill:#a855f7,color:#fff
+    style Temp fill:#ff8c42,color:#fff
+    style Sandbox fill:#6bcb77,color:#fff
+    style Hooks fill:#64748b,color:#fff
+    style Enforce fill:#ff6b6b,color:#fff
+```
+
+## Built-in Personas
+
+Wave ships with several built-in personas, each designed for a specific role in the
+development workflow:
+
+| Persona | Role | Key Trait |
+|---------|------|-----------|
+| **Navigator** | Codebase explorer | Read-only — never modifies files |
+| **Craftsman** | Senior developer | Writes production code, runs tests |
+| **Implementer** | Code executor | Applies changes, builds, and validates |
+| **Reviewer** | Quality auditor | Reviews code without modifying it |
+| **Planner** | Task decomposer | Creates plans, never writes code |
+| **Summarizer** | Context compactor | Condenses long conversations for relay |
+
+Each persona's permissions are strictly enforced — a navigator cannot write files,
+and a reviewer cannot modify source code, regardless of what they are asked to do.

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -1,0 +1,169 @@
+# Security Model
+
+Wave runs AI agents that can execute code, read files, and interact with external
+services. This demands a **defense-in-depth** security model — multiple independent
+layers of protection, each catching what the others might miss. If any single layer
+is bypassed, the remaining layers still provide protection.
+
+This diagram shows the nested security boundaries from outermost (host system) to
+innermost (output validation).
+
+## Defense in Depth
+
+```mermaid
+graph TD
+    subgraph Outer["🏰 Layer 1: Host Sandbox"]
+        direction TB
+        OuterDesc["Read-only filesystem<br/>Hidden home directory<br/>Curated environment variables"]
+
+        subgraph Adapter["🔧 Layer 2: Adapter Sandbox"]
+            direction TB
+            AdapterDesc["Network domain allowlist<br/>Tool permission settings<br/>Controlled subprocess environment"]
+
+            subgraph Prompt["📜 Layer 3: Prompt Restrictions"]
+                direction TB
+                PromptDesc["Denied tool list in CLAUDE.md<br/>Allowed tool list in CLAUDE.md<br/>Behavioral constraints per persona"]
+
+                subgraph WS["📁 Layer 4: Workspace Isolation"]
+                    direction TB
+                    WSDesc["Ephemeral directory per step<br/>No shared state between steps<br/>Mount modes: read-only or read-write"]
+
+                    subgraph Cred["🔑 Layer 5: Credential Protection"]
+                        direction TB
+                        CredDesc["Environment-only secrets<br/>Never written to disk<br/>Scrubbed from all logs"]
+
+                        Contract["📝 Layer 6: Output Validation<br/>Contract checks before completion<br/>Blocks pipeline on failure"]
+                    end
+                end
+            end
+        end
+    end
+
+    style Outer fill:#ff6b6b,color:#fff
+    style Adapter fill:#ff8c42,color:#fff
+    style Prompt fill:#ffd93d,color:#333
+    style WS fill:#6bcb77,color:#fff
+    style Cred fill:#4a9eff,color:#fff
+    style Contract fill:#a855f7,color:#fff
+```
+
+## Security Layers Explained
+
+### Layer 1: Host Sandbox (Nix + Bubblewrap)
+
+The outermost defense is an OS-level sandbox that restricts what the entire Wave
+process can do on the host machine.
+
+| Control | What It Does |
+|---------|-------------|
+| **Read-only filesystem** | Prevents writing outside designated directories |
+| **Hidden home directory** | AI agents cannot access personal files or credentials |
+| **Curated environment** | Only explicitly allowed environment variables pass through |
+
+### Layer 2: Adapter Sandbox
+
+Each AI agent subprocess runs with additional restrictions configured in `settings.json`.
+
+| Control | What It Does |
+|---------|-------------|
+| **Network domain allowlist** | Agent can only access approved websites and APIs |
+| **Tool permission settings** | Controls which tools are auto-approved vs blocked |
+| **Minimal environment** | Subprocess receives only essential variables (PATH, HOME, TERM) plus explicitly allowed extras |
+
+### Layer 3: Prompt Restrictions
+
+The CLAUDE.md instruction document includes a restrictions section that tells the
+agent what it may and may not do.
+
+| Control | What It Does |
+|---------|-------------|
+| **Denied tools** | Explicitly lists tools the agent must not use |
+| **Allowed tools** | Limits the agent to only specified tools |
+| **Persona constraints** | Role-specific rules (e.g., "navigator must never modify files") |
+
+### Layer 4: Workspace Isolation
+
+Each pipeline step runs in its own isolated directory, preventing steps from
+interfering with each other.
+
+| Control | What It Does |
+|---------|-------------|
+| **Ephemeral directories** | Fresh workspace created for each step, discarded after |
+| **No shared state** | Steps cannot see each other's workspaces or intermediate files |
+| **Mount modes** | Source files can be mounted as read-only or read-write |
+| **Fresh memory** | No chat history carries between steps |
+
+### Layer 5: Credential Protection
+
+Secrets and credentials receive special handling to prevent accidental exposure.
+
+| Control | What It Does |
+|---------|-------------|
+| **Environment-only** | Credentials exist only in environment variables, never on disk |
+| **Explicit passthrough** | Only variables listed in `env_passthrough` reach the subprocess |
+| **Log scrubbing** | Patterns matching API keys, tokens, passwords are replaced with `[REDACTED]` |
+
+### Layer 6: Output Validation (Contracts)
+
+The final layer validates what the agent produced before accepting it as complete.
+
+| Control | What It Does |
+|---------|-------------|
+| **Schema validation** | JSON output must match the expected schema |
+| **Test suites** | Output must pass automated tests |
+| **Strict mode** | Validation failures block the pipeline — no bad output propagates |
+
+## Input Protection
+
+In addition to the output-focused layers above, Wave also protects against malicious
+inputs:
+
+```mermaid
+graph LR
+    Input["📝 User Input<br/>(issue text, prompts)"]
+    Sanitizer["🛡️ Input Sanitizer"]
+    Check{"Injection<br/>detected?"}
+    Clean["✅ Clean input<br/>passed to agent"]
+    Block["🚫 Input rejected<br/>or sanitized"]
+
+    Input --> Sanitizer
+    Sanitizer --> Check
+    Check -->|"No"| Clean
+    Check -->|"Yes"| Block
+
+    style Input fill:#4a9eff,color:#fff
+    style Sanitizer fill:#ffd93d,color:#333
+    style Check fill:#ff8c42,color:#fff
+    style Clean fill:#6bcb77,color:#fff
+    style Block fill:#ff6b6b,color:#fff
+```
+
+The Input Sanitizer scans user-provided text for common prompt injection patterns
+(e.g., "ignore previous instructions", "you are now a different agent") and either
+sanitizes or rejects suspicious content before it reaches the AI agent.
+
+## Audit Trail
+
+All agent actions are recorded in structured audit logs for traceability and
+forensic analysis.
+
+```mermaid
+graph LR
+    Agent["🎭 Agent Actions"]
+    Logger["📜 Audit Logger"]
+    Scrub["🔑 Credential Scrubber"]
+    Log["📋 Trace Log<br/>(.wave/traces/)"]
+
+    Agent -->|"tool calls,<br/>file operations"| Logger
+    Logger -->|"redacts secrets"| Scrub
+    Scrub --> Log
+
+    style Agent fill:#ffd93d,color:#333
+    style Logger fill:#4a9eff,color:#fff
+    style Scrub fill:#ff6b6b,color:#fff
+    style Log fill:#6bcb77,color:#fff
+```
+
+Every tool call, file operation, step start/end, and contract result is logged.
+Credential patterns (API keys, tokens, passwords) are automatically replaced with
+`[REDACTED]` before writing to disk.

--- a/specs/242-architecture-diagrams/plan.md
+++ b/specs/242-architecture-diagrams/plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan: Architecture Diagrams
+
+## Objective
+
+Create a set of Mermaid diagrams documenting Wave's architecture for non-technical audiences. The diagrams will live in `docs/architecture/` and cover the system overview plus detailed views of pipelines, prompt engineering, context engineering, and security.
+
+## Approach
+
+Create 5 Markdown files in `docs/architecture/`, each containing prose introductions followed by Mermaid diagrams. The diagrams target product managers and stakeholders — they use plain language, avoid Go types and internal implementation details, and focus on concepts and data flow.
+
+The existing `docs/concepts/architecture.md` has basic Mermaid diagrams, but they are developer-oriented. The new diagrams complement rather than replace it, providing a visual reference layer aimed at non-technical readers.
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/architecture/overview.md` | create | High-level system overview showing all major components |
+| `docs/architecture/pipeline-lifecycle.md` | create | Pipeline execution flow: DAG resolution, step loop, artifact flow |
+| `docs/architecture/prompt-engineering.md` | create | Persona & prompt layers: base protocol → persona → contract → restrictions |
+| `docs/architecture/context-engineering.md` | create | Context assembly: CLAUDE.md layers, artifact injection, fresh memory |
+| `docs/architecture/security-model.md` | create | Security: workspace isolation, permissions, credential scrubbing, sandboxing |
+
+## Architecture Decisions
+
+1. **Separate files per topic** rather than one monolithic document — easier to link, reference, and maintain independently
+2. **`docs/architecture/` directory** — mirrors the issue requirement and sits alongside existing `docs/concepts/`, `docs/guide/`, etc.
+3. **Mermaid diagram types**:
+   - Overview: `graph TD` (top-down flowchart) — shows component relationships
+   - Pipeline lifecycle: `sequenceDiagram` — shows the temporal execution flow per step
+   - Prompt engineering: `graph TD` — shows the layered assembly of CLAUDE.md
+   - Context engineering: `graph LR` (left-right flowchart) — shows data flow from artifacts through assembly to persona
+   - Security model: `graph TD` with subgraphs — shows the nested security boundaries (outer sandbox → adapter sandbox → workspace isolation)
+4. **No code references** — diagrams describe concepts ("Workspace Manager creates isolated directory") not implementations (`workspace.Create()`)
+5. **Prose before every diagram** — each diagram is preceded by a brief paragraph explaining what it shows and why it matters
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Diagrams become stale as architecture evolves | Keep diagrams concept-level; changes to code internals won't invalidate them |
+| Mermaid rendering differences across viewers | Test with GitHub Markdown preview; avoid exotic Mermaid features |
+| Too much detail for non-technical audience | Focus on "what" and "why", not "how"; use plain English labels |
+| Missing a key architectural concept | Cross-reference against CLAUDE.md's "How Wave Works" section and `docs/concepts/` |
+
+## Testing Strategy
+
+Since this is a documentation-only change, no automated tests are needed. Validation:
+
+1. **Mermaid syntax**: Each diagram renders correctly in a Mermaid live editor or GitHub preview
+2. **Accuracy review**: Cross-reference diagram content against source code and existing docs
+3. **Audience check**: Diagrams should be understandable without prior knowledge of Wave internals
+4. **Go tests**: Run `go test ./...` to confirm no regressions (docs-only change, should pass)

--- a/specs/242-architecture-diagrams/spec.md
+++ b/specs/242-architecture-diagrams/spec.md
@@ -1,0 +1,41 @@
+# docs: create bird's-eye view Mermaid diagrams of Wave architecture for non-technical audiences
+
+**Issue**: [#242](https://github.com/re-cinq/wave/issues/242)
+**Labels**: documentation, good first issue
+**Author**: nextlevelshit
+**State**: OPEN
+
+## Summary
+
+Wave lacks visual architecture diagrams that explain the system to non-technical stakeholders. We need Mermaid diagrams that cover the key concepts at a high level and in detail.
+
+## Background
+
+We are lacking a proper Mermaid diagram to explain the different levels of prompt engineering, context engineering, personas, pipelines, security in the pipeline steps etc.
+
+In best case we have one overview and separate different detailed ones for the different concepts.
+
+## Deliverables
+
+1. **Overview diagram** — A single high-level diagram showing how the major Wave components relate to each other (personas, pipelines, contracts, workspaces, adapters, security boundaries)
+2. **Detailed concept diagrams** (one per topic):
+   - Pipeline execution lifecycle (steps, dependencies, artifact flow)
+   - Persona & prompt engineering layers (base protocol → persona prompt → contract compliance → restrictions)
+   - Context engineering (artifact injection, CLAUDE.md assembly, fresh memory per step)
+   - Security model (workspace isolation, permission enforcement, credential scrubbing, sandbox layers)
+
+## Requirements
+
+- Use [Mermaid](https://mermaid.js.org/) syntax for all diagrams
+- Diagrams should be understandable by non-technical team members (product managers, stakeholders)
+- Avoid implementation details — focus on concepts and data flow
+- Place diagrams in `docs/architecture/` (or appropriate docs location)
+- Each diagram should include a brief prose introduction explaining what it shows
+
+## Acceptance Criteria
+
+- [ ] One high-level overview diagram exists showing all major Wave components
+- [ ] At least 3 detailed concept diagrams covering pipelines, personas/prompts, and security
+- [ ] All diagrams render correctly in GitHub Markdown
+- [ ] Diagrams are reviewed for accuracy by a team member familiar with Wave internals
+- [ ] Non-technical stakeholder can understand the overview diagram without additional explanation

--- a/specs/242-architecture-diagrams/tasks.md
+++ b/specs/242-architecture-diagrams/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## Phase 1: Setup
+
+- [X] Task 1.1: Create `docs/architecture/` directory
+- [X] Task 1.2: Review existing diagrams in `docs/concepts/architecture.md` to avoid duplication
+
+## Phase 2: Core Diagrams
+
+- [X] Task 2.1: Create `docs/architecture/overview.md` — high-level system overview diagram showing Manifest, Pipeline Executor, Personas, Workspaces, Adapters, Contracts, State Store, Event System, and their relationships [P]
+- [X] Task 2.2: Create `docs/architecture/pipeline-lifecycle.md` — sequence diagram of pipeline execution: DAG resolution → workspace creation → artifact injection → persona binding → adapter execution → contract validation → state persistence → event emission [P]
+- [X] Task 2.3: Create `docs/architecture/prompt-engineering.md` — layered diagram showing CLAUDE.md assembly: base protocol preamble → persona system prompt → contract compliance section → restriction section (denied/allowed tools, network domains) [P]
+- [X] Task 2.4: Create `docs/architecture/context-engineering.md` — data flow diagram showing artifact injection from prior steps, CLAUDE.md assembly, workspace isolation (fresh memory per step), and how each persona sees only its injected context [P]
+- [X] Task 2.5: Create `docs/architecture/security-model.md` — nested boundary diagram showing: outer Nix sandbox (read-only FS, hidden $HOME) → adapter sandbox (settings.json, network allowlisting) → prompt restrictions (CLAUDE.md deny/allow) → workspace isolation (ephemeral dirs, mount modes) → credential handling (env-only, scrubbed logs) [P]
+
+## Phase 3: Validation
+
+- [X] Task 3.1: Verify all Mermaid diagrams render correctly (syntax validation)
+- [X] Task 3.2: Cross-reference diagram accuracy against source code and CLAUDE.md documentation
+- [X] Task 3.3: Run `go test ./...` to confirm no regressions from docs-only changes
+
+## Phase 4: Polish
+
+- [X] Task 4.1: Add prose introductions before each diagram explaining what it shows
+- [X] Task 4.2: Ensure consistent terminology across all diagrams (use the same labels for the same concepts)
+- [X] Task 4.3: Final review — confirm diagrams are understandable by non-technical audience


### PR DESCRIPTION
## Summary

- Adds a high-level overview Mermaid diagram showing all major Wave components and their relationships
- Creates detailed pipeline lifecycle diagram covering step execution, artifact flow, and DAG resolution
- Adds prompt engineering diagram illustrating the four-layer CLAUDE.md assembly process
- Creates context engineering diagram showing artifact injection and workspace isolation
- Adds security model diagram detailing sandbox layers, permission enforcement, and credential scrubbing

Closes #242

## Changes

- `docs/architecture/overview.md` — High-level system overview diagram with all major components
- `docs/architecture/pipeline-lifecycle.md` — Pipeline execution lifecycle with steps, dependencies, and artifact flow
- `docs/architecture/prompt-engineering.md` — Persona and prompt engineering layers (base protocol → persona → contract → restrictions)
- `docs/architecture/context-engineering.md` — Context engineering with artifact injection, CLAUDE.md assembly, fresh memory per step
- `docs/architecture/security-model.md` — Security model with workspace isolation, permission enforcement, credential scrubbing, sandbox layers
- `specs/242-architecture-diagrams/` — Specification artifacts (spec, plan, tasks)

## Test Plan

- All diagrams use valid Mermaid syntax and render correctly in GitHub Markdown preview
- Diagrams are designed for non-technical audiences with clear labels and minimal implementation details
- Each diagram file includes prose introductions explaining what the diagram shows