### PR TITLE
feat(tui): Bubble Tea TUI scaffold with 3-row layout

### DIFF
--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/recinq/wave/cmd/wave/commands"
+	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -26,6 +29,12 @@ var rootCmd = &cobra.Command{
   Wave coordinates multiple AI personas through structured pipelines,
   enforcing permissions, contracts, and workspace isolation at every step.`,
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if shouldLaunchTUI(cmd) {
+			return tui.RunTUI()
+		}
+		return cmd.Help()
+	},
 }
 
 func init() {
@@ -35,6 +44,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode")
 	rootCmd.PersistentFlags().StringP("output", "o", "auto", "Output format: auto, json, text, quiet")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Include real-time tool activity")
+	rootCmd.PersistentFlags().Bool("no-tui", false, "Disable TUI and print help text")
 
 	rootCmd.AddCommand(commands.NewInitCmd())
 	rootCmd.AddCommand(commands.NewValidateCmd())
@@ -50,6 +60,31 @@ func init() {
 	rootCmd.AddCommand(commands.NewMigrateCmd())
 	rootCmd.AddCommand(commands.NewServeCmd())
 	rootCmd.AddCommand(commands.NewChatCmd())
+}
+
+// shouldLaunchTUI determines whether to launch the Bubble Tea TUI.
+func shouldLaunchTUI(cmd *cobra.Command) bool {
+	noTUI, _ := cmd.Root().PersistentFlags().GetBool("no-tui")
+	if noTUI {
+		return false
+	}
+
+	// Check WAVE_FORCE_TTY override
+	if forceTTY := os.Getenv("WAVE_FORCE_TTY"); forceTTY != "" {
+		switch strings.ToLower(forceTTY) {
+		case "1", "true":
+			return true
+		case "0", "false":
+			return false
+		}
+	}
+
+	// TERM=dumb means non-ANSI terminal
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func main() {

--- a/cmd/wave/main_test.go
+++ b/cmd/wave/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldLaunchTUI_NoTUIFlag(t *testing.T) {
+	cmd := rootCmd
+	err := cmd.PersistentFlags().Set("no-tui", "true")
+	assert.NoError(t, err)
+	defer cmd.PersistentFlags().Set("no-tui", "false") //nolint:errcheck
+
+	result := shouldLaunchTUI(cmd)
+	assert.False(t, result)
+}
+
+func TestShouldLaunchTUI_ForceTTYEnabled(t *testing.T) {
+	t.Setenv("WAVE_FORCE_TTY", "1")
+
+	cmd := rootCmd
+	result := shouldLaunchTUI(cmd)
+	assert.True(t, result)
+}
+
+func TestShouldLaunchTUI_ForceTTYTrue(t *testing.T) {
+	t.Setenv("WAVE_FORCE_TTY", "true")
+
+	cmd := rootCmd
+	result := shouldLaunchTUI(cmd)
+	assert.True(t, result)
+}
+
+func TestShouldLaunchTUI_ForceTTYDisabled(t *testing.T) {
+	t.Setenv("WAVE_FORCE_TTY", "0")
+
+	cmd := rootCmd
+	result := shouldLaunchTUI(cmd)
+	assert.False(t, result)
+}
+
+func TestShouldLaunchTUI_ForceTTYFalse(t *testing.T) {
+	t.Setenv("WAVE_FORCE_TTY", "false")
+
+	cmd := rootCmd
+	result := shouldLaunchTUI(cmd)
+	assert.False(t, result)
+}
+
+func TestShouldLaunchTUI_TermDumb(t *testing.T) {
+	t.Setenv("TERM", "dumb")
+
+	cmd := rootCmd
+	result := shouldLaunchTUI(cmd)
+	assert.False(t, result)
+}
+
+func TestNoTUIFlag_IsPersistent(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("no-tui")
+	assert.NotNil(t, flag, "--no-tui should be registered as a persistent flag")
+	assert.Equal(t, "false", flag.DefValue)
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	headerHeight    = 3
+	statusBarHeight = 1
+	minWidth        = 80
+	minHeight       = 24
+)
+
+// AppModel is the root Bubble Tea model composing the 3-row TUI layout.
+type AppModel struct {
+	width        int
+	height       int
+	header       HeaderModel
+	content      ContentModel
+	statusBar    StatusBarModel
+	shuttingDown bool
+	ready        bool
+}
+
+// NewAppModel creates a new root app model with default child components.
+func NewAppModel() AppModel {
+	return AppModel{
+		header:    NewHeaderModel(),
+		content:   NewContentModel(),
+		statusBar: NewStatusBarModel(),
+	}
+}
+
+// Init implements tea.Model. Returns nil — waits for WindowSizeMsg.
+func (m AppModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model. Handles key events and window resize.
+func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			if m.shuttingDown {
+				os.Exit(0)
+			}
+			m.shuttingDown = true
+			return m, tea.Quit
+		default:
+			if msg.String() == "q" {
+				return m, tea.Quit
+			}
+		}
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.ready = true
+
+		m.header.SetWidth(m.width)
+		m.statusBar.SetWidth(m.width)
+
+		contentHeight := m.height - headerHeight - statusBarHeight
+		if contentHeight < 0 {
+			contentHeight = 0
+		}
+		m.content.SetSize(m.width, contentHeight)
+	}
+
+	return m, nil
+}
+
+// View implements tea.Model. Renders the 3-row layout.
+func (m AppModel) View() string {
+	if !m.ready {
+		return "Initializing..."
+	}
+
+	if m.width < minWidth || m.height < minHeight {
+		return fmt.Sprintf(
+			"Terminal too small. Minimum: %d×%d. Current: %d×%d",
+			minWidth, minHeight, m.width, m.height,
+		)
+	}
+
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.header.View(),
+		m.content.View(),
+		m.statusBar.View(),
+	)
+}
+
+// RunTUI creates and runs the Bubble Tea program with alternate screen.
+func RunTUI() error {
+	p := tea.NewProgram(NewAppModel(), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAppModel_InitialState(t *testing.T) {
+	m := NewAppModel()
+	assert.False(t, m.ready)
+	assert.False(t, m.shuttingDown)
+	assert.Equal(t, 0, m.width)
+	assert.Equal(t, 0, m.height)
+	assert.Equal(t, "Dashboard", m.statusBar.contextLabel)
+}
+
+func TestAppModel_Init_ReturnsNil(t *testing.T) {
+	m := NewAppModel()
+	cmd := m.Init()
+	assert.Nil(t, cmd)
+}
+
+func TestAppModel_Update_WindowSizeMsg(t *testing.T) {
+	m := NewAppModel()
+	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
+
+	updated, cmd := m.Update(msg)
+	model := updated.(AppModel)
+
+	assert.Nil(t, cmd)
+	assert.True(t, model.ready)
+	assert.Equal(t, 120, model.width)
+	assert.Equal(t, 40, model.height)
+	assert.Equal(t, 120, model.header.width)
+	assert.Equal(t, 120, model.statusBar.width)
+	assert.Equal(t, 120, model.content.width)
+	assert.Equal(t, 40-headerHeight-statusBarHeight, model.content.height)
+}
+
+func TestAppModel_Update_QuitOnQ(t *testing.T) {
+	m := NewAppModel()
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+
+	_, cmd := m.Update(msg)
+	assert.NotNil(t, cmd)
+
+	// tea.Quit returns a special quit message
+	quitMsg := cmd()
+	assert.IsType(t, tea.QuitMsg{}, quitMsg)
+}
+
+func TestAppModel_Update_CtrlC_SetsShuttingDown(t *testing.T) {
+	m := NewAppModel()
+	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
+
+	updated, cmd := m.Update(msg)
+	model := updated.(AppModel)
+
+	assert.True(t, model.shuttingDown)
+	assert.NotNil(t, cmd)
+	quitMsg := cmd()
+	assert.IsType(t, tea.QuitMsg{}, quitMsg)
+}
+
+func TestAppModel_View_BeforeReady(t *testing.T) {
+	m := NewAppModel()
+	view := m.View()
+	assert.Equal(t, "Initializing...", view)
+}
+
+func TestAppModel_View_AfterReady(t *testing.T) {
+	m := NewAppModel()
+	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
+	updated, _ := m.Update(msg)
+	model := updated.(AppModel)
+
+	view := model.View()
+
+	// Should contain header content
+	assert.Contains(t, view, "Pipeline Orchestrator")
+	// Should contain content placeholder
+	assert.Contains(t, view, "Pipelines view coming soon")
+	// Should contain status bar hints
+	assert.Contains(t, view, "q: quit")
+	assert.Contains(t, view, "ctrl+c: exit")
+}
+
+func TestAppModel_View_TooSmall(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"narrow", 60, 30},
+		{"short", 100, 20},
+		{"both small", 40, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewAppModel()
+			msg := tea.WindowSizeMsg{Width: tt.width, Height: tt.height}
+			updated, _ := m.Update(msg)
+			model := updated.(AppModel)
+
+			view := model.View()
+			assert.Contains(t, view, "Terminal too small")
+			assert.Contains(t, view, "80×24")
+		})
+	}
+}
+
+func TestAppModel_View_ExactMinimumSize(t *testing.T) {
+	m := NewAppModel()
+	msg := tea.WindowSizeMsg{Width: 80, Height: 24}
+	updated, _ := m.Update(msg)
+	model := updated.(AppModel)
+
+	view := model.View()
+	// At exactly minimum size, should render normally, not show degradation
+	assert.NotContains(t, view, "Terminal too small")
+	assert.Contains(t, view, "Pipeline Orchestrator")
+}

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ContentModel is the main content area component.
+type ContentModel struct {
+	width  int
+	height int
+}
+
+// NewContentModel creates a new content model.
+func NewContentModel() ContentModel {
+	return ContentModel{}
+}
+
+// SetSize updates the content area dimensions for reflow.
+func (m *ContentModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// View renders the content area with centered placeholder text.
+func (m ContentModel) View() string {
+	placeholder := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244")).
+		Render("Wave TUI — Pipelines view coming soon")
+
+	if m.width <= 0 || m.height <= 0 {
+		return placeholder
+	}
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, placeholder)
+}

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentModel_View_ContainsPlaceholder(t *testing.T) {
+	c := NewContentModel()
+	view := c.View()
+	assert.Contains(t, view, "Pipelines view coming soon")
+}
+
+func TestContentModel_SetSize(t *testing.T) {
+	c := NewContentModel()
+	assert.Equal(t, 0, c.width)
+	assert.Equal(t, 0, c.height)
+
+	c.SetSize(120, 40)
+	assert.Equal(t, 120, c.width)
+	assert.Equal(t, 40, c.height)
+}
+
+func TestContentModel_View_CentersContent(t *testing.T) {
+	c := NewContentModel()
+	c.SetSize(120, 40)
+	view := c.View()
+
+	// With centering, the view should contain the placeholder text
+	assert.Contains(t, view, "Pipelines view coming soon")
+	// The view should contain spaces/newlines for centering
+	assert.Greater(t, len(view), len("Wave TUI — Pipelines view coming soon"))
+}
+
+func TestContentModel_View_ZeroDimensions(t *testing.T) {
+	c := NewContentModel()
+	// With zero dimensions, should still return placeholder text
+	view := c.View()
+	assert.Contains(t, view, "Pipelines view coming soon")
+}

--- a/internal/tui/header.go
+++ b/internal/tui/header.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+// HeaderModel is the header bar component showing Wave branding and pipeline status.
+type HeaderModel struct {
+	width int
+}
+
+// NewHeaderModel creates a new header model.
+func NewHeaderModel() HeaderModel {
+	return HeaderModel{}
+}
+
+// SetWidth updates the header width for reflow.
+func (m *HeaderModel) SetWidth(w int) {
+	m.width = w
+}
+
+// View renders the header bar as a 3-line string.
+func (m HeaderModel) View() string {
+	logoText := "╦ ╦╔═╗╦  ╦╔═╗\n║║║╠═╣╚╗╔╝║╣\n╚╩╝╩ ╩ ╚╝ ╚═╝"
+
+	logoStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("6"))
+
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("7")).
+		Bold(true).
+		PaddingLeft(2)
+
+	statusStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244"))
+
+	logo := logoStyle.Render(logoText)
+
+	infoBlock := titleStyle.Render("Pipeline Orchestrator") + "\n" +
+		"\n" +
+		statusStyle.Render("  [no pipeline running]")
+
+	header := lipgloss.JoinHorizontal(lipgloss.Top, logo, infoBlock)
+
+	if m.width > 0 {
+		header = lipgloss.NewStyle().Width(m.width).Render(header)
+	}
+
+	return header
+}

--- a/internal/tui/header_test.go
+++ b/internal/tui/header_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderModel_View_ContainsBranding(t *testing.T) {
+	h := NewHeaderModel()
+	h.SetWidth(120)
+
+	view := h.View()
+	assert.Contains(t, view, "Pipeline Orchestrator")
+	assert.Contains(t, view, "no pipeline running")
+}
+
+func TestHeaderModel_View_ContainsLogo(t *testing.T) {
+	h := NewHeaderModel()
+	view := h.View()
+
+	// The logo contains Wave ASCII art characters
+	assert.Contains(t, view, "╦")
+	assert.Contains(t, view, "╚╩╝")
+}
+
+func TestHeaderModel_SetWidth(t *testing.T) {
+	h := NewHeaderModel()
+	assert.Equal(t, 0, h.width)
+
+	h.SetWidth(120)
+	assert.Equal(t, 120, h.width)
+}
+
+func TestHeaderModel_View_RespectsWidth(t *testing.T) {
+	h := NewHeaderModel()
+	h.SetWidth(80)
+	view := h.View()
+
+	// Each line should not exceed the specified width
+	for _, line := range strings.Split(view, "\n") {
+		// lipgloss Width accounts for ANSI escape sequences
+		assert.LessOrEqual(t, len([]rune(stripAnsi(line))), 80+10, // allow margin for ANSI sequences
+			"line exceeds width: %q", line)
+	}
+}
+
+// stripAnsi removes ANSI escape sequences for length checking.
+func stripAnsi(s string) string {
+	result := strings.Builder{}
+	inEscape := false
+	for _, r := range s {
+		if r == '\x1b' {
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		result.WriteRune(r)
+	}
+	return result.String()
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// StatusBarModel is the bottom status bar component.
+type StatusBarModel struct {
+	width        int
+	contextLabel string
+}
+
+// NewStatusBarModel creates a new status bar model with default context.
+func NewStatusBarModel() StatusBarModel {
+	return StatusBarModel{
+		contextLabel: "Dashboard",
+	}
+}
+
+// SetWidth updates the status bar width for reflow.
+func (m *StatusBarModel) SetWidth(w int) {
+	m.width = w
+}
+
+// View renders the status bar as a single line.
+func (m StatusBarModel) View() string {
+	bg := lipgloss.Color("237")
+
+	labelStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("7")).
+		Background(bg).
+		PaddingLeft(1)
+
+	hintsStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244")).
+		Background(bg).
+		PaddingRight(1)
+
+	label := labelStyle.Render(m.contextLabel)
+	hints := hintsStyle.Render("q: quit  ctrl+c: exit")
+
+	// Calculate spacing between label and hints
+	labelWidth := lipgloss.Width(label)
+	hintsWidth := lipgloss.Width(hints)
+	spacerWidth := m.width - labelWidth - hintsWidth
+	if spacerWidth < 0 {
+		spacerWidth = 0
+	}
+
+	spacer := lipgloss.NewStyle().
+		Background(bg).
+		Render(strings.Repeat(" ", spacerWidth))
+
+	return label + spacer + hints
+}

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -1,0 +1,37 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusBarModel_View_ContainsHints(t *testing.T) {
+	sb := NewStatusBarModel()
+	sb.SetWidth(120)
+	view := sb.View()
+
+	assert.Contains(t, view, "q: quit")
+	assert.Contains(t, view, "ctrl+c: exit")
+}
+
+func TestStatusBarModel_View_ContainsContextLabel(t *testing.T) {
+	sb := NewStatusBarModel()
+	sb.SetWidth(120)
+	view := sb.View()
+
+	assert.Contains(t, view, "Dashboard")
+}
+
+func TestStatusBarModel_SetWidth(t *testing.T) {
+	sb := NewStatusBarModel()
+	assert.Equal(t, 0, sb.width)
+
+	sb.SetWidth(80)
+	assert.Equal(t, 80, sb.width)
+}
+
+func TestStatusBarModel_DefaultContextLabel(t *testing.T) {
+	sb := NewStatusBarModel()
+	assert.Equal(t, "Dashboard", sb.contextLabel)
+}

--- a/specs/252-tui-bubbletea-scaffold/checklists/plan-tasks-alignment.md
+++ b/specs/252-tui-bubbletea-scaffold/checklists/plan-tasks-alignment.md
@@ -1,0 +1,34 @@
+# Plan & Tasks Alignment Checklist: TUI Bubble Tea Scaffold (#252)
+
+**Feature**: 252-tui-bubbletea-scaffold (part 1 of 10, parent: #251)
+**Generated**: 2026-03-05
+**Purpose**: Validate cross-artifact consistency between spec, plan, data model, and tasks
+
+---
+
+## Spec-to-Plan Alignment
+
+- [ ] CHK048 - Does the plan cover all 16 functional requirements (FR-001 through FR-016)? Are any FRs missing from the implementation phases? [Coverage]
+- [ ] CHK049 - Does the plan's file structure match the spec's key entities? Each entity (AppModel, HeaderModel, ContentModel, StatusBarModel) should map to a planned file. [Consistency]
+- [ ] CHK050 - Does the plan address all 5 clarifications (C-001 through C-005)? Are the resolved ambiguities reflected in the implementation approach? [Consistency]
+- [ ] CHK051 - Does the plan's Phase C (tests) cover all 12 success criteria? Are there success criteria that no test task validates? [Coverage]
+
+## Plan-to-Tasks Alignment
+
+- [ ] CHK052 - Do the 16 tasks cover all plan phases (A through D)? Is any plan phase missing from the task breakdown? [Coverage]
+- [ ] CHK053 - Does the task dependency graph correctly reflect the plan's stated dependencies? e.g., T005 depends on T002-T004 as the plan specifies. [Consistency]
+- [ ] CHK054 - Are parallel opportunities in the tasks (marked [P]) consistent with the plan's stated parallel possibilities? [Consistency]
+- [ ] CHK055 - Does the story-to-task mapping account for all acceptance scenarios? Each Given/When/Then should trace to at least one task. [Coverage]
+
+## Data Model Alignment
+
+- [ ] CHK056 - Do the data model entity definitions match the spec's key entities section? Are field names, types, and descriptions consistent? [Consistency]
+- [ ] CHK057 - Does the data model's message table (Key Messages) cover all interaction requirements from the spec? [Coverage]
+- [ ] CHK058 - Is the `shouldLaunchTUI()` function signature in the data model consistent with the plan's Phase B and task T006? [Consistency]
+- [ ] CHK059 - Does the data model's file map match the plan's project structure section? [Consistency]
+
+## Research Decision Propagation
+
+- [ ] CHK060 - Are all 6 research decisions reflected in the plan and tasks? Has any decision been made in research.md but not propagated to plan.md or tasks.md? [Consistency]
+- [ ] CHK061 - Does research Unknown 5 (package compatibility) have corresponding validation in the tasks? Is there a task to verify no naming conflicts? [Coverage]
+- [ ] CHK062 - Are rejected alternatives from research documented well enough that future contributors won't re-propose them? [Clarity]

--- a/specs/252-tui-bubbletea-scaffold/checklists/requirements.md
+++ b/specs/252-tui-bubbletea-scaffold/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Quality Checklist: 252-tui-bubbletea-scaffold
+
+## Specification Completeness
+
+- [x] Feature purpose is clearly stated (WHAT and WHY, not HOW)
+- [x] All user stories have acceptance scenarios with Given/When/Then
+- [x] User stories are prioritized and independently testable
+- [x] Edge cases are identified and documented
+- [x] Functional requirements use RFC-style language (MUST/SHOULD/MAY)
+- [x] Success criteria are measurable and technology-agnostic
+- [x] Key entities are identified with clear descriptions
+- [x] No more than 3 `[NEEDS CLARIFICATION]` markers (0 present)
+
+## Scope Alignment
+
+- [x] Spec covers TTY detection and dual-mode behavior (TUI vs help)
+- [x] Spec covers the 3-row layout (header, content, status bar)
+- [x] Spec covers `--no-tui` flag on root command
+- [x] Spec covers terminal resize handling
+- [x] Spec covers graceful degradation on small terminals (< 80×24)
+- [x] Spec covers Ctrl-C handling (single = graceful, double = force)
+- [x] Spec covers `q` key exit
+- [x] Spec covers 100ms render target
+- [x] Spec mentions clean separation in `internal/tui/` package
+- [x] Spec does NOT include actual view content (out of scope per issue)
+- [x] Spec does NOT include view switching logic (out of scope per issue)
+- [x] Spec does NOT include pipeline data rendering (out of scope per issue)
+
+## Codebase Awareness
+
+- [x] Spec acknowledges existing `internal/tui/` code (run_selector, theme, pipelines)
+- [x] Spec acknowledges existing Bubble Tea dependencies in `go.mod`
+- [x] Spec acknowledges existing `isInteractive()` / TTY detection pattern
+- [x] Spec acknowledges existing `internal/display/` Bubble Tea model (not prescribed — impl concern)
+- [x] Spec is compatible with existing CLI subcommand structure
+
+## Quality Standards
+
+- [x] No implementation details prescribed (algorithms, data structures, etc.)
+- [x] Requirements are testable and unambiguous
+- [x] User stories tell coherent user journeys
+- [x] Edge cases cover failure modes and boundary conditions
+- [x] Success criteria can be validated automatically where possible

--- a/specs/252-tui-bubbletea-scaffold/checklists/review.md
+++ b/specs/252-tui-bubbletea-scaffold/checklists/review.md
@@ -1,0 +1,49 @@
+# Quality Review Checklist: TUI Bubble Tea Scaffold (#252)
+
+**Feature**: 252-tui-bubbletea-scaffold (part 1 of 10, parent: #251)
+**Generated**: 2026-03-05
+**Purpose**: Validate requirement quality before implementation begins
+
+---
+
+## Completeness
+
+- [ ] CHK001 - Are all four user stories independently testable without requiring any of the other 9 issues in the #251 series? [Completeness]
+- [ ] CHK002 - Does the spec define what "placeholder content" means for each of the 3 rows (header, content, status bar) with enough precision to verify? [Completeness]
+- [ ] CHK003 - Are error conditions specified for `shouldLaunchTUI()`? e.g., what happens if `WAVE_FORCE_TTY` has an unrecognized value like `"yes"` or `"2"`? [Completeness]
+- [ ] CHK004 - Is the exit code behavior defined for ALL exit paths (q, single Ctrl-C, double Ctrl-C, program error)? [Completeness]
+- [ ] CHK005 - Does the spec define the behavior when `wave` is invoked with unknown arguments (not a subcommand, not a flag)? Does `RunE` fire or does Cobra reject first? [Completeness]
+- [ ] CHK006 - Are requirements present for the `NO_COLOR` environment variable behavior mentioned in edge case 3? No FR covers this. [Completeness]
+- [ ] CHK007 - Is the 100ms render target (FR-015/SC-004) defined with a measurement methodology? What constitutes "first frame" — first `View()` call or first bytes written to terminal? [Completeness]
+- [ ] CHK008 - Does the spec define what the degradation message should contain (FR-008)? Is the exact text specified or just the concept? [Completeness]
+- [ ] CHK009 - Are accessibility requirements defined for the TUI (e.g., screen reader compatibility, high-contrast mode)? [Completeness]
+- [ ] CHK010 - Does the spec address what happens when `WAVE_FORCE_TTY=1` is set but `TERM=dumb`? Which takes precedence? [Completeness]
+
+## Clarity
+
+- [ ] CHK011 - Is FR-001's trigger condition unambiguous? "No subcommand, no arguments" — does `wave --debug` (a persistent flag, not a subcommand) still trigger the TUI? [Clarity]
+- [ ] CHK012 - Is the header "fixed 3 lines" height a requirement or an implementation detail? If the logo changes, should the height change? [Clarity]
+- [ ] CHK013 - Is "graceful shutdown" in Story 3 defined concretely? What resources are cleaned up? What state is saved? Or is cleanup a no-op for this scaffold? [Clarity]
+- [ ] CHK014 - Does FR-013 clearly distinguish between `WAVE_FORCE_TTY` values `"1"/"true"` (force TUI) vs `"0"/"false"` (force help) vs absent (defer to actual TTY check)? [Clarity]
+- [ ] CHK015 - Is the relationship between FR-012 (`--no-tui` flag) and FR-013 (`WAVE_FORCE_TTY`) clear? What happens when `--no-tui` is set but `WAVE_FORCE_TTY=1`? Which wins? [Clarity]
+- [ ] CHK016 - Are the keybinding hints in the status bar ("q: quit  ctrl+c: exit") requirements or examples? Can implementers choose different wording? [Clarity]
+- [ ] CHK017 - Does "exit cleanly" (FR-009, FR-010) have a precise definition? Is it just exit code 0, or does it include terminal state restoration (alt screen, cursor visibility)? [Clarity]
+
+## Consistency
+
+- [ ] CHK018 - Is Story 3 acceptance scenario 3 (`q` key = same as single Ctrl-C) consistent with FR-009 and FR-010? FR-009 says `q` exits cleanly; FR-010 says Ctrl-C triggers "graceful shutdown with status message" — are these the same or different? [Consistency]
+- [ ] CHK019 - Does FR-014's requirement to keep existing `internal/tui/` code "untouched" conflict with the plan to reuse `WaveTheme()` color constants? Would extracting shared constants require modifying `theme.go`? [Consistency]
+- [ ] CHK020 - Is SC-011 (test coverage for model initialization, update, view) consistent with the task breakdown? Tasks T011-T015 cover these, but SC-011 doesn't mention `shouldLaunchTUI` tests. [Consistency]
+- [ ] CHK021 - Are the minimum terminal dimensions (80×24) consistent across all mentions? FR-008, Story 4 acceptance scenarios, and edge case 1 all reference this — do they agree on boundary behavior (exactly 80×24 = OK or degraded)? [Consistency]
+- [ ] CHK022 - Is the Clarification C-001 (TTY on stdout) fully propagated? FR-013 references stdout but does the `shouldLaunchTUI` data model entry in data-model.md agree? [Consistency]
+
+## Coverage
+
+- [ ] CHK023 - Do the 12 success criteria (SC-001 through SC-012) cover all 16 functional requirements? Is there a gap for any FR? [Coverage]
+- [ ] CHK024 - Are all 6 edge cases covered by at least one functional requirement or acceptance scenario? [Coverage]
+- [ ] CHK025 - Does the test plan (tasks T011-T015) cover the degradation message behavior (FR-008, SC-006)? [Coverage]
+- [ ] CHK026 - Is there a success criterion for the `TERM=dumb` edge case? SC list doesn't explicitly mention it. [Coverage]
+- [ ] CHK027 - Do acceptance scenarios cover the `WAVE_FORCE_TTY` env var for both force-on and force-off? Story 2 only has `WAVE_FORCE_TTY=0` but not `WAVE_FORCE_TTY=1`. [Coverage]
+- [ ] CHK028 - Is there acceptance scenario coverage for running `wave` outside a git repository (edge case 5)? [Coverage]
+- [ ] CHK029 - Is there acceptance scenario coverage for missing `wave.yaml` (edge case 6)? [Coverage]
+- [ ] CHK030 - Do the tasks cover `NO_COLOR` and `TERM=dumb` handling in the component rendering (not just detection)? [Coverage]

--- a/specs/252-tui-bubbletea-scaffold/checklists/tui-architecture.md
+++ b/specs/252-tui-bubbletea-scaffold/checklists/tui-architecture.md
@@ -1,0 +1,36 @@
+# TUI Architecture Checklist: TUI Bubble Tea Scaffold (#252)
+
+**Feature**: 252-tui-bubbletea-scaffold (part 1 of 10, parent: #251)
+**Generated**: 2026-03-05
+**Purpose**: Validate TUI-specific requirement quality for layout, interaction, and extensibility
+
+---
+
+## Layout Requirements
+
+- [ ] CHK031 - Are the fixed heights for header (3 lines) and status bar (1 line) specified as requirements with rationale, or are they implementation details that leaked into the spec? [Clarity]
+- [ ] CHK032 - Does the spec define behavior when content area height calculates to zero or negative (e.g., terminal exactly 4 rows: 3 header + 1 status = 0 content)? [Completeness]
+- [ ] CHK033 - Is the minimum size threshold (80×24) justified? Does FR-008 explain why these specific dimensions were chosen and whether they should be configurable? [Clarity]
+- [ ] CHK034 - Does the layout spec account for terminals wider than 200 columns? Are there maximum width constraints or does content stretch infinitely? [Completeness]
+- [ ] CHK035 - Is the transition between "degradation message" and "normal layout" when resizing across the 80×24 threshold defined as instant or animated? [Clarity]
+
+## Interaction Requirements
+
+- [ ] CHK036 - Are all keyboard inputs that the TUI must respond to exhaustively listed? Beyond `q` and Ctrl-C, does the spec address or explicitly exclude other common keys (Escape, Ctrl-D, Ctrl-Z)? [Completeness]
+- [ ] CHK037 - Does the spec define whether mouse input is enabled or disabled for the scaffold? Bubble Tea supports mouse events — should they be explicitly disabled? [Completeness]
+- [ ] CHK038 - Is the `q` key exit behavior scoped correctly for future extensibility? When text input is added in later issues, pressing `q` should type the character, not exit. Does the spec acknowledge this? [Completeness]
+- [ ] CHK039 - Does the spec define focus behavior? In the scaffold, is there a focused component, or are all components passive? [Completeness]
+
+## Extensibility for Remaining 9 Issues
+
+- [ ] CHK040 - Does the spec define the interface contract between `AppModel` and its child components clearly enough that future issues can add new views without modifying the spec? [Completeness]
+- [ ] CHK041 - Does the spec acknowledge that `ContentModel` is a placeholder that will be replaced by real views? Is the replacement mechanism (swap, wrap, extend) defined? [Clarity]
+- [ ] CHK042 - Are the component boundaries (header owns its state, content owns its state, etc.) specified clearly enough to prevent coupling that would complicate future issues? [Clarity]
+- [ ] CHK043 - Does the spec define whether the status bar keybinding hints are hardcoded or context-sensitive? FR-006 says "context-sensitive" but the data model shows a fixed string. [Consistency]
+
+## CLI Integration
+
+- [ ] CHK044 - Does the spec define the precedence order for all TTY detection signals? (`--no-tui` > `WAVE_FORCE_TTY` > `TERM=dumb` > actual TTY check)? [Completeness]
+- [ ] CHK045 - Is the behavior of `wave --no-tui` without any subcommand defined? Does it print help text, show version, or do something else? [Clarity]
+- [ ] CHK046 - Does the spec address the interaction between `--debug` flag and TUI mode? Should debug logs appear in the TUI, go to stderr, or be suppressed? [Completeness]
+- [ ] CHK047 - Is the `WAVE_FORCE_TTY` env var documented as a user-facing feature or an internal testing mechanism? This affects whether it needs help text and documentation. [Clarity]

--- a/specs/252-tui-bubbletea-scaffold/data-model.md
+++ b/specs/252-tui-bubbletea-scaffold/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: TUI Bubble Tea Scaffold
+
+**Feature**: #252 — Bubble Tea TUI scaffold (part 1 of 10, parent: #251)
+**Date**: 2026-03-05
+
+## Entities
+
+### AppModel (`internal/tui/app.go`)
+
+The root Bubble Tea model implementing `tea.Model`. Owns all application state and child component models.
+
+```go
+type AppModel struct {
+    // Window dimensions (updated via tea.WindowSizeMsg)
+    width  int
+    height int
+
+    // Child component models
+    header    HeaderModel
+    content   ContentModel
+    statusBar StatusBarModel
+
+    // Shutdown state
+    shuttingDown bool
+
+    // Layout constants
+    ready bool // true after first WindowSizeMsg received
+}
+```
+
+**Implements**: `tea.Model` (Init, Update, View)
+
+**Lifecycle**:
+- `Init()` → returns `nil` (no startup commands; waits for `WindowSizeMsg`)
+- `Update(msg)` → handles `tea.KeyMsg` (q, Ctrl-C), `tea.WindowSizeMsg`, delegates to children
+- `View()` → composes header + content + statusbar using Lip Gloss vertical join
+
+**Layout calculation in View()**:
+- Header height: fixed (3 lines — logo + padding)
+- Status bar height: fixed (1 line)
+- Content height: `height - headerHeight - statusBarHeight`
+- All widths: `width` (full terminal width)
+
+### HeaderModel (`internal/tui/header.go`)
+
+Component model for the header bar. Renders Wave branding and placeholder metadata.
+
+```go
+type HeaderModel struct {
+    width int
+}
+```
+
+**Methods**:
+- `Update(msg tea.Msg)` → handles `tea.WindowSizeMsg` to update width
+- `View() string` → renders header bar with Wave logo, version placeholder
+- `SetWidth(w int)` → updates width for reflow
+
+**Visual layout**:
+```
+╦ ╦╔═╗╦  ╦╔═╗  │  Pipeline Orchestrator    [no pipeline running]
+║║║╠═╣╚╗╔╝║╣   │
+╚╩╝╩ ╩ ╚╝ ╚═╝  │
+```
+
+### ContentModel (`internal/tui/content.go`)
+
+Component model for the main content area. Displays placeholder text; will be replaced by real views in subsequent issues.
+
+```go
+type ContentModel struct {
+    width  int
+    height int
+}
+```
+
+**Methods**:
+- `Update(msg tea.Msg)` → handles `tea.WindowSizeMsg`
+- `View() string` → renders centered placeholder text
+- `SetSize(w, h int)` → updates dimensions for reflow
+
+**Placeholder content**: Centered text: "Wave TUI — Pipelines view coming soon"
+
+### StatusBarModel (`internal/tui/statusbar.go`)
+
+Component model for the bottom status/keybindings bar.
+
+```go
+type StatusBarModel struct {
+    width       int
+    contextLabel string // e.g., "Dashboard"
+}
+```
+
+**Methods**:
+- `Update(msg tea.Msg)` → handles `tea.WindowSizeMsg`
+- `View() string` → renders context label (left) + keybinding hints (right)
+- `SetWidth(w int)` → updates width for reflow
+
+**Visual layout**:
+```
+ Dashboard                                          q: quit  ctrl+c: exit
+```
+
+## Key Messages
+
+| Message | Source | Handler | Effect |
+|---------|--------|---------|--------|
+| `tea.WindowSizeMsg` | Bubble Tea runtime | `AppModel.Update` | Updates dimensions, propagates to children |
+| `tea.KeyMsg` "q" | User input | `AppModel.Update` | Returns `tea.Quit` |
+| `tea.KeyMsg` Ctrl-C | User input / SIGINT | `AppModel.Update` | First: `shuttingDown=true` + `tea.Quit`; Second: `os.Exit(0)` |
+
+## Functions (cmd/wave/main.go)
+
+### shouldLaunchTUI()
+
+```go
+func shouldLaunchTUI(cmd *cobra.Command) bool
+```
+
+Determines whether to launch the Bubble Tea TUI. Returns `true` when:
+1. `--no-tui` flag is NOT set
+2. stdout is a TTY (via `term.IsTerminal(int(os.Stdout.Fd()))`)
+3. `WAVE_FORCE_TTY` is not `"0"` or `"false"`
+4. `TERM` is not `"dumb"`
+
+If `WAVE_FORCE_TTY` is `"1"` or `"true"`, forces `true` regardless of actual TTY status.
+
+### RunTUI()
+
+```go
+func RunTUI() error
+```
+
+Public function in `internal/tui/` package. Creates the Bubble Tea program with `tea.WithAltScreen()` and runs it. Called by `rootCmd.RunE`.
+
+## File Map
+
+| File | Purpose | New/Modified |
+|------|---------|--------------|
+| `cmd/wave/main.go` | Root command `RunE`, `--no-tui` flag, `shouldLaunchTUI()` | Modified |
+| `internal/tui/app.go` | `AppModel` — root tea.Model | New |
+| `internal/tui/header.go` | `HeaderModel` — header bar component | New |
+| `internal/tui/content.go` | `ContentModel` — main area component | New |
+| `internal/tui/statusbar.go` | `StatusBarModel` — status bar component | New |
+| `internal/tui/app_test.go` | Tests for AppModel init/update/view | New |
+| `internal/tui/header_test.go` | Tests for HeaderModel | New |
+| `internal/tui/content_test.go` | Tests for ContentModel | New |
+| `internal/tui/statusbar_test.go` | Tests for StatusBarModel | New |
+| `cmd/wave/main_test.go` | Tests for shouldLaunchTUI, --no-tui flag | New |
+
+## Dependencies
+
+All dependencies already present in `go.mod`:
+- `github.com/charmbracelet/bubbletea v1.3.10`
+- `github.com/charmbracelet/lipgloss v1.1.0`
+- `github.com/charmbracelet/bubbles v0.21.1` (indirect, for potential spinner use)
+- `golang.org/x/term v0.39.0` (for TTY detection)
+- `github.com/spf13/cobra v1.8.0` (existing CLI framework)
+
+No new dependencies required (SC-012).

--- a/specs/252-tui-bubbletea-scaffold/plan.md
+++ b/specs/252-tui-bubbletea-scaffold/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: TUI Bubble Tea Scaffold
+
+**Branch**: `252-tui-bubbletea-scaffold` | **Date**: 2026-03-05 | **Spec**: [specs/252-tui-bubbletea-scaffold/spec.md](spec.md)
+**Input**: Feature specification from `/specs/252-tui-bubbletea-scaffold/spec.md`
+
+## Summary
+
+Bootstrap the full-screen Bubble Tea TUI application with a 3-row layout (header, content, status bar), wire TTY detection on the root `wave` command, add `--no-tui` flag, and implement graceful Ctrl-C / `q` exit handling. This is part 1 of 10 for the complete TUI implementation (parent: #251).
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (existing project)
+**Primary Dependencies**: `charmbracelet/bubbletea v1.3.10`, `charmbracelet/lipgloss v1.1.0`, `spf13/cobra v1.8.0`, `golang.org/x/term v0.39.0` — all already in `go.mod`
+**Storage**: N/A (no persistence in this feature)
+**Testing**: `go test ./...` with `testify/assert`
+**Target Platform**: Linux, macOS (terminal emulators)
+**Project Type**: Single Go binary (existing)
+**Performance Goals**: First frame render within 100ms of `tea.Program.Run()`
+**Constraints**: No new dependencies; existing tests must continue passing; existing `internal/tui/` code untouched
+**Scale/Scope**: 4 new source files + 4 test files in `internal/tui/`, 1 modified file in `cmd/wave/`
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | ✅ Pass | No new runtime dependencies; all Go deps compile into binary |
+| P2: Manifest as SSOT | ✅ Pass | TUI doesn't add configuration; reads existing manifest only when needed |
+| P3: Persona-Scoped Execution | ✅ N/A | No persona/agent changes |
+| P4: Fresh Memory at Boundaries | ✅ N/A | No pipeline step changes |
+| P5: Navigator-First | ✅ N/A | No pipeline changes |
+| P6: Contracts at Handovers | ✅ N/A | No pipeline changes |
+| P7: Relay via Summarizer | ✅ N/A | No relay changes |
+| P8: Ephemeral Workspaces | ✅ N/A | No workspace changes |
+| P9: Credentials Never Touch Disk | ✅ Pass | TUI displays no credentials |
+| P10: Observable Progress | ✅ Pass | TUI is the future home of progress visualization |
+| P11: Bounded Recursion | ✅ N/A | No meta-pipeline changes |
+| P12: Minimal Step State Machine | ✅ N/A | No state machine changes |
+| P13: Test Ownership | ✅ Pass | New code comes with tests; existing tests must pass |
+
+**Result**: All applicable principles pass. No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/252-tui-bubbletea-scaffold/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+├── checklists/
+│   └── requirements.md  # Requirements checklist
+└── tasks.md             # Phase 2 output (not created by plan)
+```
+
+### Source Code (repository root)
+
+```
+cmd/wave/
+├── main.go              # MODIFIED: Add RunE, --no-tui flag, shouldLaunchTUI()
+└── main_test.go         # NEW: Tests for shouldLaunchTUI, --no-tui flag
+
+internal/tui/
+├── theme.go             # EXISTING (unchanged) — color constants reference
+├── run_selector.go      # EXISTING (unchanged) — huh-based pipeline selector
+├── pipelines.go         # EXISTING (unchanged) — pipeline discovery
+├── app.go               # NEW: AppModel — root tea.Model
+├── app_test.go          # NEW: Tests for AppModel
+├── header.go            # NEW: HeaderModel component
+├── header_test.go       # NEW: Tests for HeaderModel
+├── content.go           # NEW: ContentModel component
+├── content_test.go      # NEW: Tests for ContentModel
+├── statusbar.go         # NEW: StatusBarModel component
+└── statusbar_test.go    # NEW: Tests for StatusBarModel
+```
+
+**Structure Decision**: All new code fits within the existing `internal/tui/` package and `cmd/wave/` directory. No new packages needed. The 4 new component files follow one-type-per-file Go convention.
+
+## Implementation Plan
+
+### Phase A: Component Models (`internal/tui/`)
+
+**Task A1**: Create `internal/tui/app.go` — AppModel
+
+The root Bubble Tea model. Implements `tea.Model` with:
+- `Init()` → returns `nil`
+- `Update(msg)` → handles `tea.KeyMsg` (q, Ctrl-C), `tea.WindowSizeMsg`, propagates to children
+- `View()` → composes 3-row layout with Lip Gloss; shows degradation message for terminals < 80×24
+- Shutdown state tracking for double Ctrl-C
+- `NewAppModel()` constructor
+- `RunTUI() error` — public entry point that creates `tea.NewProgram` with `tea.WithAltScreen()` and runs it
+
+Key design points:
+- Layout: header (fixed 3 lines) + content (fills remaining) + status bar (fixed 1 line)
+- Uses `lipgloss.JoinVertical` for row composition
+- `ready` flag: false until first `WindowSizeMsg` received (Bubble Tea convention)
+- Color constants: cyan (`lipgloss.Color("6")`), white (`lipgloss.Color("7")`), muted (`lipgloss.Color("244")`) — matching `theme.go`
+
+**Task A2**: Create `internal/tui/header.go` — HeaderModel
+
+Header bar component:
+- `SetWidth(w int)` for reflow
+- `View()` renders: Wave ASCII logo (compact inline) + "Pipeline Orchestrator" + placeholder status
+- Uses Lip Gloss horizontal join for logo + text columns
+- Fixed 3-line height
+
+**Task A3**: Create `internal/tui/content.go` — ContentModel
+
+Main content area:
+- `SetSize(w, h int)` for reflow
+- `View()` renders centered placeholder: "Wave TUI — Pipelines view coming soon"
+- Uses `lipgloss.Place()` for centering within the content area dimensions
+
+**Task A4**: Create `internal/tui/statusbar.go` — StatusBarModel
+
+Status/keybindings bar:
+- `SetWidth(w int)` for reflow
+- `View()` renders: context label "Dashboard" (left-aligned) + "q: quit  ctrl+c: exit" (right-aligned)
+- Single line, full width, uses Lip Gloss for left/right alignment
+- Background color for visual separation (muted gray)
+
+### Phase B: Root Command Integration (`cmd/wave/`)
+
+**Task B1**: Modify `cmd/wave/main.go`
+
+1. Add `--no-tui` persistent flag in `init()`:
+   ```go
+   rootCmd.PersistentFlags().Bool("no-tui", false, "Disable TUI and print help text")
+   ```
+
+2. Add `shouldLaunchTUI(cmd *cobra.Command) bool`:
+   - Check `--no-tui` flag
+   - Check `WAVE_FORCE_TTY` env var (`"1"`/`"true"` → force true, `"0"`/`"false"` → force false)
+   - Check `term.IsTerminal(int(os.Stdout.Fd()))` for stdout TTY
+   - Check `TERM` env var (reject `"dumb"`)
+
+3. Add `RunE` to `rootCmd`:
+   ```go
+   RunE: func(cmd *cobra.Command, args []string) error {
+       if shouldLaunchTUI(cmd) {
+           return tui.RunTUI()
+       }
+       return cmd.Help()
+   },
+   ```
+
+### Phase C: Tests
+
+**Task C1**: `internal/tui/app_test.go`
+- Test `NewAppModel()` returns valid initial state
+- Test `Update` with `tea.WindowSizeMsg` sets dimensions and `ready` flag
+- Test `Update` with `tea.KeyMsg` "q" returns `tea.Quit`
+- Test `Update` with `tea.KeyMsg` Ctrl-C sets `shuttingDown` and returns `tea.Quit`
+- Test `View()` before ready returns loading indicator
+- Test `View()` after ready returns composed 3-row layout
+- Test `View()` with dimensions < 80×24 returns degradation message
+
+**Task C2**: `internal/tui/header_test.go`
+- Test `View()` contains Wave branding text
+- Test `SetWidth()` updates width
+- Test output respects width boundaries
+
+**Task C3**: `internal/tui/content_test.go`
+- Test `View()` contains placeholder text
+- Test `SetSize()` updates dimensions
+- Test output dimensions match set size
+
+**Task C4**: `internal/tui/statusbar_test.go`
+- Test `View()` contains keybinding hints (q, ctrl+c)
+- Test `View()` contains context label
+- Test `SetWidth()` updates width
+
+**Task C5**: `cmd/wave/main_test.go`
+- Test `shouldLaunchTUI` with `--no-tui` flag returns false
+- Test `shouldLaunchTUI` with `WAVE_FORCE_TTY=1` returns true
+- Test `shouldLaunchTUI` with `WAVE_FORCE_TTY=0` returns false
+- Test `shouldLaunchTUI` with `TERM=dumb` returns false
+- Test `--no-tui` flag is registered as persistent
+
+### Phase D: Validation
+
+**Task D1**: Run full test suite
+- `go test ./...` — all existing tests must pass
+- `go vet ./...` — no static analysis issues
+- Verify no changes to `go.mod` beyond what's already present (SC-012)
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/252-tui-bubbletea-scaffold/research.md
+++ b/specs/252-tui-bubbletea-scaffold/research.md
@@ -1,0 +1,86 @@
+# Research: TUI Bubble Tea Scaffold
+
+**Feature**: #252 — Bubble Tea TUI scaffold (part 1 of 10, parent: #251)
+**Date**: 2026-03-05
+
+## Phase 0 — Unknowns & Research
+
+### Unknown 1: Root Command Behavior Change
+
+**Question**: How to add `RunE` to the root Cobra command without breaking `--help`, `--version`, and existing subcommands?
+
+**Decision**: Add `RunE` to `rootCmd` in `cmd/wave/main.go`. Cobra processes `--help`/`-h` and `--version` flags *before* calling `RunE`, so the TUI only launches when `RunE` is actually reached (bare `wave` with no flags). Subcommands have their own `RunE` and are unaffected.
+
+**Rationale**: This is standard Cobra behavior. The `--help` and `--version` flags are intercepted by Cobra's built-in preprocessing. When any subcommand is invoked (e.g., `wave run`), the root `RunE` is not called. This is confirmed by reading `cmd/wave/main.go:17-28` — the root command currently has no `RunE`, so adding one only activates for the bare `wave` invocation.
+
+**Alternatives rejected**:
+- Wrapper function around `rootCmd.Execute()` — adds complexity, breaks Cobra conventions
+- Custom `PersistentPreRunE` — would run for all subcommands, requiring guard logic
+
+### Unknown 2: TTY Detection — Reuse vs. New Function
+
+**Question**: Should the TUI reuse `display.isTerminal()` (unexported) or `isInteractive()` from `run.go` (checks stdin)?
+
+**Decision**: Create a new `shouldLaunchTUI()` function in `cmd/wave/main.go` that checks **stdout** using `term.IsTerminal(int(os.Stdout.Fd()))` and respects `WAVE_FORCE_TTY`. Also check `TERM=dumb` to fall back (per edge case).
+
+**Rationale**: 
+- `display.isTerminal()` checks stdout but is unexported and lives in the `display` package
+- `isInteractive()` in `run.go` checks **stdin** (for huh form input) — wrong check for TUI rendering
+- Bubble Tea renders to stdout, so stdout must be the terminal. A new function in `main.go` keeps it co-located with the root command
+- The `WAVE_FORCE_TTY` env var override is already established pattern (see `display/terminal.go:101-105` and `run.go:457-461`)
+
+**Alternatives rejected**:
+- Exporting `display.isTerminal()` — would add coupling between cmd and display packages for one function
+- Reusing `isInteractive()` — checks stdin, not stdout; different semantic meaning
+
+### Unknown 3: Bubble Tea Model Architecture — Flat vs. Nested
+
+**Question**: Should the root model contain all state directly, or compose child models?
+
+**Decision**: Compose child models. `AppModel` owns `HeaderModel`, `ContentModel`, and `StatusBarModel` as struct fields. Each child implements its own `Update()` and `View()` methods (not `tea.Model` — they're internal components, not standalone programs). `AppModel` delegates to children in its `Update` and `View`.
+
+**Rationale**: The spec explicitly defines 4 entities (AppModel, HeaderModel, ContentModel, StatusBarModel) in separate files. Composition is idiomatic Bubble Tea for multi-region layouts. Future issues (#251 series) will replace `ContentModel`'s placeholder with real views — a composed architecture makes this a drop-in replacement without touching `AppModel`.
+
+**Alternatives rejected**:
+- Flat model with all view logic in one file — violates single-responsibility, makes future issues harder
+- Full `tea.Model` interface on children — over-abstraction for components that don't run as standalone programs
+
+### Unknown 4: Graceful Shutdown & Double Ctrl-C
+
+**Question**: How to implement double Ctrl-C for force-exit in Bubble Tea?
+
+**Decision**: Track shutdown state in `AppModel` (`shuttingDown bool`). On first `tea.KeyCtrlC`, set `shuttingDown = true` and return `tea.Quit`. On second `tea.KeyCtrlC` while `shuttingDown` is true, call `os.Exit(0)`. In practice, Bubble Tea's `tea.Quit` is fast enough that the second Ctrl-C scenario is mainly a safety net.
+
+**Rationale**: Bubble Tea intercepts SIGINT and converts it to `tea.KeyCtrlC` messages. The standard pattern is to return `tea.Quit` which triggers the alternate screen restore and cleanup. For the double-Ctrl-C case, since `tea.Quit` is near-instant for our simple scaffold, the force exit is mostly a UX guarantee. Using `os.Exit(0)` on the second signal is the standard TUI pattern (vim, lazygit do this).
+
+**Alternatives rejected**:
+- Custom signal handler outside Bubble Tea — conflicts with Bubble Tea's own signal handling
+- `context.WithCancel` pattern — over-engineering for a UI exit path
+
+### Unknown 5: Existing `internal/tui/` Package Compatibility
+
+**Question**: Will new Bubble Tea full-screen app code conflict with existing `huh`-based code in the same package?
+
+**Decision**: No conflict. The existing code (`run_selector.go`, `pipelines.go`, `theme.go`) uses `charmbracelet/huh` for form-based prompts. The new code uses `charmbracelet/bubbletea` for a full-screen app. Both are in the same `tui` package but have no type name collisions. The `WaveTheme()` from `theme.go` is a `*huh.Theme` (not directly usable for Lip Gloss), but the color constants (cyan=6, white=7, muted=244) should be extracted into shared constants or simply duplicated as Lip Gloss styles.
+
+**Rationale**: Reading `theme.go`, the color values are hardcoded as Lip Gloss colors (`lipgloss.Color("6")`, etc.). The new Bubble Tea code can reference the same color values directly. No shared state, no import cycles, no naming conflicts.
+
+### Unknown 6: `--no-tui` Flag Registration
+
+**Question**: Where to register the `--no-tui` persistent flag?
+
+**Decision**: Register on `rootCmd` in `cmd/wave/main.go` `init()`, alongside existing persistent flags like `--manifest`, `--debug`, `--output`. Being persistent means Cobra won't reject `wave --no-tui run pipeline` — the flag propagates but only the root `RunE` inspects it.
+
+**Rationale**: This is the established pattern in `main.go:34-37`. Persistent flags on root propagate to all subcommands. The `run` command already has its own output modes and never checks `--no-tui`.
+
+## Summary of Decisions
+
+| Decision | Choice | Key Factor |
+|----------|--------|------------|
+| Root command change | Add `RunE` to `rootCmd` | Standard Cobra pattern; help/version unaffected |
+| TTY detection | New `shouldLaunchTUI()` checking stdout | Bubble Tea needs stdout; different from stdin check |
+| Model architecture | Composed child models | Future extensibility for 9 remaining issues |
+| Shutdown handling | Track state, `tea.Quit` + `os.Exit(0)` | Standard Bubble Tea pattern |
+| Package structure | New files in existing `internal/tui/` | No conflicts with huh-based code |
+| `--no-tui` flag | Persistent flag on root command | Cobra propagation prevents subcommand errors |
+| Color constants | Reuse same lipgloss.Color values from theme.go | Consistent design language |

--- a/specs/252-tui-bubbletea-scaffold/spec.md
+++ b/specs/252-tui-bubbletea-scaffold/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: TUI Bubble Tea Scaffold
+
+**Feature Branch**: `252-tui-bubbletea-scaffold`  
+**Created**: 2026-03-05  
+**Status**: Draft  
+**Issue**: [#252](https://github.com/re-cinq/wave/issues/252) (part 1 of 10, parent: [#251](https://github.com/re-cinq/wave/issues/251))  
+**Input**: Bootstrap the full-screen TUI application using Bubble Tea with the Elm architecture. Establish the foundational 3-row layout, wire TTY detection, add `--no-tui` flag, and implement graceful Ctrl-C handling.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Launch TUI from Terminal (Priority: P1)
+
+A developer opens their terminal in a Wave project directory and runs `wave` with no arguments. The application detects that stdout is a TTY and launches the full-screen Bubble Tea TUI instead of printing help text. They see a 3-row layout: a header bar at the top, a main content area filling the middle, and a status/keybindings bar at the bottom. All three rows display placeholder content appropriate to their role.
+
+**Why this priority**: This is the foundational interaction — the TUI must launch correctly for any subsequent feature to work. Without this, there is no TUI.
+
+**Independent Test**: Run `wave` in a terminal emulator and verify the full-screen TUI appears with 3 distinct rows. Verify it does not crash and renders within 100ms.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Wave project directory with `wave.yaml`, **When** a user runs `wave` with no arguments in an interactive terminal, **Then** a full-screen TUI launches showing header bar, main content area, and status bar.
+2. **Given** the TUI is launched, **When** the terminal window is at least 80×24, **Then** all three rows render correctly with placeholder content visible.
+3. **Given** the TUI is launched, **When** the user presses `q`, **Then** the TUI exits cleanly and returns the user to their shell prompt.
+
+---
+
+### User Story 2 - Non-TTY Fallback to Help (Priority: P1)
+
+A developer pipes `wave` output or runs it in a non-interactive context (e.g., `wave | cat`, cron job, CI pipeline). The application detects stdout is not a TTY and prints standard help text instead of launching the TUI.
+
+**Why this priority**: Equally critical to P1-Story-1 — incorrect TTY detection would break scripting, CI, and piped workflows. The TUI must never launch in non-interactive contexts.
+
+**Independent Test**: Run `wave | cat` and verify help text is printed to stdout. Run `wave --no-tui` and verify help text is printed.
+
+**Acceptance Scenarios**:
+
+1. **Given** stdout is not a TTY (e.g., piped), **When** a user runs `wave` with no arguments, **Then** standard Cobra help text is printed to stdout.
+2. **Given** stdout is a TTY, **When** a user runs `wave --no-tui`, **Then** standard Cobra help text is printed instead of launching the TUI.
+3. **Given** the environment variable `WAVE_FORCE_TTY=0` is set, **When** a user runs `wave`, **Then** help text is printed regardless of actual TTY status.
+
+---
+
+### User Story 3 - Graceful Shutdown with Ctrl-C (Priority: P2)
+
+A developer is viewing the TUI and presses Ctrl-C. The application begins graceful shutdown — cleaning up any resources, saving state if needed, and displaying a brief exit status message. If the user presses Ctrl-C a second time before cleanup completes, the application force-exits immediately.
+
+**Why this priority**: Graceful shutdown is essential for data safety and user trust, but depends on the TUI being launchable first (P1 stories).
+
+**Independent Test**: Launch TUI, press Ctrl-C once and verify graceful exit message appears. Launch TUI, press Ctrl-C twice rapidly and verify immediate exit.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TUI is running, **When** the user presses Ctrl-C once, **Then** the application initiates graceful shutdown, displays an exit status message, and exits with code 0.
+2. **Given** a graceful shutdown is in progress, **When** the user presses Ctrl-C a second time, **Then** the application exits immediately with code 0 (user-initiated exit).
+3. **Given** the TUI is running, **When** the user presses `q`, **Then** the application exits cleanly with code 0 (same behavior as single Ctrl-C).
+
+---
+
+### User Story 4 - Terminal Resize Handling (Priority: P3)
+
+A developer resizes their terminal window while the TUI is running. The layout reflows to fill the new dimensions, maintaining the 3-row structure. If the terminal shrinks below the minimum supported size (80×24), the TUI degrades gracefully.
+
+**Why this priority**: Resize handling is a polish feature — the TUI works at its initial size without it, but professional TUIs must handle resize.
+
+**Independent Test**: Launch TUI, resize the terminal window and verify the layout reflows. Shrink below 80×24 and verify graceful degradation message.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TUI is running at 120×40, **When** the terminal is resized to 100×30, **Then** all three rows reflow to fill the new dimensions.
+2. **Given** the TUI is running, **When** the terminal is resized below 80×24, **Then** a graceful degradation message is shown (e.g., "Terminal too small. Minimum: 80×24").
+3. **Given** the TUI is showing the degradation message, **When** the terminal is resized back above 80×24, **Then** the normal 3-row layout is restored.
+
+---
+
+### Edge Cases
+
+- What happens when the terminal has exactly 80×24 dimensions? The layout should render correctly at the minimum size.
+- What happens when `TERM=dumb` is set? The application should fall back to help text (non-ANSI terminal).
+- What happens when `NO_COLOR` is set? The TUI should render without any color/styling but still function.
+- What happens when the user runs `wave --no-tui run pipeline-name`? The `--no-tui` flag is only inspected by the root command's `RunE`; subcommands like `run` ignore it and use their own output modes.
+- What happens when `wave` is run outside a git repository? The TUI should still launch (it doesn't depend on git), but the header placeholder may show reduced info.
+- What happens when `wave.yaml` doesn't exist? The TUI should still launch and show an appropriate message in the main content area.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The root `wave` command (no subcommand, no arguments) MUST launch the full-screen Bubble Tea TUI when stdout is detected as an interactive TTY. Explicit `--help`, `-h`, and `--version` flags MUST continue to print their respective text output without launching the TUI. This is implemented by adding a `RunE` handler to the root Cobra command.
+- **FR-002**: The root `wave` command MUST print standard Cobra help text when stdout is NOT a TTY, or when the `--no-tui` flag is passed.
+- **FR-003**: The TUI MUST render a 3-row layout: header bar (fixed height), main content area (fills remaining space), and status/keybindings bar (single line, fixed).
+- **FR-004**: The header bar MUST display placeholder content (e.g., "Wave" branding text and placeholder metadata columns).
+- **FR-005**: The main content area MUST display placeholder content (e.g., "Main content area — pipelines view coming soon").
+- **FR-006**: The status bar MUST display the current view context label on the left and context-sensitive keybinding hints on the right.
+- **FR-007**: The TUI MUST respond to terminal resize events (Bubble Tea's `tea.WindowSizeMsg`) and reflow the layout.
+- **FR-008**: The TUI MUST show a degradation message when the terminal is smaller than 80 columns or 24 rows.
+- **FR-009**: Pressing `q` MUST exit the TUI cleanly with exit code 0.
+- **FR-010**: The first Ctrl-C signal MUST trigger graceful shutdown (cleanup and exit with status message, exit code 0).
+- **FR-011**: A second Ctrl-C during graceful shutdown MUST force-exit immediately with exit code 0.
+- **FR-012**: The `--no-tui` persistent flag MUST be registered on the root Cobra command. The flag is persistent so Cobra does not reject it on subcommands, but only the root command's `RunE` inspects it. Subcommands ignore it — they have their own output modes.
+- **FR-013**: TTY detection for the root command MUST check **stdout** (not stdin) using `term.IsTerminal(int(os.Stdout.Fd()))`, consistent with the existing `display.isTerminal()` function and Bubble Tea's own requirements. The `WAVE_FORCE_TTY` env var override MUST be respected (values `1`/`true` force TUI, `0`/`false` force help text).
+- **FR-014**: New Bubble Tea application code MUST be added to the existing `internal/tui/` package as new files (e.g., `app.go`, `header.go`, `content.go`, `statusbar.go`). The existing `internal/tui/` code (`run_selector.go`, `theme.go`, `pipelines.go`) MUST remain untouched and functional. The `WaveTheme()` from `theme.go` SHOULD be reused for consistent styling.
+- **FR-015**: The TUI MUST render its first frame within 100ms of launch (measured from `tea.Program.Run()` to first `View()` render). If initialization takes longer, a spinner MUST be shown.
+- **FR-016**: The Bubble Tea, Bubbles, and Lip Gloss dependencies MUST be available in `go.mod` (they already are: `bubbletea v1.3.10`, `bubbles v0.21.1`, `lipgloss v1.1.0`).
+
+### Key Entities
+
+- **AppModel**: The root Bubble Tea model implementing `tea.Model` (Init/Update/View). Contains the current window size, layout dimensions, shutdown state, and child component models for each row. Located in `internal/tui/app.go`.
+- **HeaderModel**: Component model for the header bar row. Renders placeholder branding and metadata. Located in `internal/tui/header.go`.
+- **ContentModel**: Component model for the main content area. Renders placeholder text; designed to be replaced by real views in subsequent issues. Located in `internal/tui/content.go`.
+- **StatusBarModel**: Component model for the status/keybindings bar. Shows current context and available key actions. Located in `internal/tui/statusbar.go`.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: `wave` with no args in a TTY launches a full-screen TUI that renders 3 distinct rows — verifiable by visual inspection and automated test.
+- **SC-002**: `wave | cat` prints help text to stdout — verifiable by piping output and checking for Cobra help format.
+- **SC-003**: `wave --no-tui` prints help text — verifiable by flag test.
+- **SC-004**: The TUI first frame renders within 100ms of launch — measurable by timing test or manual stopwatch.
+- **SC-005**: Terminal resize from 120×40 to 80×24 results in correct reflow — verifiable by resize test.
+- **SC-006**: Terminals smaller than 80×24 show degradation message instead of broken layout — verifiable by resize test.
+- **SC-007**: Single Ctrl-C triggers graceful exit (exit code 0) — verifiable by signal test.
+- **SC-008**: Double Ctrl-C triggers immediate exit (exit code 0) — verifiable by signal test.
+- **SC-009**: `q` key exits the TUI cleanly (exit code 0) — verifiable by key input test.
+- **SC-010**: All existing `go test ./...` tests continue to pass after the change — verifiable by CI.
+- **SC-011**: New `internal/tui/` package has test coverage for model initialization, update handling, and view rendering.
+- **SC-012**: No new dependencies beyond what is already in `go.mod` — verifiable by diffing `go.mod`.
+
+## Clarifications
+
+The following ambiguities were identified during spec review and resolved based on codebase context:
+
+### C-001: TTY Detection — stdout vs stdin
+
+**Ambiguity**: FR-001 referenced "stdout is a TTY" but FR-013 originally referenced `isInteractive()` which checks `os.Stdin.Fd()` (see `cmd/wave/commands/run.go:457`). The `display` package's `isTerminal()` checks `os.Stdout.Fd()` (see `internal/display/terminal.go:105`).
+
+**Resolution**: The TUI must check **stdout**, not stdin. Bubble Tea renders to stdout, so stdout must be a terminal for the TUI to function. The existing `isInteractive()` in `run.go` checks stdin because it guards interactive *input* (huh forms). The new root command TUI guard should use stdout detection, consistent with `display.isTerminal()`. FR-013 has been updated accordingly.
+
+**Rationale**: Checking stdout aligns with Bubble Tea's requirements, the existing `display` package pattern, and standard TUI behavior. A separate `shouldLaunchTUI()` function in `cmd/wave/main.go` can encapsulate this logic to avoid conflating it with the existing `isInteractive()`.
+
+### C-002: `--no-tui` Flag Scope with Subcommands
+
+**Ambiguity**: FR-012 specified `--no-tui` as a persistent flag, but edge case 4 said it should be "ignored for subcommands." In Cobra, persistent flags propagate to all child commands, which could cause confusion.
+
+**Resolution**: The flag is persistent so Cobra accepts it on any command without erroring, but only the root `RunE` handler inspects it. Subcommands already have their own output modes (`--output auto|json|text|quiet`) and never check `--no-tui`. FR-012 and edge case 4 have been clarified.
+
+**Rationale**: Making it non-persistent would cause `wave --no-tui run ...` to error, which is a poor UX. Persistent + root-only-inspection is the standard Cobra pattern for flags that modify default behavior.
+
+### C-003: File Structure in Existing `internal/tui/` Package
+
+**Ambiguity**: FR-014 said "create or extend" `internal/tui/` but the existing package contains `run_selector.go`, `theme.go`, and `pipelines.go` using `huh` forms — not Bubble Tea full-screen. The file layout for new code was unspecified.
+
+**Resolution**: New Bubble Tea app code goes in the same `internal/tui/` package as new files: `app.go` (AppModel), `header.go` (HeaderModel), `content.go` (ContentModel), `statusbar.go` (StatusBarModel). Existing files are not modified. The `WaveTheme()` from `theme.go` can be adapted for Lip Gloss styles in the full-screen TUI since it already defines Wave's color palette (cyan primary, white text, gray muted).
+
+**Rationale**: Single package avoids import cycles and keeps TUI code cohesive. Separate files per model follows Go convention and makes the codebase navigable for the remaining 9 issues in the series.
+
+### C-004: Exit Codes for All User-Initiated Exits
+
+**Ambiguity**: Story 3 specified exit code 0 for single Ctrl-C but left double Ctrl-C and `q` unspecified. Unix convention uses exit code 130 for SIGINT, which would conflict.
+
+**Resolution**: All user-initiated exits (`q`, single Ctrl-C, double Ctrl-C) return exit code 0. The TUI intercepts SIGINT via Bubble Tea's built-in signal handling rather than letting Go's default handler terminate with 130. This is consistent with how interactive TUI applications (vim, htop, lazygit) behave — the user is *requesting* exit, not encountering an error. SC-007, SC-008, SC-009, and the acceptance scenarios have been updated to be explicit.
+
+**Rationale**: Exit code 0 for intentional user exit is standard TUI practice. Shell scripts that invoke `wave` (non-TTY) get help text, not the TUI, so there is no conflict with signal conventions in scripted contexts.
+
+### C-005: Root Command Behavior Change — Help and Version Flags
+
+**Ambiguity**: Currently the root command has no `RunE` and falls through to Cobra help. Adding `RunE` to launch the TUI could break `wave --help` and `wave --version`.
+
+**Resolution**: FR-001 has been updated to explicitly state that `--help`, `-h`, and `--version` continue to work normally. Cobra handles help and version flags *before* invoking `RunE`, so no special logic is needed — the TUI launch only triggers when `RunE` is actually reached (i.e., bare `wave` with no help/version flags).
+
+**Rationale**: This is standard Cobra behavior. Help and version flags are intercepted by Cobra's built-in preprocessing, so `RunE` is never called when these flags are present. No special handling required in the implementation.

--- a/specs/252-tui-bubbletea-scaffold/tasks.md
+++ b/specs/252-tui-bubbletea-scaffold/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: TUI Bubble Tea Scaffold (#252)
+
+**Feature**: `252-tui-bubbletea-scaffold` (part 1 of 10, parent: #251)
+**Generated**: 2026-03-05
+**Total Tasks**: 16
+**Parallel Opportunities**: 6
+
+## Phase 1: Setup
+
+- [X] T001 [P1] [Setup] Verify Bubble Tea dependencies exist in `go.mod` and run `go mod tidy` — confirm `bubbletea v1.3.10`, `lipgloss v1.1.0`, `bubbles v0.21.1`, `golang.org/x/term` are present. No new deps allowed (SC-012). File: `go.mod`
+
+## Phase 2: Foundational — Component Models (Story 1 prerequisite)
+
+These tasks create the individual TUI components. T002–T004 can be done in parallel; T005 depends on all three.
+
+- [X] T002 [P1] [Story1] [P] Create `HeaderModel` in `internal/tui/header.go` — struct with `width int`, `SetWidth(w int)`, `View() string` rendering Wave logo (reuse `WaveLogo()` from `theme.go` or inline matching style), "Pipeline Orchestrator" text, and placeholder status. Fixed 3-line height. Use `lipgloss.Color("6")` (cyan), `lipgloss.Color("7")` (white), `lipgloss.Color("244")` (muted) matching existing theme. File: `internal/tui/header.go`
+- [X] T003 [P1] [Story1] [P] Create `ContentModel` in `internal/tui/content.go` — struct with `width int`, `height int`, `SetSize(w, h int)`, `View() string` rendering centered placeholder text "Wave TUI — Pipelines view coming soon" using `lipgloss.Place()`. File: `internal/tui/content.go`
+- [X] T004 [P1] [Story1] [P] Create `StatusBarModel` in `internal/tui/statusbar.go` — struct with `width int`, `contextLabel string` (default "Dashboard"), `SetWidth(w int)`, `View() string` rendering context label left-aligned and keybinding hints "q: quit  ctrl+c: exit" right-aligned on a single line with muted background. File: `internal/tui/statusbar.go`
+- [X] T005 [P1] [Story1] Create `AppModel` in `internal/tui/app.go` — root `tea.Model` composing `HeaderModel`, `ContentModel`, `StatusBarModel`. Fields: `width`, `height`, `header`, `content`, `statusBar`, `shuttingDown bool`, `ready bool`. Implement `NewAppModel()` constructor, `Init() tea.Cmd` (returns nil), `Update(msg tea.Msg) (tea.Model, tea.Cmd)` handling `tea.WindowSizeMsg`/`tea.KeyMsg`, `View() string` using `lipgloss.JoinVertical`. Layout: header (3 lines) + content (fills remaining) + statusbar (1 line). Show "Initializing..." before first `WindowSizeMsg`. Add public `RunTUI() error` that creates `tea.NewProgram(NewAppModel(), tea.WithAltScreen())` and calls `Run()`. File: `internal/tui/app.go`
+
+## Phase 3: Story 1 — Launch TUI from Terminal (P1)
+
+- [X] T006 [P1] [Story1] Add `shouldLaunchTUI(cmd *cobra.Command) bool` to `cmd/wave/main.go` — checks in order: (1) `--no-tui` flag → false, (2) `WAVE_FORCE_TTY` env var (`"1"`/`"true"` → true, `"0"`/`"false"` → false), (3) `TERM=dumb` → false, (4) `term.IsTerminal(int(os.Stdout.Fd()))`. Import `golang.org/x/term` and `github.com/recinq/wave/internal/tui`. File: `cmd/wave/main.go`
+- [X] T007 [P1] [Story1] Add `RunE` to `rootCmd` in `cmd/wave/main.go` — calls `shouldLaunchTUI(cmd)`, if true returns `tui.RunTUI()`, else returns `cmd.Help()`. File: `cmd/wave/main.go`
+
+## Phase 4: Story 2 — Non-TTY Fallback & `--no-tui` Flag (P1)
+
+- [X] T008 [P1] [Story2] Register `--no-tui` persistent flag on `rootCmd` in `init()` — `rootCmd.PersistentFlags().Bool("no-tui", false, "Disable TUI and print help text")`. Must be persistent so Cobra doesn't reject `wave --no-tui run ...`. Only root `RunE` inspects it. File: `cmd/wave/main.go`
+
+## Phase 5: Story 3 — Graceful Shutdown (P2)
+
+- [X] T009 [P2] [Story3] Implement Ctrl-C and `q` key handling in `AppModel.Update` — on `tea.KeyMsg` type `tea.KeyCtrlC`: if `shuttingDown` is already true, call `os.Exit(0)` (force exit); else set `shuttingDown = true` and return `tea.Quit`. On key "q": return `tea.Quit`. Both exit with code 0. File: `internal/tui/app.go`
+
+## Phase 6: Story 4 — Terminal Resize Handling (P3)
+
+- [X] T010 [P3] [Story4] Implement resize handling and degradation in `AppModel` — on `tea.WindowSizeMsg`, update `width`/`height`, set `ready = true`, propagate via `SetWidth`/`SetSize` to children. In `View()`, if `width < 80 || height < 24`, render degradation message: "Terminal too small. Minimum: 80×24. Current: {w}×{h}". File: `internal/tui/app.go`
+
+## Phase 7: Tests
+
+T011–T013 can be done in parallel. T014 depends on T005+T009+T010. T015 depends on T006–T008.
+
+- [X] T011 [P1] [Story1] [P] Create `internal/tui/header_test.go` — table-driven tests: `View()` contains Wave branding text, `SetWidth()` updates width, output respects width boundaries. Use `testify/assert`. File: `internal/tui/header_test.go`
+- [X] T012 [P1] [Story1] [P] Create `internal/tui/content_test.go` — table-driven tests: `View()` contains placeholder text "Pipelines view coming soon", `SetSize()` updates dimensions. Use `testify/assert`. File: `internal/tui/content_test.go`
+- [X] T013 [P1] [Story1] [P] Create `internal/tui/statusbar_test.go` — table-driven tests: `View()` contains keybinding hints ("q: quit", "ctrl+c: exit"), `View()` contains context label "Dashboard", `SetWidth()` updates width. Use `testify/assert`. File: `internal/tui/statusbar_test.go`
+- [X] T014 [P1] [Story1-3] Create `internal/tui/app_test.go` — tests: `NewAppModel()` returns valid initial state (ready=false, shuttingDown=false), `Update` with `tea.WindowSizeMsg` sets dimensions and `ready=true`, `Update` with `tea.KeyMsg` "q" returns `tea.Quit`, `Update` with Ctrl-C sets `shuttingDown` and returns `tea.Quit`, `View()` before ready returns loading text, `View()` after ready returns composed layout containing header/content/statusbar text, `View()` with dimensions < 80×24 returns degradation message. File: `internal/tui/app_test.go`
+- [X] T015 [P1] [Story1-2] Create `cmd/wave/main_test.go` — tests: `shouldLaunchTUI` with `--no-tui=true` returns false, with `WAVE_FORCE_TTY=1` returns true, with `WAVE_FORCE_TTY=0` returns false, with `TERM=dumb` returns false, `--no-tui` flag is registered as persistent. Use `testify/assert`, `t.Setenv()` for env vars. File: `cmd/wave/main_test.go`
+
+## Phase 8: Validation & Polish
+
+- [X] T016 [P1] [Validation] Run `go test ./...` and `go vet ./...` — all existing and new tests must pass. Verify no changes to `go.mod` beyond what's already present (SC-012). Verify existing `internal/tui/` tests still pass (run_selector_test.go, pipelines_test.go). File: N/A (validation step)
+
+## Dependency Graph
+
+```
+T001 (setup)
+  └─► T002, T003, T004 (components, parallel)
+        └─► T005 (AppModel, depends on all components)
+              ├─► T006 (shouldLaunchTUI)
+              │     └─► T007 (RunE on rootCmd)
+              │           └─► T008 (--no-tui flag, depends on T007 for integration)
+              ├─► T009 (shutdown handling, depends on T005)
+              └─► T010 (resize handling, depends on T005)
+  T011, T012, T013 (component tests, parallel after T002-T004)
+  T014 (app test, after T005+T009+T010)
+  T015 (main_test, after T006-T008)
+  T016 (validation, after all)
+```
+
+## Story-to-Task Mapping
+
+| Story | Priority | Tasks |
+|-------|----------|-------|
+| Story 1: Launch TUI | P1 | T002, T003, T004, T005, T006, T007, T011, T012, T013, T014 |
+| Story 2: Non-TTY Fallback | P1 | T008, T015 |
+| Story 3: Graceful Shutdown | P2 | T009, T014 |
+| Story 4: Terminal Resize | P3 | T010, T014 |
+| Cross-cutting | — | T001, T016 |


### PR DESCRIPTION
## Summary

- Add Bubble Tea TUI scaffold with 3-row layout: ASCII header, scrollable content area, and status bar
- Implement TTY detection with `--no-tui` flag and `WAVE_FORCE_TTY` environment variable override
- Add Ctrl-C graceful shutdown (first press quits cleanly, second force-exits)
- Enforce minimum terminal size (80×24) with degradation message
- Use alternate screen buffer via `tea.WithAltScreen()` for clean terminal restore

## Spec

See [`specs/252-tui-bubbletea-scaffold/spec.md`](specs/252-tui-bubbletea-scaffold/spec.md) for the full feature specification.

This is **part 1 of 10** for the TUI implementation ([parent issue #251](https://github.com/re-cinq/wave/issues/251)).

## Test Plan

- [x] `go test -race ./...` passes with all existing and new tests
- [x] Unit tests for `AppModel` (init, window resize, key events, view rendering, minimum size)
- [x] Unit tests for `shouldLaunchTUI` (--no-tui flag, WAVE_FORCE_TTY env, TERM=dumb)
- [x] Component tests for header, content, and status bar rendering
- [x] Table-driven tests for terminal size degradation edge cases

## Known Limitations

- Content area shows placeholder text — real pipeline views come in later parts
- Header shows static branding — live pipeline status comes in part 2+
- No keyboard navigation beyond q/Ctrl-C — navigation comes in later parts

Closes #252