### PR TITLE
docs: sync documentation with implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Each pipeline is a **topologically-sorted DAG** of steps. For every step:
    - Contract compliance section (auto-generated from step contract schema)
    - Restriction section (denied/allowed tools, network domains from manifest permissions)
 4. **Adapter execution** — the persona runs in isolated context with fresh memory (no chat history inheritance)
-5. **Contract validation** — step output is validated against its contract (json_schema, test_suite, typescript, quality_gate) **before** marking the step successful. Hard failures block; soft failures log warnings
+5. **Contract validation** — step output is validated against its contract (json_schema, typescript_interface, test_suite, markdown_spec, format) **before** marking the step successful. Hard failures block; soft failures log warnings
 
 Key source files: `internal/pipeline/executor.go`, `internal/adapter/claude.go`, `internal/contract/`, `internal/workspace/`
 
@@ -55,17 +55,23 @@ internal/
 ├── adapter/      # Subprocess execution and adapter management
 ├── audit/        # Audit logging and credential scrubbing
 ├── contract/     # Output validation (JSON, TypeScript, test suites)
+├── defaults/     # Embedded default personas, pipelines, and contracts
 ├── deliverable/  # Pipeline deliverable tracking and output
 ├── display/      # Terminal progress display and formatting
 ├── event/        # Progress event emission and monitoring
 ├── github/       # GitHub API integration for issue enhancement
 ├── manifest/     # Configuration loading and validation
+├── onboarding/   # Interactive wave init flow
+├── pathfmt/      # Path formatting and normalization utilities
 ├── pipeline/     # Pipeline execution and step management
 ├── preflight/    # Pipeline dependency validation and auto-install
+├── recovery/     # Pipeline recovery hints and error guidance
 ├── relay/        # Context compaction and summarization
 ├── security/     # Security validation and sanitization
 ├── skill/        # Skill discovery, provisioning, and command management
 ├── state/        # SQLite persistence and state management
+├── tui/          # Bubble Tea terminal UI
+├── webui/        # Web operations dashboard (embedded assets)
 ├── worktree/     # Git worktree lifecycle for isolated workspaces
 └── workspace/    # Ephemeral workspace management
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Usage:
 Available Commands:
   artifacts   List and export pipeline artifacts
   cancel      Cancel a running pipeline
+  chat        Interactive analysis of pipeline runs
   clean       Clean up project artifacts
   completion  Generate the autocompletion script for the specified shell
   do          Execute an ad-hoc task
@@ -112,8 +113,8 @@ Available Commands:
   logs        Show pipeline logs
   meta        Generate a custom pipeline
   migrate     Database migration commands
-  resume      Resume a paused pipeline
-  run         Run a pipeline
+  run         Run a pipeline (use --from-step to resume)
+  serve       Start the web operations dashboard
   status      Show pipeline status
   validate    Validate Wave configuration
 
@@ -123,6 +124,7 @@ Flags:
   -m, --manifest string   Path to manifest file (default "wave.yaml")
   -o, --output string     Output format: auto, json, text, quiet (default "auto")
   -v, --verbose           Include real-time tool activity
+      --no-tui            Disable TUI and print help text
       --version           version for wave
 
 Use "wave [command] --help" for more information about a command.
@@ -303,7 +305,7 @@ personas:
       deny: [Write(*), Edit(*)]
 ```
 
-**14 built-in personas** including `navigator`, `craftsman`, `auditor`, `philosopher`, `debugger`, and more.
+**30 built-in personas** including `navigator`, `craftsman`, `auditor`, `philosopher`, `debugger`, and more.
 
 > Explore all personas in [`.wave/personas/`](.wave/personas/)
 
@@ -321,7 +323,7 @@ steps:
     dependencies: [implement]
 ```
 
-**23 built-in pipelines** for development, debugging, documentation, and GitHub automation.
+**42 built-in pipelines** for development, debugging, documentation, and GitHub automation.
 
 > Explore all pipelines in [`.wave/pipelines/`](.wave/pipelines/)
 
@@ -333,7 +335,7 @@ Every step boundary validates output against JSON Schema, TypeScript interfaces,
 
 ## Pipelines
 
-A selection of the 23 built-in pipelines:
+A selection of the 42 built-in pipelines:
 
 ### Development
 
@@ -366,7 +368,7 @@ A selection of the 23 built-in pipelines:
 | `github-issue-enhancer` | Analyze and enhance poorly documented issues |
 | `doc-audit` | Documentation impact analysis before merge |
 
-> **More pipelines:** `hello-world`, `smoke-test`, `explain`, `onboard`, `improve`, `dead-code`, `security-scan`
+> **More pipelines:** `hello-world`, `smoke-test`, `explain`, `onboard`, `improve`, `dead-code`, `security-scan`, `adr`, `changelog`, `feature`, `recinq`, `supervise`, plus `bb-*` (Bitbucket), `gl-*` (GitLab), and `gt-*` (Gitea) platform variants
 >
 > Explore all in [`.wave/pipelines/`](.wave/pipelines/)
 
@@ -374,7 +376,7 @@ A selection of the 23 built-in pipelines:
 
 ## Personas
 
-A selection of the 14 built-in personas:
+A selection of the 30 built-in personas:
 
 | Persona | Temp | Purpose | Key Permissions |
 |---------|------|---------|--------------------|
@@ -386,7 +388,7 @@ A selection of the 14 built-in personas:
 | `auditor` | 0.1 | Security review | Read + audit tools |
 | `summarizer` | 0.0 | Context compaction | Read-only |
 
-> **More personas:** `implementer`, `researcher`, `reviewer`, `github-analyst`, `github-commenter`, `github-enhancer`, `github-pr-creator`
+> **More personas:** `implementer`, `researcher`, `reviewer`, `provocateur`, `supervisor`, `synthesizer`, `validator`, `github-analyst`, `github-commenter`, `github-enhancer`, `github-scoper`, plus `bitbucket-*`, `gitea-*`, and `gitlab-*` platform variants
 >
 > Explore all in [`.wave/personas/`](.wave/personas/)
 

--- a/docs/concepts/contracts.md
+++ b/docs/concepts/contracts.md
@@ -85,6 +85,7 @@ handover:
 | `json_schema` | JSON structure | Ensuring data format |
 | `typescript_interface` | TypeScript compiles | Validating generated types |
 | `markdown_spec` | Markdown structure | Checking documentation |
+| `format` | Output format rules (e.g., GitHub issue, PR, code) | Ensuring production-ready formatting |
 
 ## Contract Fields
 

--- a/docs/concepts/personas.md
+++ b/docs/concepts/personas.md
@@ -23,7 +23,7 @@ personas:
 
 ## Built-in Personas
 
-Wave includes **14 built-in personas** designed for secure, specialized execution. The following table highlights four core personas commonly used in pipelines:
+Wave includes **30 built-in personas** designed for secure, specialized execution. The following table highlights four core personas commonly used in pipelines:
 
 <script setup>
 const builtInPersonas = [
@@ -292,9 +292,11 @@ flowchart TB
 
 ```yaml
 workspace:
-  type: ephemeral          # Always isolated
-  clone_depth: 1           # Shallow clone for speed
-  preserve_on_failure: true # Keep workspace for debugging
+  type: worktree           # Git worktree for full isolation
+  ref: my-shared-workspace # Optional: share workspace with another step
+  mounts:                  # Optional: mount paths into workspace
+    - path: ./config
+      mode: readonly
 ```
 
 ## Using Personas in Pipelines

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -31,9 +31,9 @@ personas:                  # Required
     hooks: {}               # Optional - Pre/Post hooks
 
 runtime:                    # Required
-  workspace_root: string         # Optional - Default "/tmp/wave"
+  workspace_root: string         # Optional - Default ".wave/workspaces"
   max_concurrent_workers: int   # Optional - Default 5
-  default_timeout_minutes: int   # Optional - Default 30
+  default_timeout_minutes: int   # Optional - Default 5
   relay: {}                   # Optional - Relay config
   audit: {}                   # Optional - Audit config
   meta_pipeline: {}            # Optional - Meta pipeline limits
@@ -104,7 +104,7 @@ personas:
 
 ```yaml
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
   max_concurrent_workers: 3
   default_timeout_minutes: 30
 ```
@@ -197,7 +197,7 @@ runtime:
 
 # Production
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
   audit:
     log_all_tool_calls: true
     log_all_file_operations: true

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -103,5 +103,5 @@ rm -rf ~/.wave
 
 ## Next Steps
 
-- [Quickstart](/quickstart) - Get running in 60 seconds
+- [Quick Start](/guide/quick-start) - Get running in 60 seconds
 - [Pipeline Configuration](/guides/pipeline-configuration) - Configure your first pipeline

--- a/docs/guide/personas.md
+++ b/docs/guide/personas.md
@@ -4,7 +4,7 @@ Personas define how agents behave in Wave. Each persona binds an adapter to a sp
 
 ## Built-in Personas
 
-Wave ships with 14 built-in personas:
+Wave ships with 30 built-in personas:
 
 | Persona | Purpose | Permissions |
 |---------|---------|-------------|
@@ -21,7 +21,7 @@ Wave ships with 14 built-in personas:
 | `github-analyst` | GitHub issue analysis | Read, Grep, Bash(gh *) |
 | `github-enhancer` | GitHub issue enhancement | Read, Bash(gh *) |
 | `github-commenter` | GitHub issue commenting | Read, Bash(gh *) |
-| `github-pr-creator` | Pull request creation | Read, Bash(gh *), Bash(git *) |
+| `github-scoper` | Epic decomposition and issue scoping | Read, Bash(gh *), Bash(git *) |
 
 ## Persona Definitions
 
@@ -194,9 +194,9 @@ Enhances poorly documented GitHub issues with structured details, reproduction s
 
 Posts analysis results and recommendations as comments on GitHub issues.
 
-### GitHub PR Creator
+### GitHub Scoper
 
-Creates pull requests with proper descriptions, linking related issues and summarizing changes.
+Analyzes epic/umbrella issues and decomposes them into well-scoped child issues for implementation.
 
 ## Defining Custom Personas
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -40,7 +40,7 @@ personas:
       deny: ["Write(*)"]
 
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
   max_concurrent_workers: 3
 ```
 
@@ -79,7 +79,7 @@ wave run speckit-flow "add user authentication" -o text
 
 ## 5. Check Results
 
-Artifacts are saved in `/tmp/wave/<pipeline-id>/<step-id>/`. Each step produces its own workspace.
+Artifacts are saved in `.wave/workspaces/<pipeline-id>/<step-id>/`. Each step produces its own workspace.
 
 ## Quick Commands
 

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -257,7 +257,7 @@ Credentials are **never** written to disk. They flow via curated process environ
 
 ## Timeout Handling
 
-- Default timeout: 10 minutes per step
+- Default timeout: 5 minutes per step
 - Override via `runtime.default_timeout_minutes` or `--timeout` flag
 - On timeout, entire process group receives `SIGKILL`
 - Timeout counts as step failure, triggering retry logic

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,6 +12,7 @@ Wave CLI commands for pipeline orchestration.
 | `wave status` | Check pipeline status |
 | `wave logs` | View execution logs |
 | `wave cancel` | Cancel running pipeline |
+| `wave chat` | Interactive analysis of pipeline runs |
 | `wave artifacts` | List and export artifacts |
 | `wave list` | List adapters, runs, pipelines, personas, contracts |
 | `wave validate` | Validate configuration |
@@ -532,6 +533,45 @@ wave serve --db .wave/state.db
 
 ---
 
+
+## wave chat
+
+Interactive analysis and exploration of pipeline runs. Opens a conversational session where you can investigate step outputs, artifacts, and execution details.
+
+```bash
+wave chat run-abc123
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--step` | `""` | Focus context on a specific step |
+| `--model` | `sonnet` | Model to use for the chat session |
+| `--list` | `false` | List recent runs |
+| `--continue` | `""` | Continue work in a step's workspace (read-write) |
+| `--rewrite` | `""` | Re-execute a step with modified prompt |
+| `--extend` | `""` | Add supplementary instructions to a step |
+
+```bash
+# List recent runs
+wave chat --list
+
+# Chat about a specific step
+wave chat run-abc123 --step implement
+
+# Continue working in a step's workspace
+wave chat run-abc123 --continue implement
+
+# Re-execute a step with a new prompt
+wave chat run-abc123 --rewrite implement
+
+# Add supplementary instructions to a step
+wave chat run-abc123 --extend implement
+```
+
+---
+
 ## wave migrate
 
 Database migration commands.
@@ -596,6 +636,7 @@ All commands support:
 | `--debug` | `-d` | Enable debug mode |
 | `--output` | `-o` | Output format: auto, json, text, quiet (default: auto) |
 | `--verbose` | `-v` | Include real-time tool activity |
+| `--no-tui` | | Disable TUI and print help text |
 
 ---
 
@@ -615,6 +656,6 @@ All commands support:
 
 ## Next Steps
 
-- [Quickstart](/quickstart) - Run your first pipeline
+- [Quick Start](/guide/quick-start) - Run your first pipeline
 - [Pipelines](/concepts/pipelines) - Define multi-step workflows
 - [Manifest Reference](/reference/manifest) - Configuration options

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -53,7 +53,7 @@ wave run flow "task" 2>/dev/null
 Human-friendly format with color and formatting.
 
 ```bash
-WAVE_LOG_FORMAT=text wave run flow "task"
+wave run flow "task" -o text
 ```
 
 Text output example:

--- a/docs/reference/manifest-schema.md
+++ b/docs/reference/manifest-schema.md
@@ -12,6 +12,7 @@ Complete field reference for `wave.yaml` — the single source of truth for all 
 | `adapters` | `map[string]`[`Adapter`](#adapter) | **yes** | Named adapter configurations. |
 | `personas` | `map[string]`[`Persona`](#persona) | **yes** | Named persona configurations. |
 | `runtime` | [`Runtime`](#runtime) | **yes** | Global runtime settings. |
+| `project` | [`Project`](#project) | no | Project metadata for language, test commands, and source globs. |
 | `skills` | `map[string]`[`SkillConfig`](#skillconfig) | no | Named skill configurations with install, check, and provisioning settings. |
 
 ### Minimal Example
@@ -30,7 +31,7 @@ personas:
     adapter: claude
     system_prompt_file: .wave/personas/navigator.md
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
 ```
 
 ---
@@ -48,6 +49,30 @@ metadata:
   name: acme-backend
   description: "Acme Corp backend API service"
   repo: https://github.com/acme/backend
+```
+
+---
+
+
+## Project
+
+Optional project-level settings used for build, test, and source discovery.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `language` | `string` | no | `""` | Project language (e.g., "go", "typescript"). Used for adapter heuristics. |
+| `test_command` | `string` | no | `""` | Command to run tests (e.g., "go test ./..."). Used by contract validation. |
+| `lint_command` | `string` | no | `""` | Command to run linting. |
+| `build_command` | `string` | no | `""` | Command to build the project. |
+| `source_glob` | `string` | no | `""` | Glob pattern matching source files (e.g., "**/*.go"). |
+
+```yaml
+project:
+  language: go
+  test_command: "go test ./..."
+  lint_command: "golangci-lint run"
+  build_command: "go build ./..."
+  source_glob: "**/*.go"
 ```
 
 ---
@@ -107,6 +132,7 @@ Agent configuration binding an adapter to a specific role. Personas enforce sepa
 | `system_prompt_file` | `string` | **yes** | — | Path to markdown file containing the persona's system prompt. Relative to project root. |
 | `temperature` | `float` | no | adapter default | LLM temperature setting. Range: `0.0` to `1.0`. Lower values produce more deterministic output. |
 | `permissions` | [`Permissions`](#permissions) | no | inherit from adapter | Tool permission overrides. Merged with adapter defaults; persona-level `deny` always takes precedence. |
+| `model` | `string` | no | adapter default | LLM model override for this persona (e.g., "opus", "sonnet"). |
 | `hooks` | [`HookConfig`](#hookconfig) | no | `{}` | Pre/post tool use hook definitions. |
 
 ### Built-in Persona Archetypes
@@ -261,12 +287,16 @@ Global runtime settings governing execution behavior.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `workspace_root` | `string` | no | `"/tmp/wave"` | Root directory for ephemeral workspaces. Each pipeline run creates subdirectories here. |
+| `workspace_root` | `string` | no | `".wave/workspaces"` | Root directory for ephemeral workspaces. Each pipeline run creates subdirectories here. |
 | `max_concurrent_workers` | `int` | no | `5` | Maximum parallel matrix strategy workers. Range: `1`–`10`. |
-| `default_timeout_minutes` | `int` | no | `30` | Default per-step timeout. Steps exceeding this are killed (entire process group). |
+| `default_timeout_minutes` | `int` | no | `5` | Default per-step timeout. Steps exceeding this are killed (entire process group). |
 | `relay` | [`RelayConfig`](#relayconfig) | no | see defaults | Context relay/compaction settings. |
 | `audit` | [`AuditConfig`](#auditconfig) | no | see defaults | Audit logging settings. |
 | `meta_pipeline` | [`MetaPipelineConfig`](#metapipelineconfig) | no | see defaults | Meta-pipeline recursion and resource limits. |
+| `routing` | [`RoutingConfig`](#routingconfig) | no | see defaults | Pipeline routing rules for matching inputs to pipelines. |
+| `sandbox` | [`RuntimeSandbox`](#runtimesandbox) | no | see defaults | Sandbox settings including env passthrough and domain allowlisting. |
+| `artifacts` | [`RuntimeArtifactsConfig`](#runtimeartifactsconfig) | no | see defaults | Global artifact handling configuration. |
+| `pipeline_id_hash_length` | `int` | no | `4` | Length of hash suffix appended to pipeline workspace IDs. |
 
 ### RelayConfig
 
@@ -296,13 +326,43 @@ Audit logs **never** capture environment variable values or credential content. 
 | `max_total_tokens` | `int` | no | `500000` | Maximum total token consumption across all meta-pipeline levels. |
 | `timeout_minutes` | `int` | no | `60` | Hard timeout for entire meta-pipeline tree. |
 
+### RoutingConfig
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `default` | `string` | no | `""` | Pipeline to use when no routing rules match. |
+| `rules` | `[]RoutingRule` | no | `[]` | Routing rules evaluated in priority order. |
+
+#### RoutingRule
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `pattern` | `string` | no | `""` | Glob pattern for matching input strings. Supports `*`, `?`, `[abc]`, `[a-z]`. |
+| `pipeline` | `string` | **yes** | — | Pipeline name to route to when this rule matches. |
+| `priority` | `int` | no | `0` | Evaluation order. Higher priority rules are evaluated first. |
+
+### RuntimeSandbox
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | `bool` | no | `false` | Enable sandbox mode for adapter subprocesses. |
+| `default_allowed_domains` | `[]string` | no | `[]` | Network domain allowlist applied to all personas. |
+| `env_passthrough` | `[]string` | no | `[]` | Environment variables passed through to adapter subprocesses. |
+
+### RuntimeArtifactsConfig
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `max_stdout_size` | `int` | no | `10485760` | Maximum bytes to capture from stdout (default: 10MB). |
+| `default_artifact_dir` | `string` | no | `".wave/artifacts"` | Base directory for artifacts. |
+
 ### Full Runtime Example
 
 ```yaml
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
   max_concurrent_workers: 5
-  default_timeout_minutes: 30
+  default_timeout_minutes: 5
   relay:
     token_threshold_percent: 80
     strategy: summarize_to_checkpoint
@@ -532,9 +592,9 @@ personas:
       deny: ["Write(*)", "Bash(*)"]
 
 runtime:
-  workspace_root: /tmp/wave
+  workspace_root: .wave/workspaces
   max_concurrent_workers: 5
-  default_timeout_minutes: 30
+  default_timeout_minutes: 5
   relay:
     token_threshold_percent: 80
     strategy: summarize_to_checkpoint


### PR DESCRIPTION
## Summary

Automated documentation sync fixing 20 inconsistencies between docs and source code across 12 files. Addresses stale references, inaccurate counts, missing command docs, and broken links.

## Changes

- **CLAUDE.md** — Fixed contract types (json_schema, typescript_interface, test_suite, markdown_spec, format), added 6 missing internal packages (defaults, onboarding, pathfmt, recovery, tui, webui)
- **README.md** — Removed nonexistent `resume` command, added `chat`/`serve` commands, updated persona count (14→30) and pipeline count (23→42), replaced `github-pr-creator` with `github-scoper`, added `--no-tui` flag
- **docs/concepts/contracts.md** — Added `format` contract type documentation
- **docs/concepts/personas.md** — Updated persona count to 30, fixed invalid `ephemeral` workspace type example
- **docs/guide/configuration.md** — Fixed workspace_root default to `.wave/workspaces`, fixed timeout default
- **docs/guide/installation.md** — Fixed broken `/quickstart` link → `/guide/quick-start`
- **docs/guide/personas.md** — Updated persona count to 30, replaced `github-pr-creator` with `github-scoper`
- **docs/guide/quick-start.md** — Fixed workspace path from `/tmp/wave/` to `.wave/workspaces/`
- **docs/reference/adapters.md** — Fixed default timeout from 10 to 5 minutes
- **docs/reference/cli.md** — Added `chat` command section, added `--no-tui` flag
- **docs/reference/events.md** — Replaced nonexistent `WAVE_LOG_FORMAT` env var with `-o text` flag
- **docs/reference/manifest-schema.md** — Added Project field, Persona.Model field, Runtime sub-fields

## Findings Addressed

| ID | Type | Severity | Resolution |
|----|------|----------|------------|
| DOC-001 | STALE_DOCS | HIGH | Removed nonexistent `resume` command from README |
| DOC-002 | INACCURATE | HIGH | Updated persona count 14→30 |
| DOC-003 | INACCURATE | HIGH | Updated pipeline count 23→42 |
| DOC-004 | STALE_DOCS | HIGH | Replaced `github-pr-creator` → `github-scoper` |
| DOC-005 | MISSING_DOCS | HIGH | Added `chat` command to README + CLI reference |
| DOC-006 | INACCURATE | HIGH | Fixed workspace_root default to `.wave/workspaces` |
| DOC-007 | STALE_DOCS | MEDIUM | Replaced `WAVE_LOG_FORMAT` with `-o text` |
| DOC-008 | STALE_DOCS | HIGH | Fixed `github-pr-creator` in personas guide |
| DOC-009 | INACCURATE | MEDIUM | Updated persona count in guide/concepts |
| DOC-010 | INCOMPLETE | MEDIUM | Added 6 missing packages to CLAUDE.md |
| DOC-011 | INACCURATE | MEDIUM | Fixed contract types in CLAUDE.md |
| DOC-012 | MISSING_DOCS | MEDIUM | Added Persona.Model to manifest schema |
| DOC-013 | MISSING_DOCS | MEDIUM | Added Runtime sub-fields to manifest schema |
| DOC-014 | MISSING_DOCS | LOW | Added `--no-tui` flag to docs |
| DOC-015 | INACCURATE | MEDIUM | Fixed default timeout to 5 minutes |
| DOC-016 | INACCURATE | MEDIUM | Fixed invalid `ephemeral` workspace type |
| DOC-017 | MISSING_DOCS | LOW | Documented `format` contract type |
| DOC-018 | INCOMPLETE | LOW | Fixed broken `/quickstart` link |
| DOC-019 | MISSING_DOCS | LOW | Added Project field to manifest schema |
| DOC-020 | INCOMPLETE | LOW | Added `serve` command, fixed command list |

## Skipped

None — all 20 findings were fixed.