### PR TITLE
feat(tui): add pipeline list left pane with navigation, filtering, and sections

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -27,21 +27,23 @@ type AppModel struct {
 }
 
 // NewAppModel creates a new root app model with default child components.
-func NewAppModel(provider MetadataProvider) AppModel {
+func NewAppModel(metaProvider MetadataProvider, pipelineProvider PipelineDataProvider) AppModel {
 	return AppModel{
-		header:    NewHeaderModel(provider),
-		content:   NewContentModel(),
+		header:    NewHeaderModel(metaProvider),
+		content:   NewContentModel(pipelineProvider),
 		statusBar: NewStatusBarModel(),
 	}
 }
 
-// Init implements tea.Model. Returns header init commands for async data loading.
+// Init implements tea.Model. Returns commands from header and content for async data loading.
 func (m AppModel) Init() tea.Cmd {
-	return m.header.Init()
+	return tea.Batch(m.header.Init(), m.content.Init())
 }
 
 // Update implements tea.Model. Handles key events and window resize.
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
@@ -52,7 +54,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.shuttingDown = true
 			return m, tea.Quit
 		default:
-			if msg.String() == "q" {
+			if msg.String() == "q" && !m.content.list.filtering {
 				return m, tea.Quit
 			}
 		}
@@ -75,8 +77,18 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Forward all messages to header for state updates
 	var headerCmd tea.Cmd
 	m.header, headerCmd = m.header.Update(msg)
+	if headerCmd != nil {
+		cmds = append(cmds, headerCmd)
+	}
 
-	return m, headerCmd
+	// Forward all messages to content for list updates
+	var contentCmd tea.Cmd
+	m.content, contentCmd = m.content.Update(msg)
+	if contentCmd != nil {
+		cmds = append(cmds, contentCmd)
+	}
+
+	return m, tea.Batch(cmds...)
 }
 
 // View implements tea.Model. Renders the 3-row layout.
@@ -102,8 +114,8 @@ func (m AppModel) View() string {
 
 // RunTUI creates and runs the Bubble Tea program with alternate screen.
 func RunTUI() error {
-	provider := &DefaultMetadataProvider{}
-	p := tea.NewProgram(NewAppModel(provider), tea.WithAltScreen())
+	metaProvider := &DefaultMetadataProvider{}
+	p := tea.NewProgram(NewAppModel(metaProvider, nil), tea.WithAltScreen())
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -25,8 +25,22 @@ func (m *mockProvider) FetchPipelineHealth() (HealthStatus, error) {
 	return HealthOK, nil
 }
 
+type mockPipelineDataProvider struct{}
+
+func (m *mockPipelineDataProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
+	return nil, nil
+}
+
+func (m *mockPipelineDataProvider) FetchFinishedPipelines(limit int) ([]FinishedPipeline, error) {
+	return nil, nil
+}
+
+func (m *mockPipelineDataProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+	return nil, nil
+}
+
 func TestNewAppModel_InitialState(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	assert.False(t, m.ready)
 	assert.False(t, m.shuttingDown)
 	assert.Equal(t, 0, m.width)
@@ -35,14 +49,20 @@ func TestNewAppModel_InitialState(t *testing.T) {
 }
 
 func TestAppModel_Init_ReturnsCmds(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	cmd := m.Init()
 	// Header.Init() returns a batch of async fetch commands
 	assert.NotNil(t, cmd)
 }
 
+func TestAppModel_Init_IncludesContentCmds(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
+	cmd := m.Init()
+	assert.NotNil(t, cmd)
+}
+
 func TestAppModel_Update_WindowSizeMsg(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 
 	updated, _ := m.Update(msg)
@@ -57,8 +77,22 @@ func TestAppModel_Update_WindowSizeMsg(t *testing.T) {
 	assert.Equal(t, 40-headerHeight-statusBarHeight, model.content.height)
 }
 
+func TestAppModel_Update_WindowSizeMsg_PropagatesContent(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
+	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
+	updated, _ := m.Update(msg)
+	model := updated.(AppModel)
+
+	assert.Equal(t, 120, model.content.width)
+	contentHeight := 40 - headerHeight - statusBarHeight
+	assert.Equal(t, contentHeight, model.content.height)
+	// List should have received size too
+	assert.Greater(t, model.content.list.width, 0)
+	assert.Equal(t, contentHeight, model.content.list.height)
+}
+
 func TestAppModel_Update_QuitOnQ(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
 
 	_, cmd := m.Update(msg)
@@ -70,7 +104,7 @@ func TestAppModel_Update_QuitOnQ(t *testing.T) {
 }
 
 func TestAppModel_Update_CtrlC_SetsShuttingDown(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
 
 	updated, cmd := m.Update(msg)
@@ -83,13 +117,13 @@ func TestAppModel_Update_CtrlC_SetsShuttingDown(t *testing.T) {
 }
 
 func TestAppModel_View_BeforeReady(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	view := m.View()
 	assert.Equal(t, "Initializing...", view)
 }
 
 func TestAppModel_View_AfterReady(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
@@ -100,7 +134,7 @@ func TestAppModel_View_AfterReady(t *testing.T) {
 	assert.Contains(t, view, "╦")
 	assert.Contains(t, view, "╚╩╝")
 	// Should contain content placeholder
-	assert.Contains(t, view, "Pipelines view coming soon")
+	assert.Contains(t, view, "Select a pipeline to view details")
 	// Should contain status bar hints
 	assert.Contains(t, view, "q: quit")
 	assert.Contains(t, view, "ctrl+c: exit")
@@ -119,7 +153,7 @@ func TestAppModel_View_TooSmall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewAppModel(&mockProvider{})
+			m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 			msg := tea.WindowSizeMsg{Width: tt.width, Height: tt.height}
 			updated, _ := m.Update(msg)
 			model := updated.(AppModel)
@@ -132,7 +166,7 @@ func TestAppModel_View_TooSmall(t *testing.T) {
 }
 
 func TestAppModel_View_ExactMinimumSize(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	msg := tea.WindowSizeMsg{Width: 80, Height: 24}
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
@@ -148,7 +182,7 @@ func TestAppModel_View_ExactMinimumSize(t *testing.T) {
 // --- T033: App integration tests for header message forwarding ---
 
 func TestAppModel_Update_ForwardsGitStateMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	// First, set up with a window size
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
@@ -173,7 +207,7 @@ func TestAppModel_Update_ForwardsGitStateMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsManifestInfoMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -189,7 +223,7 @@ func TestAppModel_Update_ForwardsManifestInfoMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsPipelineHealthMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -201,7 +235,7 @@ func TestAppModel_Update_ForwardsPipelineHealthMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsRunningCountMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -215,7 +249,7 @@ func TestAppModel_Update_ForwardsRunningCountMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsPipelineSelectedMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -230,7 +264,7 @@ func TestAppModel_Update_ForwardsPipelineSelectedMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_View_HeaderRendersForwardedData(t *testing.T) {
-	m := NewAppModel(&mockProvider{})
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 40})
 	model := updated.(AppModel)
 

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -1,35 +1,76 @@
 package tui
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
-// ContentModel is the main content area component.
+// ContentModel is the main content area component composing a left pipeline list pane and a right detail pane.
 type ContentModel struct {
 	width  int
 	height int
+	list   PipelineListModel
 }
 
-// NewContentModel creates a new content model.
-func NewContentModel() ContentModel {
-	return ContentModel{}
+// NewContentModel creates a new content model with the given pipeline data provider.
+func NewContentModel(provider PipelineDataProvider) ContentModel {
+	return ContentModel{
+		list: NewPipelineListModel(provider),
+	}
 }
 
-// SetSize updates the content area dimensions for reflow.
+// Init returns commands from child components.
+func (m ContentModel) Init() tea.Cmd {
+	return m.list.Init()
+}
+
+// SetSize updates the content area dimensions and propagates to children.
 func (m *ContentModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
+
+	leftWidth := m.leftPaneWidth()
+	m.list.SetSize(leftWidth, h)
 }
 
-// View renders the content area with centered placeholder text.
-func (m ContentModel) View() string {
-	placeholder := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("244")).
-		Render("Wave TUI — Pipelines view coming soon")
+// Update handles messages by forwarding to child components.
+func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
 
+// View renders the content area with left pipeline list and right detail placeholder.
+func (m ContentModel) View() string {
 	if m.width <= 0 || m.height <= 0 {
-		return placeholder
+		return ""
 	}
 
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, placeholder)
+	leftWidth := m.leftPaneWidth()
+	rightWidth := m.width - leftWidth
+
+	leftView := m.list.View()
+
+	rightPlaceholder := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244"))
+	rightContent := rightPlaceholder.Render("Select a pipeline to view details")
+
+	rightView := lipgloss.Place(rightWidth, m.height, lipgloss.Center, lipgloss.Center, rightContent)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, leftView, rightView)
+}
+
+// leftPaneWidth computes the left pane width: 30% of total, min 25, max 50.
+func (m ContentModel) leftPaneWidth() int {
+	w := m.width * 30 / 100
+	if w < 25 {
+		w = 25
+	}
+	if w > 50 {
+		w = 50
+	}
+	if w > m.width {
+		w = m.width
+	}
+	return w
 }

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -6,14 +6,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContentModel_View_ContainsPlaceholder(t *testing.T) {
-	c := NewContentModel()
-	view := c.View()
-	assert.Contains(t, view, "Pipelines view coming soon")
+type contentTestPipelineProvider struct{}
+
+func (m *contentTestPipelineProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
+	return nil, nil
+}
+
+func (m *contentTestPipelineProvider) FetchFinishedPipelines(limit int) ([]FinishedPipeline, error) {
+	return nil, nil
+}
+
+func (m *contentTestPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+	return nil, nil
+}
+
+func TestContentModel_NewContentModel(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{})
+	assert.True(t, c.list.focused)
 }
 
 func TestContentModel_SetSize(t *testing.T) {
-	c := NewContentModel()
+	c := NewContentModel(&contentTestPipelineProvider{})
 	assert.Equal(t, 0, c.width)
 	assert.Equal(t, 0, c.height)
 
@@ -22,20 +35,52 @@ func TestContentModel_SetSize(t *testing.T) {
 	assert.Equal(t, 40, c.height)
 }
 
-func TestContentModel_View_CentersContent(t *testing.T) {
-	c := NewContentModel()
+func TestContentModel_SetSize_PropagatesListDimensions(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{})
+	c.SetSize(120, 40)
+
+	// Left pane: 30% of 120 = 36, clamped to [25, 50] -> 36
+	assert.Equal(t, 36, c.list.width)
+	assert.Equal(t, 40, c.list.height)
+}
+
+func TestContentModel_LeftPaneWidth(t *testing.T) {
+	tests := []struct {
+		name     string
+		width    int
+		expected int
+	}{
+		{"30 percent of 120", 120, 36},
+		{"minimum 25", 60, 25},  // 30% of 60 = 18 -> clamped to 25
+		{"maximum 50", 200, 50}, // 30% of 200 = 60 -> clamped to 50
+		{"exact 100", 100, 30},  // 30% of 100 = 30
+		{"narrow 80", 80, 25},   // 30% of 80 = 24 -> clamped to 25
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewContentModel(&contentTestPipelineProvider{})
+			c.SetSize(tt.width, 40)
+			assert.Equal(t, tt.expected, c.list.width)
+		})
+	}
+}
+
+func TestContentModel_View_RightPanePlaceholder(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{})
 	c.SetSize(120, 40)
 	view := c.View()
-
-	// With centering, the view should contain the placeholder text
-	assert.Contains(t, view, "Pipelines view coming soon")
-	// The view should contain spaces/newlines for centering
-	assert.Greater(t, len(view), len("Wave TUI — Pipelines view coming soon"))
+	assert.Contains(t, view, "Select a pipeline to view details")
 }
 
 func TestContentModel_View_ZeroDimensions(t *testing.T) {
-	c := NewContentModel()
-	// With zero dimensions, should still return placeholder text
+	c := NewContentModel(&contentTestPipelineProvider{})
 	view := c.View()
-	assert.Contains(t, view, "Pipelines view coming soon")
+	assert.Equal(t, "", view)
+}
+
+func TestContentModel_Init_ReturnsCommands(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{})
+	cmd := c.Init()
+	assert.NotNil(t, cmd)
 }

--- a/internal/tui/pipeline_list.go
+++ b/internal/tui/pipeline_list.go
@@ -1,0 +1,637 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	pipelineRefreshInterval = 5 * time.Second
+	finishedPipelineLimit   = 20
+)
+
+// itemKind identifies the type of navigable item in the flat list.
+type itemKind int
+
+const (
+	itemKindSectionHeader itemKind = iota
+	itemKindRunning
+	itemKindFinished
+	itemKindAvailable
+)
+
+// navigableItem is a single entry in the flat navigation list.
+type navigableItem struct {
+	kind         itemKind
+	sectionIndex int    // 0=Running, 1=Finished, 2=Available
+	dataIndex    int    // index into section's data slice (-1 for headers)
+	label        string // display text
+}
+
+// PipelineListModel is the Bubble Tea model for the pipeline list left pane.
+type PipelineListModel struct {
+	width    int
+	height   int
+	provider PipelineDataProvider
+
+	// Section data
+	running   []RunningPipeline
+	finished  []FinishedPipeline
+	available []PipelineInfo
+
+	// Navigation state
+	cursor    int
+	navigable []navigableItem
+
+	// Filter state
+	filtering   bool
+	filterInput textinput.Model
+	filterQuery string
+
+	// Section collapse state
+	collapsed [3]bool // [Running, Finished, Available]
+
+	// Focus state
+	focused bool
+
+	// Scroll state
+	scrollOffset int
+}
+
+// NewPipelineListModel creates a new pipeline list model with the given data provider.
+func NewPipelineListModel(provider PipelineDataProvider) PipelineListModel {
+	ti := textinput.New()
+	ti.Placeholder = "Filter pipelines..."
+	ti.CharLimit = 100
+
+	return PipelineListModel{
+		provider:    provider,
+		filterInput: ti,
+		focused:     true,
+	}
+}
+
+// Init returns commands to fetch initial data and start the refresh timer.
+func (m PipelineListModel) Init() tea.Cmd {
+	return tea.Batch(m.fetchPipelineData, m.refreshTick())
+}
+
+// SetSize updates the list dimensions for reflow.
+func (m *PipelineListModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// Update handles messages to update list state.
+func (m PipelineListModel) Update(msg tea.Msg) (PipelineListModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case PipelineDataMsg:
+		return m.handleDataMsg(msg)
+
+	case PipelineRefreshTickMsg:
+		return m, tea.Batch(m.fetchPipelineData, m.refreshTick())
+
+	case tea.KeyMsg:
+		if !m.focused {
+			return m, nil
+		}
+		return m.handleKeyMsg(msg)
+	}
+
+	return m, nil
+}
+
+// View renders the pipeline list.
+func (m PipelineListModel) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+
+	var lines []string
+	visibleHeight := m.height
+
+	// Render filter input if active
+	if m.filtering {
+		filterLine := "/ " + m.filterInput.View()
+		lines = append(lines, filterLine)
+		visibleHeight--
+	}
+
+	if len(m.navigable) == 0 {
+		// Empty state
+		emptyMsg := "No pipelines found"
+		if m.filtering && m.filterQuery != "" {
+			emptyMsg = "No matching pipelines"
+		}
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("244")).
+			Width(m.width)
+		placeholder := style.Render(emptyMsg)
+
+		if m.filtering {
+			lines = append(lines, placeholder)
+		} else {
+			lines = append(lines, lipgloss.Place(m.width, visibleHeight, lipgloss.Center, lipgloss.Center, placeholder))
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	}
+
+	// Ensure scroll offset keeps cursor visible
+	m.adjustScrollOffset(visibleHeight)
+
+	// Render visible items
+	endOffset := m.scrollOffset + visibleHeight
+	if endOffset > len(m.navigable) {
+		endOffset = len(m.navigable)
+	}
+
+	for i := m.scrollOffset; i < endOffset; i++ {
+		item := m.navigable[i]
+		isSelected := i == m.cursor
+		lines = append(lines, m.renderItem(item, isSelected))
+	}
+
+	// Pad remaining height
+	for len(lines) < m.height {
+		lines = append(lines, strings.Repeat(" ", m.width))
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+// handleDataMsg processes a PipelineDataMsg.
+func (m PipelineListModel) handleDataMsg(msg PipelineDataMsg) (PipelineListModel, tea.Cmd) {
+	if msg.Err != nil {
+		return m, nil
+	}
+
+	m.running = msg.Running
+	m.finished = msg.Finished
+	m.available = msg.Available
+	m.buildNavigableItems()
+
+	// Clamp cursor to new bounds
+	if len(m.navigable) == 0 {
+		m.cursor = 0
+	} else if m.cursor >= len(m.navigable) {
+		m.cursor = len(m.navigable) - 1
+	}
+
+	cmds := []tea.Cmd{
+		func() tea.Msg { return RunningCountMsg{Count: len(m.running)} },
+	}
+
+	// Re-emit PipelineSelectedMsg if cursor is on a pipeline item
+	if cmd := m.emitSelectionMsg(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+// handleKeyMsg processes keyboard input.
+func (m PipelineListModel) handleKeyMsg(msg tea.KeyMsg) (PipelineListModel, tea.Cmd) {
+	// When filtering, forward most keys to filter input
+	if m.filtering {
+		switch msg.Type {
+		case tea.KeyEscape:
+			m.filtering = false
+			m.filterQuery = ""
+			m.filterInput.SetValue("")
+			m.buildNavigableItems()
+			m.cursor = 0
+			return m, nil
+
+		case tea.KeyUp, tea.KeyDown:
+			// Allow navigation while filtering
+			return m.handleNavigation(msg)
+
+		case tea.KeyEnter:
+			// Enter while filtering: deactivate filter but keep results
+			m.filtering = false
+			return m, nil
+
+		default:
+			var cmd tea.Cmd
+			m.filterInput, cmd = m.filterInput.Update(msg)
+			newQuery := m.filterInput.Value()
+			if newQuery != m.filterQuery {
+				m.filterQuery = newQuery
+				oldCursor := m.cursor
+				m.buildNavigableItems()
+				if oldCursor >= len(m.navigable) {
+					m.cursor = 0
+				}
+			}
+			return m, cmd
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyUp, tea.KeyDown:
+		return m.handleNavigation(msg)
+
+	case tea.KeyEnter:
+		// Toggle collapse on section headers
+		if len(m.navigable) > 0 && m.cursor < len(m.navigable) {
+			item := m.navigable[m.cursor]
+			if item.kind == itemKindSectionHeader {
+				m.collapsed[item.sectionIndex] = !m.collapsed[item.sectionIndex]
+				m.buildNavigableItems()
+				// Clamp cursor after rebuild
+				if m.cursor >= len(m.navigable) {
+					m.cursor = len(m.navigable) - 1
+				}
+				return m, nil
+			}
+		}
+		return m, nil
+
+	default:
+		if msg.String() == "/" {
+			m.filtering = true
+			m.filterInput.SetValue("")
+			m.filterQuery = ""
+			m.filterInput.Focus()
+			return m, m.filterInput.Cursor.BlinkCmd()
+		}
+	}
+
+	return m, nil
+}
+
+// handleNavigation processes up/down arrow key events.
+func (m PipelineListModel) handleNavigation(msg tea.KeyMsg) (PipelineListModel, tea.Cmd) {
+	if len(m.navigable) == 0 {
+		return m, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case tea.KeyDown:
+		if m.cursor < len(m.navigable)-1 {
+			m.cursor++
+		}
+	}
+
+	return m, m.emitSelectionMsg()
+}
+
+// emitSelectionMsg returns a command to emit PipelineSelectedMsg if cursor is on a pipeline item.
+func (m PipelineListModel) emitSelectionMsg() tea.Cmd {
+	if len(m.navigable) == 0 || m.cursor >= len(m.navigable) {
+		return nil
+	}
+
+	item := m.navigable[m.cursor]
+	switch item.kind {
+	case itemKindRunning:
+		if item.dataIndex >= 0 && item.dataIndex < len(m.running) {
+			r := m.running[item.dataIndex]
+			return func() tea.Msg {
+				return PipelineSelectedMsg{RunID: r.RunID, BranchName: r.BranchName}
+			}
+		}
+	case itemKindFinished:
+		if item.dataIndex >= 0 && item.dataIndex < len(m.finished) {
+			f := m.finished[item.dataIndex]
+			return func() tea.Msg {
+				return PipelineSelectedMsg{RunID: f.RunID, BranchName: f.BranchName}
+			}
+		}
+	case itemKindAvailable:
+		if item.dataIndex >= 0 && item.dataIndex < len(m.available) {
+			return func() tea.Msg {
+				return PipelineSelectedMsg{RunID: "", BranchName: ""}
+			}
+		}
+	}
+
+	return nil
+}
+
+// buildNavigableItems rebuilds the flat navigable item list from section data.
+func (m *PipelineListModel) buildNavigableItems() {
+	m.navigable = nil
+	query := strings.ToLower(m.filterQuery)
+
+	// Running section
+	var filteredRunning []int
+	for i, r := range m.running {
+		if query == "" || strings.Contains(strings.ToLower(r.Name), query) {
+			filteredRunning = append(filteredRunning, i)
+		}
+	}
+	if len(filteredRunning) > 0 || query == "" {
+		m.navigable = append(m.navigable, navigableItem{
+			kind:         itemKindSectionHeader,
+			sectionIndex: 0,
+			dataIndex:    -1,
+			label:        fmt.Sprintf("Running (%d)", len(filteredRunning)),
+		})
+		if !m.collapsed[0] {
+			for _, idx := range filteredRunning {
+				m.navigable = append(m.navigable, navigableItem{
+					kind:         itemKindRunning,
+					sectionIndex: 0,
+					dataIndex:    idx,
+					label:        m.running[idx].Name,
+				})
+			}
+		}
+	}
+
+	// Finished section
+	var filteredFinished []int
+	for i, f := range m.finished {
+		if query == "" || strings.Contains(strings.ToLower(f.Name), query) {
+			filteredFinished = append(filteredFinished, i)
+		}
+	}
+	if len(filteredFinished) > 0 || query == "" {
+		m.navigable = append(m.navigable, navigableItem{
+			kind:         itemKindSectionHeader,
+			sectionIndex: 1,
+			dataIndex:    -1,
+			label:        fmt.Sprintf("Finished (%d)", len(filteredFinished)),
+		})
+		if !m.collapsed[1] {
+			for _, idx := range filteredFinished {
+				m.navigable = append(m.navigable, navigableItem{
+					kind:         itemKindFinished,
+					sectionIndex: 1,
+					dataIndex:    idx,
+					label:        m.finished[idx].Name,
+				})
+			}
+		}
+	}
+
+	// Available section
+	var filteredAvailable []int
+	for i, a := range m.available {
+		if query == "" || strings.Contains(strings.ToLower(a.Name), query) {
+			filteredAvailable = append(filteredAvailable, i)
+		}
+	}
+	if len(filteredAvailable) > 0 || query == "" {
+		m.navigable = append(m.navigable, navigableItem{
+			kind:         itemKindSectionHeader,
+			sectionIndex: 2,
+			dataIndex:    -1,
+			label:        fmt.Sprintf("Available (%d)", len(filteredAvailable)),
+		})
+		if !m.collapsed[2] {
+			for _, idx := range filteredAvailable {
+				m.navigable = append(m.navigable, navigableItem{
+					kind:         itemKindAvailable,
+					sectionIndex: 2,
+					dataIndex:    idx,
+					label:        m.available[idx].Name,
+				})
+			}
+		}
+	}
+}
+
+// adjustScrollOffset ensures the cursor is within the visible window.
+func (m *PipelineListModel) adjustScrollOffset(visibleHeight int) {
+	if visibleHeight <= 0 {
+		return
+	}
+	if m.cursor < m.scrollOffset {
+		m.scrollOffset = m.cursor
+	}
+	if m.cursor >= m.scrollOffset+visibleHeight {
+		m.scrollOffset = m.cursor - visibleHeight + 1
+	}
+	// Clamp scroll offset
+	maxOffset := len(m.navigable) - visibleHeight
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.scrollOffset > maxOffset {
+		m.scrollOffset = maxOffset
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
+}
+
+// renderItem renders a single navigable item line.
+func (m PipelineListModel) renderItem(item navigableItem, isSelected bool) string {
+	maxWidth := m.width
+	if maxWidth <= 0 {
+		maxWidth = 40
+	}
+
+	switch item.kind {
+	case itemKindSectionHeader:
+		return m.renderSectionHeader(item, isSelected, maxWidth)
+	case itemKindRunning:
+		return m.renderRunningItem(item, isSelected, maxWidth)
+	case itemKindFinished:
+		return m.renderFinishedItem(item, isSelected, maxWidth)
+	case itemKindAvailable:
+		return m.renderAvailableItem(item, isSelected, maxWidth)
+	}
+	return ""
+}
+
+// renderSectionHeader renders a section header line.
+func (m PipelineListModel) renderSectionHeader(item navigableItem, isSelected bool, maxWidth int) string {
+	// Collapse indicator
+	indicator := "▾"
+	if m.collapsed[item.sectionIndex] {
+		indicator = "▸"
+	}
+
+	text := fmt.Sprintf("%s %s", indicator, item.label)
+
+	if isSelected {
+		style := lipgloss.NewStyle().
+			Bold(true).
+			Reverse(true).
+			Width(maxWidth)
+		return style.Render(text)
+	}
+
+	style := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("7")).
+		Width(maxWidth)
+	return style.Render(text)
+}
+
+// renderRunningItem renders a running pipeline item line.
+func (m PipelineListModel) renderRunningItem(item navigableItem, isSelected bool, maxWidth int) string {
+	if item.dataIndex < 0 || item.dataIndex >= len(m.running) {
+		return ""
+	}
+	r := m.running[item.dataIndex]
+
+	elapsed := formatDuration(time.Since(r.StartedAt))
+	// Reserve space: prefix (3) + elapsed + padding
+	nameMaxWidth := maxWidth - 3 - len(elapsed) - 3
+	name := truncateName(r.Name, nameMaxWidth)
+
+	if isSelected {
+		spacer := maxWidth - lipgloss.Width("▶ "+name) - lipgloss.Width(elapsed) - 1
+		if spacer < 1 {
+			spacer = 1
+		}
+		text := fmt.Sprintf("▶ %s%s%s", name, strings.Repeat(" ", spacer), elapsed)
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6")).
+			Width(maxWidth)
+		return style.Render(text)
+	}
+
+	spacer := maxWidth - lipgloss.Width("  "+name) - lipgloss.Width(elapsed) - 1
+	if spacer < 1 {
+		spacer = 1
+	}
+	text := fmt.Sprintf("  %s%s%s", name, strings.Repeat(" ", spacer), elapsed)
+	style := lipgloss.NewStyle().
+		Width(maxWidth)
+	return style.Render(text)
+}
+
+// renderFinishedItem renders a finished pipeline item line.
+func (m PipelineListModel) renderFinishedItem(item navigableItem, isSelected bool, maxWidth int) string {
+	if item.dataIndex < 0 || item.dataIndex >= len(m.finished) {
+		return ""
+	}
+	f := m.finished[item.dataIndex]
+
+	statusIcon := "✓"
+	if f.Status == "failed" || f.Status == "cancelled" {
+		statusIcon = "✗"
+	}
+
+	duration := formatDuration(f.Duration)
+	suffix := fmt.Sprintf("%s %s  %s", statusIcon, f.Status, duration)
+
+	nameMaxWidth := maxWidth - 3 - len(suffix) - 1
+	name := truncateName(f.Name, nameMaxWidth)
+
+	if isSelected {
+		spacer := maxWidth - lipgloss.Width("▶ "+name) - lipgloss.Width(suffix) - 1
+		if spacer < 1 {
+			spacer = 1
+		}
+		text := fmt.Sprintf("▶ %s%s%s", name, strings.Repeat(" ", spacer), suffix)
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6")).
+			Width(maxWidth)
+		return style.Render(text)
+	}
+
+	spacer := maxWidth - lipgloss.Width("  "+name) - lipgloss.Width(suffix) - 1
+	if spacer < 1 {
+		spacer = 1
+	}
+	text := fmt.Sprintf("  %s%s%s", name, strings.Repeat(" ", spacer), suffix)
+	style := lipgloss.NewStyle().
+		Width(maxWidth)
+	return style.Render(text)
+}
+
+// renderAvailableItem renders an available pipeline item line.
+func (m PipelineListModel) renderAvailableItem(item navigableItem, isSelected bool, maxWidth int) string {
+	if item.dataIndex < 0 || item.dataIndex >= len(m.available) {
+		return ""
+	}
+	a := m.available[item.dataIndex]
+
+	nameMaxWidth := maxWidth - 3
+	name := truncateName(a.Name, nameMaxWidth)
+
+	if isSelected {
+		text := fmt.Sprintf("▶ %s", name)
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6")).
+			Width(maxWidth)
+		return style.Render(text)
+	}
+
+	text := fmt.Sprintf("  %s", name)
+	style := lipgloss.NewStyle().
+		Width(maxWidth)
+	return style.Render(text)
+}
+
+// truncateName truncates a name with ellipsis if it exceeds maxWidth.
+func truncateName(name string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if len(name) <= maxWidth {
+		return name
+	}
+	if maxWidth <= 1 {
+		return "…"
+	}
+	return name[:maxWidth-1] + "…"
+}
+
+// formatDuration formats a duration in a compact human-readable form.
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) % 60
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	return fmt.Sprintf("%dh%02dm", h, m)
+}
+
+// Async command factories
+
+func (m PipelineListModel) fetchPipelineData() tea.Msg {
+	if m.provider == nil {
+		return PipelineDataMsg{Err: fmt.Errorf("no provider")}
+	}
+
+	running, runErr := m.provider.FetchRunningPipelines()
+	if runErr != nil {
+		return PipelineDataMsg{Err: runErr}
+	}
+
+	finished, finErr := m.provider.FetchFinishedPipelines(finishedPipelineLimit)
+	if finErr != nil {
+		return PipelineDataMsg{Err: finErr}
+	}
+
+	available, avErr := m.provider.FetchAvailablePipelines()
+	if avErr != nil {
+		return PipelineDataMsg{Err: avErr}
+	}
+
+	return PipelineDataMsg{
+		Running:   running,
+		Finished:  finished,
+		Available: available,
+	}
+}
+
+func (m PipelineListModel) refreshTick() tea.Cmd {
+	return tea.Tick(pipelineRefreshInterval, func(time.Time) tea.Msg {
+		return PipelineRefreshTickMsg{}
+	})
+}

--- a/internal/tui/pipeline_list_test.go
+++ b/internal/tui/pipeline_list_test.go
@@ -1,0 +1,741 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// listTestPipelineProvider is a mock PipelineDataProvider scoped to
+// pipeline_list_test.go to avoid collisions with mocks in other test files.
+type listTestPipelineProvider struct {
+	running   []RunningPipeline
+	finished  []FinishedPipeline
+	available []PipelineInfo
+}
+
+func (m *listTestPipelineProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
+	return m.running, nil
+}
+
+func (m *listTestPipelineProvider) FetchFinishedPipelines(limit int) ([]FinishedPipeline, error) {
+	return m.finished, nil
+}
+
+func (m *listTestPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+	return m.available, nil
+}
+
+// newTestListModel creates a PipelineListModel pre-loaded with the given data.
+// It bypasses async commands by directly injecting a PipelineDataMsg.
+func newTestListModel(running []RunningPipeline, finished []FinishedPipeline, available []PipelineInfo) PipelineListModel {
+	provider := &listTestPipelineProvider{running: running, finished: finished, available: available}
+	m := NewPipelineListModel(provider)
+	m.SetSize(40, 20)
+	// Simulate data arrival
+	m, _ = m.Update(PipelineDataMsg{Running: running, Finished: finished, Available: available})
+	return m
+}
+
+var listAnsiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func listStripAnsi(s string) string {
+	return listAnsiRegex.ReplaceAllString(s, "")
+}
+
+// sendKey is a convenience wrapper to send a key event and return the updated model.
+func sendKey(m PipelineListModel, keyType tea.KeyType) (PipelineListModel, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: keyType})
+}
+
+// sendRune sends a rune key event (e.g. '/' or 's').
+func sendRune(m PipelineListModel, r rune) (PipelineListModel, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+}
+
+// extractSelectionMsg executes the tea.Cmd returned by Update and returns
+// the PipelineSelectedMsg if one was emitted.
+func extractSelectionMsg(cmd tea.Cmd) *PipelineSelectedMsg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+	// Direct message (tea.Batch with 1 cmd returns it directly)
+	if sel, ok := msg.(PipelineSelectedMsg); ok {
+		return &sel
+	}
+	// tea.Batch with 2+ cmds returns tea.BatchMsg ([]tea.Cmd)
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			innerMsg := c()
+			if sel, ok := innerMsg.(PipelineSelectedMsg); ok {
+				return &sel
+			}
+		}
+	}
+	return nil
+}
+
+// extractRunningCountMsg executes the tea.Cmd and returns the RunningCountMsg
+// if one was emitted, checking both direct and batched forms.
+func extractRunningCountMsg(cmd tea.Cmd) *RunningCountMsg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+	// Direct message
+	if rcm, ok := msg.(RunningCountMsg); ok {
+		return &rcm
+	}
+	// Batched
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			innerMsg := c()
+			if rcm, ok := innerMsg.(RunningCountMsg); ok {
+				return &rcm
+			}
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Sample data factories
+// ---------------------------------------------------------------------------
+
+func sampleRunning(n int) []RunningPipeline {
+	out := make([]RunningPipeline, n)
+	for i := range n {
+		out[i] = RunningPipeline{
+			RunID:      "run-" + string(rune('A'+i)),
+			Name:       "running-" + string(rune('a'+i)),
+			BranchName: "branch-" + string(rune('a'+i)),
+			StartedAt:  time.Now().Add(-time.Duration(i+1) * time.Minute),
+		}
+	}
+	return out
+}
+
+func sampleFinished(n int) []FinishedPipeline {
+	statuses := []string{"completed", "failed", "cancelled"}
+	out := make([]FinishedPipeline, n)
+	for i := range n {
+		out[i] = FinishedPipeline{
+			RunID:       "frun-" + string(rune('A'+i)),
+			Name:        "finished-" + string(rune('a'+i)),
+			BranchName:  "fbranch-" + string(rune('a'+i)),
+			Status:      statuses[i%len(statuses)],
+			StartedAt:   time.Now().Add(-time.Duration(i+2) * time.Minute),
+			CompletedAt: time.Now().Add(-time.Duration(i+1) * time.Minute),
+			Duration:    time.Duration(i+1) * time.Minute,
+		}
+	}
+	return out
+}
+
+func sampleAvailable(n int) []PipelineInfo {
+	out := make([]PipelineInfo, n)
+	for i := range n {
+		out[i] = PipelineInfo{
+			Name:        "avail-" + string(rune('a'+i)),
+			Description: "desc " + string(rune('a'+i)),
+			StepCount:   i + 1,
+		}
+	}
+	return out
+}
+
+// ===========================================================================
+// T012: Section Rendering Tests
+// ===========================================================================
+
+func TestPipelineListModel_View_AllSectionsRender(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), sampleFinished(3), sampleAvailable(2))
+	view := listStripAnsi(m.View())
+
+	assert.Contains(t, view, "Running (2)")
+	assert.Contains(t, view, "Finished (3)")
+	assert.Contains(t, view, "Available (2)")
+}
+
+func TestPipelineListModel_View_RunningItemsShowElapsedTime(t *testing.T) {
+	running := []RunningPipeline{{
+		RunID:     "r1",
+		Name:      "long-running",
+		StartedAt: time.Now().Add(-150 * time.Second),
+	}}
+	m := newTestListModel(running, nil, nil)
+	view := listStripAnsi(m.View())
+
+	// 150 seconds = 2m30s
+	assert.Contains(t, view, "2m30s")
+}
+
+func TestPipelineListModel_View_FinishedItemsShowStatusAndDuration(t *testing.T) {
+	finished := []FinishedPipeline{
+		{RunID: "f1", Name: "success-pipe", Status: "completed", Duration: 5 * time.Minute},
+		{RunID: "f2", Name: "fail-pipe", Status: "failed", Duration: 3 * time.Minute},
+		{RunID: "f3", Name: "cancel-pipe", Status: "cancelled", Duration: 1 * time.Minute},
+	}
+	m := newTestListModel(nil, finished, nil)
+	view := listStripAnsi(m.View())
+
+	// Completed shows checkmark
+	assert.Contains(t, view, "✓")
+	assert.Contains(t, view, "completed")
+	assert.Contains(t, view, "5m00s")
+
+	// Failed shows cross
+	assert.Contains(t, view, "✗")
+	assert.Contains(t, view, "failed")
+	assert.Contains(t, view, "3m00s")
+
+	// Cancelled shows cross
+	assert.Contains(t, view, "cancelled")
+	assert.Contains(t, view, "1m00s")
+}
+
+func TestPipelineListModel_View_AvailableItemsShowNameOnly(t *testing.T) {
+	avail := []PipelineInfo{{Name: "speckit-flow", Description: "A pipeline"}}
+	m := newTestListModel(nil, nil, avail)
+	view := listStripAnsi(m.View())
+
+	assert.Contains(t, view, "speckit-flow")
+	// Should not contain status markers or durations
+	assert.NotContains(t, view, "✓")
+	assert.NotContains(t, view, "✗")
+}
+
+func TestPipelineListModel_View_EmptySectionsShowZeroCount(t *testing.T) {
+	m := newTestListModel(nil, nil, sampleAvailable(1))
+	view := listStripAnsi(m.View())
+
+	assert.Contains(t, view, "Running (0)")
+	assert.Contains(t, view, "Finished (0)")
+	assert.Contains(t, view, "Available (1)")
+}
+
+func TestPipelineListModel_View_AllSectionsEmpty(t *testing.T) {
+	// When all sections have zero items, headers with "(0)" are still shown
+	// because the empty-state message ("No pipelines found") only appears
+	// when there are zero navigable items (i.e., no headers either).
+	// With no filter active and empty data, section headers are still built.
+	// Verify that the headers render correctly with zero counts.
+	m := newTestListModel(nil, nil, nil)
+	view := listStripAnsi(m.View())
+
+	assert.Contains(t, view, "Running (0)")
+	assert.Contains(t, view, "Finished (0)")
+	assert.Contains(t, view, "Available (0)")
+}
+
+func TestPipelineListModel_View_NoMatchingPipelines_ShowsEmptyMessage(t *testing.T) {
+	// The "No pipelines found" / "No matching pipelines" message appears
+	// when a filter removes ALL items (including headers).
+	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	m := newTestListModel(nil, nil, avail)
+
+	// Activate filter with a query that matches nothing
+	m, _ = sendRune(m, '/')
+	for _, ch := range "zzzzzzz" {
+		m, _ = sendRune(m, ch)
+	}
+
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "No matching pipelines")
+}
+
+func TestPipelineListModel_View_LongNamesTruncated(t *testing.T) {
+	longName := strings.Repeat("x", 50)
+	avail := []PipelineInfo{{Name: longName}}
+	m := newTestListModel(nil, nil, avail)
+	m.SetSize(40, 20)
+	// Re-inject data so View uses updated size
+	m, _ = m.Update(PipelineDataMsg{Available: avail})
+	view := listStripAnsi(m.View())
+
+	// Should contain the truncation marker
+	assert.Contains(t, view, "…")
+	// Should NOT contain the full name
+	assert.NotContains(t, view, longName)
+}
+
+// ===========================================================================
+// T015: Navigation Tests
+// ===========================================================================
+
+func TestPipelineListModel_Navigation_DownMovesCursor(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), nil, nil)
+	require.Equal(t, 0, m.cursor)
+
+	m, _ = sendKey(m, tea.KeyDown)
+	assert.Equal(t, 1, m.cursor)
+}
+
+func TestPipelineListModel_Navigation_UpAtTopStays(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), nil, nil)
+	require.Equal(t, 0, m.cursor)
+
+	m, _ = sendKey(m, tea.KeyUp)
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestPipelineListModel_Navigation_DownAtBottomStays(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), nil, nil)
+	lastIdx := len(m.navigable) - 1
+
+	// Move cursor to last item
+	for range m.navigable {
+		m, _ = sendKey(m, tea.KeyDown)
+	}
+	assert.Equal(t, lastIdx, m.cursor)
+
+	// Try moving past the end
+	m, _ = sendKey(m, tea.KeyDown)
+	assert.Equal(t, lastIdx, m.cursor)
+}
+
+func TestPipelineListModel_Navigation_CrossSectionTraversal(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), sampleFinished(1), nil)
+
+	// navigable should include:
+	// 0: Running (1) header
+	// 1: running-a
+	// 2: Finished (1) header
+	// 3: finished-a
+	// 4: Available (0) header  (empty sections still get headers)
+	require.GreaterOrEqual(t, len(m.navigable), 4)
+
+	// Navigate from top to finished item
+	m, _ = sendKey(m, tea.KeyDown) // cursor=1 running item
+	m, _ = sendKey(m, tea.KeyDown) // cursor=2 finished header
+	m, _ = sendKey(m, tea.KeyDown) // cursor=3 finished item
+	assert.Equal(t, 3, m.cursor)
+	assert.Equal(t, itemKindFinished, m.navigable[m.cursor].kind)
+}
+
+func TestPipelineListModel_Navigation_SelectionMsgOnPipelineItem(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), nil, nil)
+
+	// Move to the running item (index 1)
+	m, cmd := sendKey(m, tea.KeyDown)
+	assert.Equal(t, 1, m.cursor)
+	assert.Equal(t, itemKindRunning, m.navigable[m.cursor].kind)
+
+	sel := extractSelectionMsg(cmd)
+	require.NotNil(t, sel, "should emit PipelineSelectedMsg on pipeline item")
+}
+
+func TestPipelineListModel_Navigation_NoSelectionMsgOnHeader(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), nil, nil)
+
+	// Cursor starts at 0, which is the section header
+	assert.Equal(t, 0, m.cursor)
+	assert.Equal(t, itemKindSectionHeader, m.navigable[m.cursor].kind)
+
+	// Move up (stays at 0, header)
+	_, cmd := sendKey(m, tea.KeyUp)
+	sel := extractSelectionMsg(cmd)
+	assert.Nil(t, sel, "should NOT emit PipelineSelectedMsg on section header")
+}
+
+func TestPipelineListModel_Navigation_RunningItemIncludesRunID(t *testing.T) {
+	running := []RunningPipeline{{
+		RunID:      "run-xyz",
+		Name:       "my-pipeline",
+		BranchName: "feat/branch",
+		StartedAt:  time.Now(),
+	}}
+	m := newTestListModel(running, nil, nil)
+
+	// Move to running item
+	m, cmd := sendKey(m, tea.KeyDown)
+	sel := extractSelectionMsg(cmd)
+	require.NotNil(t, sel)
+
+	assert.Equal(t, "run-xyz", sel.RunID)
+	assert.Equal(t, "feat/branch", sel.BranchName)
+}
+
+func TestPipelineListModel_Navigation_AvailableItemHasEmptyRunID(t *testing.T) {
+	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	m := newTestListModel(nil, nil, avail)
+
+	// Move cursor to the available item
+	for i := range m.navigable {
+		if m.navigable[i].kind == itemKindAvailable {
+			m.cursor = i
+			break
+		}
+	}
+
+	// Emit selection for current cursor position
+	cmd := m.emitSelectionMsg()
+	sel := extractSelectionMsg(cmd)
+	require.NotNil(t, sel)
+
+	assert.Equal(t, "", sel.RunID)
+	assert.Equal(t, "", sel.BranchName)
+}
+
+// ===========================================================================
+// T018: Filter Tests
+// ===========================================================================
+
+func TestPipelineListModel_Filter_SlashActivates(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), nil, nil)
+	require.False(t, m.filtering)
+
+	m, _ = sendRune(m, '/')
+	assert.True(t, m.filtering)
+}
+
+func TestPipelineListModel_Filter_MatchesSubstring(t *testing.T) {
+	avail := []PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-evolve"},
+		{Name: "speckit-debug"},
+	}
+	m := newTestListModel(nil, nil, avail)
+
+	// Activate filter
+	m, _ = sendRune(m, '/')
+
+	// Type "spec" character by character
+	for _, ch := range "spec" {
+		m, _ = sendRune(m, ch)
+	}
+
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "speckit-flow")
+	assert.Contains(t, view, "speckit-debug")
+	assert.NotContains(t, view, "wave-evolve")
+}
+
+func TestPipelineListModel_Filter_AcrossAllSections(t *testing.T) {
+	running := []RunningPipeline{
+		{RunID: "r1", Name: "speckit-run", StartedAt: time.Now()},
+		{RunID: "r2", Name: "wave-run", StartedAt: time.Now()},
+	}
+	finished := []FinishedPipeline{
+		{RunID: "f1", Name: "speckit-done", Status: "completed", Duration: time.Minute},
+	}
+	avail := []PipelineInfo{
+		{Name: "wave-evolve"},
+	}
+	m := newTestListModel(running, finished, avail)
+
+	m, _ = sendRune(m, '/')
+	for _, ch := range "speckit" {
+		m, _ = sendRune(m, ch)
+	}
+
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "speckit-run")
+	assert.Contains(t, view, "speckit-done")
+	assert.NotContains(t, view, "wave-run")
+	assert.NotContains(t, view, "wave-evolve")
+}
+
+func TestPipelineListModel_Filter_EscapeDismisses(t *testing.T) {
+	avail := []PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-evolve"},
+	}
+	m := newTestListModel(nil, nil, avail)
+
+	// Activate filter and type something
+	m, _ = sendRune(m, '/')
+	for _, ch := range "spec" {
+		m, _ = sendRune(m, ch)
+	}
+	require.True(t, m.filtering)
+
+	// Press escape to dismiss
+	m, _ = sendKey(m, tea.KeyEscape)
+	assert.False(t, m.filtering)
+
+	// All items should be visible again
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "speckit-flow")
+	assert.Contains(t, view, "wave-evolve")
+}
+
+func TestPipelineListModel_Filter_ZeroMatchesMessage(t *testing.T) {
+	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	m := newTestListModel(nil, nil, avail)
+
+	m, _ = sendRune(m, '/')
+	for _, ch := range "zzzzzzz" {
+		m, _ = sendRune(m, ch)
+	}
+
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "No matching pipelines")
+}
+
+func TestPipelineListModel_Filter_NavigationInFilteredResults(t *testing.T) {
+	avail := []PipelineInfo{
+		{Name: "alpha-pipe"},
+		{Name: "alpha-debug"},
+		{Name: "beta-pipe"},
+	}
+	m := newTestListModel(nil, nil, avail)
+
+	// Filter to "alpha" items
+	m, _ = sendRune(m, '/')
+	for _, ch := range "alpha" {
+		m, _ = sendRune(m, ch)
+	}
+
+	// Navigate within filtered results — should not panic or go out of bounds
+	startCursor := m.cursor
+	m, _ = sendKey(m, tea.KeyDown)
+	assert.GreaterOrEqual(t, m.cursor, startCursor)
+
+	m, _ = sendKey(m, tea.KeyDown)
+	m, _ = sendKey(m, tea.KeyDown)
+	m, _ = sendKey(m, tea.KeyDown)
+	// Should be clamped to last navigable item
+	assert.Less(t, m.cursor, len(m.navigable))
+
+	m, _ = sendKey(m, tea.KeyUp)
+	assert.GreaterOrEqual(t, m.cursor, 0)
+}
+
+// ===========================================================================
+// T020: Scrolling Tests
+// ===========================================================================
+
+func TestPipelineListModel_Scroll_CursorBelowViewportScrollsDown(t *testing.T) {
+	// Create many items so they exceed the viewport
+	running := sampleRunning(3)
+	finished := sampleFinished(5)
+	avail := sampleAvailable(5)
+	m := newTestListModel(running, finished, avail)
+	m.SetSize(40, 5)
+	m, _ = m.Update(PipelineDataMsg{Running: running, Finished: finished, Available: avail})
+
+	// Navigate down past the viewport (7 presses)
+	for range 7 {
+		m, _ = sendKey(m, tea.KeyDown)
+	}
+
+	// Verify cursor is beyond viewport height
+	assert.Greater(t, m.cursor, 4)
+
+	// The View method adjusts scroll internally. Verify that the first
+	// navigable item (Running header at index 0) is NOT in the rendered
+	// output because the viewport has scrolled past it.
+	view := listStripAnsi(m.View())
+	lines := strings.Split(view, "\n")
+	// The first visible line should NOT be the Running header
+	require.GreaterOrEqual(t, len(lines), 1)
+	assert.NotContains(t, lines[0], "Running (3)",
+		"viewport should have scrolled past the Running header")
+}
+
+func TestPipelineListModel_Scroll_ScrollBackUp(t *testing.T) {
+	running := sampleRunning(3)
+	finished := sampleFinished(5)
+	avail := sampleAvailable(5)
+	m := newTestListModel(running, finished, avail)
+	m.SetSize(40, 5)
+	m, _ = m.Update(PipelineDataMsg{Running: running, Finished: finished, Available: avail})
+
+	// Navigate down past the viewport
+	for range 8 {
+		m, _ = sendKey(m, tea.KeyDown)
+	}
+
+	// Verify we scrolled down by checking the view content
+	viewDown := listStripAnsi(m.View())
+	assert.NotContains(t, strings.Split(viewDown, "\n")[0], "Running (3)")
+
+	// Navigate back up to the top
+	for range 8 {
+		m, _ = sendKey(m, tea.KeyUp)
+	}
+
+	// The first line should again be the Running header
+	viewUp := listStripAnsi(m.View())
+	lines := strings.Split(viewUp, "\n")
+	require.GreaterOrEqual(t, len(lines), 1)
+	assert.Contains(t, lines[0], "Running (3)",
+		"scrolling back up should show the Running header again")
+}
+
+func TestPipelineListModel_Scroll_CursorAtTopNoScroll(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), nil, nil)
+	m.SetSize(40, 20) // viewport bigger than item count
+	assert.Equal(t, 0, m.cursor)
+
+	view := listStripAnsi(m.View())
+	lines := strings.Split(view, "\n")
+	require.GreaterOrEqual(t, len(lines), 1)
+	assert.Contains(t, lines[0], "Running",
+		"no scroll needed when cursor at top and viewport fits all items")
+}
+
+// ===========================================================================
+// T022: Collapse/Expand Tests
+// ===========================================================================
+
+func TestPipelineListModel_Collapse_EnterOnHeaderCollapses(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), nil, nil)
+
+	// Cursor starts on Running header
+	require.Equal(t, 0, m.cursor)
+	require.Equal(t, itemKindSectionHeader, m.navigable[0].kind)
+
+	// Count items before collapse
+	countBefore := len(m.navigable)
+
+	// Press Enter to collapse
+	m, _ = sendKey(m, tea.KeyEnter)
+
+	// Items should be hidden — fewer navigable items
+	assert.Less(t, len(m.navigable), countBefore, "collapsing should reduce navigable items")
+	assert.True(t, m.collapsed[0], "Running section should be collapsed")
+
+	// Verify the running items are gone from the view
+	view := listStripAnsi(m.View())
+	assert.NotContains(t, view, "running-a")
+	assert.NotContains(t, view, "running-b")
+}
+
+func TestPipelineListModel_Collapse_EnterAgainExpands(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), nil, nil)
+
+	// Collapse
+	m, _ = sendKey(m, tea.KeyEnter)
+	require.True(t, m.collapsed[0])
+	collapsedCount := len(m.navigable)
+
+	// Expand
+	m, _ = sendKey(m, tea.KeyEnter)
+	assert.False(t, m.collapsed[0])
+	assert.Greater(t, len(m.navigable), collapsedCount, "expanding should restore items")
+
+	// Items should reappear
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "running-a")
+}
+
+func TestPipelineListModel_Collapse_CursorSkipsHiddenItems(t *testing.T) {
+	m := newTestListModel(sampleRunning(2), sampleFinished(1), nil)
+
+	// Navigable before collapse includes headers for empty Available section too.
+	// Find the index of the Finished header for reference.
+	var finishedHeaderIdx int
+	for i, item := range m.navigable {
+		if item.kind == itemKindSectionHeader && item.sectionIndex == 1 {
+			finishedHeaderIdx = i
+			break
+		}
+	}
+	require.Equal(t, 3, finishedHeaderIdx, "Finished header should be at index 3 before collapse")
+
+	// Collapse Running section (cursor is on header at 0)
+	m, _ = sendKey(m, tea.KeyEnter)
+
+	// After collapse, running items are hidden but all headers remain.
+	// Navigate down from collapsed Running header
+	m, _ = sendKey(m, tea.KeyDown)
+	assert.Equal(t, 1, m.cursor)
+	// The item at cursor 1 should be the Finished section header
+	assert.Equal(t, itemKindSectionHeader, m.navigable[m.cursor].kind)
+	assert.Equal(t, 1, m.navigable[m.cursor].sectionIndex, "should jump to Finished section header")
+}
+
+func TestPipelineListModel_Collapse_IndicatorRendering(t *testing.T) {
+	m := newTestListModel(sampleRunning(1), nil, nil)
+
+	// Expanded: should show ▾
+	view := listStripAnsi(m.View())
+	assert.Contains(t, view, "▾")
+
+	// Collapse
+	m, _ = sendKey(m, tea.KeyEnter)
+	view = listStripAnsi(m.View())
+	assert.Contains(t, view, "▸")
+}
+
+// ===========================================================================
+// Additional Tests
+// ===========================================================================
+
+func TestPipelineListModel_Init_ReturnsBatchCmd(t *testing.T) {
+	provider := &listTestPipelineProvider{}
+	m := NewPipelineListModel(provider)
+	cmd := m.Init()
+	assert.NotNil(t, cmd, "Init should return a non-nil batch command")
+}
+
+func TestPipelineListModel_Update_DataMsgUpdatesState(t *testing.T) {
+	provider := &listTestPipelineProvider{}
+	m := NewPipelineListModel(provider)
+	m.SetSize(40, 20)
+
+	running := sampleRunning(2)
+	finished := sampleFinished(1)
+	avail := sampleAvailable(3)
+
+	m, _ = m.Update(PipelineDataMsg{Running: running, Finished: finished, Available: avail})
+
+	assert.Equal(t, running, m.running)
+	assert.Equal(t, finished, m.finished)
+	assert.Equal(t, avail, m.available)
+	assert.Greater(t, len(m.navigable), 0, "navigable items should be built")
+}
+
+func TestPipelineListModel_Update_DataMsgEmitsRunningCount(t *testing.T) {
+	provider := &listTestPipelineProvider{}
+	m := NewPipelineListModel(provider)
+	m.SetSize(40, 20)
+
+	running := sampleRunning(3)
+	_, cmd := m.Update(PipelineDataMsg{Running: running})
+
+	rcm := extractRunningCountMsg(cmd)
+	require.NotNil(t, rcm, "should emit RunningCountMsg")
+	assert.Equal(t, 3, rcm.Count)
+}
+
+func TestPipelineListModel_SetSize(t *testing.T) {
+	provider := &listTestPipelineProvider{}
+	m := NewPipelineListModel(provider)
+
+	m.SetSize(80, 40)
+	assert.Equal(t, 80, m.width)
+	assert.Equal(t, 40, m.height)
+}
+
+func TestPipelineListModel_View_ZeroDimensions(t *testing.T) {
+	provider := &listTestPipelineProvider{}
+	m := NewPipelineListModel(provider)
+	// width and height default to 0
+	view := m.View()
+	assert.Equal(t, "", view)
+}

--- a/internal/tui/pipeline_messages.go
+++ b/internal/tui/pipeline_messages.go
@@ -1,0 +1,12 @@
+package tui
+
+// PipelineDataMsg carries refreshed pipeline data from the provider.
+type PipelineDataMsg struct {
+	Running   []RunningPipeline
+	Finished  []FinishedPipeline
+	Available []PipelineInfo
+	Err       error
+}
+
+// PipelineRefreshTickMsg triggers periodic data refresh.
+type PipelineRefreshTickMsg struct{}

--- a/internal/tui/pipeline_provider.go
+++ b/internal/tui/pipeline_provider.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"sort"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// RunningPipeline is a TUI-specific projection of a running pipeline run.
+type RunningPipeline struct {
+	RunID      string
+	Name       string
+	BranchName string
+	StartedAt  time.Time
+}
+
+// FinishedPipeline is a TUI-specific projection of a completed pipeline run.
+type FinishedPipeline struct {
+	RunID       string
+	Name        string
+	BranchName  string
+	Status      string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Duration    time.Duration
+}
+
+// PipelineDataProvider fetches pipeline data for the list component.
+type PipelineDataProvider interface {
+	FetchRunningPipelines() ([]RunningPipeline, error)
+	FetchFinishedPipelines(limit int) ([]FinishedPipeline, error)
+	FetchAvailablePipelines() ([]PipelineInfo, error)
+}
+
+// DefaultPipelineDataProvider implements PipelineDataProvider using a state store and pipeline discovery.
+type DefaultPipelineDataProvider struct {
+	store        state.StateStore
+	pipelinesDir string
+}
+
+// NewDefaultPipelineDataProvider creates a new provider wrapping the given state store and pipelines directory.
+func NewDefaultPipelineDataProvider(store state.StateStore, pipelinesDir string) *DefaultPipelineDataProvider {
+	return &DefaultPipelineDataProvider{
+		store:        store,
+		pipelinesDir: pipelinesDir,
+	}
+}
+
+// FetchRunningPipelines returns currently running pipelines, sorted newest-first.
+func (p *DefaultPipelineDataProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
+	records, err := p.store.GetRunningRuns()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]RunningPipeline, len(records))
+	for i, r := range records {
+		result[i] = RunningPipeline{
+			RunID:      r.RunID,
+			Name:       r.PipelineName,
+			BranchName: r.BranchName,
+			StartedAt:  r.StartedAt,
+		}
+	}
+
+	// Sort newest-first (GetRunningRuns already does this, but be explicit)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].StartedAt.After(result[j].StartedAt)
+	})
+
+	return result, nil
+}
+
+// FetchFinishedPipelines returns the most recent finished pipeline runs.
+func (p *DefaultPipelineDataProvider) FetchFinishedPipelines(limit int) ([]FinishedPipeline, error) {
+	// Fetch more than needed to account for filtering
+	records, err := p.store.ListRuns(state.ListRunsOptions{Limit: limit * 3})
+	if err != nil {
+		return nil, err
+	}
+
+	var result []FinishedPipeline
+	for _, r := range records {
+		if r.Status != "completed" && r.Status != "failed" && r.Status != "cancelled" {
+			continue
+		}
+
+		fp := FinishedPipeline{
+			RunID:      r.RunID,
+			Name:       r.PipelineName,
+			BranchName: r.BranchName,
+			Status:     r.Status,
+			StartedAt:  r.StartedAt,
+		}
+
+		if r.CompletedAt != nil {
+			fp.CompletedAt = *r.CompletedAt
+			fp.Duration = r.CompletedAt.Sub(r.StartedAt)
+		} else if r.CancelledAt != nil {
+			fp.CompletedAt = *r.CancelledAt
+			fp.Duration = r.CancelledAt.Sub(r.StartedAt)
+		}
+
+		result = append(result, fp)
+		if len(result) >= limit {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// FetchAvailablePipelines returns all configured pipelines from the manifest directory.
+func (p *DefaultPipelineDataProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+	return DiscoverPipelines(p.pipelinesDir)
+}

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -1,0 +1,363 @@
+package tui
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// baseStateStore — no-op implementation of state.StateStore.
+// Embed this in mocks so only the needed methods must be overridden.
+// ---------------------------------------------------------------------------
+
+type baseStateStore struct{}
+
+func (b baseStateStore) SavePipelineState(string, string, string) error { return nil }
+func (b baseStateStore) SaveStepState(string, string, state.StepState, string) error {
+	return nil
+}
+func (b baseStateStore) GetPipelineState(string) (*state.PipelineStateRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) GetStepStates(string) ([]state.StepStateRecord, error) { return nil, nil }
+func (b baseStateStore) ListRecentPipelines(int) ([]state.PipelineStateRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) Close() error                                      { return nil }
+func (b baseStateStore) CreateRun(string, string) (string, error)          { return "", nil }
+func (b baseStateStore) UpdateRunStatus(string, string, string, int) error { return nil }
+func (b baseStateStore) UpdateRunBranch(string, string) error              { return nil }
+func (b baseStateStore) GetRun(string) (*state.RunRecord, error)           { return nil, nil }
+func (b baseStateStore) GetRunningRuns() ([]state.RunRecord, error)        { return nil, nil }
+func (b baseStateStore) ListRuns(state.ListRunsOptions) ([]state.RunRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) DeleteRun(string) error { return nil }
+func (b baseStateStore) LogEvent(string, string, string, string, string, int, int64) error {
+	return nil
+}
+func (b baseStateStore) GetEvents(string, state.EventQueryOptions) ([]state.LogRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) RegisterArtifact(string, string, string, string, string, int64) error {
+	return nil
+}
+func (b baseStateStore) GetArtifacts(string, string) ([]state.ArtifactRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) RequestCancellation(string, bool) error { return nil }
+func (b baseStateStore) CheckCancellation(string) (*state.CancellationRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) ClearCancellation(string) error { return nil }
+func (b baseStateStore) RecordPerformanceMetric(*state.PerformanceMetricRecord) error {
+	return nil
+}
+func (b baseStateStore) GetPerformanceMetrics(string, string) ([]state.PerformanceMetricRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) GetStepPerformanceStats(string, string, time.Time) (*state.StepPerformanceStats, error) {
+	return nil, nil
+}
+func (b baseStateStore) GetRecentPerformanceHistory(state.PerformanceQueryOptions) ([]state.PerformanceMetricRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) CleanupOldPerformanceMetrics(time.Duration) (int, error) { return 0, nil }
+func (b baseStateStore) SaveProgressSnapshot(string, string, int, string, int64, string, string) error {
+	return nil
+}
+func (b baseStateStore) GetProgressSnapshots(string, string, int) ([]state.ProgressSnapshotRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) UpdateStepProgress(string, string, string, string, int, string, string, int64, int) error {
+	return nil
+}
+func (b baseStateStore) GetStepProgress(string) (*state.StepProgressRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) GetAllStepProgress(string) ([]state.StepProgressRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) UpdatePipelineProgress(string, int, int, int, int, int64) error {
+	return nil
+}
+func (b baseStateStore) GetPipelineProgress(string) (*state.PipelineProgressRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) SaveArtifactMetadata(int64, string, string, string, string, string, string) error {
+	return nil
+}
+func (b baseStateStore) GetArtifactMetadata(int64) (*state.ArtifactMetadataRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) SetRunTags(string, []string) error { return nil }
+func (b baseStateStore) GetRunTags(string) ([]string, error) { return nil, nil }
+func (b baseStateStore) AddRunTag(string, string) error      { return nil }
+func (b baseStateStore) RemoveRunTag(string, string) error   { return nil }
+
+// Compile-time check: baseStateStore must satisfy state.StateStore.
+var _ state.StateStore = baseStateStore{}
+
+// ---------------------------------------------------------------------------
+// mockStateStore — overrides only GetRunningRuns and ListRuns.
+// ---------------------------------------------------------------------------
+
+type mockStateStore struct {
+	baseStateStore
+	runningRuns    []state.RunRecord
+	runningRunsErr error
+	listRuns       []state.RunRecord
+	listRunsErr    error
+	listRunsOpts   state.ListRunsOptions // captured for assertions
+}
+
+func (m *mockStateStore) GetRunningRuns() ([]state.RunRecord, error) {
+	return m.runningRuns, m.runningRunsErr
+}
+
+func (m *mockStateStore) ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error) {
+	m.listRunsOpts = opts
+	return m.listRuns, m.listRunsErr
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func timeAt(hour, min int) time.Time {
+	return time.Date(2026, 3, 6, hour, min, 0, 0, time.UTC)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultPipelineDataProvider_FetchRunningPipelines(t *testing.T) {
+	mock := &mockStateStore{
+		runningRuns: []state.RunRecord{
+			{
+				RunID:        "run-1",
+				PipelineName: "speckit-flow",
+				BranchName:   "feat/speckit",
+				StartedAt:    timeAt(10, 0),
+				Status:       "running",
+			},
+			{
+				RunID:        "run-2",
+				PipelineName: "wave-evolve",
+				BranchName:   "feat/evolve",
+				StartedAt:    timeAt(11, 0),
+				Status:       "running",
+			},
+		},
+	}
+
+	provider := NewDefaultPipelineDataProvider(mock, "")
+	got, err := provider.FetchRunningPipelines()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Verify field mapping — newest first after sort
+	assert.Equal(t, "run-2", got[0].RunID)
+	assert.Equal(t, "wave-evolve", got[0].Name)
+	assert.Equal(t, "feat/evolve", got[0].BranchName)
+	assert.Equal(t, timeAt(11, 0), got[0].StartedAt)
+
+	assert.Equal(t, "run-1", got[1].RunID)
+	assert.Equal(t, "speckit-flow", got[1].Name)
+	assert.Equal(t, "feat/speckit", got[1].BranchName)
+	assert.Equal(t, timeAt(10, 0), got[1].StartedAt)
+}
+
+func TestDefaultPipelineDataProvider_FetchRunningPipelines_SortOrder(t *testing.T) {
+	// Records arrive oldest-first; verify result is newest-first.
+	mock := &mockStateStore{
+		runningRuns: []state.RunRecord{
+			{RunID: "old", StartedAt: timeAt(8, 0)},
+			{RunID: "new", StartedAt: timeAt(12, 0)},
+		},
+	}
+
+	provider := NewDefaultPipelineDataProvider(mock, "")
+	got, err := provider.FetchRunningPipelines()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "new", got[0].RunID)
+	assert.Equal(t, "old", got[1].RunID)
+}
+
+func TestDefaultPipelineDataProvider_FetchFinishedPipelines(t *testing.T) {
+	completedAt := timeAt(10, 30)
+	cancelledAt := timeAt(11, 15)
+	mock := &mockStateStore{
+		listRuns: []state.RunRecord{
+			{RunID: "r1", PipelineName: "p1", Status: "running", StartedAt: timeAt(10, 0)},
+			{RunID: "r2", PipelineName: "p2", Status: "completed", StartedAt: timeAt(9, 0), CompletedAt: &completedAt, BranchName: "b2"},
+			{RunID: "r3", PipelineName: "p3", Status: "failed", StartedAt: timeAt(8, 0), CompletedAt: &completedAt, BranchName: "b3"},
+			{RunID: "r4", PipelineName: "p4", Status: "cancelled", StartedAt: timeAt(7, 0), CancelledAt: &cancelledAt, BranchName: "b4"},
+			{RunID: "r5", PipelineName: "p5", Status: "pending", StartedAt: timeAt(6, 0)},
+		},
+	}
+
+	provider := NewDefaultPipelineDataProvider(mock, "")
+	got, err := provider.FetchFinishedPipelines(10)
+	require.NoError(t, err)
+
+	// Only terminal statuses: completed, failed, cancelled
+	require.Len(t, got, 3)
+
+	assert.Equal(t, "r2", got[0].RunID)
+	assert.Equal(t, "completed", got[0].Status)
+	assert.Equal(t, "p2", got[0].Name)
+	assert.Equal(t, "b2", got[0].BranchName)
+
+	assert.Equal(t, "r3", got[1].RunID)
+	assert.Equal(t, "failed", got[1].Status)
+
+	assert.Equal(t, "r4", got[2].RunID)
+	assert.Equal(t, "cancelled", got[2].Status)
+}
+
+func TestDefaultPipelineDataProvider_FetchFinishedPipelines_Duration(t *testing.T) {
+	tests := []struct {
+		name         string
+		record       state.RunRecord
+		wantDuration time.Duration
+		wantComplAt  time.Time
+	}{
+		{
+			name: "completed — Duration = CompletedAt - StartedAt",
+			record: state.RunRecord{
+				RunID:       "r1",
+				Status:      "completed",
+				StartedAt:   timeAt(10, 0),
+				CompletedAt: timePtr(timeAt(10, 45)),
+			},
+			wantDuration: 45 * time.Minute,
+			wantComplAt:  timeAt(10, 45),
+		},
+		{
+			name: "cancelled — Duration = CancelledAt - StartedAt",
+			record: state.RunRecord{
+				RunID:       "r2",
+				Status:      "cancelled",
+				StartedAt:   timeAt(14, 0),
+				CancelledAt: timePtr(timeAt(14, 20)),
+			},
+			wantDuration: 20 * time.Minute,
+			wantComplAt:  timeAt(14, 20),
+		},
+		{
+			name: "failed with CompletedAt",
+			record: state.RunRecord{
+				RunID:       "r3",
+				Status:      "failed",
+				StartedAt:   timeAt(9, 0),
+				CompletedAt: timePtr(timeAt(9, 10)),
+			},
+			wantDuration: 10 * time.Minute,
+			wantComplAt:  timeAt(9, 10),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockStateStore{
+				listRuns: []state.RunRecord{tt.record},
+			}
+			provider := NewDefaultPipelineDataProvider(mock, "")
+			got, err := provider.FetchFinishedPipelines(10)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+
+			assert.Equal(t, tt.wantDuration, got[0].Duration)
+			assert.Equal(t, tt.wantComplAt, got[0].CompletedAt)
+		})
+	}
+}
+
+func TestDefaultPipelineDataProvider_FetchFinishedPipelines_Limit(t *testing.T) {
+	completedAt := timeAt(12, 0)
+	records := make([]state.RunRecord, 10)
+	for i := range records {
+		records[i] = state.RunRecord{
+			RunID:       "r" + string(rune('A'+i)),
+			Status:      "completed",
+			StartedAt:   timeAt(10, i),
+			CompletedAt: &completedAt,
+		}
+	}
+
+	mock := &mockStateStore{listRuns: records}
+	provider := NewDefaultPipelineDataProvider(mock, "")
+
+	got, err := provider.FetchFinishedPipelines(3)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+
+	// Verify ListRuns was called with limit*3
+	assert.Equal(t, 9, mock.listRunsOpts.Limit)
+}
+
+func TestDefaultPipelineDataProvider_FetchAvailablePipelines(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `kind: WavePipeline
+metadata:
+  name: test-pipeline
+  description: A test pipeline
+input:
+  source: cli
+steps:
+  - id: step1
+    persona: navigator
+`
+	err := os.WriteFile(filepath.Join(dir, "test-pipeline.yaml"), []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	mock := &mockStateStore{}
+	provider := NewDefaultPipelineDataProvider(mock, dir)
+
+	got, err := provider.FetchAvailablePipelines()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.Equal(t, "test-pipeline", got[0].Name)
+	assert.Equal(t, "A test pipeline", got[0].Description)
+	assert.Equal(t, 1, got[0].StepCount)
+}
+
+func TestDefaultPipelineDataProvider_FetchRunningPipelines_Error(t *testing.T) {
+	mock := &mockStateStore{
+		runningRunsErr: errors.New("database connection lost"),
+	}
+
+	provider := NewDefaultPipelineDataProvider(mock, "")
+	got, err := provider.FetchRunningPipelines()
+
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "database connection lost")
+}
+
+func TestDefaultPipelineDataProvider_FetchFinishedPipelines_Error(t *testing.T) {
+	mock := &mockStateStore{
+		listRunsErr: errors.New("query timeout"),
+	}
+
+	provider := NewDefaultPipelineDataProvider(mock, "")
+	got, err := provider.FetchFinishedPipelines(5)
+
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "query timeout")
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -39,7 +39,7 @@ func (m StatusBarModel) View() string {
 		PaddingRight(1)
 
 	label := labelStyle.Render(m.contextLabel)
-	hints := hintsStyle.Render("q: quit  ctrl+c: exit")
+	hints := hintsStyle.Render("↑↓: navigate  /: filter  q: quit  ctrl+c: exit")
 
 	// Calculate spacing between label and hints
 	labelWidth := lipgloss.Width(label)

--- a/specs/254-tui-pipeline-list/checklists/requirements.md
+++ b/specs/254-tui-pipeline-list/checklists/requirements.md
@@ -1,0 +1,72 @@
+# Requirements Checklist: TUI Pipeline List Left Pane
+
+**Purpose**: Validate that the specification for issue #254 is complete, testable, and aligned with the TUI epic (#251) architecture.  
+**Created**: 2026-03-05  
+**Feature**: [spec.md](../spec.md)  
+**Validation**: Pass (35/35) — 2026-03-05
+
+## Completeness
+
+- [x] **CHK001**: All three pipeline sections (Running, Finished, Available) are specified with data sources and sort order — FR-001, FR-003, FR-004, FR-005, FR-013/014/015
+- [x] **CHK002**: Section header format is defined (name + count) — FR-002
+- [x] **CHK003**: Running pipeline display includes elapsed time indicator — FR-003, US1-AS2
+- [x] **CHK004**: Finished pipeline display includes status and duration — FR-004, US1-AS4
+- [x] **CHK005**: Available pipeline display includes pipeline names from manifest discovery — FR-005, FR-015
+
+## Navigation
+
+- [x] **CHK006**: Arrow key (↑/↓) navigation is specified with cross-section boundary behavior — FR-006, US2-AS1
+- [x] **CHK007**: Selection clamping at list boundaries is specified (no wrap) — FR-007, US2-AS2/AS3
+- [x] **CHK008**: Visual selection indicator (▶) is defined — FR-006, US2-AS4
+- [x] **CHK009**: Selection-changed message emission is specified for inter-component communication — FR-008, US2-AS5
+- [x] **CHK010**: Default focus on left pane at TUI launch is specified — FR-012
+
+## Search/Filter
+
+- [x] **CHK011**: `/` key activation for filter input is specified — FR-009, US3-AS1
+- [x] **CHK012**: Case-insensitive substring matching behavior is defined — FR-009, US3-AS2
+- [x] **CHK013**: Escape key to dismiss filter is specified — FR-010, US3-AS3
+- [x] **CHK014**: Empty results state ("No matching pipelines") is specified — US3-AS4
+- [x] **CHK015**: Navigation within filtered results is specified — US3-AS5
+
+## Scrolling
+
+- [x] **CHK016**: Viewport scrolling to keep selected item visible is specified — FR-011, US4-AS1/AS2
+- [x] **CHK017**: Behavior for lists exceeding visible area is covered — US4-AS1/AS2/AS3
+
+## Section Collapse
+
+- [x] **CHK018**: Section collapse/expand toggle is specified (as SHOULD) — FR-016
+- [x] **CHK019**: Collapsed section display (header + indicator) is defined — US5-AS1
+- [x] **CHK020**: Navigation behavior with collapsed sections is specified — US5-AS3
+
+## Integration
+
+- [x] **CHK021**: Integration with existing ContentModel is specified (replaces placeholder) — FR-017
+- [x] **CHK022**: Data sources are identified (SQLite state DB for Running/Finished, DiscoverPipelines for Available) — FR-013/014/015
+- [x] **CHK023**: Message types for inter-component communication are referenced (PipelineSelectedMsg) — FR-008
+- [x] **CHK024**: NO_COLOR compliance is specified — FR-018
+
+## Edge Cases
+
+- [x] **CHK025**: Missing/inaccessible SQLite database behavior is specified — Edge Case 1
+- [x] **CHK026**: Missing/malformed wave.yaml behavior is specified — Edge Case 2
+- [x] **CHK027**: Terminal resize below minimum width behavior is specified — Edge Case 3
+- [x] **CHK028**: Long pipeline name truncation is specified — Edge Case 5
+- [x] **CHK029**: All-empty sections state is specified — Edge Case 6
+- [x] **CHK030**: Runtime status change (running → finished) behavior is specified — Edge Case 4
+
+## Quality Gates
+
+- [x] **CHK031**: All user stories have acceptance scenarios in Given/When/Then format — 5/5 stories verified
+- [x] **CHK032**: All functional requirements use MUST/SHOULD language — FR-001 to FR-015 (MUST), FR-016 (SHOULD)
+- [x] **CHK033**: Success criteria are measurable and technology-agnostic — SC-001 to SC-007 verified
+- [x] **CHK034**: No more than 3 [NEEDS CLARIFICATION] markers remain — 0 markers present
+- [x] **CHK035**: Spec focuses on WHAT/WHY, not HOW (no implementation details) — verified, no code or architecture specifics
+
+## Notes
+
+- Section collapse is specified as SHOULD (FR-016) since it is P3 priority
+- The right pane detail view is explicitly out of scope per issue #254
+- Pipeline launching and live output streaming are out of scope
+- Data refresh mechanism (polling interval for Running section elapsed time updates) is left to implementation discretion

--- a/specs/254-tui-pipeline-list/checklists/review.md
+++ b/specs/254-tui-pipeline-list/checklists/review.md
@@ -1,0 +1,56 @@
+# Quality Review Checklist: TUI Pipeline List Left Pane
+
+**Purpose**: Validate requirements quality across completeness, clarity, consistency, and coverage dimensions before implementation begins.  
+**Feature**: #254 — TUI Pipeline List Left Pane  
+**Created**: 2026-03-05  
+**Spec**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md) | **Tasks**: [tasks.md](../tasks.md)
+
+---
+
+## Completeness
+
+- [ ] CHK001 - Are error handling requirements defined for all three data sources (SQLite for Running/Finished, manifest for Available)? [Completeness]
+- [ ] CHK002 - Is the behavior specified when the PipelineDataProvider returns errors mid-session (after successful initial load)? [Completeness]
+- [ ] CHK003 - Are loading/initialization states specified for the left pane before the first data fetch completes? [Completeness]
+- [ ] CHK004 - Is the right pane placeholder content and behavior fully specified (dimensions, styling, alignment)? [Completeness]
+- [ ] CHK005 - Are keyboard shortcut discoverability requirements defined (how does the user learn about `/` for filter, Enter for collapse)? [Completeness]
+- [ ] CHK006 - Is the elapsed time update frequency for Running items specified (does it update live or only on 5s polling refresh)? [Completeness]
+- [ ] CHK007 - Are the sort criteria for the Finished section specified (most recent first? by completion time or start time)? [Completeness]
+- [ ] CHK008 - Is the maximum number of finished pipelines to display defined as a hard requirement (FR-014 says "default limit: 20" — is this configurable or fixed)? [Completeness]
+- [ ] CHK009 - Are accessibility requirements defined for the pipeline list (screen reader support, high contrast mode)? [Completeness]
+- [ ] CHK010 - Is the section ordering specified as fixed (Running → Finished → Available) or is it left to implementation? [Completeness]
+
+## Clarity
+
+- [ ] CHK011 - Is the exact visual layout of a Running item row unambiguous (name position, elapsed time position, separator/padding)? [Clarity]
+- [ ] CHK012 - Is the exact visual layout of a Finished item row unambiguous (name, status icon, status text, duration — positioning and truncation priority)? [Clarity]
+- [ ] CHK013 - Is "case-insensitive substring match" for the filter clearly defined for non-ASCII pipeline names (Unicode handling)? [Clarity]
+- [ ] CHK014 - Are the collapsed/expanded indicators (▸/▾) clearly specified in terms of position (before or after section label)? [Clarity]
+- [ ] CHK015 - Is the filter input activation behavior unambiguous (does `/` insert a `/` character or only activate the input)? [Clarity]
+- [ ] CHK016 - Is "visual selection indicator" sufficiently precise — are the exact styling properties (color, bold, background) defined or left to the theme? [Clarity]
+- [ ] CHK017 - Is the minimum terminal size for correct rendering specified (FR-001 says min 25 columns for left pane, but what about overall minimum)? [Clarity]
+
+## Consistency
+
+- [ ] CHK018 - Does the PipelineSelectedMsg contract match the existing header_messages.go definition exactly (field types, empty value semantics)? [Consistency]
+- [ ] CHK019 - Does the 5-second polling interval align with the header's separate polling cycle, or could they race/conflict? [Consistency]
+- [ ] CHK020 - Does the PipelineDataProvider interface follow the MetadataProvider pattern precisely (method naming, error return, constructor pattern)? [Consistency]
+- [ ] CHK021 - Is the left pane width calculation (30%, min 25, max 50) consistent with how the header bar handles terminal width constraints? [Consistency]
+- [ ] CHK022 - Does the "focused by default" requirement (FR-012) align with how other TUI components handle focus (are there competing focus claims)? [Consistency]
+- [ ] CHK023 - Is the NO_COLOR requirement (FR-018) consistent with how existing TUI components (header, status bar) handle NO_COLOR? [Consistency]
+- [ ] CHK024 - Does the section collapse toggle key (Enter) conflict with any existing key bindings in the TUI? [Consistency]
+
+## Coverage
+
+- [ ] CHK025 - Is the behavior specified when a pipeline run finishes while the user has it selected in the Running section (cursor stability)? [Coverage]
+- [ ] CHK026 - Is the behavior specified when the user is in filter mode and a data refresh changes the filtered results? [Coverage]
+- [ ] CHK027 - Is the behavior specified when terminal resize occurs during active filter mode? [Coverage]
+- [ ] CHK028 - Is the behavior specified when multiple pipelines share the same name (duplicate names across sections)? [Coverage]
+- [ ] CHK029 - Is the behavior specified for very rapid ↑/↓ key repeats (debouncing or queue handling)? [Coverage]
+- [ ] CHK030 - Is the behavior specified when the database becomes unavailable after initial load (stale data display vs error state)? [Coverage]
+- [ ] CHK031 - Is the behavior specified when a collapsed section receives new items via polling refresh (does it stay collapsed)? [Coverage]
+
+---
+
+**Total items**: 31  
+**Dimensions**: Completeness (10), Clarity (7), Consistency (7), Coverage (7)

--- a/specs/254-tui-pipeline-list/checklists/tui-ux.md
+++ b/specs/254-tui-pipeline-list/checklists/tui-ux.md
@@ -1,0 +1,42 @@
+# TUI/UX Quality Checklist: TUI Pipeline List Left Pane
+
+**Purpose**: Validate TUI-specific and user experience quality concerns for the pipeline list component.  
+**Feature**: #254 — TUI Pipeline List Left Pane  
+**Created**: 2026-03-05  
+**Spec**: [spec.md](../spec.md)
+
+---
+
+## Visual Hierarchy & Layout
+
+- [ ] CHK101 - Are visual weight rules defined for section headers vs pipeline items (font weight, indentation, spacing) to establish clear hierarchy? [Visual Hierarchy]
+- [ ] CHK102 - Is the vertical spacing between sections specified (blank line, divider, or flush)? [Visual Hierarchy]
+- [ ] CHK103 - Is the truncation strategy for pipeline names specified in priority order (which metadata is truncated first when space is constrained)? [Visual Hierarchy]
+- [ ] CHK104 - Are color/styling requirements expressed as semantic roles (e.g., "success", "error") rather than hard-coded values, ensuring theme adaptability? [Visual Hierarchy]
+
+## Interaction Design
+
+- [ ] CHK105 - Is focus transfer behavior defined (how does the user move focus from left pane to future right pane and back)? [Interaction]
+- [ ] CHK106 - Are the keymap conflicts documented between filter mode (text input active) and normal mode (↑/↓ navigation)? [Interaction]
+- [ ] CHK107 - Is the transition animation/rendering specified when switching between filter mode and normal mode (smooth or instant)? [Interaction]
+- [ ] CHK108 - Is the scroll position preservation behavior defined when exiting and re-entering filter mode? [Interaction]
+- [ ] CHK109 - Is the cursor placement rule specified after a data refresh adds/removes items (preserve selection by identity or by index)? [Interaction]
+
+## Responsiveness & Performance
+
+- [ ] CHK110 - Are rendering performance requirements specified for the target item count (100 items per SC-004)? [Performance]
+- [ ] CHK111 - Is the minimum usable terminal size documented as a requirement (not just the left pane minimum of 25 columns)? [Performance]
+- [ ] CHK112 - Is the behavior specified when the terminal height is too small to show even one item per section? [Performance]
+
+## Data Display
+
+- [ ] CHK113 - Is the elapsed time format specified precisely (e.g., "2m30s" vs "2:30" vs "2 minutes")? [Data Display]
+- [ ] CHK114 - Is the duration format for Finished items specified precisely (same format as elapsed time?)? [Data Display]
+- [ ] CHK115 - Are the status indicator symbols specified (✓/✗) and their fallback for terminals without Unicode support? [Data Display]
+- [ ] CHK116 - Is the "cancelled" status display specified with the same precision as "completed" and "failed"? [Data Display]
+- [ ] CHK117 - Is the empty section body display specified (blank, placeholder text like "No running pipelines", or section hidden)? [Data Display]
+
+---
+
+**Total items**: 17  
+**Dimensions**: Visual Hierarchy (4), Interaction (5), Responsiveness (3), Data Display (5)

--- a/specs/254-tui-pipeline-list/data-model.md
+++ b/specs/254-tui-pipeline-list/data-model.md
@@ -1,0 +1,175 @@
+# Data Model: TUI Pipeline List Left Pane
+
+**Feature**: #254 — TUI Pipeline List Left Pane  
+**Date**: 2026-03-05
+
+## Entities
+
+### PipelineDataProvider (Interface)
+
+Follows the `MetadataProvider` pattern from `header_provider.go`.
+
+```go
+// PipelineDataProvider fetches pipeline data for the list component.
+// Decoupled from state store for testability.
+type PipelineDataProvider interface {
+    FetchRunningPipelines() ([]RunningPipeline, error)
+    FetchFinishedPipelines(limit int) ([]FinishedPipeline, error)
+    FetchAvailablePipelines() ([]PipelineInfo, error)
+}
+```
+
+### RunningPipeline (Value Object)
+
+TUI-specific view of a running pipeline. Derived from `state.RunRecord`.
+
+```go
+type RunningPipeline struct {
+    RunID      string
+    Name       string
+    BranchName string
+    StartedAt  time.Time
+}
+```
+
+### FinishedPipeline (Value Object)
+
+TUI-specific view of a finished pipeline. Derived from `state.RunRecord`.
+
+```go
+type FinishedPipeline struct {
+    RunID       string
+    Name        string
+    BranchName  string
+    Status      string    // "completed", "failed", "cancelled"
+    StartedAt   time.Time
+    CompletedAt time.Time
+    Duration    time.Duration
+}
+```
+
+### PipelineInfo (Existing — `pipelines.go`)
+
+Already defined in `internal/tui/pipelines.go`. Reused for the Available section.
+
+```go
+type PipelineInfo struct {
+    Name         string
+    Description  string
+    StepCount    int
+    InputExample string
+    Release      bool
+    Category     string
+}
+```
+
+### PipelineListModel (Bubble Tea Model)
+
+The left pane model implementing `Init()`, `Update()`, `View()`.
+
+```go
+type PipelineListModel struct {
+    width    int
+    height   int
+    provider PipelineDataProvider
+
+    // Section data
+    running   []RunningPipeline
+    finished  []FinishedPipeline
+    available []PipelineInfo
+
+    // Navigation state
+    cursor     int              // index into navigable items
+    navigable  []navigableItem  // flattened list of headers + items
+
+    // Filter state
+    filtering   bool
+    filterInput textinput.Model
+    filterQuery string
+
+    // Section collapse state
+    collapsed [3]bool // [Running, Finished, Available]
+
+    // Focus state
+    focused bool
+}
+```
+
+### navigableItem (Internal Type)
+
+Discriminated union for the flat navigation list.
+
+```go
+type itemKind int
+
+const (
+    itemKindSectionHeader itemKind = iota
+    itemKindRunning
+    itemKindFinished
+    itemKindAvailable
+)
+
+type navigableItem struct {
+    kind         itemKind
+    sectionIndex int    // 0=Running, 1=Finished, 2=Available
+    dataIndex    int    // index into section's data slice (-1 for headers)
+    label        string // display text
+}
+```
+
+### Messages (Bubble Tea)
+
+```go
+// PipelineDataMsg carries refreshed pipeline data from the provider.
+type PipelineDataMsg struct {
+    Running   []RunningPipeline
+    Finished  []FinishedPipeline
+    Available []PipelineInfo
+    Err       error
+}
+
+// PipelineRefreshTickMsg triggers periodic data refresh.
+type PipelineRefreshTickMsg struct{}
+```
+
+`PipelineSelectedMsg` — reused from `header_messages.go` (no changes needed).
+
+## Data Flow
+
+```
+                    ┌──────────────┐
+                    │  StateStore  │ (SQLite, read-only)
+                    └──────┬───────┘
+                           │
+                    ┌──────▼───────────────┐
+                    │ PipelineDataProvider  │
+                    │  (DefaultPipeline     │
+                    │   DataProvider)       │
+                    └──────┬───────────────┘
+                           │ FetchRunning/Finished/Available
+                    ┌──────▼───────────────┐
+                    │  PipelineListModel   │
+                    │  - sections data     │
+                    │  - navigation state  │
+                    │  - filter state      │
+                    └──────┬───────────────┘
+                           │ PipelineSelectedMsg
+                    ┌──────▼───────────────┐
+                    │   ContentModel       │
+                    │  (left + right pane) │
+                    └──────┬───────────────┘
+                           │ tea.Cmd(PipelineSelectedMsg)
+                    ┌──────▼───────────────┐
+                    │     AppModel         │
+                    │  (routes to header)  │
+                    └──────────────────────┘
+```
+
+## Polling Sequence
+
+1. `Init()` → batch: `fetchPipelineData` (initial load) + `refreshTick()` (5s timer)
+2. Timer fires `PipelineRefreshTickMsg`
+3. `Update()` returns `tea.Batch(fetchPipelineData, refreshTick())`
+4. `fetchPipelineData` calls all three provider methods, returns `PipelineDataMsg`
+5. `Update(PipelineDataMsg)` updates section data, rebuilds navigable items
+6. If cursor was on a pipeline item, re-emit `PipelineSelectedMsg` if the item still exists

--- a/specs/254-tui-pipeline-list/plan.md
+++ b/specs/254-tui-pipeline-list/plan.md
@@ -1,0 +1,193 @@
+# Implementation Plan: TUI Pipeline List Left Pane
+
+**Branch**: `254-tui-pipeline-list` | **Date**: 2026-03-05 | **Spec**: `specs/254-tui-pipeline-list/spec.md`
+**Input**: Feature specification from `/specs/254-tui-pipeline-list/spec.md`
+
+## Summary
+
+Add a pipeline list left pane to the TUI content area, displaying Running, Finished, and Available pipelines in three navigable sections. The `ContentModel` is refactored from a single placeholder to a left/right split composition. A `PipelineDataProvider` interface (following the established `MetadataProvider` pattern) abstracts data fetching from the state store and manifest discovery. Keyboard navigation (↑/↓), search/filter (`/`), viewport scrolling, and section collapse/expand are implemented as an interactive `PipelineListModel` Bubble Tea component.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (existing project)
+**Primary Dependencies**: `charmbracelet/bubbletea` v1.3.10, `charmbracelet/lipgloss` v1.1.0, `charmbracelet/bubbles` (textinput — already indirect dep)
+**Storage**: SQLite via `internal/state` (read-only `NewReadOnlyStateStore`)
+**Testing**: `go test` with `testify/assert`, `testify/require`
+**Target Platform**: Linux/macOS terminal (80–300 columns, 24–100 rows)
+**Project Type**: Single Go binary — all changes in `internal/tui/` package
+**Constraints**: No new external dependencies (bubbles/textinput is already indirect); must not break existing tests
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | ✅ Pass | No new runtime dependencies. bubbles/textinput is already indirect via huh. |
+| P2: Manifest as SSOT | ✅ Pass | Available pipelines loaded via `DiscoverPipelines` (manifest-based). |
+| P3: Persona-Scoped Execution | N/A | TUI component, not a persona. |
+| P4: Fresh Memory at Step Boundary | N/A | TUI component, not a pipeline step. |
+| P5: Navigator-First Architecture | N/A | TUI component, not a pipeline execution. |
+| P6: Contracts at Every Handover | N/A | TUI component, no inter-step handover. |
+| P7: Relay via Dedicated Summarizer | N/A | TUI component, no context compaction. |
+| P8: Ephemeral Workspaces | N/A | TUI component, no workspace creation. |
+| P9: Credentials Never Touch Disk | ✅ Pass | No credential handling. |
+| P10: Observable Progress | ✅ Pass | Running pipelines show elapsed time; status visible at a glance. |
+| P11: Bounded Recursion | N/A | No recursion in TUI. |
+| P12: Minimal Step State Machine | ✅ Pass | Uses existing step states from state store. |
+| P13: Test Ownership | ✅ Pass | All new code will have tests; existing tests updated for refactored ContentModel. |
+
+No violations. No complexity tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/254-tui-pipeline-list/
+├── plan.md              # This file
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```
+internal/tui/
+├── app.go                    # MODIFY — accept PipelineDataProvider, forward msgs to content
+├── app_test.go               # MODIFY — update for new ContentModel + provider injection
+├── content.go                # MODIFY — refactor to left/right pane composition
+├── content_test.go           # MODIFY — update for new ContentModel behavior
+├── header.go                 # UNCHANGED
+├── header_logo.go            # UNCHANGED
+├── header_messages.go        # UNCHANGED (PipelineSelectedMsg already defined)
+├── header_metadata.go        # UNCHANGED
+├── header_provider.go        # UNCHANGED
+├── header_provider_test.go   # UNCHANGED
+├── header_test.go            # UNCHANGED
+├── pipeline_list.go          # NEW — PipelineListModel (Init, Update, View)
+├── pipeline_list_test.go     # NEW — comprehensive tests for list model
+├── pipeline_messages.go      # NEW — PipelineDataMsg, PipelineRefreshTickMsg
+├── pipeline_provider.go      # NEW — PipelineDataProvider interface + DefaultPipelineDataProvider
+├── pipeline_provider_test.go # NEW — provider tests with mock state store
+├── pipelines.go              # UNCHANGED (PipelineInfo, DiscoverPipelines)
+├── pipelines_test.go         # UNCHANGED
+├── run_selector.go           # UNCHANGED
+├── run_selector_test.go      # UNCHANGED
+├── statusbar.go              # UNCHANGED
+├── statusbar_test.go         # UNCHANGED
+└── theme.go                  # UNCHANGED
+```
+
+**Structure Decision**: All changes are within `internal/tui/`. New files follow the established naming convention (`pipeline_*.go` matching `header_*.go`). No new packages needed.
+
+## Implementation Strategy
+
+### Phase A: Data Layer (provider + messages)
+
+**Files**: `pipeline_provider.go`, `pipeline_provider_test.go`, `pipeline_messages.go`
+
+1. Define `RunningPipeline` and `FinishedPipeline` value types (TUI-specific projections of `state.RunRecord`)
+2. Define `PipelineDataProvider` interface with three fetch methods
+3. Implement `DefaultPipelineDataProvider` wrapping `state.StateStore` + `DiscoverPipelines`
+   - `FetchRunningPipelines()` → calls `store.GetRunningRuns()`, maps to `RunningPipeline`
+   - `FetchFinishedPipelines(limit)` → calls `store.ListRuns(ListRunsOptions{Status: in("completed","failed","cancelled"), Limit: limit})`, maps to `FinishedPipeline`. Note: the `ListRunsOptions.Status` is a single string; we'll need three separate queries (completed, failed, cancelled) merged and sorted, OR use a custom query. Simplest: query without status filter, then filter in Go for terminal statuses. Actually, looking at the store, `ListRuns` sorts by `started_at DESC` and supports limit. We can call `ListRuns` with no status filter and limit=20, then filter in Go for terminal statuses (completed/failed/cancelled). Or make 3 calls. Simplest approach: call with no status filter, limit=60 (buffer), filter in Go to terminal statuses, take first 20.
+   - `FetchAvailablePipelines()` → calls `DiscoverPipelines(pipelinesDir)`
+4. Define `PipelineDataMsg` and `PipelineRefreshTickMsg` message types
+5. Tests: mock state store, verify mapping logic, verify error handling
+
+### Phase B: List Model (core component)
+
+**Files**: `pipeline_list.go`, `pipeline_list_test.go`
+
+1. Define `navigableItem` and `itemKind` types
+2. Implement `PipelineListModel` struct with all fields from data model
+3. Implement `NewPipelineListModel(provider PipelineDataProvider)` constructor
+4. Implement `Init()` — returns batch of `fetchPipelineData` + `refreshTick()`
+5. Implement `buildNavigableItems()` — computes flat list from sections, respecting filter and collapse state
+6. Implement `Update()`:
+   - `PipelineDataMsg` → update section data, rebuild navigable items, emit `RunningCountMsg` for header
+   - `PipelineRefreshTickMsg` → return `tea.Batch(fetchPipelineData, refreshTick())`
+   - `tea.KeyMsg` (↑/↓) → move cursor, clamp, emit `PipelineSelectedMsg` if on a pipeline item
+   - `tea.KeyMsg` (`/`) → activate filter mode
+   - `tea.KeyMsg` (Escape) → dismiss filter, clear query, rebuild items
+   - `tea.KeyMsg` (Enter on section header) → toggle collapse
+   - Forward to `filterInput` when filtering
+7. Implement `View()`:
+   - Render each navigable item with appropriate styling
+   - Selection indicator: `▶` for pipeline items, bold/inverse for section headers
+   - Section headers: `"Running (N)"`, `"Finished (N)"`, `"Available (N)"`
+   - Running items: `"name   2m30s"`
+   - Finished items: `"name   ✓ completed  1m15s"` or `"name   ✗ failed  45s"`
+   - Available items: `"name"`
+   - Viewport scrolling: calculate visible window based on height and cursor position
+   - Filter input rendered at top when active
+   - Truncation: pipeline names truncated with `…` when exceeding pane width
+   - Empty state: `"No pipelines found"` when all sections empty
+   - Filter empty: `"No matching pipelines"` when filter matches nothing
+8. Implement `SetSize(w, h)` for resize handling
+9. Tests:
+   - Navigation: cursor movement, boundary clamping, cross-section traversal
+   - Filter: activation, matching, dismissal, empty results
+   - Collapse: toggle, cursor skip over hidden items
+   - Selection messages: emitted for pipeline items, not headers
+   - View rendering: section headers with counts, item formatting
+   - Data refresh: section data updates, cursor preservation
+   - Edge cases: empty sections, all empty, very long names
+
+### Phase C: Content Model Refactoring
+
+**Files**: `content.go`, `content_test.go`
+
+1. Refactor `ContentModel` to hold a `PipelineListModel` (left pane)
+2. Add `NewContentModel(provider PipelineDataProvider)` — injects provider into list model
+3. Implement `Init()` — delegates to `PipelineListModel.Init()`
+4. Implement `Update()` — forwards all messages to `PipelineListModel`, returns combined commands
+5. Implement `View()`:
+   - Calculate left pane width: `min(max(width*30/100, 25), 50)`
+   - Right pane width: `width - leftWidth`
+   - Left: `PipelineListModel.View()`
+   - Right: placeholder text (centered "Pipeline details coming soon")
+   - Join with `lipgloss.JoinHorizontal`
+6. Implement `SetSize(w, h)` — propagate to list model with left pane width
+7. Update tests:
+   - Remove "Pipelines view coming soon" assertion (replaced by list)
+   - Add tests for left/right split width calculation
+   - Add tests for message forwarding to list model
+
+### Phase D: App Model Integration
+
+**Files**: `app.go`, `app_test.go`
+
+1. Update `NewAppModel` to accept `PipelineDataProvider` in addition to `MetadataProvider`
+2. Pass provider to `NewContentModel(provider)`
+3. Update `Init()` — return `tea.Batch(m.header.Init(), m.content.Init())`
+4. Update `Update()`:
+   - Forward all messages to `m.content.Update()` (in addition to existing header forwarding)
+   - Collect commands from both header and content updates
+   - For `PipelineSelectedMsg`: forward to both header (existing) and content
+   - Route ↑/↓ and `/` keys to content instead of (or in addition to) header
+5. Handle key routing: when left pane is focused (default), keys go to content
+6. Update `RunTUI()` — create `DefaultPipelineDataProvider` and pass to `NewAppModel`
+7. Update tests:
+   - `NewAppModel` now takes both providers
+   - Window resize propagates to content with list model
+   - Key events forwarded to content
+   - Integration: PipelineSelectedMsg flows from content to header
+
+### Phase E: Integration & Polish
+
+1. Verify `go test ./internal/tui/...` passes
+2. Verify `go test ./...` passes (no regressions)
+3. Manual smoke test at 80×24 and 200×50
+4. Verify NO_COLOR compliance
+5. Verify status bar key hints update (add ↑↓ / filter hints)
+
+## Complexity Tracking
+
+_No constitution violations identified._
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|-----------|--------------------------------------|
+| (none)    | —         | —                                    |

--- a/specs/254-tui-pipeline-list/research.md
+++ b/specs/254-tui-pipeline-list/research.md
@@ -1,0 +1,75 @@
+# Research: TUI Pipeline List Left Pane
+
+**Feature**: #254 — TUI Pipeline List Left Pane  
+**Date**: 2026-03-05
+
+## R1: Bubble Tea List Component Patterns
+
+**Decision**: Build a custom list model from scratch rather than using `charmbracelet/bubbles/list`.
+
+**Rationale**: The spec requires three grouped sections (Running, Finished, Available) with section headers as navigable cursor targets, section collapse, and custom rendering per section type (elapsed time, status badges, etc.). The `bubbles/list` component is designed for flat, homogeneous lists with a built-in filter — it doesn't support grouped sections, heterogeneous item rendering, or navigable section headers. Building from scratch gives full control and avoids fighting the library.
+
+**Alternatives Rejected**:
+- `bubbles/list` — flat list, no sections, no heterogeneous rendering
+- `bubbles/table` — tabular layout, wrong UX metaphor
+- Third-party list libraries — adds dependencies, no clear win for this use case
+
+## R2: Content Area Left/Right Split
+
+**Decision**: Refactor `ContentModel` to compose `PipelineListModel` (left) and a placeholder right pane using `lipgloss.JoinHorizontal`. Left pane is 30% width (min 25, max 50 columns).
+
+**Rationale**: This matches the spec's FR-001 and FR-017. `lipgloss.JoinHorizontal` is the idiomatic approach for side-by-side layout in Bubble Tea. The 30% ratio with min/max bounds follows industry-standard TUI sidebar patterns (k9s, lazygit).
+
+**Alternatives Rejected**:
+- Single-column layout — blocks future detail pane work
+- Fixed-width sidebar — doesn't adapt to terminal width
+
+## R3: Data Provider Interface Pattern
+
+**Decision**: Create a `PipelineDataProvider` interface following the established `MetadataProvider` pattern from `header_provider.go`. Uses `NewReadOnlyStateStore` for concurrent database access.
+
+**Rationale**: The header bar already uses this exact pattern — an interface with fetch methods, a default implementation wrapping external sources, and mock injection for tests. Reusing the pattern reduces cognitive load and ensures consistency. `NewReadOnlyStateStore` provides WAL-mode read access suitable for polling.
+
+**Alternatives Rejected**:
+- Direct state store injection — couples TUI to state package, harder to test
+- Channel-based data push — over-engineered for 5-second polling
+
+## R4: Navigation Model (Flat Cursor)
+
+**Decision**: Maintain a flat index into a computed list of navigable items (section headers + pipeline items). The list is recomputed on data refresh, filter change, or section collapse/expand. Cursor clamps at boundaries (no wrapping).
+
+**Rationale**: A flat cursor simplifies keyboard handling — ↑/↓ just increment/decrement the index. The navigable items list acts as a view model over the underlying section data. Section headers are distinguishable by type, enabling different visual treatment and suppression of `PipelineSelectedMsg` when a header is selected.
+
+**Alternatives Rejected**:
+- Two-level cursor (section index + item index) — complex cross-section traversal logic
+- Separate header/item navigation modes — confusing UX
+
+## R5: Async Polling with tea.Tick
+
+**Decision**: Use `tea.Tick` at 5-second intervals for Running/Finished sections. Available pipelines loaded once at startup via `Init()`.
+
+**Rationale**: The header already uses `tea.Tick` for git refresh (30s). A 5-second interval balances responsiveness for active pipeline monitoring with SQLite read load. Available pipelines rarely change (only on manifest edit), so one-time load is sufficient.
+
+**Alternatives Rejected**:
+- File watching for manifest changes — adds complexity, low value for prototype phase
+- Shorter polling interval (1s) — unnecessary SQLite load
+
+## R6: Message Forwarding Architecture
+
+**Decision**: `PipelineListModel` emits `PipelineSelectedMsg` (existing type from `header_messages.go`). `ContentModel.Update()` forwards all messages to `PipelineListModel` and returns its commands. `AppModel.Update()` already forwards all messages to the header; it will also forward to content.
+
+**Rationale**: Reusing `PipelineSelectedMsg` leverages the header's existing branch override handler. The unidirectional message flow (list → content → app → header) is the standard Bubble Tea pattern.
+
+**Alternatives Rejected**:
+- New message type — unnecessary when existing type has all needed fields
+- Direct header↔list communication — breaks Bubble Tea's parent-mediated message model
+
+## R7: Filter Implementation
+
+**Decision**: Embed a `textinput.Model` from `charmbracelet/bubbles` for the filter input. Activated on `/`, dismissed on Escape. Filter applies case-insensitive substring match across all sections simultaneously.
+
+**Rationale**: `bubbles/textinput` handles cursor rendering, key input, and styling. It's already an indirect dependency via `charmbracelet/huh`. Using it avoids reimplementing text input.
+
+**Alternatives Rejected**:
+- Custom text input — unnecessary when bubbles provides one
+- Regex filter — over-complex for pipeline names; substring match is sufficient

--- a/specs/254-tui-pipeline-list/spec.md
+++ b/specs/254-tui-pipeline-list/spec.md
@@ -1,0 +1,188 @@
+# Feature Specification: TUI Pipeline List Left Pane
+
+**Feature Branch**: `254-tui-pipeline-list`  
+**Created**: 2026-03-05  
+**Status**: Clarified  
+**Input**: User description: "https://github.com/re-cinq/wave/issues/254 — feat(tui): pipeline list left pane with running/finished/available sections and navigation"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - View Pipeline Inventory at a Glance (Priority: P1)
+
+A developer launches Wave TUI and immediately sees all pipelines organized into three distinct sections: Running (active executions with elapsed time), Finished (completed/failed with status and duration), and Available (all configured pipelines from the manifest). Each section header shows a count (e.g., "Running (2)"). The left pane is focused by default, giving the user an instant overview of the pipeline landscape without any interaction.
+
+**Why this priority**: The pipeline list is the foundational navigation surface for the entire TUI — every downstream feature (detail views, launching, live output) depends on it being visible and populated. Without this, the TUI has no actionable content area.
+
+**Independent Test**: Can be tested by launching the TUI with a combination of running, finished, and available pipelines and verifying that all three sections render with correct counts, items, and ordering.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TUI is launched with 2 running pipelines, 5 finished pipelines, and 8 available pipelines in `wave.yaml`, **When** the main view renders, **Then** the left pane displays three sections: "Running (2)", "Finished (5)", "Available (8)" with correct items in each.
+2. **Given** a pipeline is currently running, **When** it appears in the Running section, **Then** an elapsed time indicator shows how long it has been active, updating periodically.
+3. **Given** multiple running pipelines exist, **When** the Running section renders, **Then** items are sorted newest-first (most recently started at top).
+4. **Given** finished pipelines exist with mixed statuses, **When** the Finished section renders, **Then** each item shows its terminal status (completed/failed/cancelled) and total duration.
+5. **Given** no pipelines are running, **When** the Running section renders, **Then** the section header shows "Running (0)" and the section body is empty or shows a placeholder message.
+
+---
+
+### User Story 2 - Navigate the Pipeline List with Keyboard (Priority: P1)
+
+A developer uses arrow keys (↑/↓) to move a visual selection cursor through the pipeline list. The navigable items include both section headers and pipeline items. Section headers are navigable targets (required for collapse/expand in US-5) but are visually distinct from pipeline items. The cursor moves seamlessly from the last item in one section to the header of the next section. The currently selected item is highlighted with a visual indicator (▶ or ›). The selection state determines what appears in the right detail pane (handled by a future issue).
+
+**Why this priority**: Navigation is essential to make the list interactive. Without it, the list is read-only and the user cannot select pipelines for further action — blocking all downstream detail/action features.
+
+**Independent Test**: Can be tested by rendering the list with items in all three sections, simulating ↑/↓ key events, and asserting the cursor position updates correctly including cross-section traversal and section header stops.
+
+**Acceptance Scenarios**:
+
+1. **Given** the left pane is focused with pipelines in all three sections, **When** the user presses ↓, **Then** the selection moves to the next navigable item (section header or pipeline item) in the list.
+2. **Given** the selection is on the first item in the list (the Running section header), **When** the user presses ↑, **Then** the selection does not wrap to the bottom (stays at top).
+3. **Given** the selection is on the last item in the list, **When** the user presses ↓, **Then** the selection does not wrap to the top (stays at bottom).
+4. **Given** a pipeline item is selected, **When** the view renders, **Then** the selected item displays a visual indicator (▶) and is styled distinctly from unselected items. Section headers use a different highlight style (e.g., inverse/bold) when selected.
+5. **Given** the left pane has focus, **When** the selection changes to a pipeline item (not a section header), **Then** a `PipelineSelectedMsg` is emitted to notify other components (header, future right pane) of the newly selected pipeline. The message includes the pipeline name and, for Running/Finished items, the `RunID` and `BranchName` from the `RunRecord`. For Available items, `RunID` is empty.
+
+---
+
+### User Story 3 - Filter Pipelines by Search (Priority: P2)
+
+A developer presses `/` to activate a search/filter input at the top of the left pane. As they type, the list filters in real-time to show only pipelines whose names match the query (case-insensitive substring match). Pressing Escape clears the filter and restores the full list. The filter applies across all three sections simultaneously.
+
+**Why this priority**: Search becomes important as the number of pipelines grows, but the list is usable without it for smaller projects. It enhances efficiency but is not a prerequisite for core navigation.
+
+**Independent Test**: Can be tested by rendering a list with 10+ pipelines, activating search with `/`, typing a partial name, and verifying the displayed items match the query across all sections.
+
+**Acceptance Scenarios**:
+
+1. **Given** the left pane is focused, **When** the user presses `/`, **Then** a text input field appears at the top of the pane with a cursor and filter icon.
+2. **Given** the filter input is active and the user types "spec", **When** the list re-renders, **Then** only pipelines whose names contain "spec" (case-insensitive) remain visible.
+3. **Given** the filter is active with results showing, **When** the user presses Escape, **Then** the filter input closes, the query clears, and the full list is restored.
+4. **Given** the filter matches zero pipelines, **When** the list renders, **Then** a "No matching pipelines" message is displayed.
+5. **Given** the filter is active, **When** the user presses ↑/↓, **Then** navigation works within the filtered results.
+
+---
+
+### User Story 4 - Scroll Through Long Pipeline Lists (Priority: P2)
+
+A developer with many pipelines (more items than fit in the visible area) scrolls the list using arrow key navigation. The viewport follows the selection cursor, keeping the selected item visible. Section headers remain contextually visible when scrolling through their items.
+
+**Why this priority**: Scrolling is necessary for real-world usage but only becomes critical when the pipeline count exceeds the terminal height. Most early users will have fewer pipelines, so this is secondary to basic rendering and navigation.
+
+**Independent Test**: Can be tested by creating a list taller than the available content height, navigating past the visible area, and verifying the viewport scrolls to keep the selected item in view.
+
+**Acceptance Scenarios**:
+
+1. **Given** the list contains more items than the visible height allows, **When** the user navigates past the bottom edge, **Then** the viewport scrolls down to keep the selected item visible.
+2. **Given** the viewport has scrolled down, **When** the user navigates back up past the top edge, **Then** the viewport scrolls up accordingly.
+3. **Given** a section has many items, **When** scrolling through them, **Then** the section header remains visible or the current section context is otherwise indicated.
+
+---
+
+### User Story 5 - Collapse and Expand Sections (Priority: P3)
+
+A developer can collapse a section (e.g., the Available section) to reduce visual noise and focus on Running or Finished pipelines. Pressing a toggle key on a section header collapses or expands that section. Collapsed sections show only the header with count and a collapsed indicator.
+
+**Why this priority**: Section collapsing is a convenience feature that improves the experience with many pipelines but is not required for core functionality.
+
+**Independent Test**: Can be tested by rendering all three sections, collapsing one, verifying items are hidden, and expanding it again to restore visibility.
+
+**Acceptance Scenarios**:
+
+1. **Given** the cursor is on a section header, **When** the user presses Enter or a toggle key, **Then** the section collapses — hiding all items and showing a collapsed indicator (▸) on the header.
+2. **Given** a section is collapsed, **When** the user presses the toggle key on its header, **Then** the section expands and all items reappear.
+3. **Given** a section is collapsed, **When** the user navigates with ↑/↓, **Then** the cursor skips over the hidden items and moves to the next visible item or section header.
+
+---
+
+### Edge Cases
+
+- What happens when the SQLite state database is inaccessible or empty? The Running and Finished sections show zero items; the Available section still populates from `wave.yaml`.
+- What happens when `wave.yaml` is missing or malformed? The Available section shows an error indicator; Running and Finished sections still populate from the database.
+- What happens when the terminal is resized below the minimum width? The left pane degrades gracefully — truncates pipeline names rather than breaking layout.
+- What happens when a pipeline run changes status while the TUI is open (e.g., running → completed)? The list updates on the next data refresh tick (5-second polling interval for run state, matching the urgency of running pipeline status), moving the item from Running to Finished.
+- What happens when a pipeline name is very long? The name is truncated with ellipsis (…) to fit within the pane width.
+- What happens when all sections are empty? A centered "No pipelines found" placeholder is shown in the left pane.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST render a left pane in the main content area displaying pipeline items grouped into three sections: Running, Finished, and Available. The left pane occupies 30% of the content area width (minimum 25 columns, maximum 50 columns). The remaining width is reserved for a future right detail pane (rendered as empty/placeholder for now).
+- **FR-002**: Each section header MUST display the section name and the count of items in parentheses (e.g., "Running (2)"). Section headers are navigable items in the cursor list.
+- **FR-003**: Running section items MUST display the pipeline name and an elapsed time indicator, sorted newest-first by start time.
+- **FR-004**: Finished section items MUST display the pipeline name, terminal status (completed/failed/cancelled), and total duration.
+- **FR-005**: Available section items MUST display pipeline names discovered from the pipeline manifest directory, sorted alphabetically.
+- **FR-006**: System MUST support ↑/↓ arrow key navigation with a visual selection indicator (▶ for pipeline items, bold/inverse for section headers) that moves through all navigable items including section headers.
+- **FR-007**: Navigation MUST clamp at list boundaries — no wrapping from top to bottom or vice versa.
+- **FR-008**: System MUST emit a `PipelineSelectedMsg` (reusing the existing message type from `header_messages.go`) when the cursor moves to a pipeline item. For Running/Finished items, the message includes `RunID` and `BranchName` from the `RunRecord`. For Available items, `RunID` is empty and `BranchName` is empty. Moving to a section header does NOT emit a selection message.
+- **FR-009**: System MUST support a `/` key binding that activates a text filter input for case-insensitive substring matching across all sections.
+- **FR-010**: System MUST support Escape key to dismiss the filter input and restore the full list.
+- **FR-011**: System MUST scroll the viewport to keep the selected item visible when the list exceeds the visible area height.
+- **FR-012**: The left pane MUST be focused by default when the TUI launches.
+- **FR-013**: Running pipelines MUST query their data from the SQLite state database via a `PipelineDataProvider` interface (following the `MetadataProvider` pattern from `header_provider.go`). The provider wraps `GetRunningRuns()` from the `StateStore`.
+- **FR-014**: Finished pipelines MUST query their data from the SQLite state database via the same `PipelineDataProvider` interface, wrapping `ListRuns()` with a terminal status filter. Default limit: 20 most recent finished runs.
+- **FR-015**: Available pipelines MUST be loaded using the existing `DiscoverPipelines` function or equivalent manifest-based discovery, also exposed via the `PipelineDataProvider` interface.
+- **FR-016**: System SHOULD support section collapse/expand toggling on section headers.
+- **FR-017**: System MUST integrate with the existing `ContentModel` component, replacing the placeholder text currently rendered in `content.go`. The `ContentModel` is refactored to compose a `PipelineListModel` (left pane) and a placeholder right pane using `lipgloss.JoinHorizontal`.
+- **FR-018**: System MUST respect `NO_COLOR` environment variable and terminal theme conventions via lipgloss.
+- **FR-019**: System MUST poll for data updates using a `tea.Tick` at a 5-second interval for run state (Running/Finished sections). Available pipelines are loaded once at startup and on manifest change.
+
+### Key Entities
+
+- **PipelineListModel**: The Bubble Tea model for the left pane, implementing `Init()`, `Update()`, and `View()`. Owns the section data, selection state, filter state, and scroll offset.
+- **PipelineListSection**: A grouping container (Running, Finished, Available) with a label, item count, collapsed state, and a slice of `PipelineListItem`.
+- **PipelineListItem**: A single entry within a section — holds a pipeline name, display metadata (status, elapsed time, duration), and a reference to the underlying data source (RunRecord for Running/Finished, PipelineInfo for Available).
+- **PipelineDataProvider**: Interface for fetching pipeline data, following the `MetadataProvider` pattern. Methods: `FetchRunningPipelines() ([]RunRecord, error)`, `FetchFinishedPipelines(limit int) ([]RunRecord, error)`, `FetchAvailablePipelines() ([]PipelineInfo, error)`. Enables mock injection for testing.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: All three sections (Running, Finished, Available) render correctly with accurate counts when the TUI launches with known pipeline data.
+- **SC-002**: Arrow key navigation traverses all navigable items (section headers and pipeline items) across all sections in the correct order without errors or panics.
+- **SC-003**: The `/` search filter reduces the displayed list to only matching items within 1 render cycle of each keystroke.
+- **SC-004**: Viewport scrolling keeps the selected item visible for lists up to 100 items tall.
+- **SC-005**: The left pane renders without visual artifacts at terminal widths from 80 to 300 columns and heights from 24 to 100 rows.
+- **SC-006**: Component integration with the existing `AppModel` and `ContentModel` does not break any existing tests (`go test ./internal/tui/...` passes).
+- **SC-007**: The pipeline list correctly reflects state database contents, verified by unit tests with mock `PipelineDataProvider` implementations.
+
+## Clarifications _(resolved during refinement)_
+
+### C1: Content area split strategy (left pane width and layout)
+
+**Ambiguity**: The current `ContentModel` is a single component with no left/right split. FR-001 references a "left pane" but the spec did not define width ratio, right pane behavior, or how `ContentModel` is refactored.
+
+**Resolution**: The left pane occupies 30% of the content area width (min 25 columns, max 50 columns). `ContentModel` is refactored to compose a `PipelineListModel` (left) and a placeholder right pane using `lipgloss.JoinHorizontal`. This matches standard TUI sidebar patterns (e.g., k9s, lazygit) and leaves room for the detail pane in a future issue.
+
+**Rationale**: 30% is the industry-standard sidebar ratio for master-detail TUI layouts. Min/max bounds ensure usability at both 80-column and ultra-wide terminals.
+
+### C2: Section headers as navigable cursor targets
+
+**Ambiguity**: US-2 says cursor "moves seamlessly across section boundaries" (could imply headers are skipped), but US-5 says "the cursor is on a section header" for collapse (requires headers to be navigable).
+
+**Resolution**: Section headers ARE navigable items in the cursor list. The cursor traverses: `[Running header] → [running item 1] → ... → [Finished header] → [finished item 1] → ... → [Available header] → [available item 1] → ...`. Section headers use a visually distinct selection style (bold/inverse) compared to pipeline items (▶ indicator). Selection messages are only emitted when a pipeline item (not a header) is selected.
+
+**Rationale**: Making headers navigable is required for the collapse/expand feature (US-5). It also provides clear visual orientation when scrolling through long lists. The distinct styling prevents user confusion between selecting a header vs. an item.
+
+### C3: Data refresh mechanism (polling interval and approach)
+
+**Ambiguity**: Edge case mentions "next data refresh cycle" but the spec did not define the polling interval, refresh approach, or which sections refresh.
+
+**Resolution**: A `tea.Tick` at 5-second intervals triggers a data refresh for Running and Finished sections. Available pipelines are loaded once at startup (and could be refreshed on manifest file change in a future enhancement). This interval balances responsiveness (running pipelines need timely updates) with system load. The header already uses `gitRefreshInterval = 30 * time.Second` for lower-priority git state; 5 seconds is appropriate for active pipeline monitoring.
+
+**Rationale**: 5 seconds provides near-real-time feedback for running pipelines while being reasonable for SQLite read load. It's a common polling interval in monitoring dashboards (e.g., Grafana defaults to 5s).
+
+### C4: Selection message type for mixed item types
+
+**Ambiguity**: `PipelineSelectedMsg` already exists in `header_messages.go` with `RunID` and `BranchName` fields. The spec's FR-008 said "a message is emitted" but didn't specify whether to reuse the existing type. Available pipelines have no `RunID`, creating a type mismatch.
+
+**Resolution**: Reuse the existing `PipelineSelectedMsg` type. For Running/Finished items, populate `RunID` and `BranchName` from the `RunRecord`. For Available items, send with empty `RunID` and empty `BranchName`. The header already handles `PipelineSelectedMsg` for branch override display, so this maintains consistency. No new message types needed.
+
+**Rationale**: Reusing the existing message avoids message type proliferation and leverages the header's existing `PipelineSelectedMsg` handler. Empty `RunID` is a clear sentinel for "no active run" which downstream components can branch on.
+
+### C5: State store injection pattern (provider interface)
+
+**Ambiguity**: FR-013/014 reference `GetRunningRuns` and `ListRuns` from the state database, but the spec didn't specify how the state store is injected into the pipeline list component. The TUI already uses a `MetadataProvider` interface for the header — should the list follow the same pattern?
+
+**Resolution**: Introduce a `PipelineDataProvider` interface following the established `MetadataProvider` pattern from `header_provider.go`. The interface wraps `FetchRunningPipelines()`, `FetchFinishedPipelines(limit)`, and `FetchAvailablePipelines()`. A `DefaultPipelineDataProvider` implementation wraps the `StateStore` (using `NewReadOnlyStateStore` for concurrent access) and `DiscoverPipelines`. This enables straightforward mock injection in tests.
+
+**Rationale**: The provider interface pattern is already proven in the codebase (`MetadataProvider` / `DefaultMetadataProvider`). It decouples the TUI component from the state package, enables unit testing with mocks, and allows future data source changes without modifying the list component.

--- a/specs/254-tui-pipeline-list/tasks.md
+++ b/specs/254-tui-pipeline-list/tasks.md
@@ -1,0 +1,298 @@
+# Tasks: TUI Pipeline List Left Pane
+
+**Feature**: #254 — TUI Pipeline List Left Pane
+**Branch**: `254-tui-pipeline-list`
+**Generated**: 2026-03-05
+**Spec**: `specs/254-tui-pipeline-list/spec.md`
+**Plan**: `specs/254-tui-pipeline-list/plan.md`
+
+---
+
+## Phase 1: Setup & Data Layer
+
+- [X] T001 [P1] [Setup] Define `RunningPipeline` and `FinishedPipeline` value types in `internal/tui/pipeline_provider.go`
+  - Create TUI-specific projection types derived from `state.RunRecord`
+  - `RunningPipeline`: `RunID`, `Name`, `BranchName`, `StartedAt time.Time`
+  - `FinishedPipeline`: `RunID`, `Name`, `BranchName`, `Status string`, `StartedAt time.Time`, `CompletedAt time.Time`, `Duration time.Duration`
+  - File: `internal/tui/pipeline_provider.go`
+
+- [X] T002 [P1] [Setup] Define `PipelineDataProvider` interface in `internal/tui/pipeline_provider.go`
+  - Follow the `MetadataProvider` pattern from `header_metadata.go:79`
+  - Methods: `FetchRunningPipelines() ([]RunningPipeline, error)`, `FetchFinishedPipelines(limit int) ([]FinishedPipeline, error)`, `FetchAvailablePipelines() ([]PipelineInfo, error)`
+  - File: `internal/tui/pipeline_provider.go`
+
+- [X] T003 [P1] [Setup] Implement `DefaultPipelineDataProvider` in `internal/tui/pipeline_provider.go`
+  - Wraps `state.StateStore` (via `NewReadOnlyStateStore`) + `DiscoverPipelines`
+  - `FetchRunningPipelines()` → calls `store.GetRunningRuns()`, maps `state.RunRecord` → `RunningPipeline`
+  - `FetchFinishedPipelines(limit)` → calls `store.ListRuns(ListRunsOptions{Limit: limit*3})`, filters in Go for terminal statuses (completed/failed/cancelled), takes first `limit` results, maps to `FinishedPipeline`
+  - `FetchAvailablePipelines()` → calls `DiscoverPipelines(pipelinesDir)`
+  - File: `internal/tui/pipeline_provider.go`
+
+- [X] T004 [P1] [Setup] [P] Define `PipelineDataMsg` and `PipelineRefreshTickMsg` message types in `internal/tui/pipeline_messages.go`
+  - `PipelineDataMsg`: `Running []RunningPipeline`, `Finished []FinishedPipeline`, `Available []PipelineInfo`, `Err error`
+  - `PipelineRefreshTickMsg`: empty struct (timer tick)
+  - File: `internal/tui/pipeline_messages.go`
+
+- [X] T005 [P1] [Setup] Write tests for `DefaultPipelineDataProvider` in `internal/tui/pipeline_provider_test.go`
+  - Mock `state.StateStore` to return known `RunRecord` slices
+  - Verify `RunningPipeline` mapping (name, runID, branchName, startedAt)
+  - Verify `FinishedPipeline` mapping with duration computation
+  - Verify terminal status filtering (only completed/failed/cancelled)
+  - Verify `FetchAvailablePipelines` calls `DiscoverPipelines`
+  - Verify error propagation from store
+  - File: `internal/tui/pipeline_provider_test.go`
+
+---
+
+## Phase 2: Foundational — Navigation Types & Core List Model
+
+- [X] T006 [P1] [US-1] Define `navigableItem`, `itemKind`, and `PipelineListModel` struct in `internal/tui/pipeline_list.go`
+  - `itemKind` enum: `itemKindSectionHeader`, `itemKindRunning`, `itemKindFinished`, `itemKindAvailable`
+  - `navigableItem`: `kind itemKind`, `sectionIndex int`, `dataIndex int`, `label string`
+  - `PipelineListModel` struct: `width`, `height`, `provider`, `running []RunningPipeline`, `finished []FinishedPipeline`, `available []PipelineInfo`, `cursor int`, `navigable []navigableItem`, `filtering bool`, `filterInput textinput.Model`, `filterQuery string`, `collapsed [3]bool`, `focused bool`, `scrollOffset int`
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T007 [P1] [US-1] Implement `NewPipelineListModel(provider)` constructor and `Init()` in `internal/tui/pipeline_list.go`
+  - Constructor: initializes `filterInput` from `textinput.New()`, sets `focused: true`
+  - `Init()`: returns `tea.Batch(fetchPipelineData, refreshTick())` where `refreshTick` uses 5-second `tea.Tick` returning `PipelineRefreshTickMsg`
+  - `fetchPipelineData`: async command calling all three provider methods, returning `PipelineDataMsg`
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T008 [P1] [US-1] Implement `buildNavigableItems()` in `internal/tui/pipeline_list.go`
+  - Builds flat slice from sections: `[Running header] → [running items...] → [Finished header] → [finished items...] → [Available header] → [available items...]`
+  - Respects `collapsed` state: collapsed sections include header only, skip items
+  - Respects `filterQuery`: when filtering, include only items whose name contains the query (case-insensitive substring); always include section headers even when filtering (but hide headers with zero matching items)
+  - Section header labels: `"Running (N)"`, `"Finished (N)"`, `"Available (N)"` where N is the count of items (after filtering)
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T009 [P1] [US-1] Implement `View()` for section rendering in `internal/tui/pipeline_list.go`
+  - Render each `navigableItem` with appropriate styling per `itemKind`
+  - Section headers: bold text, collapsed indicator `▸`/`▾` prefix
+  - Running items: `"  name   2m30s"` with elapsed time from `time.Since(StartedAt)`
+  - Finished items: `"  name   ✓ completed  1m15s"` or `"  name   ✗ failed  45s"` or `"  name   ✗ cancelled  30s"`
+  - Available items: `"  name"`
+  - Truncate pipeline names with `…` when exceeding pane width minus indicator and metadata
+  - Empty state: `"No pipelines found"` centered when all sections empty
+  - Handle `width <= 0 || height <= 0` gracefully
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T010 [P1] [US-1] Implement `Update()` for `PipelineDataMsg` and `PipelineRefreshTickMsg` in `internal/tui/pipeline_list.go`
+  - `PipelineDataMsg`: update `running`, `finished`, `available` fields; call `buildNavigableItems()`; clamp cursor to new bounds; emit `RunningCountMsg{Count: len(running)}` as a command; if cursor is on a pipeline item, re-emit `PipelineSelectedMsg`
+  - `PipelineRefreshTickMsg`: return `tea.Batch(fetchPipelineData, refreshTick())`
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T011 [P1] [US-1] Implement `SetSize(w, h)` for resize handling in `internal/tui/pipeline_list.go`
+  - Update `width` and `height` fields
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T012 [P1] [US-1] Write tests for section rendering in `internal/tui/pipeline_list_test.go`
+  - Create a `mockPipelineDataProvider` returning known data
+  - Test: all three sections render with correct counts in headers
+  - Test: running items show elapsed time format
+  - Test: finished items show status icon and duration
+  - Test: available items show name only
+  - Test: empty sections show header with count 0
+  - Test: all sections empty shows "No pipelines found"
+  - Test: long pipeline names are truncated with `…`
+  - File: `internal/tui/pipeline_list_test.go`
+
+---
+
+## Phase 3: User Story 2 — Keyboard Navigation (P1)
+
+- [X] T013 [P1] [US-2] Implement `Update()` key handling for ↑/↓ navigation in `internal/tui/pipeline_list.go`
+  - `tea.KeyUp`: decrement `cursor`, clamp at 0 (no wrap)
+  - `tea.KeyDown`: increment `cursor`, clamp at `len(navigable)-1` (no wrap)
+  - After cursor change: if new item is a pipeline item (not header), emit `PipelineSelectedMsg` with appropriate `RunID`/`BranchName` (empty for Available items)
+  - If new item is a section header, do NOT emit `PipelineSelectedMsg`
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T014 [P1] [US-2] Implement selection indicator rendering in `View()` in `internal/tui/pipeline_list.go`
+  - Selected pipeline item: prepend `▶ ` and use distinct foreground color (cyan)
+  - Selected section header: render with bold + inverse style
+  - Unselected items: normal rendering (no indicator prefix)
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T015 [P1] [US-2] Write tests for keyboard navigation in `internal/tui/pipeline_list_test.go`
+  - Test: ↓ moves cursor from 0 to 1
+  - Test: ↑ at cursor 0 stays at 0 (no wrap)
+  - Test: ↓ at last item stays at last (no wrap)
+  - Test: cross-section traversal (last running item → finished header → first finished item)
+  - Test: `PipelineSelectedMsg` emitted when cursor moves to pipeline item
+  - Test: `PipelineSelectedMsg` NOT emitted when cursor is on section header
+  - Test: `PipelineSelectedMsg` for Running item includes `RunID` and `BranchName`
+  - Test: `PipelineSelectedMsg` for Available item has empty `RunID` and `BranchName`
+  - File: `internal/tui/pipeline_list_test.go`
+
+---
+
+## Phase 4: User Story 3 — Search/Filter (P2)
+
+- [X] T016 [P2] [US-3] Implement filter activation and dismissal in `Update()` in `internal/tui/pipeline_list.go`
+  - `/` key: set `filtering = true`, focus `filterInput`, clear previous query
+  - `Escape` key (when filtering): set `filtering = false`, clear `filterQuery`, rebuild navigable items, reset cursor to 0
+  - When filtering: forward key events to `filterInput.Update()`; on each change, update `filterQuery` from `filterInput.Value()`, rebuild navigable items
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T017 [P2] [US-3] Implement filter input rendering in `View()` in `internal/tui/pipeline_list.go`
+  - When `filtering` is true: render filter input at the top of the pane with a search icon (🔍 or `/`) and the `filterInput.View()` output
+  - Reduce available height for items by 1 line when filter input is visible
+  - When filter matches zero items: display `"No matching pipelines"` message
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T018 [P2] [US-3] Write tests for search/filter in `internal/tui/pipeline_list_test.go`
+  - Test: `/` key activates filter mode
+  - Test: typing "spec" filters to only pipelines containing "spec" (case-insensitive)
+  - Test: filter applies across all sections simultaneously
+  - Test: Escape dismisses filter and restores full list
+  - Test: filter with zero matches shows "No matching pipelines"
+  - Test: ↑/↓ navigation works within filtered results
+  - File: `internal/tui/pipeline_list_test.go`
+
+---
+
+## Phase 5: User Story 4 — Viewport Scrolling (P2)
+
+- [X] T019 [P2] [US-4] Implement viewport scrolling in `View()` in `internal/tui/pipeline_list.go`
+  - Calculate visible window: `scrollOffset` adjusted so cursor is always within `[scrollOffset, scrollOffset + visibleHeight)`
+  - When cursor moves below visible area: scroll down
+  - When cursor moves above visible area: scroll up
+  - Render only the items within the visible window
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T020 [P2] [US-4] Write tests for viewport scrolling in `internal/tui/pipeline_list_test.go`
+  - Test: with height=5 and 20 items, navigating to item 6 scrolls viewport
+  - Test: scrolling back up keeps selected item visible
+  - Test: cursor at top of viewport doesn't scroll unnecessarily
+  - File: `internal/tui/pipeline_list_test.go`
+
+---
+
+## Phase 6: User Story 5 — Section Collapse/Expand (P3)
+
+- [X] T021 [P3] [US-5] Implement collapse/expand toggle in `Update()` in `internal/tui/pipeline_list.go`
+  - Enter key on a section header: toggle `collapsed[sectionIndex]`
+  - After toggle: rebuild navigable items; if cursor was on a now-hidden item, move cursor to the section header
+  - File: `internal/tui/pipeline_list.go`
+
+- [X] T022 [P3] [US-5] Write tests for collapse/expand in `internal/tui/pipeline_list_test.go`
+  - Test: Enter on Running header collapses Running section, items hidden
+  - Test: Enter again on collapsed header expands it, items reappear
+  - Test: cursor skips hidden items during ↑/↓ navigation
+  - Test: collapsed section header shows `▸` indicator, expanded shows `▾`
+  - File: `internal/tui/pipeline_list_test.go`
+
+---
+
+## Phase 7: ContentModel Refactoring & App Integration
+
+- [X] T023 [P1] [Integration] Refactor `ContentModel` to compose `PipelineListModel` in `internal/tui/content.go`
+  - Add `list PipelineListModel` field to `ContentModel`
+  - Update `NewContentModel(provider PipelineDataProvider)` to accept and forward provider
+  - Add `Init()` method delegating to `list.Init()`
+  - Add `Update(msg) (ContentModel, tea.Cmd)` method forwarding messages to `list.Update()`
+  - Implement `View()` with left/right split: left pane width = `min(max(width*30/100, 25), 50)`, right pane = placeholder "Select a pipeline to view details"
+  - Use `lipgloss.JoinHorizontal(lipgloss.Top, leftView, rightView)`
+  - Propagate `SetSize` to list model with computed left pane width and full content height
+  - File: `internal/tui/content.go`
+
+- [X] T024 [P1] [Integration] Update `AppModel` to accept and forward `PipelineDataProvider` in `internal/tui/app.go`
+  - Update `NewAppModel(metaProvider MetadataProvider, pipelineProvider PipelineDataProvider)` signature
+  - Pass `pipelineProvider` to `NewContentModel(pipelineProvider)`
+  - Update `Init()` to `tea.Batch(m.header.Init(), m.content.Init())`
+  - Update `Update()`: forward messages to `m.content.Update()` and collect commands from both header and content
+  - Route ↑/↓, `/`, Escape, Enter keys to content when not in quit flow
+  - Update `RunTUI()` to create `DefaultPipelineDataProvider` and pass both providers
+  - File: `internal/tui/app.go`
+
+- [X] T025 [P1] [Integration] Update `content_test.go` for refactored `ContentModel` in `internal/tui/content_test.go`
+  - Replace "Pipelines view coming soon" assertions with new left/right pane assertions
+  - Test: left pane width is 30% (min 25, max 50) of total width
+  - Test: placeholder right pane renders
+  - Test: `SetSize` propagates to list model
+  - Test: `Init()` returns commands from list model
+  - File: `internal/tui/content_test.go`
+
+- [X] T026 [P1] [Integration] Update `app_test.go` for new `NewAppModel` signature in `internal/tui/app_test.go`
+  - Add `mockPipelineDataProvider` to test helpers (or reuse from `pipeline_list_test.go`)
+  - Update all `NewAppModel(&mockProvider{})` calls to `NewAppModel(&mockProvider{}, &mockPipelineDataProvider{})`
+  - Test: `Init()` returns batch including content init commands
+  - Test: `WindowSizeMsg` propagates to content with correct dimensions
+  - Test: key events (↑/↓) forwarded to content model
+  - Test: `PipelineSelectedMsg` flows from content to header (existing test updated)
+  - Remove or update assertion for "Pipelines view coming soon" in `TestAppModel_View_AfterReady`
+  - File: `internal/tui/app_test.go`
+
+---
+
+## Phase 8: Polish & Cross-Cutting
+
+- [X] T027 [P2] [Polish] [P] Update status bar key hints in `internal/tui/statusbar.go`
+  - Add `↑↓: navigate  /: filter` hints to the existing hint string
+  - File: `internal/tui/statusbar.go`
+
+- [X] T028 [P1] [Polish] Verify all existing tests pass with `go test ./internal/tui/...`
+  - Run full TUI test suite
+  - Fix any regressions from ContentModel/AppModel refactoring
+  - Ensure no test uses `t.Skip()` without a linked issue
+
+- [X] T029 [P1] [Polish] Verify full project tests pass with `go test ./...`
+  - Run complete project test suite
+  - Ensure no regressions outside TUI package
+
+- [X] T030 [P2] [Polish] [P] Verify `NO_COLOR` compliance in pipeline list rendering
+  - Ensure lipgloss respects `NO_COLOR` environment variable
+  - No hardcoded ANSI escape sequences — all styling via lipgloss
+
+---
+
+## Dependency Graph
+
+```
+T001 ─┬─► T002 ─► T003 ─► T005
+      │
+T004 ─┘
+      │
+      ▼
+T006 ─► T007 ─► T008 ─► T009 ─► T010 ─► T011 ─► T012
+                                    │
+                                    ▼
+                              T013 ─► T014 ─► T015
+                                        │
+                                        ▼
+                                  T016 ─► T017 ─► T018
+                                            │
+                                            ▼
+                                      T019 ─► T020
+                                        │
+                                        ▼
+                                  T021 ─► T022
+                                        │
+                                        ▼
+                              T023 ─► T024 ─► T025
+                                        │       │
+                                        ▼       ▼
+                                      T026    T027 [P]
+                                        │
+                                        ▼
+                                  T028 ─► T029
+                                    │
+                                    ▼
+                                  T030 [P]
+```
+
+## Summary
+
+| Phase | Tasks | Description |
+|-------|-------|-------------|
+| Phase 1: Setup & Data Layer | T001–T005 | Provider interface, value types, messages, tests |
+| Phase 2: Core List Model | T006–T012 | Navigation types, model struct, View/Update, section rendering |
+| Phase 3: Navigation (P1) | T013–T015 | ↑/↓ keyboard nav, selection indicators, PipelineSelectedMsg |
+| Phase 4: Filter (P2) | T016–T018 | `/` search activation, real-time filtering, Escape dismissal |
+| Phase 5: Scrolling (P2) | T019–T020 | Viewport follows cursor, visible window calculation |
+| Phase 6: Collapse (P3) | T021–T022 | Section toggle on Enter, cursor skip over hidden items |
+| Phase 7: Integration | T023–T026 | ContentModel refactor, AppModel wiring, test updates |
+| Phase 8: Polish | T027–T030 | Status bar hints, test verification, NO_COLOR compliance |
+
+**Total tasks**: 30
+**Parallelizable**: T004, T027, T030 (marked with [P])


### PR DESCRIPTION
## Summary

Implements the pipeline list left pane (#254), part 3 of the TUI epic (#251).

- **Pipeline data provider** — `PipelineDataProvider` interface with `DefaultPipelineDataProvider` wrapping StateStore and manifest pipeline discovery, enabling decoupled data access and testability
- **Three-section list** — Running (with elapsed time), Finished (with status/duration), and Available pipelines displayed in collapsible sections with item counts
- **Keyboard navigation** — Flat cursor traversal across section headers and pipeline items with ↑/↓ keys, section collapse/expand with Enter on headers, and `PipelineSelectedMsg` emission on selection changes
- **Real-time search filtering** — `/` activates filter mode with incremental text matching; Esc clears and exits filter mode
- **Content layout** — `ContentModel` refactored to compose `PipelineListModel` (left, 30% width) and placeholder detail pane (right) via `lipgloss.JoinHorizontal`
- **Polling refresh** — 5-second tick updates running/finished pipeline state

Closes #254

## Spec

[`specs/254-tui-pipeline-list/spec.md`](specs/254-tui-pipeline-list/spec.md)

## Test Plan

- 25+ unit tests covering `PipelineListModel` (navigation, filtering, section collapse, viewport scrolling, edge cases)
- 11 unit tests for `PipelineDataProvider` (state store integration, manifest discovery, error handling)
- Updated `AppModel` and `ContentModel` tests for new composition and message routing
- All tests pass with `-race` flag: `go test -race ./...`

## Dependencies

- #252 — TUI Bubble Tea scaffold (merged)
- #253 — Header bar with animated logo (merged)