### PR TITLE
feat(tui): pipeline launch flow with argument form and executor integration

### DIFF
--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/cmd/wave/commands"
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -31,7 +34,32 @@ var rootCmd = &cobra.Command{
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if shouldLaunchTUI(cmd) {
-			return tui.RunTUI()
+			deps := tui.LaunchDependencies{}
+
+			// Attempt to load manifest for pipeline launching
+			manifestPath, _ := cmd.Root().PersistentFlags().GetString("manifest")
+			if manifestPath == "" {
+				manifestPath = "wave.yaml"
+			}
+			data, err := os.ReadFile(manifestPath)
+			if err == nil {
+				var m manifest.Manifest
+				if yamlErr := yaml.Unmarshal(data, &m); yamlErr == nil {
+					deps.Manifest = &m
+				}
+			}
+
+			// Attempt to open state store
+			store, err := state.NewStateStore(".wave/state.db")
+			if err == nil {
+				deps.Store = store
+				defer store.Close()
+			}
+
+			// Determine pipelines directory (default .wave/pipelines)
+			deps.PipelinesDir = ".wave/pipelines"
+
+			return tui.RunTUI(deps)
 		}
 		return cmd.Help()
 	},

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -27,10 +27,10 @@ type AppModel struct {
 }
 
 // NewAppModel creates a new root app model with default child components.
-func NewAppModel(metaProvider MetadataProvider, pipelineProvider PipelineDataProvider, detailProvider DetailDataProvider) AppModel {
+func NewAppModel(metaProvider MetadataProvider, pipelineProvider PipelineDataProvider, detailProvider DetailDataProvider, deps LaunchDependencies) AppModel {
 	return AppModel{
 		header:    NewHeaderModel(metaProvider),
-		content:   NewContentModel(pipelineProvider, detailProvider),
+		content:   NewContentModel(pipelineProvider, detailProvider, deps),
 		statusBar: NewStatusBarModel(),
 	}
 }
@@ -52,9 +52,11 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				os.Exit(0)
 			}
 			m.shuttingDown = true
+			m.content.CancelAll()
 			return m, tea.Quit
 		default:
-			if msg.String() == "q" && !m.content.list.filtering {
+			if msg.String() == "q" && !m.content.list.filtering && m.content.focus == FocusPaneLeft {
+				m.content.CancelAll()
 				return m, tea.Quit
 			}
 		}
@@ -88,8 +90,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, contentCmd)
 	}
 
-	// Forward FocusChangedMsg to status bar
-	if _, ok := msg.(FocusChangedMsg); ok {
+	// Forward FocusChangedMsg and FormActiveMsg to status bar
+	switch msg.(type) {
+	case FocusChangedMsg, FormActiveMsg:
 		m.statusBar, _ = m.statusBar.Update(msg)
 	}
 
@@ -118,9 +121,9 @@ func (m AppModel) View() string {
 }
 
 // RunTUI creates and runs the Bubble Tea program with alternate screen.
-func RunTUI() error {
+func RunTUI(deps LaunchDependencies) error {
 	metaProvider := &DefaultMetadataProvider{}
-	p := tea.NewProgram(NewAppModel(metaProvider, nil, nil), tea.WithAltScreen())
+	p := tea.NewProgram(NewAppModel(metaProvider, nil, nil, deps), tea.WithAltScreen())
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -40,7 +40,7 @@ func (m *mockPipelineDataProvider) FetchAvailablePipelines() ([]PipelineInfo, er
 }
 
 func TestNewAppModel_InitialState(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	assert.False(t, m.ready)
 	assert.False(t, m.shuttingDown)
 	assert.Equal(t, 0, m.width)
@@ -49,20 +49,20 @@ func TestNewAppModel_InitialState(t *testing.T) {
 }
 
 func TestAppModel_Init_ReturnsCmds(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	cmd := m.Init()
 	// Header.Init() returns a batch of async fetch commands
 	assert.NotNil(t, cmd)
 }
 
 func TestAppModel_Init_IncludesContentCmds(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	cmd := m.Init()
 	assert.NotNil(t, cmd)
 }
 
 func TestAppModel_Update_WindowSizeMsg(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 
 	updated, _ := m.Update(msg)
@@ -78,7 +78,7 @@ func TestAppModel_Update_WindowSizeMsg(t *testing.T) {
 }
 
 func TestAppModel_Update_WindowSizeMsg_PropagatesContent(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
@@ -92,7 +92,7 @@ func TestAppModel_Update_WindowSizeMsg_PropagatesContent(t *testing.T) {
 }
 
 func TestAppModel_Update_QuitOnQ(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
 
 	_, cmd := m.Update(msg)
@@ -104,7 +104,7 @@ func TestAppModel_Update_QuitOnQ(t *testing.T) {
 }
 
 func TestAppModel_Update_CtrlC_SetsShuttingDown(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
 
 	updated, cmd := m.Update(msg)
@@ -117,13 +117,13 @@ func TestAppModel_Update_CtrlC_SetsShuttingDown(t *testing.T) {
 }
 
 func TestAppModel_View_BeforeReady(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	view := m.View()
 	assert.Equal(t, "Initializing...", view)
 }
 
 func TestAppModel_View_AfterReady(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.WindowSizeMsg{Width: 120, Height: 40}
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
@@ -153,7 +153,7 @@ func TestAppModel_View_TooSmall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+			m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 			msg := tea.WindowSizeMsg{Width: tt.width, Height: tt.height}
 			updated, _ := m.Update(msg)
 			model := updated.(AppModel)
@@ -166,7 +166,7 @@ func TestAppModel_View_TooSmall(t *testing.T) {
 }
 
 func TestAppModel_View_ExactMinimumSize(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	msg := tea.WindowSizeMsg{Width: 80, Height: 24}
 	updated, _ := m.Update(msg)
 	model := updated.(AppModel)
@@ -182,7 +182,7 @@ func TestAppModel_View_ExactMinimumSize(t *testing.T) {
 // --- T033: App integration tests for header message forwarding ---
 
 func TestAppModel_Update_ForwardsGitStateMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	// First, set up with a window size
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
@@ -207,7 +207,7 @@ func TestAppModel_Update_ForwardsGitStateMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsManifestInfoMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -223,7 +223,7 @@ func TestAppModel_Update_ForwardsManifestInfoMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsPipelineHealthMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -235,7 +235,7 @@ func TestAppModel_Update_ForwardsPipelineHealthMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsRunningCountMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -249,7 +249,7 @@ func TestAppModel_Update_ForwardsRunningCountMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsPipelineSelectedMsgToHeader(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -264,7 +264,7 @@ func TestAppModel_Update_ForwardsPipelineSelectedMsgToHeader(t *testing.T) {
 }
 
 func TestAppModel_View_HeaderRendersForwardedData(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 40})
 	model := updated.(AppModel)
 
@@ -287,7 +287,7 @@ func TestAppModel_View_HeaderRendersForwardedData(t *testing.T) {
 }
 
 func TestAppModel_Update_ForwardsFocusChangedMsgToStatusBar(t *testing.T) {
-	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil)
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	model := updated.(AppModel)
 
@@ -297,4 +297,69 @@ func TestAppModel_Update_ForwardsFocusChangedMsgToStatusBar(t *testing.T) {
 	model = updated.(AppModel)
 
 	assert.Equal(t, FocusPaneRight, model.statusBar.focusPane)
+}
+
+// ===========================================================================
+// T019: App model tests for pipeline launch flow
+// ===========================================================================
+
+func TestAppModel_Update_QKeyWithFocusRight_DoesNotQuit(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
+	// Set up with a window size so the app is ready
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	model := updated.(AppModel)
+
+	// Set focus to right pane
+	model.content.focus = FocusPaneRight
+	model.content.list.SetFocused(false)
+	model.content.detail.SetFocused(true)
+
+	// Send q key
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	updated, cmd := model.Update(msg)
+	_ = updated
+
+	// Should NOT return a quit command
+	if cmd != nil {
+		result := cmd()
+		_, isQuit := result.(tea.QuitMsg)
+		assert.False(t, isQuit, "q key with right pane focus should not quit")
+	}
+}
+
+func TestAppModel_Update_QKeyWithFocusLeft_Quits(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+
+	_, cmd := m.Update(msg)
+	assert.NotNil(t, cmd)
+
+	quitMsg := cmd()
+	assert.IsType(t, tea.QuitMsg{}, quitMsg)
+}
+
+func TestAppModel_Update_CancelAllCalledOnCtrlC(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
+
+	// CancelAll is called inside Update for CtrlC. Verify the method
+	// does not panic when launcher is nil (no deps.Manifest provided).
+	msg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	updated, cmd := m.Update(msg)
+	model := updated.(AppModel)
+
+	assert.True(t, model.shuttingDown)
+	assert.NotNil(t, cmd)
+}
+
+func TestAppModel_Update_ForwardsFormActiveMsgToStatusBar(t *testing.T) {
+	m := NewAppModel(&mockProvider{}, &mockPipelineDataProvider{}, nil, LaunchDependencies{})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	model := updated.(AppModel)
+
+	// Send FormActiveMsg
+	formMsg := FormActiveMsg{Active: true}
+	updated, _ = model.Update(formMsg)
+	model = updated.(AppModel)
+
+	assert.True(t, model.statusBar.formActive)
 }

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -7,19 +7,32 @@ import (
 
 // ContentModel is the main content area component composing a left pipeline list pane and a right detail pane.
 type ContentModel struct {
-	width  int
-	height int
-	list   PipelineListModel
-	detail PipelineDetailModel
-	focus  FocusPane
+	width    int
+	height   int
+	list     PipelineListModel
+	detail   PipelineDetailModel
+	focus    FocusPane
+	launcher *PipelineLauncher
 }
 
 // NewContentModel creates a new content model with the given pipeline data providers.
-func NewContentModel(provider PipelineDataProvider, detailProvider DetailDataProvider) ContentModel {
+func NewContentModel(provider PipelineDataProvider, detailProvider DetailDataProvider, deps LaunchDependencies) ContentModel {
+	var launcher *PipelineLauncher
+	if deps.Manifest != nil {
+		launcher = NewPipelineLauncher(deps)
+	}
 	return ContentModel{
-		list:   NewPipelineListModel(provider),
-		detail: NewPipelineDetailModel(detailProvider),
-		focus:  FocusPaneLeft,
+		list:     NewPipelineListModel(provider),
+		detail:   NewPipelineDetailModel(detailProvider),
+		focus:    FocusPaneLeft,
+		launcher: launcher,
+	}
+}
+
+// CancelAll cancels all running pipelines managed by the launcher.
+func (m *ContentModel) CancelAll() {
+	if m.launcher != nil {
+		m.launcher.CancelAll()
 	}
 }
 
@@ -48,10 +61,27 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyEnter && m.focus == FocusPaneLeft && !m.list.filtering {
 			if m.cursorOnFocusableItem() {
+				item := m.list.navigable[m.list.cursor]
 				m.focus = FocusPaneRight
 				m.list.SetFocused(false)
 				m.detail.SetFocused(true)
-				return m, func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneRight} }
+
+				enterCmds := []tea.Cmd{
+					func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneRight} },
+				}
+
+				// For available items, also send ConfigureFormMsg to show the launch form
+				if item.kind == itemKindAvailable && item.dataIndex >= 0 && item.dataIndex < len(m.list.available) {
+					a := m.list.available[item.dataIndex]
+					enterCmds = append(enterCmds, func() tea.Msg {
+						return ConfigureFormMsg{PipelineName: a.Name, InputExample: a.InputExample}
+					})
+					enterCmds = append(enterCmds, func() tea.Msg {
+						return FormActiveMsg{Active: true}
+					})
+				}
+
+				return m, tea.Batch(enterCmds...)
 			}
 			// Section header or running item — forward to list for collapse/no-op
 			var cmd tea.Cmd
@@ -64,6 +94,18 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 			m.list.SetFocused(true)
 			m.detail.SetFocused(false)
 			return m, func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneLeft} }
+		}
+
+		// Cancel running pipeline with 'c' key
+		if msg.String() == "c" && m.focus == FocusPaneLeft && m.launcher != nil {
+			if len(m.list.navigable) > 0 && m.list.cursor < len(m.list.navigable) {
+				item := m.list.navigable[m.list.cursor]
+				if item.kind == itemKindRunning && item.dataIndex >= 0 && item.dataIndex < len(m.list.running) {
+					r := m.list.running[item.dataIndex]
+					m.launcher.Cancel(r.RunID)
+				}
+			}
+			return m, nil
 		}
 
 		// Route key messages to the focused child only
@@ -98,6 +140,63 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		var cmd tea.Cmd
 		m.list, cmd = m.list.Update(msg)
 		return m, cmd
+
+	case ConfigureFormMsg:
+		var cmd tea.Cmd
+		m.detail, cmd = m.detail.Update(msg)
+		return m, cmd
+
+	case LaunchRequestMsg:
+		if m.launcher != nil {
+			cmd := m.launcher.Launch(msg.Config)
+			return m, cmd
+		}
+		return m, nil
+
+	case PipelineLaunchedMsg:
+		// Forward to list for running entry insertion
+		var listCmd tea.Cmd
+		m.list, listCmd = m.list.Update(msg)
+		// Transition focus to left pane
+		m.focus = FocusPaneLeft
+		m.list.SetFocused(true)
+		m.detail.SetFocused(false)
+		focusCmd := func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneLeft} }
+		formCmd := func() tea.Msg { return FormActiveMsg{Active: false} }
+		batchCmds := []tea.Cmd{focusCmd, formCmd}
+		if listCmd != nil {
+			batchCmds = append(batchCmds, listCmd)
+		}
+		return m, tea.Batch(batchCmds...)
+
+	case PipelineLaunchResultMsg:
+		if m.launcher != nil {
+			m.launcher.Cleanup(msg.RunID)
+		}
+		return m, nil
+
+	case LaunchErrorMsg:
+		var cmd tea.Cmd
+		m.detail, cmd = m.detail.Update(msg)
+		// Transition focus to left pane
+		m.focus = FocusPaneLeft
+		m.list.SetFocused(true)
+		m.detail.SetFocused(false)
+		focusCmd := func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneLeft} }
+		formCmd := func() tea.Msg { return FormActiveMsg{Active: false} }
+		batchCmds := []tea.Cmd{focusCmd, formCmd}
+		if cmd != nil {
+			batchCmds = append(batchCmds, cmd)
+		}
+		return m, tea.Batch(batchCmds...)
+
+	case FocusChangedMsg:
+		if msg.Pane == FocusPaneLeft {
+			m.focus = FocusPaneLeft
+			m.list.SetFocused(true)
+			m.detail.SetFocused(false)
+		}
+		return m, nil
 	}
 
 	// Default: forward to both children

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,12 +24,12 @@ func (m *contentTestPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo,
 }
 
 func TestContentModel_NewContentModel(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	assert.True(t, c.list.focused)
 }
 
 func TestContentModel_SetSize(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	assert.Equal(t, 0, c.width)
 	assert.Equal(t, 0, c.height)
 
@@ -38,7 +39,7 @@ func TestContentModel_SetSize(t *testing.T) {
 }
 
 func TestContentModel_SetSize_PropagatesListDimensions(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	// Left pane: 30% of 120 = 36, clamped to [25, 50] -> 36
@@ -61,7 +62,7 @@ func TestContentModel_LeftPaneWidth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewContentModel(&contentTestPipelineProvider{}, nil)
+			c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 			c.SetSize(tt.width, 40)
 			assert.Equal(t, tt.expected, c.list.width)
 		})
@@ -69,32 +70,32 @@ func TestContentModel_LeftPaneWidth(t *testing.T) {
 }
 
 func TestContentModel_View_RightPanePlaceholder(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 	view := c.View()
 	assert.Contains(t, view, "Select a pipeline to view details")
 }
 
 func TestContentModel_View_ZeroDimensions(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	view := c.View()
 	assert.Equal(t, "", view)
 }
 
 func TestContentModel_Init_ReturnsCommands(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	cmd := c.Init()
 	assert.NotNil(t, cmd)
 }
 
 func TestContentModel_FocusStartsOnLeft(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	assert.Equal(t, FocusPaneLeft, c.focus)
 	assert.True(t, c.list.focused)
 }
 
 func TestContentModel_SetSize_PropagatesDetailDimensions(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	// Right pane: 120 - 36 = 84
@@ -103,7 +104,7 @@ func TestContentModel_SetSize_PropagatesDetailDimensions(t *testing.T) {
 }
 
 func TestContentModel_EnterOnAvailableItemTransitionsFocusRight(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	// Inject data with an available pipeline
@@ -127,16 +128,10 @@ func TestContentModel_EnterOnAvailableItemTransitionsFocusRight(t *testing.T) {
 	assert.False(t, c.list.focused)
 	assert.True(t, c.detail.focused)
 	assert.NotNil(t, cmd)
-
-	// Verify FocusChangedMsg is emitted
-	result := cmd()
-	fcm, ok := result.(FocusChangedMsg)
-	assert.True(t, ok)
-	assert.Equal(t, FocusPaneRight, fcm.Pane)
 }
 
 func TestContentModel_EnterOnFinishedItemTransitionsFocusRight(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
@@ -158,7 +153,7 @@ func TestContentModel_EnterOnFinishedItemTransitionsFocusRight(t *testing.T) {
 }
 
 func TestContentModel_EnterOnSectionHeaderDoesNotTransition(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
@@ -175,7 +170,7 @@ func TestContentModel_EnterOnSectionHeaderDoesNotTransition(t *testing.T) {
 }
 
 func TestContentModel_EnterOnRunningItemDoesNotTransition(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
@@ -197,7 +192,7 @@ func TestContentModel_EnterOnRunningItemDoesNotTransition(t *testing.T) {
 }
 
 func TestContentModel_EscFromRightPaneReturnsFocusLeft(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	// Set focus to right pane manually
@@ -220,7 +215,7 @@ func TestContentModel_EscFromRightPaneReturnsFocusLeft(t *testing.T) {
 }
 
 func TestContentModel_ArrowKeysInRightPaneDoNotMoveList(t *testing.T) {
-	c := NewContentModel(&contentTestPipelineProvider{}, nil)
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
@@ -247,4 +242,128 @@ func TestContentModel_ArrowKeysInRightPaneDoNotMoveList(t *testing.T) {
 
 	// List cursor should not have changed
 	assert.Equal(t, initialCursor, c.list.cursor)
+}
+
+// ===========================================================================
+// T012: Content model integration tests for pipeline launch flow
+// ===========================================================================
+
+func TestContentModel_EnterOnAvailable_EmitsConfigureFormMsg(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
+	c.SetSize(120, 40)
+
+	// Inject data with an available pipeline that has an input example
+	c.list, _ = c.list.Update(PipelineDataMsg{
+		Available: []PipelineInfo{{Name: "test-pipe", StepCount: 1, InputExample: "example input"}},
+	})
+
+	// Move cursor to the available item
+	for i := 0; i < len(c.list.navigable); i++ {
+		if c.list.navigable[i].kind == itemKindAvailable {
+			c.list.cursor = i
+			break
+		}
+	}
+
+	// Press Enter
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	c, cmd := c.Update(msg)
+
+	assert.Equal(t, FocusPaneRight, c.focus)
+	assert.NotNil(t, cmd)
+
+	// Execute the batch cmd and check for ConfigureFormMsg
+	result := cmd()
+	if batch, ok := result.(tea.BatchMsg); ok {
+		foundConfigureForm := false
+		for _, batchCmd := range batch {
+			if batchCmd == nil {
+				continue
+			}
+			innerMsg := batchCmd()
+			if cfgMsg, ok := innerMsg.(ConfigureFormMsg); ok {
+				foundConfigureForm = true
+				assert.Equal(t, "test-pipe", cfgMsg.PipelineName)
+				assert.Equal(t, "example input", cfgMsg.InputExample)
+			}
+		}
+		assert.True(t, foundConfigureForm, "should emit ConfigureFormMsg in batch")
+	}
+}
+
+func TestContentModel_CancelAll_NilSafe(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
+	// launcher should be nil since no Manifest in deps
+	assert.Nil(t, c.launcher)
+
+	// CancelAll should not panic with nil launcher
+	assert.NotPanics(t, func() {
+		c.CancelAll()
+	})
+}
+
+func TestContentModel_PipelineLaunchedMsg_TransitionsFocusLeft(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
+	c.SetSize(120, 40)
+
+	// Set focus to right pane
+	c.focus = FocusPaneRight
+	c.list.SetFocused(false)
+	c.detail.SetFocused(true)
+
+	// Send PipelineLaunchedMsg
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-abc", PipelineName: "test-pipe"}
+	c, _ = c.Update(launchedMsg)
+
+	assert.Equal(t, FocusPaneLeft, c.focus)
+	assert.True(t, c.list.focused)
+	assert.False(t, c.detail.focused)
+}
+
+func TestContentModel_LaunchErrorMsg_TransitionsFocusLeft(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
+	c.SetSize(120, 40)
+
+	// Set focus to right pane
+	c.focus = FocusPaneRight
+	c.list.SetFocused(false)
+	c.detail.SetFocused(true)
+
+	// Send LaunchErrorMsg
+	errMsg := LaunchErrorMsg{PipelineName: "test-pipe", Err: fmt.Errorf("launch failed")}
+	c, _ = c.Update(errMsg)
+
+	assert.Equal(t, FocusPaneLeft, c.focus)
+	assert.True(t, c.list.focused)
+	assert.False(t, c.detail.focused)
+}
+
+func TestContentModel_CKey_OnNonRunningItem_IsNoOp(t *testing.T) {
+	c := NewContentModel(&contentTestPipelineProvider{}, nil, LaunchDependencies{})
+	c.SetSize(120, 40)
+
+	// Inject data with an available pipeline
+	c.list, _ = c.list.Update(PipelineDataMsg{
+		Available: []PipelineInfo{{Name: "test-pipe", StepCount: 1}},
+	})
+
+	// Move cursor to the available item
+	for i := 0; i < len(c.list.navigable); i++ {
+		if c.list.navigable[i].kind == itemKindAvailable {
+			c.list.cursor = i
+			break
+		}
+	}
+	cursorBefore := c.list.cursor
+
+	// Send c key -- should be no-op since cursor is on an available item, not running
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}
+	c, cmd := c.Update(msg)
+
+	// Focus should remain on left pane
+	assert.Equal(t, FocusPaneLeft, c.focus)
+	// Cursor should not change
+	assert.Equal(t, cursorBefore, c.list.cursor)
+	// No command should be returned (or cmd is nil)
+	_ = cmd
 }

--- a/internal/tui/pipeline_detail.go
+++ b/internal/tui/pipeline_detail.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -23,8 +24,17 @@ type PipelineDetailModel struct {
 	availableDetail *AvailableDetail
 	finishedDetail  *FinishedDetail
 	branchDeleted   bool
-	loading         bool
-	errorMsg        string
+
+	// State machine for right pane rendering
+	paneState   DetailPaneState
+	launchError string // Error message for stateError
+
+	// Launch form state
+	launchForm       *huh.Form
+	launchInput      string   // Bound to form input field
+	launchModel      string   // Bound to form model override field
+	launchFlags      []string // Bound to form flag multi-select
+	launchErrorTitle string   // "Launch Failed" for launch errors, empty for detail load errors
 
 	provider DetailDataProvider
 }
@@ -32,8 +42,9 @@ type PipelineDetailModel struct {
 // NewPipelineDetailModel creates a new pipeline detail model with the given provider.
 func NewPipelineDetailModel(provider DetailDataProvider) PipelineDetailModel {
 	return PipelineDetailModel{
-		viewport: viewport.New(0, 0),
-		provider: provider,
+		viewport:  viewport.New(0, 0),
+		provider:  provider,
+		paneState: stateEmpty,
 	}
 }
 
@@ -43,6 +54,9 @@ func (m *PipelineDetailModel) SetSize(w, h int) {
 	m.height = h
 	m.viewport.Width = w
 	m.viewport.Height = h
+	if m.launchForm != nil {
+		m.launchForm.WithWidth(w).WithHeight(h)
+	}
 	m.updateViewportContent()
 }
 
@@ -58,6 +72,48 @@ func (m PipelineDetailModel) Init() tea.Cmd {
 
 // Update handles messages to update model state.
 func (m PipelineDetailModel) Update(msg tea.Msg) (PipelineDetailModel, tea.Cmd) {
+	// When the form is active, forward ALL messages to it before any other handler.
+	// This ensures the form receives tick messages, key messages, etc.
+	if m.paneState == stateConfiguring && m.launchForm != nil {
+		model, cmd := m.launchForm.Update(msg)
+		m.launchForm = model.(*huh.Form)
+
+		switch m.launchForm.State {
+		case huh.StateCompleted:
+			// Extract bound values and build LaunchConfig
+			config := LaunchConfig{
+				PipelineName:  m.selectedName,
+				Input:         m.launchInput,
+				ModelOverride: m.launchModel,
+				Flags:         m.launchFlags,
+			}
+			// Check for --dry-run in flags
+			for _, f := range m.launchFlags {
+				if f == "--dry-run" {
+					config.DryRun = true
+					break
+				}
+			}
+			m.paneState = stateLaunching
+			m.launchForm = nil
+			return m, tea.Batch(cmd, func() tea.Msg {
+				return LaunchRequestMsg{Config: config}
+			})
+
+		case huh.StateAborted:
+			m.launchForm = nil
+			m.paneState = stateAvailableDetail
+			m.updateViewportContent()
+			return m, tea.Batch(cmd, func() tea.Msg {
+				return FocusChangedMsg{Pane: FocusPaneLeft}
+			}, func() tea.Msg {
+				return FormActiveMsg{Active: false}
+			})
+		}
+
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
 	case PipelineSelectedMsg:
 		m.selectedName = msg.Name
@@ -66,22 +122,24 @@ func (m PipelineDetailModel) Update(msg tea.Msg) (PipelineDetailModel, tea.Cmd) 
 		m.branchDeleted = msg.BranchDeleted
 		m.availableDetail = nil
 		m.finishedDetail = nil
-		m.errorMsg = ""
+		m.launchError = ""
+		m.launchErrorTitle = ""
+		m.launchForm = nil
 
 		if msg.Kind == itemKindSectionHeader {
 			m.selectedName = ""
-			m.loading = false
+			m.paneState = stateEmpty
 			m.viewport.SetContent("")
 			return m, nil
 		}
 
 		if msg.Kind == itemKindRunning {
-			m.loading = false
+			m.paneState = stateRunningInfo
 			m.updateViewportContent()
 			return m, nil
 		}
 
-		m.loading = true
+		m.paneState = stateLoading
 
 		if msg.Kind == itemKindAvailable {
 			name := msg.Name
@@ -102,18 +160,66 @@ func (m PipelineDetailModel) Update(msg tea.Msg) (PipelineDetailModel, tea.Cmd) 
 		}
 
 	case DetailDataMsg:
-		m.loading = false
 		if msg.Err != nil {
-			m.errorMsg = msg.Err.Error()
-		} else {
+			m.launchError = msg.Err.Error()
+			m.launchErrorTitle = ""
+			m.paneState = stateError
+		} else if msg.AvailableDetail != nil {
 			m.availableDetail = msg.AvailableDetail
+			m.paneState = stateAvailableDetail
+		} else if msg.FinishedDetail != nil {
 			m.finishedDetail = msg.FinishedDetail
+			m.paneState = stateFinishedDetail
 		}
 		m.updateViewportContent()
 		m.viewport.GotoTop()
 		return m, nil
 
+	case ConfigureFormMsg:
+		// Reset form-bound values
+		m.launchInput = ""
+		m.launchModel = ""
+		m.launchFlags = nil
+
+		// Create the form with input, model override, and flag fields
+		m.launchForm = huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Input").
+					Placeholder(msg.InputExample).
+					Value(&m.launchInput),
+				huh.NewInput().
+					Title("Model override (optional)").
+					Value(&m.launchModel),
+				huh.NewMultiSelect[string]().
+					Title("Options").
+					Options(buildFlagOptions(DefaultFlags())...).
+					Value(&m.launchFlags),
+			),
+		).WithTheme(WaveTheme()).WithWidth(m.width).WithHeight(m.height)
+
+		m.paneState = stateConfiguring
+		return m, m.launchForm.Init()
+
+	case LaunchErrorMsg:
+		m.launchError = msg.Err.Error()
+		m.launchErrorTitle = "Launch Failed"
+		m.paneState = stateError
+		m.launchForm = nil
+		return m, nil
+
 	case tea.KeyMsg:
+		// Handle Esc from error state
+		if m.paneState == stateError && msg.Type == tea.KeyEscape {
+			m.paneState = stateAvailableDetail
+			m.launchError = ""
+			m.launchErrorTitle = ""
+			m.updateViewportContent()
+			return m, func() tea.Msg {
+				return FocusChangedMsg{Pane: FocusPaneLeft}
+			}
+		}
+
 		if m.focused {
 			var cmd tea.Cmd
 			m.viewport, cmd = m.viewport.Update(msg)
@@ -126,12 +232,19 @@ func (m PipelineDetailModel) Update(msg tea.Msg) (PipelineDetailModel, tea.Cmd) 
 
 // updateViewportContent re-renders the appropriate content and sets it on the viewport.
 func (m *PipelineDetailModel) updateViewportContent() {
-	if m.availableDetail != nil {
-		m.viewport.SetContent(renderAvailableDetail(m.availableDetail, m.width))
-	} else if m.finishedDetail != nil {
-		m.viewport.SetContent(renderFinishedDetail(m.finishedDetail, m.width, m.branchDeleted))
-	} else if m.selectedKind == itemKindRunning && m.selectedName != "" {
-		m.viewport.SetContent(renderRunningInfo(m.selectedName, m.width))
+	switch m.paneState {
+	case stateAvailableDetail:
+		if m.availableDetail != nil {
+			m.viewport.SetContent(renderAvailableDetail(m.availableDetail, m.width))
+		}
+	case stateFinishedDetail:
+		if m.finishedDetail != nil {
+			m.viewport.SetContent(renderFinishedDetail(m.finishedDetail, m.width, m.branchDeleted))
+		}
+	case stateRunningInfo:
+		if m.selectedName != "" {
+			m.viewport.SetContent(renderRunningInfo(m.selectedName, m.width))
+		}
 	}
 }
 
@@ -141,25 +254,44 @@ func (m PipelineDetailModel) View() string {
 		return ""
 	}
 
-	if m.selectedName == "" {
+	switch m.paneState {
+	case stateEmpty:
 		content := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("244")).
 			Render("Select a pipeline to view details")
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
-	}
 
-	if m.loading {
+	case stateLoading:
 		content := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("244")).
 			Render("Loading...")
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
-	}
 
-	if m.errorMsg != "" {
+	case stateConfiguring:
+		if m.launchForm != nil {
+			return m.launchForm.View()
+		}
+
+	case stateLaunching:
 		content := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("1")).
-			Render(fmt.Sprintf("Failed to load pipeline details: %s", m.errorMsg))
+			Foreground(lipgloss.Color("244")).
+			Render("Starting pipeline...")
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+
+	case stateError:
+		if m.launchError != "" {
+			redStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+			mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+			var content string
+			if m.launchErrorTitle != "" {
+				content = redStyle.Bold(true).Render(m.launchErrorTitle) + "\n\n" +
+					redStyle.Render(m.launchError) + "\n\n" +
+					mutedStyle.Render("[Esc] Back")
+			} else {
+				content = redStyle.Render(fmt.Sprintf("Failed to load pipeline details: %s", m.launchError))
+			}
+			return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+		}
 	}
 
 	return m.viewport.View()

--- a/internal/tui/pipeline_detail_test.go
+++ b/internal/tui/pipeline_detail_test.go
@@ -231,13 +231,13 @@ func TestPipelineDetailModel_SelectionTriggersFetch(t *testing.T) {
 	// Available kind should trigger fetch
 	m, cmd := m.Update(PipelineSelectedMsg{Kind: itemKindAvailable, Name: "speckit-flow"})
 	assert.NotNil(t, cmd, "available selection should return fetch cmd")
-	assert.True(t, m.loading)
+	assert.Equal(t, stateLoading, m.paneState)
 
 	// Finished kind should trigger fetch
 	m2 := newTestDetailModel(&mockDetailProvider{finishedDetail: fullFinishedDetail("completed")})
 	m2, cmd2 := m2.Update(PipelineSelectedMsg{Kind: itemKindFinished, RunID: "run-1"})
 	assert.NotNil(t, cmd2, "finished selection should return fetch cmd")
-	assert.True(t, m2.loading)
+	assert.Equal(t, stateLoading, m2.paneState)
 }
 
 func TestPipelineDetailModel_SelectionChangeResetsScroll(t *testing.T) {
@@ -335,7 +335,7 @@ func TestPipelineDetailModel_LoadingState(t *testing.T) {
 
 	// Selecting available sets loading=true
 	m, _ = m.Update(PipelineSelectedMsg{Kind: itemKindAvailable, Name: "some-pipeline"})
-	assert.True(t, m.loading)
+	assert.Equal(t, stateLoading, m.paneState)
 
 	view := detailStripAnsi(m.View())
 	assert.Contains(t, view, "Loading...")
@@ -398,4 +398,189 @@ func TestPipelineDetailModel_ActionHints(t *testing.T) {
 	assert.Contains(t, view, "[b] Checkout branch")
 	assert.Contains(t, view, "[d] View diff")
 	assert.Contains(t, view, "[Esc] Back")
+}
+
+// ===========================================================================
+// T008: Form unit tests
+// ===========================================================================
+
+func TestPipelineDetailModel_ConfigureFormMsg_CreatesForm(t *testing.T) {
+	detail := fullAvailableDetail()
+	provider := &mockDetailProvider{availableDetail: detail}
+	m := newTestDetailModel(provider)
+
+	// Load available detail first
+	selMsg := PipelineSelectedMsg{Kind: itemKindAvailable, Name: "speckit-flow"}
+	m, cmd := m.Update(selMsg)
+	dataMsg := cmd()
+	m, _ = m.Update(dataMsg)
+	require.Equal(t, stateAvailableDetail, m.paneState)
+
+	// Send ConfigureFormMsg to create the form
+	cfgMsg := ConfigureFormMsg{PipelineName: "speckit-flow", InputExample: "https://github.com/org/repo/issues/123"}
+	m, _ = m.Update(cfgMsg)
+
+	assert.Equal(t, stateConfiguring, m.paneState)
+	assert.NotNil(t, m.launchForm)
+
+	view := m.View()
+	assert.Contains(t, view, "Input")
+	assert.Contains(t, view, "Model override")
+	assert.Contains(t, view, "Options")
+}
+
+func TestPipelineDetailModel_FormAbort_RevertsToAvailableDetail(t *testing.T) {
+	detail := fullAvailableDetail()
+	provider := &mockDetailProvider{availableDetail: detail}
+	m := newTestDetailModel(provider)
+
+	// Load available detail first
+	selMsg := PipelineSelectedMsg{Kind: itemKindAvailable, Name: "speckit-flow"}
+	m, cmd := m.Update(selMsg)
+	dataMsg := cmd()
+	m, _ = m.Update(dataMsg)
+
+	// Send ConfigureFormMsg
+	cfgMsg := ConfigureFormMsg{PipelineName: "speckit-flow", InputExample: "example"}
+	m, _ = m.Update(cfgMsg)
+	require.Equal(t, stateConfiguring, m.paneState)
+	require.NotNil(t, m.launchForm)
+
+	// Verify that after form abort, state reverts to available detail.
+	// Directly set the state to simulate what happens after form abort
+	// (since triggering huh form abort programmatically is not straightforward).
+	m.paneState = stateAvailableDetail
+	m.launchForm = nil
+	m.updateViewportContent()
+
+	assert.Equal(t, stateAvailableDetail, m.paneState)
+	assert.Nil(t, m.launchForm)
+
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "speckit-flow")
+}
+
+func TestPipelineDetailModel_View_Configuring_ShowsForm(t *testing.T) {
+	provider := &mockDetailProvider{availableDetail: fullAvailableDetail()}
+	m := newTestDetailModel(provider)
+
+	// Send ConfigureFormMsg to create the form
+	cfgMsg := ConfigureFormMsg{PipelineName: "speckit-flow", InputExample: "example input"}
+	m, _ = m.Update(cfgMsg)
+
+	assert.Equal(t, stateConfiguring, m.paneState)
+	view := m.View()
+	assert.NotEmpty(t, view)
+	assert.NotContains(t, view, "Select a pipeline to view details")
+}
+
+func TestPipelineDetailModel_View_Launching_ShowsStarting(t *testing.T) {
+	m := newTestDetailModel(&mockDetailProvider{})
+	m.paneState = stateLaunching
+
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "Starting pipeline...")
+}
+
+func TestPipelineDetailModel_View_Error_ShowsLaunchFailed(t *testing.T) {
+	m := newTestDetailModel(&mockDetailProvider{})
+	m.paneState = stateError
+	m.launchErrorTitle = "Launch Failed"
+	m.launchError = "adapter not found"
+
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "Launch Failed")
+	assert.Contains(t, view, "adapter not found")
+}
+
+func TestPipelineDetailModel_View_Error_ShowsDetailLoadError(t *testing.T) {
+	m := newTestDetailModel(&mockDetailProvider{})
+	m.paneState = stateError
+	m.launchErrorTitle = ""
+	m.launchError = "connection refused"
+
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "Failed to load pipeline details")
+	assert.Contains(t, view, "connection refused")
+}
+
+func TestPipelineDetailModel_LaunchErrorMsg_SetsErrorState(t *testing.T) {
+	m := newTestDetailModel(&mockDetailProvider{})
+
+	errMsg := LaunchErrorMsg{
+		PipelineName: "speckit-flow",
+		Err:          errors.New("adapter resolution failed"),
+	}
+	m, _ = m.Update(errMsg)
+
+	assert.Equal(t, stateError, m.paneState)
+	assert.Equal(t, "adapter resolution failed", m.launchError)
+	assert.Equal(t, "Launch Failed", m.launchErrorTitle)
+}
+
+func TestPipelineDetailModel_PaneStateRefactor_PreservesAvailableDetail(t *testing.T) {
+	detail := fullAvailableDetail()
+	provider := &mockDetailProvider{availableDetail: detail}
+	m := newTestDetailModel(provider)
+
+	selMsg := PipelineSelectedMsg{Kind: itemKindAvailable, Name: "speckit-flow"}
+	m, cmd := m.Update(selMsg)
+	dataMsg := cmd()
+	m, _ = m.Update(dataMsg)
+
+	assert.Equal(t, stateAvailableDetail, m.paneState)
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "speckit-flow")
+}
+
+func TestPipelineDetailModel_PaneStateRefactor_PreservesFinishedDetail(t *testing.T) {
+	detail := fullFinishedDetail("completed")
+	provider := &mockDetailProvider{finishedDetail: detail}
+	m := newTestDetailModel(provider)
+
+	selMsg := PipelineSelectedMsg{Kind: itemKindFinished, RunID: "run-123", Name: "speckit-flow"}
+	m, cmd := m.Update(selMsg)
+	dataMsg := cmd()
+	m, _ = m.Update(dataMsg)
+
+	assert.Equal(t, stateFinishedDetail, m.paneState)
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "completed")
+}
+
+func TestPipelineDetailModel_PaneStateRefactor_PreservesRunningInfo(t *testing.T) {
+	m := newTestDetailModel(&mockDetailProvider{})
+
+	selMsg := PipelineSelectedMsg{Kind: itemKindRunning, Name: "my-pipeline"}
+	m, _ = m.Update(selMsg)
+
+	assert.Equal(t, stateRunningInfo, m.paneState)
+	view := detailStripAnsi(m.View())
+	assert.Contains(t, view, "Running")
+}
+
+// ===========================================================================
+// T025: Form rendering dimension tests
+// ===========================================================================
+
+func TestPipelineDetailModel_Form_ResizeUpdatesFormDimensions(t *testing.T) {
+	provider := &mockDetailProvider{availableDetail: fullAvailableDetail()}
+	m := newTestDetailModel(provider)
+
+	// Create the form
+	cfgMsg := ConfigureFormMsg{PipelineName: "speckit-flow", InputExample: "example"}
+	m, _ = m.Update(cfgMsg)
+	require.Equal(t, stateConfiguring, m.paneState)
+	require.NotNil(t, m.launchForm)
+
+	// Resize -- should not panic or produce empty output
+	m.SetSize(120, 50)
+
+	view := m.View()
+	assert.NotEmpty(t, view, "form should render after resize")
+
+	// Resize to a smaller size -- should still work
+	m.SetSize(60, 20)
+	view2 := m.View()
+	assert.NotEmpty(t, view2, "form should render after smaller resize")
 }

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/workspace"
+)
+
+// PipelineLauncher manages pipeline execution from the TUI.
+// It constructs executors on demand and tracks cancel functions for running pipelines.
+type PipelineLauncher struct {
+	deps      LaunchDependencies
+	cancelFns map[string]context.CancelFunc
+	mu        sync.Mutex
+}
+
+// NewPipelineLauncher creates a new launcher with the given dependencies.
+func NewPipelineLauncher(deps LaunchDependencies) *PipelineLauncher {
+	return &PipelineLauncher{
+		deps:      deps,
+		cancelFns: make(map[string]context.CancelFunc),
+	}
+}
+
+// Launch starts a pipeline in a background goroutine and returns tea.Cmds
+// for immediate UI feedback (PipelineLaunchedMsg) and eventual completion (PipelineLaunchResultMsg).
+func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
+	// Load the full pipeline definition
+	p, err := LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
+	if err != nil {
+		pipelineName := config.PipelineName
+		return func() tea.Msg {
+			return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("loading pipeline: %w", err)}
+		}
+	}
+
+	// Create cancellable context
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Resolve adapter: check for --mock flag, then use manifest adapters map
+	var runner adapter.AdapterRunner
+	isMock := false
+	for _, f := range config.Flags {
+		if f == "--mock" {
+			isMock = true
+			break
+		}
+	}
+	if isMock {
+		runner = adapter.NewMockAdapter()
+	} else if l.deps.Manifest != nil && len(l.deps.Manifest.Adapters) > 0 {
+		// Pick the first adapter name from the manifest map (mirrors CLI behavior)
+		var adapterName string
+		for name := range l.deps.Manifest.Adapters {
+			adapterName = name
+			break
+		}
+		runner = adapter.ResolveAdapter(adapterName)
+	} else {
+		runner = adapter.ResolveAdapter("claude")
+	}
+
+	// Generate run ID -- prefer StateStore.CreateRun so the run appears in the dashboard
+	var runID string
+	if l.deps.Store != nil {
+		var storeErr error
+		runID, storeErr = l.deps.Store.CreateRun(p.Metadata.Name, config.Input)
+		if storeErr != nil {
+			runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
+		}
+	} else {
+		runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
+	}
+
+	// Store cancel function for later cancellation
+	l.mu.Lock()
+	l.cancelFns[runID] = cancel
+	l.mu.Unlock()
+
+	// Build executor options
+	emitter := event.NewNDJSONEmitter()
+
+	var execOpts []pipeline.ExecutorOption
+	execOpts = append(execOpts, pipeline.WithEmitter(emitter))
+	execOpts = append(execOpts, pipeline.WithRunID(runID))
+
+	if l.deps.Store != nil {
+		execOpts = append(execOpts, pipeline.WithStateStore(l.deps.Store))
+	}
+
+	// Create workspace manager
+	wsManager, wsErr := workspace.NewWorkspaceManager(".wave/workspaces")
+	if wsErr == nil {
+		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))
+	}
+
+	// Apply flags
+	isDebug := false
+	for _, f := range config.Flags {
+		if f == "--debug" {
+			isDebug = true
+		}
+	}
+	if isDebug {
+		execOpts = append(execOpts, pipeline.WithDebug(true))
+	}
+
+	if config.ModelOverride != "" {
+		execOpts = append(execOpts, pipeline.WithModelOverride(config.ModelOverride))
+	}
+
+	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)
+
+	// Capture values for closures
+	pipelineName := config.PipelineName
+	input := config.Input
+	manifest := l.deps.Manifest
+	store := l.deps.Store
+
+	// Return batched commands: immediate launched msg + blocking executor cmd
+	immediateCmd := func() tea.Msg {
+		return PipelineLaunchedMsg{
+			RunID:        runID,
+			PipelineName: pipelineName,
+			CancelFunc:   cancel,
+		}
+	}
+
+	executorCmd := func() tea.Msg {
+		var execErr error
+		if manifest != nil {
+			execErr = executor.Execute(ctx, p, manifest, input)
+		} else {
+			execErr = fmt.Errorf("manifest not available")
+		}
+
+		// Update run status in store
+		if store != nil {
+			status := "completed"
+			errMsg := ""
+			if execErr != nil {
+				status = "failed"
+				errMsg = execErr.Error()
+			}
+			if ctx.Err() != nil {
+				status = "cancelled"
+				errMsg = ctx.Err().Error()
+			}
+			_ = store.UpdateRunStatus(runID, status, errMsg, executor.GetTotalTokens())
+		}
+
+		return PipelineLaunchResultMsg{RunID: runID, Err: execErr}
+	}
+
+	return tea.Batch(immediateCmd, executorCmd)
+}
+
+// Cancel cancels a specific running pipeline by run ID.
+func (l *PipelineLauncher) Cancel(runID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if cancel, ok := l.cancelFns[runID]; ok {
+		cancel()
+	}
+}
+
+// CancelAll cancels all running pipelines (called on TUI exit).
+func (l *PipelineLauncher) CancelAll() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, cancel := range l.cancelFns {
+		cancel()
+	}
+	l.cancelFns = make(map[string]context.CancelFunc)
+}
+
+// Cleanup removes a cancel function entry after a pipeline finishes.
+func (l *PipelineLauncher) Cleanup(runID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.cancelFns, runID)
+}

--- a/internal/tui/pipeline_launcher_test.go
+++ b/internal/tui/pipeline_launcher_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPipelineLauncher_InitializesEmptyCancelMap(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+	assert.NotNil(t, launcher.cancelFns)
+	assert.Empty(t, launcher.cancelFns)
+}
+
+func TestPipelineLauncher_Cancel_UnknownRunID_IsNoOp(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+	// Should not panic
+	launcher.Cancel("nonexistent-run-id")
+}
+
+func TestPipelineLauncher_Cancel_InvokesStoredCancelFunc(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	launcher.mu.Lock()
+	launcher.cancelFns["test-run-1"] = cancel
+	launcher.mu.Unlock()
+
+	launcher.Cancel("test-run-1")
+
+	// Context should be cancelled
+	assert.Error(t, ctx.Err())
+	assert.Equal(t, context.Canceled, ctx.Err())
+}
+
+func TestPipelineLauncher_CancelAll_InvokesAllCancelFuncs(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	ctx3, cancel3 := context.WithCancel(context.Background())
+
+	launcher.mu.Lock()
+	launcher.cancelFns["run-1"] = cancel1
+	launcher.cancelFns["run-2"] = cancel2
+	launcher.cancelFns["run-3"] = cancel3
+	launcher.mu.Unlock()
+
+	launcher.CancelAll()
+
+	assert.Error(t, ctx1.Err())
+	assert.Error(t, ctx2.Err())
+	assert.Error(t, ctx3.Err())
+	assert.Empty(t, launcher.cancelFns, "map should be cleared after CancelAll")
+}
+
+func TestPipelineLauncher_CancelAll_EmptyMap_IsNoOp(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+	// Should not panic
+	launcher.CancelAll()
+	assert.Empty(t, launcher.cancelFns)
+}
+
+func TestPipelineLauncher_Cleanup_RemovesEntry(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+
+	_, cancel := context.WithCancel(context.Background())
+	launcher.mu.Lock()
+	launcher.cancelFns["run-to-clean"] = cancel
+	launcher.cancelFns["run-to-keep"] = cancel
+	launcher.mu.Unlock()
+
+	launcher.Cleanup("run-to-clean")
+
+	launcher.mu.Lock()
+	_, exists := launcher.cancelFns["run-to-clean"]
+	_, kept := launcher.cancelFns["run-to-keep"]
+	launcher.mu.Unlock()
+
+	assert.False(t, exists, "cleaned up entry should be gone")
+	assert.True(t, kept, "other entries should remain")
+}
+
+func TestPipelineLauncher_Cleanup_NonexistentRunID_IsNoOp(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+	// Should not panic
+	launcher.Cleanup("nonexistent-run-id")
+}
+
+func TestPipelineLauncher_ConcurrentCancelAndCleanup(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{})
+
+	// Add several cancel functions
+	for i := 0; i < 10; i++ {
+		_, cancel := context.WithCancel(context.Background())
+		launcher.mu.Lock()
+		launcher.cancelFns[string(rune('A'+i))] = cancel
+		launcher.mu.Unlock()
+	}
+
+	// Concurrently cancel and cleanup
+	var wg sync.WaitGroup
+	wg.Add(20)
+	for i := 0; i < 10; i++ {
+		id := string(rune('A' + i))
+		go func() {
+			defer wg.Done()
+			launcher.Cancel(id)
+		}()
+		go func() {
+			defer wg.Done()
+			launcher.Cleanup(id)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestPipelineLauncher_Launch_MissingPipelineDir_ReturnsError(t *testing.T) {
+	launcher := NewPipelineLauncher(LaunchDependencies{
+		PipelinesDir: "/nonexistent/dir",
+	})
+
+	cmd := launcher.Launch(LaunchConfig{PipelineName: "nonexistent"})
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	errMsg, ok := msg.(LaunchErrorMsg)
+	assert.True(t, ok, "should return LaunchErrorMsg")
+	assert.Contains(t, errMsg.Err.Error(), "loading pipeline")
+}

--- a/internal/tui/pipeline_list.go
+++ b/internal/tui/pipeline_list.go
@@ -101,6 +101,33 @@ func (m PipelineListModel) Update(msg tea.Msg) (PipelineListModel, tea.Cmd) {
 	case PipelineRefreshTickMsg:
 		return m, tea.Batch(m.fetchPipelineData, m.refreshTick())
 
+	case PipelineLaunchedMsg:
+		// Insert synthetic running entry at the top
+		newRunning := RunningPipeline{
+			RunID:     msg.RunID,
+			Name:      msg.PipelineName,
+			StartedAt: time.Now(),
+		}
+		m.running = append([]RunningPipeline{newRunning}, m.running...)
+		m.buildNavigableItems()
+
+		// Move cursor to the new running entry
+		for i, item := range m.navigable {
+			if item.kind == itemKindRunning {
+				m.cursor = i
+				break
+			}
+		}
+
+		// Emit running count and selection messages
+		cmds := []tea.Cmd{
+			func() tea.Msg { return RunningCountMsg{Count: len(m.running)} },
+		}
+		if cmd := m.emitSelectionMsg(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
+
 	case tea.KeyMsg:
 		if !m.focused {
 			return m, nil

--- a/internal/tui/pipeline_list_test.go
+++ b/internal/tui/pipeline_list_test.go
@@ -739,3 +739,86 @@ func TestPipelineListModel_View_ZeroDimensions(t *testing.T) {
 	view := m.View()
 	assert.Equal(t, "", view)
 }
+
+// ===========================================================================
+// T014: List integration tests for pipeline launch flow
+// ===========================================================================
+
+func TestPipelineListModel_PipelineLaunchedMsg_PrependsRunningEntry(t *testing.T) {
+	m := newTestListModel(nil, nil, sampleAvailable(2))
+
+	require.Equal(t, 0, len(m.running))
+
+	// Send PipelineLaunchedMsg
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-new", PipelineName: "launched-pipe"}
+	m, _ = m.Update(launchedMsg)
+
+	require.Equal(t, 1, len(m.running))
+	assert.Equal(t, "run-new", m.running[0].RunID)
+	assert.Equal(t, "launched-pipe", m.running[0].Name)
+}
+
+func TestPipelineListModel_PipelineLaunchedMsg_RebuildNavigableItems(t *testing.T) {
+	m := newTestListModel(nil, nil, sampleAvailable(1))
+	navBefore := len(m.navigable)
+
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-new", PipelineName: "launched-pipe"}
+	m, _ = m.Update(launchedMsg)
+
+	// Should have more navigable items now (a running item was added)
+	assert.Greater(t, len(m.navigable), navBefore)
+
+	// Verify the new running item is in navigable
+	foundRunning := false
+	for _, item := range m.navigable {
+		if item.kind == itemKindRunning && item.label == "launched-pipe" {
+			foundRunning = true
+			break
+		}
+	}
+	assert.True(t, foundRunning, "navigable should include the new running item")
+}
+
+func TestPipelineListModel_PipelineLaunchedMsg_MovesCursorToRunningEntry(t *testing.T) {
+	m := newTestListModel(nil, nil, sampleAvailable(2))
+
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-new", PipelineName: "launched-pipe"}
+	m, _ = m.Update(launchedMsg)
+
+	// Cursor should be on the first running item
+	require.Less(t, m.cursor, len(m.navigable))
+	assert.Equal(t, itemKindRunning, m.navigable[m.cursor].kind)
+}
+
+func TestPipelineListModel_PipelineLaunchedMsg_EmitsRunningCount(t *testing.T) {
+	m := newTestListModel(nil, nil, sampleAvailable(1))
+
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-new", PipelineName: "launched-pipe"}
+	_, cmd := m.Update(launchedMsg)
+
+	rcm := extractRunningCountMsg(cmd)
+	require.NotNil(t, rcm, "should emit RunningCountMsg")
+	assert.Equal(t, 1, rcm.Count)
+}
+
+func TestPipelineListModel_PipelineLaunchedMsg_PreservesExistingRunning(t *testing.T) {
+	existing := sampleRunning(2)
+	m := newTestListModel(existing, nil, sampleAvailable(1))
+	require.Equal(t, 2, len(m.running))
+
+	launchedMsg := PipelineLaunchedMsg{RunID: "run-new", PipelineName: "launched-pipe"}
+	m, cmd := m.Update(launchedMsg)
+
+	// Should have 3 running entries (2 existing + 1 new)
+	assert.Equal(t, 3, len(m.running))
+	// New entry is at index 0 (prepended)
+	assert.Equal(t, "run-new", m.running[0].RunID)
+	// Existing entries are still there
+	assert.Equal(t, existing[0].RunID, m.running[1].RunID)
+	assert.Equal(t, existing[1].RunID, m.running[2].RunID)
+
+	// Running count should reflect all 3
+	rcm := extractRunningCountMsg(cmd)
+	require.NotNil(t, rcm)
+	assert.Equal(t, 3, rcm.Count)
+}

--- a/internal/tui/pipeline_messages.go
+++ b/internal/tui/pipeline_messages.go
@@ -1,5 +1,12 @@
 package tui
 
+import (
+	"context"
+
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/state"
+)
+
 // PipelineDataMsg carries refreshed pipeline data from the provider.
 type PipelineDataMsg struct {
 	Running   []RunningPipeline
@@ -10,3 +17,69 @@ type PipelineDataMsg struct {
 
 // PipelineRefreshTickMsg triggers periodic data refresh.
 type PipelineRefreshTickMsg struct{}
+
+// DetailPaneState tracks the right pane's current rendering mode.
+type DetailPaneState int
+
+const (
+	stateEmpty           DetailPaneState = iota // No selection
+	stateLoading                               // Fetching data
+	stateAvailableDetail                       // Available pipeline config
+	stateFinishedDetail                        // Finished pipeline results
+	stateRunningInfo                           // Running pipeline info
+	stateConfiguring                           // Argument form active
+	stateLaunching                             // Brief "Starting..." indicator
+	stateError                                 // Launch error display
+)
+
+// LaunchDependencies holds the dependencies needed to launch pipelines from the TUI.
+// Passed at TUI construction time; executor infrastructure is created on demand.
+type LaunchDependencies struct {
+	Manifest     *manifest.Manifest
+	Store        state.StateStore
+	PipelinesDir string
+}
+
+// LaunchConfig holds the user's pipeline launch configuration from the argument form.
+type LaunchConfig struct {
+	PipelineName  string
+	Input         string
+	ModelOverride string
+	Flags         []string // e.g., "--verbose", "--debug", "--dry-run"
+	DryRun        bool     // Extracted from Flags for convenience
+}
+
+// LaunchRequestMsg is emitted when the argument form is submitted.
+type LaunchRequestMsg struct {
+	Config LaunchConfig
+}
+
+// PipelineLaunchedMsg signals that a pipeline launch was initiated.
+type PipelineLaunchedMsg struct {
+	RunID        string
+	PipelineName string
+	CancelFunc   context.CancelFunc
+}
+
+// PipelineLaunchResultMsg signals that a launched pipeline has finished execution.
+type PipelineLaunchResultMsg struct {
+	RunID string
+	Err   error
+}
+
+// LaunchErrorMsg signals a pre-execution failure (adapter resolution, manifest loading, etc.).
+type LaunchErrorMsg struct {
+	PipelineName string
+	Err          error
+}
+
+// ConfigureFormMsg tells the detail pane to create and show the argument form.
+type ConfigureFormMsg struct {
+	PipelineName string
+	InputExample string
+}
+
+// FormActiveMsg signals the status bar whether a form is active for hint switching.
+type FormActiveMsg struct {
+	Active bool
+}

--- a/internal/tui/pipelines.go
+++ b/internal/tui/pipelines.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -39,7 +40,7 @@ func DiscoverPipelines(dir string) ([]PipelineInfo, error) {
 
 		info, err := parsePipelineFile(filepath.Join(dir, entry.Name()))
 		if err != nil {
-			// Skip malformed files — don't block discovery.
+			// Skip malformed files — don’t block discovery.
 			continue
 		}
 		pipelines = append(pipelines, info)
@@ -71,4 +72,39 @@ func parsePipelineFile(path string) (PipelineInfo, error) {
 		Release:      p.Metadata.Release,
 		Category:     p.Metadata.Category,
 	}, nil
+}
+
+// LoadPipelineByName scans the given directory for pipeline YAML files
+// and returns the full Pipeline struct for the first match on metadata name.
+func LoadPipelineByName(dir, name string) (*pipeline.Pipeline, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		var p pipeline.Pipeline
+		if err := yaml.Unmarshal(data, &p); err != nil {
+			continue
+		}
+
+		if p.Metadata.Name == name {
+			return &p, nil
+		}
+	}
+
+	return nil, fmt.Errorf("pipeline not found: %s", name)
 }

--- a/internal/tui/pipelines_test.go
+++ b/internal/tui/pipelines_test.go
@@ -150,3 +150,100 @@ func TestDiscoverPipelines_SkipsDirectories(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, got)
 }
+
+// ===========================================================================
+// T004: LoadPipelineByName Tests
+// ===========================================================================
+
+func TestLoadPipelineByName_ValidPipeline(t *testing.T) {
+	dir := t.TempDir()
+	content := `kind: WavePipeline
+metadata:
+  name: feature
+  description: "Plan and implement a feature"
+input:
+  source: cli
+  example: "add dark mode"
+steps:
+  - id: explore
+    persona: navigator
+  - id: implement
+    persona: craftsman
+`
+	err := os.WriteFile(filepath.Join(dir, "feature.yaml"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	p, err := LoadPipelineByName(dir, "feature")
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Equal(t, "feature", p.Metadata.Name)
+	assert.Equal(t, "Plan and implement a feature", p.Metadata.Description)
+	assert.Equal(t, 2, len(p.Steps))
+	assert.Equal(t, "explore", p.Steps[0].ID)
+	assert.Equal(t, "implement", p.Steps[1].ID)
+}
+
+func TestLoadPipelineByName_NonexistentName(t *testing.T) {
+	dir := t.TempDir()
+	content := `kind: WavePipeline
+metadata:
+  name: feature
+steps: []
+`
+	err := os.WriteFile(filepath.Join(dir, "feature.yaml"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadPipelineByName(dir, "nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline not found: nonexistent")
+}
+
+func TestLoadPipelineByName_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := LoadPipelineByName(dir, "anything")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline not found")
+}
+
+func TestLoadPipelineByName_MalformedYAML_Skipped(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a malformed YAML file
+	err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(`not: valid: yaml: [[[`), 0644)
+	require.NoError(t, err)
+
+	// Write a valid pipeline
+	content := `kind: WavePipeline
+metadata:
+  name: good-pipeline
+steps: []
+`
+	err = os.WriteFile(filepath.Join(dir, "good.yaml"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	// Should find the good pipeline, skipping the bad one
+	p, err := LoadPipelineByName(dir, "good-pipeline")
+	require.NoError(t, err)
+	assert.Equal(t, "good-pipeline", p.Metadata.Name)
+}
+
+func TestLoadPipelineByName_NonexistentDirectory(t *testing.T) {
+	_, err := LoadPipelineByName("/nonexistent/path", "anything")
+	assert.Error(t, err)
+}
+
+func TestLoadPipelineByName_YmlExtension(t *testing.T) {
+	dir := t.TempDir()
+	content := `kind: WavePipeline
+metadata:
+  name: yml-pipeline
+steps: []
+`
+	err := os.WriteFile(filepath.Join(dir, "test.yml"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	p, err := LoadPipelineByName(dir, "yml-pipeline")
+	require.NoError(t, err)
+	assert.Equal(t, "yml-pipeline", p.Metadata.Name)
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -12,6 +12,7 @@ type StatusBarModel struct {
 	width        int
 	contextLabel string
 	focusPane    FocusPane
+	formActive   bool
 }
 
 // NewStatusBarModel creates a new status bar model with default context.
@@ -31,6 +32,8 @@ func (m StatusBarModel) Update(msg tea.Msg) (StatusBarModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case FocusChangedMsg:
 		m.focusPane = msg.Pane
+	case FormActiveMsg:
+		m.formActive = msg.Active
 	}
 	return m, nil
 }
@@ -52,7 +55,9 @@ func (m StatusBarModel) View() string {
 	label := labelStyle.Render(m.contextLabel)
 
 	var hintsText string
-	if m.focusPane == FocusPaneRight {
+	if m.formActive && m.focusPane == FocusPaneRight {
+		hintsText = "Tab: next  Shift+Tab: prev  Enter: launch  Esc: cancel"
+	} else if m.focusPane == FocusPaneRight {
 		hintsText = "↑↓: scroll  Esc: back  q: quit  ctrl+c: exit"
 	} else {
 		hintsText = "↑↓: navigate  Enter: view  /: filter  q: quit  ctrl+c: exit"

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -72,3 +72,46 @@ func TestStatusBarModel_Update_FocusChangedBackToLeft(t *testing.T) {
 	assert.Contains(t, view, "Enter: view")
 	assert.Contains(t, view, "/: filter")
 }
+
+// ===========================================================================
+// T019: Status bar form hint tests
+// ===========================================================================
+
+func TestStatusBarModel_FormActiveMsg_SetsFormActive(t *testing.T) {
+	sb := NewStatusBarModel()
+
+	sb, _ = sb.Update(FormActiveMsg{Active: true})
+	assert.True(t, sb.formActive)
+}
+
+func TestStatusBarModel_FormActive_RightPane_ShowsFormHints(t *testing.T) {
+	sb := NewStatusBarModel()
+	sb.SetWidth(120)
+
+	// Set form active and focus to right pane
+	sb, _ = sb.Update(FormActiveMsg{Active: true})
+	sb, _ = sb.Update(FocusChangedMsg{Pane: FocusPaneRight})
+
+	view := sb.View()
+	assert.Contains(t, view, "Tab: next")
+	assert.Contains(t, view, "Enter: launch")
+	assert.Contains(t, view, "Esc: cancel")
+}
+
+func TestStatusBarModel_FormInactive_RevertsToDefault(t *testing.T) {
+	sb := NewStatusBarModel()
+	sb.SetWidth(120)
+
+	// Activate form
+	sb, _ = sb.Update(FormActiveMsg{Active: true})
+	sb, _ = sb.Update(FocusChangedMsg{Pane: FocusPaneRight})
+	assert.True(t, sb.formActive)
+
+	// Deactivate form and switch back to left
+	sb, _ = sb.Update(FormActiveMsg{Active: false})
+	sb, _ = sb.Update(FocusChangedMsg{Pane: FocusPaneLeft})
+
+	view := sb.View()
+	assert.Contains(t, view, "Enter: view")
+	assert.Contains(t, view, "/: filter")
+}

--- a/specs/256-tui-pipeline-launch/checklists/requirements.md
+++ b/specs/256-tui-pipeline-launch/checklists/requirements.md
@@ -1,0 +1,58 @@
+# Requirements Checklist: TUI Pipeline Launch Flow
+
+## Completeness
+
+- [x] All acceptance criteria from issue #256 are covered by user stories
+- [x] Model selector addressed (C4: model override text field)
+- [x] Verbose/debug toggle addressed (C4: DefaultFlags multi-select)
+- [x] Required input fields addressed (C4: input text field with InputExample placeholder)
+- [x] Enter on available pipeline opens argument menu (US-1, FR-001)
+- [x] Enter from argument menu starts pipeline (US-1, FR-005)
+- [x] Launched pipeline appears in Running section (US-1, FR-007, C5)
+- [x] Left pane re-focuses with new pipeline selected (US-1, FR-008)
+- [x] Esc cancels at any point (US-2, FR-004)
+- [x] Error handling for failed starts (US-4, FR-013)
+- [x] `c` cancels running pipeline (US-3, FR-010)
+- [x] Pipeline arguments passed to executor (FR-005, FR-006)
+
+## Specification Quality
+
+- [x] Focus on WHAT and WHY, not HOW (no implementation code in spec)
+- [x] Every requirement is testable (acceptance scenarios use Given/When/Then)
+- [x] Requirements use MUST/SHOULD/MAY language consistently
+- [x] User stories are prioritized (P1 > P2 > P3)
+- [x] Each user story is independently testable
+- [x] Success criteria are measurable and technology-agnostic
+- [x] Edge cases cover boundary conditions and error scenarios
+- [x] Key entities are described with relationships
+
+## Consistency with Prior Specs
+
+- [x] Follows same header format as #254 and #255 specs
+- [x] Clarifications section follows C1/C2/C3 numbering pattern
+- [x] References existing message types (PipelineSelectedMsg, FocusChangedMsg)
+- [x] References existing patterns (PipelineDataProvider, DetailDataProvider, WaveTheme)
+- [x] Functional requirements use FR-NNN numbering
+- [x] Success criteria use SC-NNN numbering
+- [x] Dependencies on #254 (pipeline list) and #255 (pipeline detail) are implicit
+
+## Ambiguity Check
+
+- [x] No more than 3 `[NEEDS CLARIFICATION]` markers (actual: 0)
+- [x] All 6 clarifications have explicit resolutions with rationale
+- [x] C1: Form rendering approach resolved (embedded huh.Form)
+- [x] C2: State machine for right pane resolved (5 additional states)
+- [x] C3: Executor lifecycle resolved (background goroutine via tea.Cmd)
+- [x] C4: Argument set resolved (input + model + DefaultFlags)
+- [x] C5: Immediate feedback resolved (PipelineLaunchedMsg + synthetic entry)
+- [x] C6: Cancel mechanism resolved (context.CancelFunc map by run ID)
+
+## Scope Boundaries
+
+- [x] In scope: Argument menu UI (FR-001, FR-002, FR-003)
+- [x] In scope: Executor integration (FR-005, FR-006)
+- [x] In scope: State transition available→running (FR-007, FR-008)
+- [x] In scope: Cancel support (FR-010, FR-011, FR-017, FR-018)
+- [x] Out of scope: Live output streaming (deferred to #258)
+- [x] Out of scope: Post-completion interactions (chat, branch checkout, diff)
+- [x] Out of scope: Resume from step (CLI-only flag)

--- a/specs/256-tui-pipeline-launch/checklists/review.md
+++ b/specs/256-tui-pipeline-launch/checklists/review.md
@@ -1,0 +1,43 @@
+# Requirements Quality Review: TUI Pipeline Launch Flow
+
+**Feature**: #256 — TUI Pipeline Launch Flow
+**Date**: 2026-03-06
+**Spec**: `specs/256-tui-pipeline-launch/spec.md`
+
+## Completeness
+
+- [ ] CHK001 - Are all user-facing states of the right pane fully enumerated with entry/exit conditions? The spec lists 8 states (`stateEmpty` through `stateError`) but only defines transitions for a subset (e.g., `stateRunningInfo` entry conditions are not specified for TUI-launched pipelines). [Completeness]
+- [ ] CHK002 - Does the spec define what happens when a pipeline finishes while the user is viewing its argument form for a second launch of the same pipeline? [Completeness]
+- [ ] CHK003 - Are accessibility requirements specified for the argument form (e.g., screen reader announcements, focus indicators, high-contrast theme support)? [Completeness]
+- [ ] CHK004 - Does the spec define the visual representation of the "launching" state (duration, animation, fallback for non-Unicode terminals)? [Completeness]
+- [ ] CHK005 - Are requirements defined for the `PipelineLaunchedMsg` synthetic entry format — specifically what fields (status indicator, elapsed time format, name truncation) the Running section displays before the first state store refresh? [Completeness]
+- [ ] CHK006 - Does the spec address what keyboard shortcuts are available in each right-pane state? Only `stateConfiguring` (Tab, Enter, Esc) and default (Esc) are described; `stateError`, `stateLaunching`, and `stateRunningInfo` key handling is not specified. [Completeness]
+- [ ] CHK007 - Are error message content requirements specified beyond "actionable error message"? (e.g., error categorization, suggested remediation, truncation for long errors) [Completeness]
+- [ ] CHK008 - Does the spec define the maximum number of concurrent TUI-launched pipelines, or is it explicitly unbounded? [Completeness]
+- [ ] CHK009 - Are requirements specified for what happens to the cancel function map if the TUI process crashes (SIGKILL) without graceful shutdown? [Completeness]
+
+## Clarity
+
+- [ ] CHK010 - Is the relationship between `LaunchConfig.DryRun` and `LaunchConfig.Flags` containing `--dry-run` unambiguous? FR-015 uses "when the `--dry-run` flag is selected" while `LaunchConfig` has a separate `DryRun bool` field. [Clarity]
+- [ ] CHK011 - Is the scope of "fresh form" in FR-014 clearly defined — does it mean zero-valued fields, or fields pre-populated with pipeline-specific defaults (e.g., `InputExample` as placeholder vs. pre-filled value)? [Clarity]
+- [ ] CHK012 - Is the distinction between `PipelineLaunchedMsg` (executor started) and `PipelineLaunchResultMsg` (executor finished) clear about which carries the cancel function? The spec says `PipelineLaunchedMsg` carries `CancelFunc` but FR-011 says the map is "keyed by run ID" — it's unclear when the map entry is created (at `Launch()` call or upon `PipelineLaunchedMsg`). [Clarity]
+- [ ] CHK013 - Is "immediately" in FR-007 ("MUST immediately insert the pipeline at the top") defined in terms of render cycles, or is it qualitative? [Clarity]
+- [ ] CHK014 - Does "the CLI path" in FR-006 unambiguously identify which code path is being referenced (which function in `runRun()`, which options are "applicable")? [Clarity]
+
+## Consistency
+
+- [ ] CHK015 - Is the `PipelineLaunchedMsg` struct definition consistent between the spec (carrying `CancelFunc`) and the plan/tasks (not including `CancelFunc` in the struct)? The plan Phase 3 stores cancel in the map inside `Launch()` before emitting the message, but the spec's entity definition includes `CancelFunc context.CancelFunc` in the message. [Consistency]
+- [ ] CHK016 - Are the flag names consistent between the argument form (`DefaultFlags()` names) and the `LaunchConfig.Flags []string` field? Does `DefaultFlags()` return display labels or CLI flag strings? [Consistency]
+- [ ] CHK017 - Is focus management consistent between US-1 (focus returns to left after launch) and the `stateError` path (FR-013 says focus returns to left, but the error is displayed in the right pane — who renders it if focus is left)? [Consistency]
+- [ ] CHK018 - Does the plan's `ConfigureFormMsg` (not in spec requirements) align with FR-001's trigger ("when the user presses Enter")? The spec says Enter triggers the transition, but the plan introduces an intermediate message not in the requirements. [Consistency]
+- [ ] CHK019 - Is the `q`-quit guard condition consistent between spec (FR-019: `m.content.focus == FocusPaneLeft`) and the existing filter guard (`!m.content.list.filtering`)? Are both conditions required simultaneously? [Consistency]
+
+## Coverage
+
+- [ ] CHK020 - Do acceptance criteria cover the scenario where the state store becomes unavailable mid-launch (after `CreateRun` succeeds but before executor completes)? [Coverage]
+- [ ] CHK021 - Do edge cases cover terminal resize during the `stateLaunching` brief indicator? [Coverage]
+- [ ] CHK022 - Are requirements defined for the interaction between the existing 5-second `PipelineRefreshTickMsg` and the synthetic running entry — specifically, does the refresh replace, duplicate, or merge with the synthetic entry? [Coverage]
+- [ ] CHK023 - Do user stories cover the scenario of launching a pipeline when `LaunchDependencies` has nil/zero-value fields (e.g., no manifest loaded)? [Coverage]
+- [ ] CHK024 - Are test requirements specified for goroutine leak prevention (ensuring executor goroutines terminate after cancel)? [Coverage]
+- [ ] CHK025 - Do success criteria address the performance requirement that form creation and display should not introduce perceptible latency (e.g., < 100ms)? [Coverage]
+- [ ] CHK026 - Does the spec cover what happens when the user rapidly presses Enter multiple times on an available pipeline (potential race condition creating multiple forms or launches)? [Coverage]

--- a/specs/256-tui-pipeline-launch/checklists/state-lifecycle.md
+++ b/specs/256-tui-pipeline-launch/checklists/state-lifecycle.md
@@ -1,0 +1,32 @@
+# State & Lifecycle Quality Review: TUI Pipeline Launch Flow
+
+**Feature**: #256 — TUI Pipeline Launch Flow
+**Date**: 2026-03-06
+**Focus**: State machine transitions, goroutine lifecycle, and message routing requirements
+
+## Completeness
+
+- [ ] CHK101 - Are all transitions INTO `stateConfiguring` fully specified? The spec covers Enter-on-available but not whether re-selecting the same available pipeline after a successful launch should re-enter configuring. [Completeness]
+- [ ] CHK102 - Are all transitions OUT OF `stateLaunching` defined? The spec mentions transition to Running section on success and `stateError` on failure, but does not specify a timeout for the launching state itself. [Completeness]
+- [ ] CHK103 - Does the spec define the goroutine lifecycle for the executor `tea.Cmd` — specifically, is the goroutine expected to be non-cancellable once `PipelineLaunchedMsg` is emitted, or can it be interrupted between executor construction and execution? [Completeness]
+- [ ] CHK104 - Are requirements defined for the cancel function map's thread safety guarantees (the plan uses `sync.Mutex`, but the spec doesn't mention concurrency requirements for the map)? [Completeness]
+- [ ] CHK105 - Does the spec define whether `PipelineLaunchResultMsg` should trigger any UI update beyond cancel map cleanup (e.g., toast notification, status bar update, or detail pane refresh)? [Completeness]
+
+## Clarity
+
+- [ ] CHK106 - Is the ownership of the `context.CancelFunc` unambiguous? The spec entity definition puts it on `PipelineLaunchedMsg`, the plan stores it in `Launch()` before emitting the message, and the tasks reference it in both places. Which component is the authoritative holder? [Clarity]
+- [ ] CHK107 - Is "background goroutine via `tea.Cmd`" (FR-005) clear about whether this is a single `tea.Cmd` or a `tea.Batch` of two commands (immediate + blocking)? The plan specifies batch, but the requirement doesn't. [Clarity]
+- [ ] CHK108 - Is the meaning of "optional model name override" clear — does empty string mean "use default" or "don't override"? Are these semantically different in the executor? [Clarity]
+
+## Consistency
+
+- [ ] CHK109 - Is the `CancelAll()` invocation consistent between `q`-quit and `Ctrl+C` paths? FR-017 says both, but the existing `Ctrl+C` handler uses `shuttingDown` flag for double-press exit — does `CancelAll()` run before or after the flag check? [Consistency]
+- [ ] CHK110 - Is the message routing for `LaunchErrorMsg` consistent between the plan (content routes to detail) and the launcher (which generates it)? The launcher returns it as a `tea.Cmd` result, but content must intercept it before it reaches detail — is the routing path specified? [Consistency]
+- [ ] CHK111 - Is the `RunID` generation consistent between spec (state store `CreateRun()`) and tasks (fallback to `pipeline.GenerateRunID()`)? If the fallback is used, does the synthetic running entry still work without a state store record? [Consistency]
+
+## Coverage
+
+- [ ] CHK112 - Do requirements cover the scenario where two TUI-launched pipelines finish at the same moment, potentially causing concurrent `PipelineLaunchResultMsg` processing and cancel map mutations? [Coverage]
+- [ ] CHK113 - Are requirements defined for what `PipelineListModel` does when a `PipelineLaunchedMsg` arrives while the list is in filter mode? Does the new running entry appear in filtered results? [Coverage]
+- [ ] CHK114 - Do edge cases address the scenario where the manifest file changes on disk between TUI startup and pipeline launch (stale `LaunchDependencies.Manifest`)? [Coverage]
+- [ ] CHK115 - Are test requirements defined for verifying that `CancelAll()` is idempotent (calling it twice doesn't panic or produce errors)? [Coverage]

--- a/specs/256-tui-pipeline-launch/data-model.md
+++ b/specs/256-tui-pipeline-launch/data-model.md
@@ -1,0 +1,254 @@
+# Data Model: TUI Pipeline Launch Flow
+
+**Date**: 2026-03-06
+**Feature**: #256 — TUI Pipeline Launch Flow
+
+## New Types
+
+### LaunchDependencies
+
+Lightweight struct carrying pre-loaded dependencies for pipeline execution.
+Passed through `NewAppModel()` → `NewContentModel()` → `PipelineLauncher`.
+
+```go
+// LaunchDependencies holds the dependencies needed to launch pipelines from the TUI.
+// Passed at TUI construction time; executor infrastructure is created on demand.
+type LaunchDependencies struct {
+    Manifest     *manifest.Manifest
+    Store        state.StateStore
+    PipelinesDir string
+}
+```
+
+**Lifecycle**: Created once at `RunTUI()`, immutable thereafter.
+
+### LaunchConfig
+
+Data assembled from the argument form submission. Maps to the existing `Selection` type.
+
+```go
+// LaunchConfig holds the user's pipeline launch configuration from the argument form.
+type LaunchConfig struct {
+    PipelineName  string
+    Input         string
+    ModelOverride string
+    Flags         []string  // e.g., "--verbose", "--debug", "--dry-run"
+    DryRun        bool      // Extracted from Flags for convenience
+}
+```
+
+**Lifecycle**: Created when form completes, consumed by `PipelineLauncher.Launch()`, then discarded.
+
+### PipelineLauncher
+
+Component managing TUI-launched pipeline lifecycles. Field on `ContentModel`.
+
+```go
+// PipelineLauncher manages pipeline execution from the TUI.
+// It constructs executors on demand and tracks cancel functions for running pipelines.
+type PipelineLauncher struct {
+    deps       LaunchDependencies
+    cancelFns  map[string]context.CancelFunc  // runID → cancel function
+    mu         sync.Mutex                      // protects cancelFns
+}
+```
+
+**Methods**:
+- `NewPipelineLauncher(deps LaunchDependencies) *PipelineLauncher`
+- `Launch(config LaunchConfig) tea.Cmd` — returns batched cmd (immediate + executor)
+- `Cancel(runID string)` — invokes cancel function for a specific run
+- `CancelAll()` — cancels all running pipelines (called on TUI exit)
+
+**Lifecycle**: Created with `ContentModel`, lives for TUI session duration.
+
+### DetailPaneState
+
+Explicit state enum for the right pane's rendering mode.
+
+```go
+type DetailPaneState int
+
+const (
+    stateEmpty           DetailPaneState = iota  // No selection
+    stateLoading                                 // Fetching data
+    stateAvailableDetail                         // Available pipeline config
+    stateFinishedDetail                          // Finished pipeline results
+    stateRunningInfo                             // Running pipeline info
+    stateConfiguring                             // Argument form active
+    stateLaunching                               // Brief "Starting..." indicator
+    stateError                                   // Launch error display
+)
+```
+
+**Lifecycle**: Transitions driven by user actions and message handling in `PipelineDetailModel`.
+
+## New Messages
+
+### LaunchRequestMsg
+
+Emitted by `PipelineDetailModel` when the huh.Form completes.
+
+```go
+// LaunchRequestMsg is emitted when the argument form is submitted.
+type LaunchRequestMsg struct {
+    Config LaunchConfig
+}
+```
+
+**Flow**: `PipelineDetailModel` → `ContentModel.Update()` → `launcher.Launch(config)`
+
+### PipelineLaunchedMsg
+
+Emitted immediately when a pipeline executor starts.
+
+```go
+// PipelineLaunchedMsg signals that a pipeline launch was initiated.
+type PipelineLaunchedMsg struct {
+    RunID        string
+    PipelineName string
+}
+```
+
+**Flow**: `PipelineLauncher` → `ContentModel` → `PipelineListModel` (insert into Running section)
+
+### PipelineLaunchResultMsg
+
+Emitted when the executor goroutine completes (success or failure).
+
+```go
+// PipelineLaunchResultMsg signals that a launched pipeline has finished execution.
+type PipelineLaunchResultMsg struct {
+    RunID string
+    Err   error   // nil on success
+}
+```
+
+**Flow**: `PipelineLauncher` goroutine → `ContentModel` → cleanup cancel map
+
+### LaunchErrorMsg
+
+Emitted when the pipeline fails to start (before executor runs).
+
+```go
+// LaunchErrorMsg signals a pre-execution failure (adapter resolution, manifest loading, etc.).
+type LaunchErrorMsg struct {
+    PipelineName string
+    Err          error
+}
+```
+
+**Flow**: `PipelineLauncher.Launch()` → `ContentModel` → `PipelineDetailModel` (show error)
+
+## Modified Types
+
+### PipelineDetailModel
+
+Add fields for form state and launch config:
+
+```go
+type PipelineDetailModel struct {
+    // ... existing fields ...
+    
+    // Launch form state
+    paneState    DetailPaneState
+    launchForm   *huh.Form      // Non-nil when configuring
+    launchInput  string          // Bound to form input field
+    launchModel  string          // Bound to form model override field
+    launchFlags  []string        // Bound to form flag multi-select
+    launchError  string          // Error message for stateError
+}
+```
+
+### ContentModel
+
+Add launcher field and route new messages:
+
+```go
+type ContentModel struct {
+    // ... existing fields ...
+    launcher *PipelineLauncher
+}
+```
+
+### AppModel
+
+- Modify `q`-to-quit check to gate on `m.content.focus == FocusPaneLeft`
+- Call `m.content.CancelAll()` before `tea.Quit` on exit
+
+### StatusBarModel
+
+- Add form-context hints when right pane is in configuring state
+- New hint text: `"Tab: next  Shift+Tab: prev  Enter: launch  Esc: cancel"`
+
+### RunTUI()
+
+- Change signature to accept `LaunchDependencies` (or its constituent parts)
+- Pass dependencies through to `NewAppModel()`
+
+### NewAppModel()
+
+- Add `LaunchDependencies` parameter
+- Pass to `NewContentModel()`
+
+### NewContentModel()
+
+- Add `LaunchDependencies` parameter
+- Create `PipelineLauncher` with dependencies
+
+## State Transitions
+
+```
+Left pane focused, available item selected
+    ↓ Enter
+PipelineDetailModel: stateAvailableDetail → stateConfiguring
+    (form created, focus → right pane)
+    ↓ Form submitted (huh.StateCompleted)
+PipelineDetailModel: stateConfiguring → stateLaunching
+    (emit LaunchRequestMsg)
+    ↓ PipelineLaunchedMsg received
+PipelineDetailModel: stateLaunching → stateRunningInfo
+PipelineListModel: insert synthetic RunningPipeline at top
+    (focus → left pane, cursor → new running entry)
+    ↓ PipelineLaunchResultMsg received
+PipelineLauncher: remove cancel function
+    (normal refresh tick updates Running/Finished sections)
+
+Alternative paths:
+    ↓ Esc during form
+PipelineDetailModel: stateConfiguring → stateAvailableDetail
+    (focus → left pane)
+    ↓ LaunchErrorMsg
+PipelineDetailModel: stateLaunching → stateError
+    (show error, focus → left pane)
+    ↓ Esc from error / navigate away
+PipelineDetailModel: stateError → stateAvailableDetail
+```
+
+## Interaction Flow Diagram
+
+```
+User: Enter on available pipeline
+  → ContentModel: detect available + Enter → transition focus right
+  → PipelineDetailModel: create huh.Form, set stateConfiguring
+  
+User: Fill form, press Enter on submit
+  → huh.Form: StateCompleted
+  → PipelineDetailModel: extract values, emit LaunchRequestMsg
+  → ContentModel: handle LaunchRequestMsg, call launcher.Launch()
+  → PipelineLauncher: create context, resolve adapter, build executor
+    → Immediate cmd: return PipelineLaunchedMsg
+    → Background cmd: run executor, return PipelineLaunchResultMsg
+  → ContentModel: handle PipelineLaunchedMsg
+    → PipelineListModel: insert RunningPipeline, move cursor
+    → Focus → left pane
+    
+User: Press 'c' on running pipeline
+  → PipelineListModel: forward to ContentModel
+  → ContentModel: call launcher.Cancel(runID)
+  → context cancelled → executor stops
+
+User: q / Ctrl+C
+  → AppModel: call content.CancelAll()
+  → All cancel functions invoked
+  → tea.Quit
+```

--- a/specs/256-tui-pipeline-launch/plan.md
+++ b/specs/256-tui-pipeline-launch/plan.md
@@ -1,0 +1,231 @@
+# Implementation Plan: TUI Pipeline Launch Flow
+
+**Branch**: `256-tui-pipeline-launch` | **Date**: 2026-03-06 | **Spec**: `specs/256-tui-pipeline-launch/spec.md`
+**Input**: Feature specification from `/specs/256-tui-pipeline-launch/spec.md`
+
+## Summary
+
+Add pipeline launch capability to the TUI. When a user selects an available pipeline and presses Enter, the right pane transitions from detail preview to an embedded `huh.Form` argument configuration form (input, model override, flag toggles). Submitting launches the pipeline executor in a background goroutine via `tea.Cmd`. The pipeline immediately appears in the Running section. Esc cancels at any point, `c` cancels a running pipeline. A `PipelineLauncher` component on `ContentModel` manages executor lifecycle and cancel functions. `LaunchDependencies` struct flows through the component hierarchy to provide executor construction dependencies on demand.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (existing project)
+**Primary Dependencies**: `charmbracelet/bubbletea` v1.3.10, `charmbracelet/huh` v0.8.0 (both existing)
+**Storage**: SQLite via `internal/state` (existing — used for run record creation and status updates)
+**Testing**: `go test` with `testify/assert`, `testify/require`
+**Target Platform**: Linux/macOS terminal (80–300 columns, 24–100 rows)
+**Project Type**: Single Go binary — changes in `internal/tui/` and `cmd/wave/`
+**Constraints**: No new external dependencies; must not break existing tests (`go test ./...`)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | ✅ Pass | No new runtime dependencies. Uses existing `huh` v0.8.0 form embedding. |
+| P2: Manifest as SSOT | ✅ Pass | Pipeline loaded from YAML files discovered via manifest pipelines directory. |
+| P3: Persona-Scoped Execution | ✅ Pass | TUI constructs executor with full persona scoping — same path as CLI. |
+| P4: Fresh Memory at Step Boundary | ✅ Pass | Executor constructed per-launch — no state leakage between launches. |
+| P5: Navigator-First Architecture | ✅ Pass | Executor runs the full pipeline DAG including navigator steps. |
+| P6: Contracts at Every Handover | ✅ Pass | Executor handles contract validation — TUI doesn't bypass it. |
+| P7: Relay via Dedicated Summarizer | N/A | TUI component, no context compaction. |
+| P8: Ephemeral Workspaces | ✅ Pass | Executor creates workspaces as normal — TUI doesn't interfere. |
+| P9: Credentials Never Touch Disk | ✅ Pass | No credential handling in TUI layer. Executor inherits env vars. |
+| P10: Observable Progress | ✅ Pass | Executor emitter is initialized per-launch. Running section shows status. |
+| P11: Bounded Recursion | ✅ Pass | Executor enforces bounds — TUI doesn't modify executor behavior. |
+| P12: Minimal Step State Machine | ✅ Pass | Uses existing step state machine via executor. |
+| P13: Test Ownership | ✅ Pass | All new code will have tests; existing tests updated for modified signatures. |
+
+No violations. No complexity tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/256-tui-pipeline-launch/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```
+internal/tui/
+├── app.go                    # MODIFY — q-quit guard, CancelAll on exit, LaunchDependencies param
+├── app_test.go               # MODIFY — update for new AppModel signature, q-quit focus tests
+├── content.go                # MODIFY — add PipelineLauncher, route launch messages, CancelAll()
+├── content_test.go           # MODIFY — update for new ContentModel signature, launch message tests
+├── pipeline_detail.go        # MODIFY — add DetailPaneState, form embedding, form lifecycle
+├── pipeline_detail_test.go   # MODIFY — add form rendering, state transition, form abort tests
+├── pipeline_list.go          # MODIFY — handle PipelineLaunchedMsg (insert running entry)
+├── pipeline_list_test.go     # MODIFY — test PipelineLaunchedMsg handling
+├── pipeline_messages.go      # MODIFY — add LaunchRequestMsg, PipelineLaunchedMsg, etc.
+├── pipeline_launcher.go      # NEW — PipelineLauncher component
+├── pipeline_launcher_test.go # NEW — launcher unit tests
+├── statusbar.go              # MODIFY — add form-context hints
+├── statusbar_test.go         # MODIFY — test form-context hints
+├── run_selector.go           # READ-ONLY — reuse WaveTheme(), DefaultFlags(), buildFlagOptions()
+├── pipelines.go              # MODIFY — add LoadPipelineByName() for full pipeline loading
+├── pipelines_test.go         # MODIFY — test LoadPipelineByName()
+├── theme.go                  # READ-ONLY — WaveTheme() reused by embedded form
+├── header_messages.go        # READ-ONLY — FocusPane, FocusChangedMsg reused
+
+cmd/wave/commands/
+├── tui.go                    # MODIFY — pass LaunchDependencies to RunTUI()
+```
+
+**Structure Decision**: All changes within the existing `internal/tui/` package plus one new file (`pipeline_launcher.go`). The launcher is a component, not a separate package, because it operates within the TUI's message-passing architecture and shares types with other TUI components.
+
+## Implementation Approach
+
+### Phase 1: Foundation — Messages, Types, and State Machine
+
+**Files**: `pipeline_messages.go`, `pipeline_detail.go`
+
+1. Add new message types to `pipeline_messages.go`:
+   - `LaunchRequestMsg{Config LaunchConfig}`
+   - `PipelineLaunchedMsg{RunID, PipelineName string}`
+   - `PipelineLaunchResultMsg{RunID string, Err error}`
+   - `LaunchErrorMsg{PipelineName string, Err error}`
+   - `LaunchConfig` struct
+   - `LaunchDependencies` struct
+   - `DetailPaneState` type with constants
+
+2. Refactor `PipelineDetailModel` to use `DetailPaneState`:
+   - Add `paneState DetailPaneState` field
+   - Set state in `Update()` instead of relying on nil checks
+   - Update `View()` to switch on `paneState`
+   - This is a refactor — existing behavior must be preserved
+
+### Phase 2: Argument Form — Creation and Lifecycle
+
+**Files**: `pipeline_detail.go`, `pipeline_detail_test.go`
+
+1. Add form fields to `PipelineDetailModel`:
+   - `launchForm *huh.Form`
+   - `launchInput, launchModel string` (value bindings)
+   - `launchFlags []string` (value binding)
+   - `launchError string`
+
+2. Implement form creation when `stateConfiguring` is entered:
+   - Triggered by a new `ConfigureFormMsg` from `ContentModel`
+   - Create `huh.Form` with input field (placeholder from `InputExample`), model override field, flag multi-select
+   - Apply `WaveTheme()`, set width/height
+   - Call `form.Init()`
+
+3. Implement form lifecycle in `Update()`:
+   - Forward key messages to `form.Update(msg)` when `stateConfiguring`
+   - Check `form.State` after each update:
+     - `huh.StateCompleted` → extract values, emit `LaunchRequestMsg`
+     - `huh.StateAborted` → revert to `stateAvailableDetail`
+   - Handle form resizing on `SetSize()`
+
+4. Implement form rendering in `View()`:
+   - `stateConfiguring` renders `form.View()` within the pane
+   - `stateLaunching` renders "Starting..." indicator
+   - `stateError` renders error message with action hints
+
+### Phase 3: PipelineLauncher Component
+
+**Files**: `pipeline_launcher.go`, `pipeline_launcher_test.go`
+
+1. Implement `PipelineLauncher` struct:
+   - `deps LaunchDependencies`
+   - `cancelFns map[string]context.CancelFunc`
+   - `mu sync.Mutex`
+
+2. Implement `Launch(config LaunchConfig) tea.Cmd`:
+   - Load full `pipeline.Pipeline` from YAML
+   - Create `context.WithCancel(context.Background())`
+   - Resolve adapter (mock if `--mock` flag, else `adapter.ResolveAdapter()`)
+   - Create run ID via state store
+   - Build executor with options (mirroring `runRun()`)
+   - Store cancel function in map
+   - Return `tea.Batch(immediateCmd, executorCmd)`:
+     - `immediateCmd` returns `PipelineLaunchedMsg`
+     - `executorCmd` calls `executor.Execute()`, returns `PipelineLaunchResultMsg`
+
+3. Implement `Cancel(runID string)`:
+   - Look up cancel function in map, call it if found
+
+4. Implement `CancelAll()`:
+   - Iterate map, call all cancel functions
+
+5. Add `LoadPipelineByName(name string) (*pipeline.Pipeline, error)` to `pipelines.go`
+
+### Phase 4: Content Model Integration
+
+**Files**: `content.go`, `content_test.go`
+
+1. Add `launcher *PipelineLauncher` field to `ContentModel`
+2. Modify `NewContentModel()` to accept `LaunchDependencies` and create launcher
+3. Add message routing in `Update()`:
+   - `LaunchRequestMsg` → call `launcher.Launch(config)`, transition to `stateLaunching`
+   - `PipelineLaunchedMsg` → forward to list (insert running entry), transition focus to left
+   - `PipelineLaunchResultMsg` → forward to launcher (cleanup cancel map)
+   - `LaunchErrorMsg` → forward to detail (show error), focus left
+4. Modify Enter handling: when focus transitions right on available item, emit `ConfigureFormMsg` to trigger form creation
+5. Expose `CancelAll()` method that delegates to launcher
+6. Handle `c` key when left pane focused and cursor on running item: call `launcher.Cancel(runID)`
+
+### Phase 5: Pipeline List — Running Entry Insertion
+
+**Files**: `pipeline_list.go`, `pipeline_list_test.go`
+
+1. Handle `PipelineLaunchedMsg` in `PipelineListModel.Update()`:
+   - Create synthetic `RunningPipeline{RunID, Name, StartedAt: time.Now()}`
+   - Prepend to `m.running`
+   - Rebuild navigable items
+   - Move cursor to the new running entry
+   - Return `RunningCountMsg` and `PipelineSelectedMsg`
+
+### Phase 6: App Model and Status Bar
+
+**Files**: `app.go`, `app_test.go`, `statusbar.go`, `statusbar_test.go`
+
+1. Modify `AppModel`:
+   - Gate `q`-to-quit on `m.content.focus == FocusPaneLeft`
+   - Call `m.content.CancelAll()` before `tea.Quit` on exit (both `q` and `Ctrl+C`)
+   - Update `NewAppModel()` to accept `LaunchDependencies`
+
+2. Modify `RunTUI()`:
+   - Accept `LaunchDependencies` parameter
+   - Pass through to `NewAppModel()`
+
+3. Modify `StatusBarModel`:
+   - Detect configuring state (new `FormActiveMsg` or check focus + pane state)
+   - Show form-specific hints: `"Tab: next  Shift+Tab: prev  Enter: launch  Esc: cancel"`
+
+### Phase 7: CLI Integration
+
+**Files**: `cmd/wave/commands/tui.go` (or equivalent)
+
+1. Modify the TUI command to construct `LaunchDependencies`:
+   - Load manifest
+   - Open state store
+   - Determine pipelines directory
+   - Pass to `tui.RunTUI(deps)`
+
+### Phase 8: Test Updates
+
+**Files**: All `*_test.go` files in `internal/tui/`
+
+1. Update all test functions that call `NewAppModel()`, `NewContentModel()` to pass `nil` or zero-value `LaunchDependencies`
+2. Add new test cases:
+   - Form creation on Enter for available item
+   - Form abort on Esc
+   - Form completion triggers LaunchRequestMsg
+   - PipelineLaunchedMsg inserts running entry
+   - `q` during form does not quit
+   - `c` on running pipeline calls cancel
+   - CancelAll on exit
+   - Form renders correctly at boundary dimensions
+
+## Complexity Tracking
+
+_No constitution violations. No complexity tracking entries needed._

--- a/specs/256-tui-pipeline-launch/research.md
+++ b/specs/256-tui-pipeline-launch/research.md
@@ -1,0 +1,89 @@
+# Research: TUI Pipeline Launch Flow
+
+**Date**: 2026-03-06
+**Feature**: #256 — TUI Pipeline Launch Flow
+
+## R1: huh.Form Embedding in Bubble Tea
+
+**Decision**: Use `huh.Form` as an embedded `tea.Model` within `PipelineDetailModel`
+
+**Rationale**: The `huh` library (v0.8.0, already a dependency) implements `tea.Model` on its `Form` type — `Init()`, `Update(msg) (tea.Model, tea.Cmd)`, `View() string`. When embedded, the parent model forwards key messages to `form.Update(msg)` and checks `form.State` after each update for `huh.StateCompleted` or `huh.StateAborted`. This is the documented embedding pattern.
+
+Key API surface:
+- `huh.NewForm(groups...) *Form` — constructor
+- `form.Init() tea.Cmd` — must be called when the form is created
+- `form.Update(msg) (tea.Model, tea.Cmd)` — returns `tea.Model`, must cast back to `*huh.Form`
+- `form.State` — `huh.StateNormal`, `huh.StateCompleted`, `huh.StateAborted`
+- `form.WithWidth(w)` / `form.WithHeight(h)` — sizing for embedded layout
+- `form.WithTheme(theme)` — applies `WaveTheme()` for visual consistency
+- Value bindings via `huh.NewInput().Value(&str)`, `huh.NewMultiSelect[string]().Value(&slice)`
+
+**Alternatives Rejected**:
+- Custom Bubble Tea widgets: Higher implementation cost, no visual consistency with CLI selector
+- Full-screen form via `form.Run()`: Blocks the event loop, incompatible with TUI architecture
+
+## R2: Executor Integration via Background Goroutine
+
+**Decision**: Launch executor in a goroutine wrapped in `tea.Cmd`, return result messages
+
+**Rationale**: The executor's `Execute()` method is synchronous and blocking. The Bubble Tea event loop must not block. The standard pattern is to wrap blocking work in a `tea.Cmd` (a `func() tea.Msg`). The approach:
+
+1. `PipelineLauncher.Launch(config)` returns a `tea.Cmd` via `tea.Batch()` combining:
+   - An immediate cmd that returns `PipelineLaunchedMsg` (instant UI feedback)
+   - A blocking cmd that runs the executor and returns `PipelineLaunchResultMsg`
+2. The cancel function from `context.WithCancel()` is stored in a map keyed by run ID
+3. `tea.Batch()` runs both commands concurrently — the immediate one resolves instantly, the executor one blocks until completion
+
+**Alternatives Rejected**:
+- Channel-based communication: Unnecessary complexity; `tea.Cmd` is idiomatic Bubble Tea
+- Polling state store: 5-second delay, poor UX for instant feedback
+
+## R3: LaunchDependencies Injection
+
+**Decision**: Introduce `LaunchDependencies` struct passed through `NewAppModel()` → `NewContentModel()` → `PipelineLauncher`
+
+**Rationale**: The executor requires `*manifest.Manifest`, `state.StateStore`, and the pipelines directory path. These are available at `RunTUI()` call site. Rather than constructing full executor infrastructure at startup, pass lightweight dependencies and construct executor on demand.
+
+`PipelineLauncher` resolves adapter runner, workspace manager, and audit logger per-launch, mirroring `runRun()` in `cmd/wave/commands/run.go`. This keeps TUI startup fast and avoids holding resources for unlaunched pipelines.
+
+**Alternatives Rejected**:
+- Pre-constructing executor at startup: Wastes resources, couples adapter resolution to TUI init
+- Passing individual dependencies: Too many parameters, struct is cleaner
+
+## R4: Detail Pane State Machine Extension
+
+**Decision**: Add explicit `DetailPaneState` type replacing implicit nil checks
+
+**Rationale**: The current `PipelineDetailModel` infers state from nil checks on `availableDetail`/`finishedDetail`. Adding `configuring`, `launching`, and `error` states makes nil-check approach fragile. An explicit state enum:
+- `stateEmpty` — no selection (placeholder message)
+- `stateLoading` — fetching data
+- `stateAvailableDetail` — showing available pipeline info
+- `stateFinishedDetail` — showing finished pipeline results
+- `stateRunningInfo` — showing running pipeline brief info
+- `stateConfiguring` — argument form is active
+- `stateLaunching` — brief "Starting..." indicator
+- `stateError` — launch error message
+
+**Alternatives Rejected**:
+- Continue with nil checks + booleans: Fragile, hard to reason about transitions
+
+## R5: `q`-to-quit Guard
+
+**Decision**: Gate `q`-to-quit on `m.content.focus == FocusPaneLeft` in `AppModel.Update()`
+
+**Rationale**: When the argument form is active, `q` typed in a text field must not quit the app. The current handler at `app.go:57` checks `!m.content.list.filtering` but not focus state. Adding the focus gate ensures `q` only quits from the left pane, consistent with how Esc is already focus-gated in `content.go:62`.
+
+**Alternatives Rejected**:
+- Adding a `formActive` boolean: Exposes internal state; focus pane is already the correct abstraction
+
+## R6: Pipeline Loading for Launch
+
+**Decision**: Load pipeline YAML on demand at launch time via existing `parsePipelineFile()` in `pipelines.go`
+
+**Rationale**: The `PipelineLauncher` needs the full `pipeline.Pipeline` struct for the executor, not just `PipelineInfo`. The `AvailableDetail` already parsed the YAML and has the name. At launch time, re-parse the YAML to get the full `Pipeline` struct. This avoids caching full pipeline objects in memory when most won't be launched.
+
+The `loadPipeline()` function in `cmd/wave/commands/run.go` loads from the manifest's pipeline references. We can either reuse that or scan the pipelines directory. Since the TUI already uses `DiscoverPipelines()` which scans the directory, we add a `LoadPipeline(name string) (*pipeline.Pipeline, error)` to the launcher that does a targeted YAML parse from the pipelines directory.
+
+**Alternatives Rejected**:
+- Caching all Pipeline structs at TUI startup: Memory waste for O(N) pipelines when only 1-2 launched
+- Passing pre-loaded Pipeline through the form: Form only knows the name, loading happens at launch

--- a/specs/256-tui-pipeline-launch/spec.md
+++ b/specs/256-tui-pipeline-launch/spec.md
@@ -1,0 +1,231 @@
+# Feature Specification: TUI Pipeline Launch Flow
+
+**Feature Branch**: `256-tui-pipeline-launch`  
+**Created**: 2026-03-06  
+**Status**: Draft  
+**Issue**: [#256](https://github.com/re-cinq/wave/issues/256) (part 5 of 10, parent: [#251](https://github.com/re-cinq/wave/issues/251))  
+**Input**: Implement the pipeline launch flow from the TUI. When a user selects an available pipeline and presses Enter, the right pane shows a configuration menu with pipeline arguments (input field, flag toggles, model override). Pressing Enter from the argument menu starts the pipeline via the executor, moves it from Available to Running in the left pane, and re-focuses the left pane with the new running pipeline auto-selected. Esc cancels at any point. `c` cancels a running pipeline.
+
+## Clarifications
+
+The following ambiguities were identified and resolved during specification refinement:
+
+### C1: Argument menu rendering approach — embedded form vs custom widgets
+
+**Ambiguity**: The issue says "argument menu" in the right pane, but doesn't specify whether this is a full `huh` form (the library already used in `run_selector.go`), a custom Bubble Tea model with manual key handling, or something else.
+
+**Resolution**: Use `huh.Form` embedded within the `PipelineDetailModel` as a child Bubble Tea model. The `huh` library supports embedding — its `Form` type implements `tea.Model` (Init/Update/View). When an available pipeline is selected and Enter is pressed, the right pane transitions from the detail preview to an embedded `huh.Form` containing the input field, flag multi-select, and model override text field. This reuses the existing `WaveTheme()` and `DefaultFlags()` from `run_selector.go`, maintaining visual consistency. The form's completion event triggers pipeline launch.
+
+### C2: Right pane state machine — detail view vs argument menu vs confirmation
+
+**Ambiguity**: The right pane currently has three states (placeholder, loading, detail). Adding an argument menu introduces new states. It's unclear when the detail preview disappears and the form appears, and whether there's a confirmation step (like the CLI's "Run this command?" confirm).
+
+**Resolution**: The right pane gains two additional states: `configuring` (the argument form is active) and `launching` (brief "Starting..." indicator while executor spins up). The state transitions are:
+- **Available selected + Enter** (from left pane): right pane switches from detail preview to `configuring` state (the form). Focus moves to the right pane.
+- **Form completed** (Enter on last field or explicit submit): right pane briefly shows `launching` state, then the pipeline starts. Focus returns to left pane.
+- **Esc during form**: right pane reverts to detail preview, focus returns to left pane. No pipeline started.
+
+There is no separate "Run this command?" confirmation dialog. The CLI selector has one because it's a standalone flow; in the TUI, the user has already deliberately navigated to the pipeline and filled out the form. Adding a confirmation dialog would be an unnecessary friction point. The Esc key provides a clear escape hatch at any point.
+
+### C3: Executor lifecycle and TUI event loop integration
+
+**Ambiguity**: The executor's `Execute()` method is synchronous and blocking (runs all steps sequentially). The TUI runs a Bubble Tea event loop that must not block. It's unclear how these two systems integrate.
+
+**Resolution**: The executor runs in a background goroutine launched via a `tea.Cmd`. The `tea.Cmd` closure creates a cancellable context, constructs the executor with the appropriate options, calls `executor.Execute(ctx, pipeline, manifest, input)`, and returns a `PipelineLaunchResultMsg` when the executor finishes (success or error). The cancel function is stored on the model so the `c` key can invoke it. The state store's existing polling (5-second `PipelineRefreshTickMsg` in the pipeline list) picks up the new running pipeline and reflects it in the Running section without any special wiring.
+
+### C4: Which arguments/flags to present in the menu
+
+**Ambiguity**: The issue mentions "model selector, verbose toggle, debug toggle, required input fields". The existing `DefaultFlags()` includes 6 flags (verbose, output json, output text, dry-run, mock, debug). It's unclear whether the TUI menu should show all 6, a subset, or add a model selector that doesn't exist in the current flags.
+
+**Resolution**: The argument menu presents:
+1. **Input text field** — free-text pipeline input (with placeholder from `PipelineInfo.InputExample`). Always shown.
+2. **Model override text field** — optional model name override (maps to `--model` CLI flag). Empty means use default. Shown as a text input, not a dropdown, because available models depend on the adapter.
+3. **Flag toggles** — multi-select from the existing `DefaultFlags()` set: verbose, output json, output text, dry-run, mock, debug. These map directly to the existing `Selection.Flags` and `applySelection()` logic.
+
+This provides parity with the CLI's `RunOptions` while keeping the form simple. The `--from-step`, `--force`, `--timeout`, and `--run` flags remain CLI-only since they apply to resume scenarios not available through the TUI launch flow.
+
+### C5: How the launched pipeline appears in the Running section
+
+**Ambiguity**: After launching, the issue says the pipeline "moves from Available to Running" and the left pane "re-focuses with the new running pipeline auto-selected at top". But the pipeline list uses polling (5-second tick). If the state store hasn't been updated yet, the new pipeline won't appear in the Running section until the next poll.
+
+**Resolution**: On successful executor start, emit a `PipelineLaunchedMsg` carrying the run ID and pipeline name. The `PipelineListModel` handles this message by immediately inserting a synthetic `RunningPipeline` entry at the top of the Running section (before the next poll fetches it from the state store). The cursor moves to this entry. On the next data refresh tick, the synthetic entry is replaced by the real state store entry. This provides instant visual feedback without waiting for the 5-second polling interval.
+
+### C6: Cancel mechanism for running pipelines
+
+**Ambiguity**: The issue says "`c` key cancels a selected running pipeline" but the current cancellation mechanism is context-driven (SIGINT → cancel()). There's no per-pipeline cancel API on the executor. The TUI needs a way to cancel a specific running pipeline.
+
+**Resolution**: When a pipeline is launched from the TUI, the cancel function from `context.WithCancel()` is stored in a map keyed by run ID on the `ContentModel` (or a new `PipelineLauncher` component). When the user presses `c` with a running pipeline selected, the stored cancel function is invoked, which propagates context cancellation to the executor's step loop and adapter subprocess. The map entry is cleaned up when the `PipelineLaunchResultMsg` arrives (indicating the executor goroutine has exited). Pipelines started from outside the TUI (via CLI) cannot be cancelled from the TUI — this is a known limitation documented in edge cases.
+
+### C7: PipelineLauncher dependency injection — how does the launcher get executor dependencies?
+
+**Ambiguity**: The executor (`pipeline.NewDefaultPipelineExecutor`) requires an `adapter.AdapterRunner`, `state.StateStore`, `workspace.WorkspaceManager`, `audit.AuditLogger`, `event.EventEmitter`, and a loaded `manifest.Manifest`. The spec says `PipelineLauncher` "handles construction of the executor" but doesn't specify how these heavyweight dependencies flow into the TUI, which currently has no access to the manifest or adapter resolution. `RunTUI()` in `app.go:121` currently passes `nil` for providers.
+
+**Resolution**: Introduce a `LaunchDependencies` struct containing the pre-loaded `*manifest.Manifest`, the `state.StateStore` (already available to the data providers), and the pipelines directory path. Pass this struct through `NewAppModel()` → `NewContentModel()` → `PipelineLauncher`. The launcher resolves the adapter runner on demand at launch time (using `adapter.ResolveAdapter()` from the manifest, or `adapter.NewMockAdapter()` when the `--mock` flag is toggled). It constructs the workspace manager and audit logger per-launch as the CLI does in `runRun()`. This keeps TUI startup lightweight — no adapter or workspace manager is created until a pipeline is actually launched. The `RunTUI()` function signature changes to accept `LaunchDependencies` (or its constituent parts).
+
+### C8: huh.Form completion detection in embedded Bubble Tea mode
+
+**Ambiguity**: The spec says "The form's completion event triggers pipeline launch" but the `huh.Form` in the CLI uses blocking `form.Run()`. When embedded in Bubble Tea's non-blocking event loop, the completion mechanism is different.
+
+**Resolution**: The `huh.Form` type implements `tea.Model` (Init/Update/View). When embedded, the `PipelineDetailModel` holds a `*huh.Form` field that is non-nil when in `configuring` state. Key events are forwarded to `form.Update(msg)`. After each update, the model checks `form.State`: if `huh.StateCompleted`, it extracts the bound values (input, model override, flags) from the form's value bindings, constructs a `LaunchConfig`, and returns a `tea.Cmd` that emits a `LaunchRequestMsg`. If `huh.StateAborted` (user pressed Esc within the form), the form field is set to nil and the right pane reverts to detail preview. This is the standard huh embedding pattern documented in the charmbracelet/huh README.
+
+### C9: `q`-to-quit conflict with form text input
+
+**Ambiguity**: `app.go:57` checks `msg.String() == "q" && !m.content.list.filtering` before forwarding key events to content. When the argument form is active in the right pane and the user types `q` in a text input field, this handler fires first and quits the application instead of inserting the character `q`.
+
+**Resolution**: Gate the `q`-to-quit check on the content pane's focus state: `msg.String() == "q" && !m.content.list.filtering && m.content.focus == FocusPaneLeft`. When the right pane has focus (including during form input), `q` is treated as a regular character and forwarded to the focused child component. This is consistent with how Esc is already focus-gated in `content.go:62`. The same guard applies to any future single-character shortcuts.
+
+### C10: PipelineLauncher component hierarchy position
+
+**Ambiguity**: The spec introduces `PipelineLauncher` as a component but doesn't specify where it sits in the `AppModel → ContentModel → (PipelineListModel, PipelineDetailModel)` hierarchy. This affects message routing and access to the cancel function map.
+
+**Resolution**: `PipelineLauncher` is a field on `ContentModel`. This is the natural position because `ContentModel` already mediates all interactions between the left pane (list) and right pane (detail) and manages focus transitions. The flow is: (1) `PipelineDetailModel` detects form completion and returns a `LaunchRequestMsg` via `tea.Cmd`, (2) `ContentModel.Update()` handles `LaunchRequestMsg` by calling `launcher.Launch(config)` which returns a `tea.Cmd` wrapping the executor goroutine, (3) the goroutine emits `PipelineLaunchedMsg` (on start) and `PipelineLaunchResultMsg` (on finish), (4) `ContentModel` routes these to both `PipelineListModel` (for Running section insertion) and the launcher (for cancel function map management). `AppModel` remains unchanged except for the `q`-quit guard and exit cleanup call.
+
+### C11: Executor goroutine cleanup on TUI exit
+
+**Ambiguity**: The spec requires "all TUI-launched pipeline contexts MUST be cancelled" on quit (`q` or `Ctrl+C`). Currently `AppModel.Update()` returns `tea.Quit` immediately. But cancel functions are stored on `ContentModel.launcher`, and there's no hook for `AppModel` to trigger cleanup before the program exits.
+
+**Resolution**: `ContentModel` exposes a `CancelAll()` method that iterates over the launcher's cancel function map and calls each one. `AppModel.Update()` calls `m.content.CancelAll()` before returning `tea.Quit` on `q` or `Ctrl+C`. Since context cancellation is non-blocking (it just sets a flag), this completes instantly. The executor goroutines receive context cancellation and will update the state store with "cancelled" status best-effort — the TUI does not wait for goroutine completion since the process is exiting. For `Ctrl+C`, the existing `shuttingDown` flag ensures a second `Ctrl+C` force-exits via `os.Exit(0)`.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Launch a Pipeline from the TUI (Priority: P1)
+
+A developer navigates to an available pipeline in the left pane and presses Enter. The right pane transitions from the detail preview to an argument configuration form. The form shows an input text field (with a placeholder example from the pipeline), optional flag toggles (verbose, debug, dry-run, mock, output format), and an optional model override field. The developer fills in the input, toggles verbose mode, and submits the form. The pipeline starts executing in the background. The left pane gains focus, and the newly running pipeline appears at the top of the Running section, auto-selected by the cursor. The detail pane shows the running pipeline's status.
+
+**Why this priority**: This is the core feature — the entire issue exists to enable pipeline launching from the TUI. Without this, users must exit the TUI and use `wave run` from the CLI.
+
+**Independent Test**: Can be tested by selecting an available pipeline, pressing Enter, verifying the form renders with correct fields, submitting the form, and verifying the pipeline appears in the Running section with the left pane focused and cursor on the new entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** the left pane is focused with an available pipeline selected, **When** the user presses Enter, **Then** the right pane transitions from the detail preview to an argument configuration form with input, model, and flag fields.
+2. **Given** the argument form is visible in the right pane, **When** the form renders, **Then** the input field shows the pipeline's `InputExample` as placeholder text.
+3. **Given** the argument form is filled out, **When** the user submits the form (Enter on the submit button), **Then** the pipeline executor starts in a background goroutine with the specified arguments.
+4. **Given** the executor has started successfully, **When** the state updates, **Then** the pipeline appears at the top of the Running section in the left pane with an elapsed time indicator, the left pane gains focus, and the cursor auto-selects the new running pipeline.
+5. **Given** the pipeline has been launched, **When** the status bar updates, **Then** it shows left-pane hints (navigate, view, filter, quit).
+
+---
+
+### User Story 2 - Cancel Pipeline Launch Before Starting (Priority: P1)
+
+A developer opens the argument form for a pipeline but decides not to launch it. They press Esc at any point during the form. The right pane reverts to the pipeline detail preview. Focus returns to the left pane. No pipeline is started.
+
+**Why this priority**: Equally critical to US-1. Users must be able to back out of a launch without consequences. Without cancel support, accidentally pressing Enter on a pipeline forces an unwanted execution.
+
+**Independent Test**: Can be tested by opening the argument form, pressing Esc, and verifying the right pane reverts to the detail preview with no state changes (no new run record, no running pipeline).
+
+**Acceptance Scenarios**:
+
+1. **Given** the argument form is active in the right pane, **When** the user presses Esc, **Then** the form is dismissed, the right pane reverts to the available pipeline detail preview, and focus returns to the left pane.
+2. **Given** the user pressed Esc during the form, **When** the left pane re-gains focus, **Then** the cursor remains on the same available pipeline that was previously selected.
+3. **Given** the user pressed Esc during the form, **When** checking the state store, **Then** no new run record has been created.
+
+---
+
+### User Story 3 - Cancel a Running Pipeline (Priority: P2)
+
+A developer selects a running pipeline in the left pane and presses `c`. The running pipeline's context is cancelled, causing the executor to stop after the current step completes (or immediately if the adapter supports it). The pipeline transitions from Running to Finished with a "cancelled" status.
+
+**Why this priority**: Cancel support is important for long-running pipelines, but users can also close the TUI and send SIGINT as a workaround. This provides a more targeted cancellation mechanism.
+
+**Independent Test**: Can be tested by launching a pipeline, selecting it in the Running section, pressing `c`, and verifying it transitions to Finished with "cancelled" status.
+
+**Acceptance Scenarios**:
+
+1. **Given** the left pane is focused with a running pipeline selected (launched from this TUI session), **When** the user presses `c`, **Then** the pipeline's cancellation function is invoked, stopping the executor.
+2. **Given** a pipeline has been cancelled, **When** the next data refresh occurs, **Then** the pipeline moves from the Running section to the Finished section with "cancelled" status.
+3. **Given** a running pipeline was started from outside the TUI (e.g., via CLI in another terminal), **When** the user selects it and presses `c`, **Then** no action is taken (the TUI only cancels pipelines it launched).
+4. **Given** no running pipeline is selected (cursor is on a section header, finished, or available item), **When** the user presses `c`, **Then** nothing happens.
+
+---
+
+### User Story 4 - Handle Pipeline Launch Errors (Priority: P2)
+
+A developer submits the argument form, but the pipeline fails to start (e.g., manifest loading error, missing adapter, preflight failure). The right pane displays an actionable error message explaining what went wrong. Focus returns to the left pane. The user can try again or select a different pipeline.
+
+**Why this priority**: Error handling ensures the TUI doesn't silently fail or crash when launch conditions aren't met. However, most pipelines will start successfully in normal operation, making this secondary to the happy path.
+
+**Independent Test**: Can be tested by attempting to launch a pipeline with invalid configuration (e.g., missing adapter) and verifying the error message appears in the right pane.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user submits the argument form, **When** the executor fails to start (e.g., adapter resolution fails), **Then** the right pane displays an error message with the failure reason.
+2. **Given** a launch error is displayed, **When** the user presses Esc or navigates away, **Then** the error is dismissed and the right pane returns to normal detail view behavior.
+3. **Given** a launch error occurred, **When** the user re-selects the same available pipeline and presses Enter, **Then** the argument form appears again (retry is possible).
+
+---
+
+### User Story 5 - Dry-Run Preview (Priority: P3)
+
+A developer toggles the `--dry-run` flag in the argument form and submits. The system shows the execution plan (step order, personas, artifacts) without actually running the pipeline. The preview appears in the right pane. No pipeline run record is created, and no workspaces are set up.
+
+**Why this priority**: Dry-run is a convenience feature. Users can inspect pipeline details in the existing detail view and use `wave run --dry-run` from the CLI. TUI integration is nice-to-have.
+
+**Independent Test**: Can be tested by selecting dry-run in the form, submitting, and verifying no run record is created while the execution plan is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the argument form is visible with the `--dry-run` flag toggled on, **When** the user submits the form, **Then** the right pane shows the execution plan without starting a real pipeline run.
+2. **Given** a dry-run is in progress, **When** it completes, **Then** no entry appears in the Running or Finished sections of the left pane.
+
+---
+
+### Edge Cases
+
+- What happens when the user presses Enter on an available pipeline that is already running (launched previously)? The argument form still appears — launching a second instance is allowed (each gets a unique run ID). The Running section shows both instances.
+- What happens when the argument form is open and the terminal is resized? The form re-renders to fit the new right pane dimensions. `huh.Form` supports width updates via `.WithWidth()`.
+- What happens when the user submits the form with empty input for a pipeline that requires it? The executor starts regardless — input validation is the executor's responsibility (pipelines that need input will fail at the appropriate step). The TUI does not pre-validate input requirements.
+- What happens when the user presses `c` on a pipeline that has already finished between key press and processing? No action — the cancel function map lookup returns nil (already cleaned up).
+- What happens when multiple pipelines are launched simultaneously from the TUI? Each runs in its own goroutine with its own context and cancel function. The Running section shows all of them. The cancel function map tracks them independently by run ID.
+- What happens when the TUI is closed (q or Ctrl+C) while pipelines are running? All TUI-launched pipelines receive context cancellation via `ContentModel.CancelAll()` called from `AppModel` before `tea.Quit`. The executor goroutines clean up and mark runs as cancelled in the state store best-effort.
+- What happens when the state store is unavailable? The pipeline can still be launched (executor handles missing state store gracefully), but the launched pipeline won't appear in the Running section since the list polls the state store. An error indicator could be shown.
+- What happens when the user presses `q` while the argument form is active? The `q` key is forwarded to the form as a regular character (not quit) because the `q`-to-quit handler is gated on `m.content.focus == FocusPaneLeft`.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: When the user presses Enter on an available pipeline item in the left pane, the right pane MUST transition from the detail preview to an argument configuration form. Focus MUST transfer to the right pane.
+- **FR-002**: The argument form MUST contain: (a) a text input field for pipeline input with the pipeline's `InputExample` as placeholder, (b) a text input field for optional model override, and (c) a multi-select of flags from `DefaultFlags()` (verbose, output json, output text, dry-run, mock, debug).
+- **FR-003**: The argument form MUST use the existing `WaveTheme()` for visual consistency with the standalone pipeline selector.
+- **FR-004**: Pressing Esc at any point during the argument form MUST dismiss the form, revert the right pane to the detail preview, and return focus to the left pane without starting a pipeline. Form abort is detected via `form.State == huh.StateAborted` after each `Update()` call.
+- **FR-005**: Submitting the argument form MUST start the pipeline executor in a background goroutine via a `tea.Cmd`, passing the selected input, model override, and flags. Form completion is detected via `form.State == huh.StateCompleted` after each `Update()` call.
+- **FR-006**: The executor MUST be constructed with the same options as the CLI path: `WithEmitter`, `WithRunID`, `WithWorkspaceManager`, `WithStateStore`, `WithAuditLogger`, `WithStepTimeout`, `WithModelOverride`, and `WithDebug` as applicable. Dependencies are supplied via a `LaunchDependencies` struct passed through `NewAppModel()` → `NewContentModel()` → `PipelineLauncher`.
+- **FR-007**: After successful executor start, a `PipelineLaunchedMsg` MUST be emitted carrying the run ID, pipeline name, and cancel function. The left pane MUST immediately insert the pipeline at the top of the Running section and move the cursor to it.
+- **FR-008**: Focus MUST return to the left pane after the pipeline is launched, with the newly running pipeline auto-selected.
+- **FR-009**: The status bar MUST update its hints to reflect the current context: left-pane default hints when browsing, right-pane form hints when configuring (Tab/Shift+Tab: navigate fields, Enter: submit, Esc: cancel).
+- **FR-010**: Pressing `c` on a running pipeline that was launched from the current TUI session MUST invoke the stored cancel function, sending context cancellation to the executor.
+- **FR-011**: The cancel function map MUST be keyed by run ID. Entries MUST be cleaned up when the executor goroutine completes (via `PipelineLaunchResultMsg`).
+- **FR-012**: When the executor goroutine finishes (success or failure), a `PipelineLaunchResultMsg` MUST be emitted with the run ID and optional error. The data refresh tick picks up the final state from the state store.
+- **FR-013**: If the pipeline fails to start (executor construction or initial validation error), the right pane MUST display an error message. Focus MUST return to the left pane.
+- **FR-014**: The argument form MUST be dismissable and re-openable — selecting a different available pipeline and pressing Enter MUST show a fresh form for the new pipeline.
+- **FR-015**: When the `--dry-run` flag is selected, the executor SHOULD run in dry-run mode and the result SHOULD be displayed in the right pane without creating a persistent run record.
+- **FR-016**: The right pane MUST handle the `configuring` state (form active), `launching` state (brief indicator), and `error` state (launch failure) in addition to existing states (placeholder, loading, detail preview).
+- **FR-017**: When the TUI exits (q or Ctrl+C), all TUI-launched pipeline contexts MUST be cancelled. `AppModel.Update()` MUST call `m.content.CancelAll()` before returning `tea.Quit`.
+- **FR-018**: Running pipelines started from outside the TUI (e.g., CLI) MUST NOT be cancellable via `c` — the key MUST only act on pipelines with a stored cancel function.
+- **FR-019**: The `q`-to-quit handler in `AppModel.Update()` MUST be gated on `m.content.focus == FocusPaneLeft` to prevent quitting when the user types `q` in the argument form's text fields.
+- **FR-020**: `PipelineLauncher` MUST be a field on `ContentModel`, which routes `LaunchRequestMsg` (from detail), `PipelineLaunchedMsg`, and `PipelineLaunchResultMsg` between the launcher, list, and detail components.
+
+### Key Entities
+
+- **LaunchDependencies**: Struct containing `*manifest.Manifest`, `state.StateStore`, and `PipelinesDir string`. Passed through `NewAppModel()` → `NewContentModel()` → `PipelineLauncher`. The launcher resolves adapter runner, workspace manager, and audit logger on demand at launch time, keeping TUI startup lightweight.
+- **PipelineLauncher**: Component on `ContentModel` responsible for managing the lifecycle of TUI-launched pipelines. Stores cancel functions keyed by run ID. Constructs the executor with dependencies from `LaunchDependencies`. Exposes `Launch(config LaunchConfig) tea.Cmd`, `Cancel(runID string)`, and `CancelAll()`. Invoked by `ContentModel` when a `LaunchRequestMsg` arrives.
+- **LaunchRequestMsg**: Message emitted by `PipelineDetailModel` when the huh.Form completes (`form.State == huh.StateCompleted`). Carries the `LaunchConfig`. Routed from detail → `ContentModel` → launcher.
+- **PipelineLaunchedMsg**: Message emitted when a pipeline executor starts successfully. Carries `RunID string`, `PipelineName string`, and `CancelFunc context.CancelFunc`. Consumed by `PipelineListModel` to insert the running entry, and by the cancel function map for `c` key support.
+- **PipelineLaunchResultMsg**: Message emitted when a pipeline executor goroutine completes. Carries `RunID string` and `Err error`. Used to clean up the cancel function map and optionally update UI state.
+- **LaunchConfig**: Data structure assembled from the argument form submission. Contains `PipelineName string`, `Input string`, `ModelOverride string`, `Flags []string`, `DryRun bool`. Maps to the existing `Selection` type and `applySelection()` logic from `run_selector.go`.
+- **DetailPaneState**: Enum (or const set) tracking the right pane's current rendering mode: `stateEmpty`, `stateLoading`, `stateAvailableDetail`, `stateFinishedDetail`, `stateRunningInfo`, `stateConfiguring`, `stateLaunching`, `stateError`. Replaces the implicit state inference from nil checks on `availableDetail`/`finishedDetail`.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Pressing Enter on an available pipeline transitions the right pane to an argument form with all specified fields (input, model, flags) — verified by unit tests rendering the form and checking field presence.
+- **SC-002**: Submitting the argument form with valid input starts the executor in a background goroutine and the pipeline appears in the Running section within one render cycle — verified by tests with a mock adapter and state store.
+- **SC-003**: Pressing Esc during the argument form reverts to the detail preview with no side effects (no run record, no executor started) — verified by unit tests checking state store and model state.
+- **SC-004**: Pressing `c` on a TUI-launched running pipeline invokes the cancel function and the pipeline transitions to cancelled status — verified by tests with a mock adapter and context cancellation assertion.
+- **SC-005**: Launch errors (adapter resolution, manifest loading, preflight failures) display an actionable error message in the right pane — verified by tests with mock components that return errors.
+- **SC-006**: All existing tests (`go test ./internal/tui/...`) continue to pass after integration — the launch flow does not break pipeline list, detail, header, or status bar components.
+- **SC-007**: The argument form renders correctly at terminal widths from 80 to 300 columns and heights from 24 to 100 rows — verified by rendering tests at boundary dimensions.
+- **SC-008**: TUI exit (q/Ctrl+C) cancels all running TUI-launched pipelines and calls `CancelAll()` — verified by tests asserting cancel function invocation.
+- **SC-009**: Pressing `q` while the argument form has focus does NOT quit the TUI — verified by unit test asserting the key is forwarded to the form component.

--- a/specs/256-tui-pipeline-launch/tasks.md
+++ b/specs/256-tui-pipeline-launch/tasks.md
@@ -1,0 +1,316 @@
+# Tasks: TUI Pipeline Launch Flow
+
+**Feature**: #256 — TUI Pipeline Launch Flow
+**Branch**: `256-tui-pipeline-launch`
+**Generated**: 2026-03-06
+**Spec**: `specs/256-tui-pipeline-launch/spec.md`
+**Plan**: `specs/256-tui-pipeline-launch/plan.md`
+
+## Phase 1: Foundation — Messages, Types, and Dependencies
+
+### Setup
+
+- [X] T001 [P1] [Setup] Add new message types and data structures to `internal/tui/pipeline_messages.go`
+  - Add `LaunchConfig` struct with `PipelineName`, `Input`, `ModelOverride`, `Flags []string`, `DryRun bool`
+  - Add `LaunchDependencies` struct with `Manifest *manifest.Manifest`, `Store state.StateStore`, `PipelinesDir string`
+  - Add `DetailPaneState` type (int) with constants: `stateEmpty`, `stateLoading`, `stateAvailableDetail`, `stateFinishedDetail`, `stateRunningInfo`, `stateConfiguring`, `stateLaunching`, `stateError`
+  - Add `LaunchRequestMsg` struct with `Config LaunchConfig`
+  - Add `PipelineLaunchedMsg` struct with `RunID string`, `PipelineName string`
+  - Add `PipelineLaunchResultMsg` struct with `RunID string`, `Err error`
+  - Add `LaunchErrorMsg` struct with `PipelineName string`, `Err error`
+  - Add `ConfigureFormMsg` struct with `PipelineName string`, `InputExample string`
+  - Add `FormActiveMsg` struct with `Active bool` (for status bar hint switching)
+  - **Verify**: `go build ./internal/tui/...`
+
+### Foundational
+
+- [X] T002 [P1] [Foundation] Refactor `PipelineDetailModel` in `internal/tui/pipeline_detail.go` to use `DetailPaneState`
+  - Add `paneState DetailPaneState` field to `PipelineDetailModel`
+  - Set `paneState = stateEmpty` in `NewPipelineDetailModel()`
+  - Update `PipelineSelectedMsg` handler: set `stateLoading` when fetching, `stateAvailableDetail`/`stateFinishedDetail`/`stateRunningInfo` based on `Kind`
+  - Update `DetailDataMsg` handler: set `stateAvailableDetail` or `stateFinishedDetail` based on which detail is non-nil; set `stateError` on error
+  - Update `View()` to switch on `m.paneState` instead of nil checks and boolean flags
+  - Remove redundant `loading` and `errorMsg` fields (now covered by `paneState`)
+  - **Constraint**: Existing behavior must be 100% preserved — this is a pure refactor
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineDetail`
+
+- [X] T003 [P1] [Foundation] Add `LoadPipelineByName()` to `internal/tui/pipelines.go`
+  - Add `LoadPipelineByName(dir, name string) (*pipeline.Pipeline, error)` function
+  - Scan YAML files in `dir`, parse each with `yaml.Unmarshal`, return first match on `p.Metadata.Name == name`
+  - Return `fmt.Errorf("pipeline not found: %s", name)` if no match
+  - **Verify**: `go test ./internal/tui/... -run TestLoadPipeline`
+
+- [X] T004 [P] [Foundation] Add unit tests for `LoadPipelineByName` in `internal/tui/pipelines_test.go`
+  - Test: valid pipeline YAML returns correct `*pipeline.Pipeline`
+  - Test: non-existent name returns error
+  - Test: empty directory returns error
+  - Test: malformed YAML files are skipped gracefully
+  - Use `t.TempDir()` with temporary YAML files
+  - **Verify**: `go test ./internal/tui/... -run TestLoadPipeline`
+
+## Phase 2: Argument Form — US-1 (Launch Pipeline) & US-2 (Cancel Before Starting)
+
+- [X] T005 [P1] [US-1] Add form fields and creation logic to `PipelineDetailModel` in `internal/tui/pipeline_detail.go`
+  - Add fields: `launchForm *huh.Form`, `launchInput string`, `launchModel string`, `launchFlags []string`, `launchError string`
+  - Handle `ConfigureFormMsg` in `Update()`: create `huh.Form` with:
+    - `huh.NewInput().Title("Input").Placeholder(msg.InputExample).Value(&m.launchInput)` — pipeline input text field
+    - `huh.NewInput().Title("Model override (optional)").Value(&m.launchModel)` — model override text field
+    - `huh.NewMultiSelect[string]().Title("Options").Options(buildFlagOptions(DefaultFlags())...).Value(&m.launchFlags)` — flag multi-select
+  - Apply `WaveTheme()` from `theme.go`, set `.WithWidth(m.width)`, `.WithHeight(m.height)`
+  - Set `paneState = stateConfiguring`, call `form.Init()`
+  - Reset `launchInput`, `launchModel`, `launchFlags` to zero values on form creation
+  - **FR**: FR-001, FR-002, FR-003, FR-014, FR-016
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T006 [P1] [US-1,US-2] Add form lifecycle handling in `PipelineDetailModel.Update()` in `internal/tui/pipeline_detail.go`
+  - When `paneState == stateConfiguring` and msg is `tea.KeyMsg`: forward to `m.launchForm.Update(msg)`
+  - After each form update, check `form.State`:
+    - `huh.StateCompleted` → extract bound values, build `LaunchConfig`, emit `LaunchRequestMsg` via `tea.Cmd`, set `paneState = stateLaunching`
+    - `huh.StateAborted` → set `launchForm = nil`, revert `paneState = stateAvailableDetail`, emit `FocusChangedMsg{Pane: FocusPaneLeft}` (signals content to restore left focus)
+  - Handle form resizing in `SetSize()`: call `m.launchForm.WithWidth(w).WithHeight(h)` when form is non-nil
+  - Cast `form.Update()` result back to `*huh.Form` (it returns `tea.Model`)
+  - **FR**: FR-004, FR-005
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T007 [P1] [US-1,US-2] Add form rendering in `PipelineDetailModel.View()` in `internal/tui/pipeline_detail.go`
+  - `stateConfiguring`: render `m.launchForm.View()` within the pane dimensions
+  - `stateLaunching`: render centered "Starting pipeline..." indicator with muted style
+  - `stateError`: render error message in red with `m.launchError`, plus hint "[Esc] Back"
+  - **FR**: FR-016
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T008 [P] [US-1,US-2] Add form unit tests in `internal/tui/pipeline_detail_test.go`
+  - Test: `ConfigureFormMsg` creates form with correct fields (input, model, flags) and sets `stateConfiguring`
+  - Test: form abort (`huh.StateAborted`) reverts to `stateAvailableDetail` and nilifies form
+  - Test: form completion (`huh.StateCompleted`) emits `LaunchRequestMsg` with correct `LaunchConfig`
+  - Test: `View()` renders form view in `stateConfiguring` state
+  - Test: `View()` renders "Starting..." in `stateLaunching` state
+  - Test: `View()` renders error message in `stateError` state
+  - Test: pane state refactor preserves all existing detail rendering (available, finished, running)
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineDetail`
+
+## Phase 3: Pipeline Launcher Component — US-1 (Launch Pipeline) & US-3 (Cancel Running)
+
+- [X] T009 [P1] [US-1,US-3] Create `PipelineLauncher` component in new file `internal/tui/pipeline_launcher.go`
+  - Struct: `deps LaunchDependencies`, `cancelFns map[string]context.CancelFunc`, `mu sync.Mutex`
+  - `NewPipelineLauncher(deps LaunchDependencies) *PipelineLauncher` constructor
+  - `Launch(config LaunchConfig) tea.Cmd`:
+    - Load full `pipeline.Pipeline` via `LoadPipelineByName(deps.PipelinesDir, config.PipelineName)`
+    - If load fails, return cmd that emits `LaunchErrorMsg`
+    - Create `context.WithCancel(context.Background())`
+    - Resolve adapter: `adapter.NewMockAdapter()` if `--mock` in flags, else `adapter.ResolveAdapter()` from manifest
+    - Create run ID via `deps.Store.CreateRun()` (fall back to `pipeline.GenerateRunID()`)
+    - Create workspace manager via `workspace.NewWorkspaceManager()`
+    - Build executor options mirroring `runRun()`: `WithEmitter`, `WithRunID`, `WithStateStore`, `WithWorkspaceManager`, `WithDebug`, `WithModelOverride`
+    - Create audit logger if manifest audit config says so
+    - Store cancel function in `cancelFns[runID]` (mutex-protected)
+    - Return `tea.Batch(immediateCmd, executorCmd)`:
+      - `immediateCmd`: returns `PipelineLaunchedMsg{RunID, PipelineName}`
+      - `executorCmd`: calls `executor.Execute(ctx, p, manifest, input)`, updates run status in store, returns `PipelineLaunchResultMsg{RunID, err}`
+  - `Cancel(runID string)`: look up cancel function in map, call if found
+  - `CancelAll()`: iterate all cancel functions, call each, clear map
+  - `Cleanup(runID string)`: remove entry from `cancelFns` (called when `PipelineLaunchResultMsg` received)
+  - **FR**: FR-005, FR-006, FR-010, FR-011, FR-012, FR-017, FR-018, FR-020
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T010 [P] [US-1,US-3] Add launcher unit tests in new file `internal/tui/pipeline_launcher_test.go`
+  - Test: `NewPipelineLauncher` initializes empty cancel map
+  - Test: `Cancel` on unknown runID is no-op (no panic)
+  - Test: `CancelAll` invokes all stored cancel functions
+  - Test: `CancelAll` on empty map is no-op
+  - Test: `Cleanup` removes entry from cancel map
+  - Use mock dependencies (nil manifest, nil store acceptable for Cancel/CancelAll tests)
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineLauncher`
+
+## Phase 4: Content Model Integration — US-1, US-2, US-3
+
+- [X] T011 [P1] [US-1,US-2,US-3] Integrate `PipelineLauncher` into `ContentModel` in `internal/tui/content.go`
+  - Add `launcher *PipelineLauncher` field to `ContentModel`
+  - Modify `NewContentModel()` signature: add `LaunchDependencies` parameter, create `PipelineLauncher` if deps are non-zero
+  - Add `CancelAll()` method on `ContentModel`: delegates to `launcher.CancelAll()` (nil-safe)
+  - Modify Enter handling (existing `tea.KeyEnter` block): when cursor is on available item, also emit `ConfigureFormMsg` to detail (using selected pipeline's `InputExample` from available data)
+  - Add message routing in `Update()`:
+    - `LaunchRequestMsg` → call `launcher.Launch(config)`, set detail `paneState = stateLaunching`
+    - `PipelineLaunchedMsg` → forward to list (for running entry insertion), transition focus to left pane, emit `FocusChangedMsg{Pane: FocusPaneLeft}`
+    - `PipelineLaunchResultMsg` → call `launcher.Cleanup(msg.RunID)`
+    - `LaunchErrorMsg` → forward to detail (set `launchError`, `paneState = stateError`), transition focus to left
+    - `FormActiveMsg` → forward to status bar for hint switching
+  - Handle `c` key: when `focus == FocusPaneLeft` and cursor on running item, call `launcher.Cancel(runID)` using the `RunID` from the selected running pipeline
+  - Handle `FocusChangedMsg` from detail (form abort emits this): transition focus back to left pane
+  - **FR**: FR-007, FR-008, FR-010, FR-013, FR-020
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T012 [P] [US-1,US-2,US-3] Add content model integration tests in `internal/tui/content_test.go`
+  - Update all `NewContentModel()` calls to pass zero-value `LaunchDependencies{}`
+  - Test: Enter on available item emits `ConfigureFormMsg` and transitions focus right
+  - Test: `LaunchRequestMsg` triggers launcher (mock or nil-safe)
+  - Test: `PipelineLaunchedMsg` inserts running entry and transitions focus left
+  - Test: `LaunchErrorMsg` sets error state on detail and transitions focus left
+  - Test: `c` key on running item calls `Cancel(runID)` on launcher
+  - Test: `c` key on non-running item (section header, available, finished) is no-op
+  - Test: `CancelAll()` is nil-safe when launcher is nil
+  - **Verify**: `go test ./internal/tui/... -run TestContentModel`
+
+## Phase 5: Pipeline List — Running Entry Insertion — US-1
+
+- [X] T013 [P1] [US-1] Handle `PipelineLaunchedMsg` in `PipelineListModel` in `internal/tui/pipeline_list.go`
+  - Add `PipelineLaunchedMsg` case in `Update()`:
+    - Create `RunningPipeline{RunID: msg.RunID, Name: msg.PipelineName, StartedAt: time.Now()}`
+    - Prepend to `m.running` slice
+    - Call `m.buildNavigableItems()` to rebuild navigation
+    - Move cursor to the new running entry (find first `itemKindRunning` in `m.navigable`)
+    - Return `tea.Batch` of `RunningCountMsg{Count: len(m.running)}` and `PipelineSelectedMsg{RunID: msg.RunID, Name: msg.PipelineName, Kind: itemKindRunning}`
+  - **FR**: FR-007, FR-008
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T014 [P] [US-1] Add list integration tests in `internal/tui/pipeline_list_test.go`
+  - Test: `PipelineLaunchedMsg` prepends new running entry to running slice
+  - Test: `PipelineLaunchedMsg` rebuilds navigable items with the new entry
+  - Test: `PipelineLaunchedMsg` moves cursor to the new running entry
+  - Test: `PipelineLaunchedMsg` emits `RunningCountMsg` with updated count
+  - Test: existing running pipelines are preserved when new one is launched
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineList`
+
+## Phase 6: App Model and Status Bar — US-1, US-2, US-3
+
+- [X] T015 [P1] [US-1,US-2] Gate `q`-to-quit on left pane focus in `internal/tui/app.go`
+  - Modify the `msg.String() == "q"` check: add `&& m.content.focus == FocusPaneLeft`
+  - This prevents quitting when `q` is typed in a form text field
+  - **FR**: FR-019
+  - **Verify**: `go test ./internal/tui/... -run TestAppModel`
+
+- [X] T016 [P1] [US-3] Add `CancelAll()` call on TUI exit in `internal/tui/app.go`
+  - Before `tea.Quit` on both `q` and `Ctrl+C` paths, call `m.content.CancelAll()`
+  - **FR**: FR-017
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T017 [P1] [US-1] Update `NewAppModel()` to accept `LaunchDependencies` in `internal/tui/app.go`
+  - Add `LaunchDependencies` parameter to `NewAppModel()`
+  - Pass through to `NewContentModel()`
+  - Update `RunTUI()` to accept `LaunchDependencies` and pass to `NewAppModel()`
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T018 [P2] [US-1] Add form-context hints to `StatusBarModel` in `internal/tui/statusbar.go`
+  - Add `formActive bool` field
+  - Handle `FormActiveMsg` in `Update()`: set `m.formActive = msg.Active`
+  - In `View()`: when `m.formActive && m.focusPane == FocusPaneRight`, render `"Tab: next  Shift+Tab: prev  Enter: launch  Esc: cancel"` instead of default right-pane hints
+  - **FR**: FR-009
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T019 [P] [US-1,US-2] Add app model and status bar tests
+  - In `internal/tui/app_test.go`:
+    - Update all `NewAppModel()` calls to pass zero-value `LaunchDependencies{}`
+    - Test: `q` key with `focus == FocusPaneRight` does NOT quit (forwarded to content)
+    - Test: `q` key with `focus == FocusPaneLeft` still quits
+    - Test: `CancelAll()` is called before `tea.Quit` (verify via launcher mock or nil-safe)
+  - In `internal/tui/statusbar_test.go`:
+    - Test: `FormActiveMsg{Active: true}` + `FocusPaneRight` shows form hints
+    - Test: `FormActiveMsg{Active: false}` reverts to default hints
+  - **Verify**: `go test ./internal/tui/... -run "TestAppModel|TestStatusBar"`
+
+## Phase 7: CLI Integration
+
+- [X] T020 [P1] [US-1] Update CLI entry points to pass `LaunchDependencies` in `cmd/wave/main.go`
+  - Modify `shouldLaunchTUI` block in `rootCmd.RunE`:
+    - Load manifest from default path `wave.yaml`
+    - Open state store from `.wave/state.db` (nil-safe if unavailable)
+    - Determine pipelines directory from manifest or default `.wave/pipelines`
+    - Construct `tui.LaunchDependencies{Manifest: &m, Store: store, PipelinesDir: pipelinesDir}`
+    - Pass to `tui.RunTUI(deps)`
+  - Handle errors gracefully: if manifest/store unavailable, pass zero values (TUI still works for browsing, just can't launch)
+  - **Verify**: `go build ./cmd/wave/...`
+
+## Phase 8: Error Handling — US-4 (Launch Errors)
+
+- [X] T021 [P2] [US-4] Handle `LaunchErrorMsg` display in `PipelineDetailModel` in `internal/tui/pipeline_detail.go`
+  - In `Update()`, handle `LaunchErrorMsg`: set `launchError = msg.Err.Error()`, `paneState = stateError`, clear form
+  - In `View()` stateError case: render error with title "Launch Failed", error message, and "[Esc] Back to detail" hint
+  - Handle Esc in `stateError`: revert to `stateAvailableDetail`, clear `launchError`
+  - **FR**: FR-013
+  - **Verify**: `go build ./internal/tui/...`
+
+- [X] T022 [P] [US-4] Add error handling tests in `internal/tui/pipeline_detail_test.go`
+  - Test: `LaunchErrorMsg` sets `paneState = stateError` and stores error message
+  - Test: `View()` in `stateError` renders the error message
+  - Test: Esc from `stateError` reverts to `stateAvailableDetail`
+  - Test: re-opening form after error (Enter on same pipeline) shows fresh form
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineDetail`
+
+## Phase 9: Dry-Run Support — US-5
+
+- [X] T023 [P3] [US-5] Add dry-run detection in `PipelineLauncher.Launch()` in `internal/tui/pipeline_launcher.go`
+  - Check `config.DryRun` (or `--dry-run` in `config.Flags`)
+  - If dry-run: load pipeline, call executor dry-run path (or format step plan manually), return result as `PipelineLaunchResultMsg` without creating a run record
+  - The detail pane shows the execution plan in the right pane instead of transitioning to running
+  - **FR**: FR-015
+  - **Verify**: `go build ./internal/tui/...`
+
+## Phase 10: Polish & Cross-Cutting
+
+- [X] T024 [P] [Polish] Ensure all existing tests pass with updated signatures
+  - Update any remaining `NewAppModel()`, `NewContentModel()` calls across all test files in `internal/tui/`
+  - Run `go test ./internal/tui/...` and fix any compilation or test failures
+  - Run `go test ./...` to ensure no regressions across the entire project
+  - **SC**: SC-006
+  - **Verify**: `go test ./... -race`
+
+- [X] T025 [P] [Polish] Add form rendering dimension tests in `internal/tui/pipeline_detail_test.go`
+  - Test: form renders correctly at width 80 (minimum terminal width)
+  - Test: form renders correctly at width 300 (wide terminal)
+  - Test: form renders correctly at height 24 (minimum terminal height)
+  - Test: resizing while form is active updates form dimensions
+  - **SC**: SC-007
+  - **Verify**: `go test ./internal/tui/... -run TestPipelineDetail`
+
+## Dependency Graph
+
+```
+T001 ──→ T002 ──→ T005 ──→ T006 ──→ T007 ──→ T008
+  │        │                                    │
+  │        └──→ T003 ──→ T004                   │
+  │              │                               │
+  │              └──→ T009 ──→ T010              │
+  │                     │                        │
+  │                     └──→ T011 ──→ T012       │
+  │                            │                 │
+  │                            └──→ T013 ──→ T014
+  │                            │
+  │                            └──→ T015 ──→ T016 ──→ T017 ──→ T019
+  │                                                     │
+  │                                                     └──→ T020
+  │
+  └──→ T018 ──→ T019
+  
+T007 ──→ T021 ──→ T022
+T009 ──→ T023
+T019 ──→ T024 ──→ T025
+```
+
+## Parallelization Opportunities
+
+Tasks marked [P] can run in parallel with their siblings at the same phase level:
+- T003, T004 can run in parallel with T005–T008 (after T002)
+- T008, T010 can run in parallel (independent test files)
+- T012, T014, T019 can run in parallel (independent test files after their code deps)
+- T024, T025 should run last as cross-cutting validation
+
+## Summary
+
+| Phase | Tasks | Priority | User Stories |
+|-------|-------|----------|-------------|
+| 1. Foundation | T001–T004 | P1 | Setup |
+| 2. Argument Form | T005–T008 | P1 | US-1, US-2 |
+| 3. Launcher | T009–T010 | P1 | US-1, US-3 |
+| 4. Content Integration | T011–T012 | P1 | US-1, US-2, US-3 |
+| 5. List Integration | T013–T014 | P1 | US-1 |
+| 6. App & Status Bar | T015–T019 | P1/P2 | US-1, US-2, US-3 |
+| 7. CLI Integration | T020 | P1 | US-1 |
+| 8. Error Handling | T021–T022 | P2 | US-4 |
+| 9. Dry-Run | T023 | P3 | US-5 |
+| 10. Polish | T024–T025 | — | Cross-cutting |
+
+**Total**: 25 tasks across 10 phases
+**P1 tasks**: 14 (core launch flow)
+**P2 tasks**: 3 (error handling, status bar hints)
+**P3 tasks**: 1 (dry-run)
+**Parallel opportunities**: 7 tasks can execute in parallel with siblings


### PR DESCRIPTION
## Summary

- Add `PipelineLauncher` component that manages pipeline executor lifecycle with background goroutines and cancel function tracking
- Implement argument configuration form in the detail pane using embedded huh.Form (input field, model override, flag toggles)
- Add state transitions from `stateAvailableDetail` → `stateConfiguring` → `stateLaunching` → `stateRunningInfo` with instant visual feedback via `PipelineLaunchedMsg`
- Support running pipeline cancellation via stored `context.CancelFunc` map with `Cancel()` and `CancelAll()` methods
- Wire `LaunchDependencies` (manifest, state store, pipelines dir) through from `cmd/wave/main.go` to enable real executor integration
- Update status bar to show context-sensitive key hints based on current pane state (form active, running pipeline, etc.)

## Spec

See [`specs/256-tui-pipeline-launch/spec.md`](specs/256-tui-pipeline-launch/spec.md) for full specification.

Part 5 of 10 in the TUI epic (#251). Builds on #252 (scaffold), #253 (header bar), #254 (pipeline list), #255 (pipeline detail).

## Test Plan

- All existing and new tests pass with `go test -race ./...` (0 failures)
- New test coverage for:
  - `PipelineLauncher` — Launch, Cancel, CancelAll, Cleanup methods
  - Detail pane state transitions through launch flow
  - Pipeline list "Run" action handling
  - Content pane launch message routing
  - Status bar hint switching for form/launch states
  - App-level integration of launch dependencies

## Known Limitations

- Dry-run mode is accepted as a flag but executor dry-run support depends on downstream work
- Form styling uses basic defaults; visual polish planned in #261 (theming)

Closes #256