### PR TITLE
fix(personas): add label create permissions and fix glab issue update

### DIFF
--- a/internal/defaults/personas/github-enhancer.yaml
+++ b/internal/defaults/personas/github-enhancer.yaml
@@ -6,6 +6,7 @@ permissions:
     - Write
     - "Bash(gh issue edit*)"
     - "Bash(gh issue view*)"
+    - "Bash(gh label create*)"
     - "Bash(gh --version)"
   deny:
     - "Bash(gh issue create*)"

--- a/internal/defaults/personas/gitlab-enhancer.yaml
+++ b/internal/defaults/personas/gitlab-enhancer.yaml
@@ -4,8 +4,9 @@ permissions:
   allowed_tools:
     - Read
     - Write
-    - "Bash(glab issue edit*)"
+    - "Bash(glab issue update*)"
     - "Bash(glab issue view*)"
+    - "Bash(glab label create*)"
     - "Bash(glab --version)"
   deny:
     - "Bash(glab issue create*)"


### PR DESCRIPTION
## Summary

- `github-enhancer` silently failed when suggested labels didn't exist in the repo — confirmed by gh-rewrite run on issue #261. Root cause: `gh label create` wasn't in `allowed_tools`
- `gitlab-enhancer` couldn't update any issues at all — `glab issue edit` is not the correct glab subcommand; all `gl-rewrite` and `gl-refresh` pipeline prompts use `glab issue update`

## Changes

- `github-enhancer.yaml`: add `Bash(gh label create*)` to `allowed_tools`
- `gitlab-enhancer.yaml`: replace `Bash(glab issue edit*)` with `Bash(glab issue update*)`, add `Bash(glab label create*)`

## How found

Diagnosed by reading the `enhancement_results.json` artifact from a completed `gh-rewrite` run (run ID `gh-rewrite-20260306-124224-b78f`), then auditing all forge personas against their pipeline prompts for similar command/permission mismatches.

## Test plan

- [ ] `wave run gh-rewrite <issue>` — label creation succeeds when labels don't exist yet
- [ ] `wave run gl-rewrite <issue>` — issue update no longer blocked by wrong subcommand