### PR TITLE
feat(cli): add CLI compliance polish per clig.dev guidelines

### DIFF
--- a/cmd/wave/commands/artifacts.go
+++ b/cmd/wave/commands/artifacts.go
@@ -68,6 +68,7 @@ Use --format json for machine-readable output.`,
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			}
+			opts.Format = ResolveFormat(cmd, opts.Format)
 			return runArtifacts(opts)
 		},
 	}
@@ -286,11 +287,11 @@ func scanDirectoryForArtifacts(dir string, stepID string) []ArtifactOutput {
 // outputArtifactsTable prints artifacts in table format
 func outputArtifactsTable(runID string, artifacts []ArtifactOutput) error {
 	if runID != "" {
-		fmt.Printf("Artifacts for run: %s\n\n", runID)
+		fmt.Fprintf(os.Stderr, "Artifacts for run: %s\n\n", runID)
 	}
 
 	if len(artifacts) == 0 {
-		fmt.Println("No artifacts found")
+		fmt.Fprintln(os.Stderr, "No artifacts found")
 		return nil
 	}
 

--- a/cmd/wave/commands/artifacts_test.go
+++ b/cmd/wave/commands/artifacts_test.go
@@ -94,15 +94,25 @@ func executeArtifactsCmd(args ...string) (stdout, stderr string, err error) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
+	// Capture stderr since informational messages now go to os.Stderr
+	oldStderr := os.Stderr
+	re, we, _ := os.Pipe()
+	os.Stderr = we
+
 	err = cmd.Execute()
 
 	w.Close()
 	os.Stdout = oldStdout
+	we.Close()
+	os.Stderr = oldStderr
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
 
-	return buf.String(), errBuf.String(), err
+	var stderrBuf bytes.Buffer
+	stderrBuf.ReadFrom(re)
+
+	return buf.String(), stderrBuf.String(), err
 }
 
 // Test: List artifacts from workspace
@@ -301,10 +311,10 @@ func TestArtifactsCmd_NoArtifacts(t *testing.T) {
 	// Create pipeline with no artifacts
 	env.createPipelineWorkspace("empty", []string{"step1"})
 
-	stdout, _, err := executeArtifactsCmd()
+	_, stderr, err := executeArtifactsCmd()
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "No artifacts found")
+	assert.Contains(t, stderr, "No artifacts found")
 }
 
 // Test: No workspaces at all
@@ -314,10 +324,10 @@ func TestArtifactsCmd_NoWorkspaces(t *testing.T) {
 
 	// Don't create any workspace structure
 
-	stdout, _, err := executeArtifactsCmd()
+	_, stderr, err := executeArtifactsCmd()
 
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "No artifacts found")
+	assert.Contains(t, stderr, "No artifacts found")
 }
 
 // Test: Different artifact types

--- a/cmd/wave/commands/cancel.go
+++ b/cmd/wave/commands/cancel.go
@@ -61,6 +61,7 @@ Examples:
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			}
+			opts.Format = ResolveFormat(cmd, opts.Format)
 			return runCancel(opts)
 		},
 	}

--- a/cmd/wave/commands/chat.go
+++ b/cmd/wave/commands/chat.go
@@ -167,7 +167,7 @@ func runChat(opts ChatOptions) error {
 	if run.CompletedAt != nil {
 		elapsed = formatElapsed(run.CompletedAt.Sub(run.StartedAt))
 	}
-	fmt.Fprintf(os.Stderr, "\n  Wave Chat — %s%s%s\n", statusColor(run.Status), run.Status, colorReset)
+	fmt.Fprintf(os.Stderr, "\n  Wave Chat — %s%s%s\n", statusColor(run.Status), run.Status, conditionalColor("\033[0m"))
 	fmt.Fprintf(os.Stderr, "  Run:      %s\n", run.RunID)
 	fmt.Fprintf(os.Stderr, "  Pipeline: %s\n", run.PipelineName)
 	if elapsed != "" {

--- a/cmd/wave/commands/clean.go
+++ b/cmd/wave/commands/clean.go
@@ -246,7 +246,7 @@ func runClean(opts CleanOptions) error {
 
 	if len(existingTargets) == 0 {
 		if !opts.Quiet {
-			fmt.Printf("Nothing to clean\n")
+			fmt.Fprintf(os.Stderr, "Nothing to clean\n")
 		}
 		return nil
 	}
@@ -263,21 +263,21 @@ func runClean(opts CleanOptions) error {
 	if !opts.Force && !opts.DryRun {
 		if !isTTY() {
 			if !opts.Quiet {
-				fmt.Printf("Stdin is not a TTY. Use --force to proceed with cleanup.\n")
-				fmt.Printf("Would clean %d item(s), total size: %s\n", workspaceCount, formatSize(totalSize))
+				fmt.Fprintf(os.Stderr, "Stdin is not a TTY. Use --force to proceed with cleanup.\n")
+				fmt.Fprintf(os.Stderr, "Would clean %d item(s), total size: %s\n", workspaceCount, formatSize(totalSize))
 			}
 			return nil
 		}
 
 		// Show confirmation prompt
-		fmt.Printf("About to remove %d item(s), total size: %s\n", workspaceCount, formatSize(totalSize))
-		fmt.Printf("Continue? [y/N] ")
+		fmt.Fprintf(os.Stderr, "About to remove %d item(s), total size: %s\n", workspaceCount, formatSize(totalSize))
+		fmt.Fprintf(os.Stderr, "Continue? [y/N] ")
 
 		var response string
 		fmt.Scanln(&response)
 		if strings.ToLower(response) != "y" && strings.ToLower(response) != "yes" {
 			if !opts.Quiet {
-				fmt.Printf("Aborted\n")
+				fmt.Fprintf(os.Stderr, "Aborted\n")
 			}
 			return nil
 		}
@@ -285,11 +285,11 @@ func runClean(opts CleanOptions) error {
 
 	if opts.DryRun {
 		if !opts.Quiet {
-			fmt.Printf("(dry-run) The following would be removed:\n")
-			fmt.Printf("  Total: %d item(s), %s\n", workspaceCount, formatSize(totalSize))
+			fmt.Fprintf(os.Stderr, "(dry-run) The following would be removed:\n")
+			fmt.Fprintf(os.Stderr, "  Total: %d item(s), %s\n", workspaceCount, formatSize(totalSize))
 			for _, target := range existingTargets {
 				size, _ := calculateDirectorySize(target)
-				fmt.Printf("  Would remove %s (%s)\n", target, formatSize(size))
+				fmt.Fprintf(os.Stderr, "  Would remove %s (%s)\n", target, formatSize(size))
 			}
 		}
 		return nil
@@ -322,29 +322,29 @@ func runClean(opts CleanOptions) error {
 			if err := os.RemoveAll(target); err != nil {
 				failed++
 				if !opts.Quiet {
-					fmt.Printf("  Failed to remove %s: %s\n", target, err)
+					fmt.Fprintf(os.Stderr, "  Failed to remove %s: %s\n", target, err)
 				}
 				continue
 			}
 			if !opts.Quiet {
-				fmt.Printf("  Removed %s\n", target)
+				fmt.Fprintf(os.Stderr, "  Removed %s\n", target)
 			}
 			cleaned++
 		}
 
 		// Show progress for large cleanups
 		if showProgress && end < len(existingTargets) {
-			fmt.Printf("  Progress: %d/%d items processed\n", end, len(existingTargets))
+			fmt.Fprintf(os.Stderr, "  Progress: %d/%d items processed\n", end, len(existingTargets))
 		}
 	}
 
 	if !opts.Quiet {
 		if cleaned == 0 && failed == 0 {
-			fmt.Printf("Nothing to clean\n")
+			fmt.Fprintf(os.Stderr, "Nothing to clean\n")
 		} else if failed > 0 {
-			fmt.Printf("\nCleaned %d item(s), failed to clean %d item(s)\n", cleaned, failed)
+			fmt.Fprintf(os.Stderr, "\nCleaned %d item(s), failed to clean %d item(s)\n", cleaned, failed)
 		} else {
-			fmt.Printf("\nCleaned %d item(s)\n", cleaned)
+			fmt.Fprintf(os.Stderr, "\nCleaned %d item(s)\n", cleaned)
 		}
 	}
 

--- a/cmd/wave/commands/clean_test.go
+++ b/cmd/wave/commands/clean_test.go
@@ -127,7 +127,7 @@ func executeCleanCmd(args ...string) (stdout, stderr string, err error) {
 	return outBuf.String(), errBuf.String(), err
 }
 
-// executeCleanCmdCapturingStdout runs the clean command and captures real stdout
+// executeCleanCmdCapturingStdout runs the clean command and captures real stdout and stderr
 func executeCleanCmdCapturingStdout(args ...string) (string, error) {
 	cmd := NewCleanCmd()
 	cmd.SetArgs(args)
@@ -137,13 +137,21 @@ func executeCleanCmdCapturingStdout(args ...string) (string, error) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
+	// Capture stderr since informational messages now go to os.Stderr
+	oldStderr := os.Stderr
+	re, we, _ := os.Pipe()
+	os.Stderr = we
+
 	err := cmd.Execute()
 
 	w.Close()
 	os.Stdout = oldStdout
+	we.Close()
+	os.Stderr = oldStderr
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
+	io.Copy(&buf, re)
 	return buf.String(), err
 }
 

--- a/cmd/wave/commands/errors.go
+++ b/cmd/wave/commands/errors.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/recinq/wave/internal/recovery"
+)
+
+// Error code constants for machine-parseable error classification.
+const (
+	CodePipelineNotFound   = "pipeline_not_found"
+	CodeManifestMissing    = "manifest_missing"
+	CodeManifestInvalid    = "manifest_invalid"
+	CodeContractViolation  = "contract_violation"
+	CodeAdapterNotFound    = "adapter_not_found"
+	CodeFlagConflict       = "flag_conflict"
+	CodeOnboardingRequired = "onboarding_required"
+	CodeStepNotFound       = "step_not_found"
+	CodeRunNotFound        = "run_not_found"
+	CodePreflightFailed    = "preflight_failed"
+	CodeTimeout            = "timeout"
+	CodeCancelled          = "cancelled"
+	CodeInternalError      = "internal_error"
+	CodeSecurityViolation  = "security_violation"
+)
+
+// CLIError represents a structured error for CLI output.
+// In JSON mode, this is rendered as a JSON object to stderr.
+// In text mode, it renders as a human-readable error with suggestion.
+type CLIError struct {
+	Message    string `json:"error"`
+	Code       string `json:"code"`
+	Suggestion string `json:"suggestion"`
+	Debug      string `json:"debug,omitempty"`
+}
+
+// NewCLIError creates a new CLIError with the given code, message, and suggestion.
+func NewCLIError(code, message, suggestion string) *CLIError {
+	return &CLIError{
+		Code:       code,
+		Message:    message,
+		Suggestion: suggestion,
+	}
+}
+
+func (e *CLIError) Error() string {
+	return e.Message
+}
+
+// RenderJSONError marshals an error as a JSON object to the writer.
+// If the error is a *CLIError, it is serialized directly.
+// Plain errors are wrapped as CLIError with code "internal_error".
+func RenderJSONError(w io.Writer, err error, debug bool) {
+	var cliErr *CLIError
+	switch e := err.(type) {
+	case *CLIError:
+		cliErr = &CLIError{
+			Message:    e.Message,
+			Code:       e.Code,
+			Suggestion: e.Suggestion,
+			Debug:      e.Debug,
+		}
+	default:
+		cliErr = &CLIError{
+			Message:    err.Error(),
+			Code:       CodeInternalError,
+			Suggestion: "",
+		}
+	}
+
+	if !debug {
+		cliErr.Debug = ""
+	}
+
+	data, marshalErr := json.Marshal(cliErr)
+	if marshalErr != nil {
+		fmt.Fprintf(w, `{"error":%q,"code":"internal_error","suggestion":""}`, err.Error())
+		fmt.Fprintln(w)
+		return
+	}
+	fmt.Fprintln(w, string(data))
+}
+
+// RenderTextError formats an error for human-readable text output.
+// CLIErrors include suggestion lines; plain errors show just the message.
+// Debug details are included only when debug=true.
+func RenderTextError(w io.Writer, err error, debug bool) {
+	switch e := err.(type) {
+	case *CLIError:
+		fmt.Fprintf(w, "Error: %s\n", e.Message)
+		if e.Suggestion != "" {
+			fmt.Fprintf(w, "  Suggestion: %s\n", e.Suggestion)
+		}
+		if debug && e.Debug != "" {
+			fmt.Fprintf(w, "  Debug: %s\n", e.Debug)
+		}
+	default:
+		fmt.Fprintf(w, "Error: %s\n", err.Error())
+	}
+}
+
+// ErrorClassToCode maps a recovery.ErrorClass to a CLIError code string.
+func ErrorClassToCode(class recovery.ErrorClass) string {
+	switch class {
+	case recovery.ClassContractValidation:
+		return CodeContractViolation
+	case recovery.ClassPreflight:
+		return CodePreflightFailed
+	case recovery.ClassSecurityViolation:
+		return CodeSecurityViolation
+	case recovery.ClassRuntimeError:
+		return CodeInternalError
+	default:
+		return CodeInternalError
+	}
+}

--- a/cmd/wave/commands/errors_test.go
+++ b/cmd/wave/commands/errors_test.go
@@ -1,0 +1,203 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/recinq/wave/internal/recovery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIError_Error(t *testing.T) {
+	err := NewCLIError(CodePipelineNotFound, "pipeline 'foo' not found", "Run 'wave list pipelines'")
+	assert.Equal(t, "pipeline 'foo' not found", err.Error())
+}
+
+func TestCLIError_JSONMarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *CLIError
+		wantCode string
+		wantMsg  string
+		hasDebug bool
+	}{
+		{
+			name:     "basic error",
+			err:      NewCLIError(CodePipelineNotFound, "not found", "try list"),
+			wantCode: CodePipelineNotFound,
+			wantMsg:  "not found",
+		},
+		{
+			name:     "debug omitted when empty",
+			err:      NewCLIError(CodeInternalError, "failed", "retry"),
+			wantCode: CodeInternalError,
+			wantMsg:  "failed",
+			hasDebug: false,
+		},
+		{
+			name: "debug included when set",
+			err: &CLIError{
+				Message:    "failed",
+				Code:       CodeInternalError,
+				Suggestion: "retry",
+				Debug:      "stack trace here",
+			},
+			wantCode: CodeInternalError,
+			wantMsg:  "failed",
+			hasDebug: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.err)
+			require.NoError(t, err)
+
+			var result map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &result))
+
+			assert.Equal(t, tt.wantMsg, result["error"])
+			assert.Equal(t, tt.wantCode, result["code"])
+			assert.NotEmpty(t, result["suggestion"])
+
+			if tt.hasDebug {
+				assert.NotEmpty(t, result["debug"])
+			} else {
+				_, hasDebug := result["debug"]
+				assert.False(t, hasDebug, "debug field should be omitted when empty")
+			}
+		})
+	}
+}
+
+func TestRenderJSONError_CLIError(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := NewCLIError(CodePipelineNotFound, "pipeline not found", "wave list pipelines")
+
+	RenderJSONError(&buf, cliErr, false)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "pipeline not found", result["error"])
+	assert.Equal(t, CodePipelineNotFound, result["code"])
+	assert.Equal(t, "wave list pipelines", result["suggestion"])
+}
+
+func TestRenderJSONError_PlainError(t *testing.T) {
+	var buf bytes.Buffer
+	plainErr := errors.New("something went wrong")
+
+	RenderJSONError(&buf, plainErr, false)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "something went wrong", result["error"])
+	assert.Equal(t, CodeInternalError, result["code"])
+}
+
+func TestRenderJSONError_DebugIncluded(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := &CLIError{
+		Message:    "failed",
+		Code:       CodeInternalError,
+		Suggestion: "retry",
+		Debug:      "detailed stack",
+	}
+
+	RenderJSONError(&buf, cliErr, true)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "detailed stack", result["debug"])
+}
+
+func TestRenderJSONError_DebugExcluded(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := &CLIError{
+		Message:    "failed",
+		Code:       CodeInternalError,
+		Suggestion: "retry",
+		Debug:      "detailed stack",
+	}
+
+	RenderJSONError(&buf, cliErr, false)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	_, hasDebug := result["debug"]
+	assert.False(t, hasDebug, "debug should not be present when debug=false")
+}
+
+func TestRenderTextError_CLIError(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := NewCLIError(CodePipelineNotFound, "pipeline not found", "wave list pipelines")
+
+	RenderTextError(&buf, cliErr, false)
+
+	output := buf.String()
+	assert.Contains(t, output, "Error: pipeline not found")
+	assert.Contains(t, output, "Suggestion: wave list pipelines")
+}
+
+func TestRenderTextError_PlainError(t *testing.T) {
+	var buf bytes.Buffer
+	plainErr := errors.New("generic failure")
+
+	RenderTextError(&buf, plainErr, false)
+
+	output := buf.String()
+	assert.Contains(t, output, "Error: generic failure")
+	assert.NotContains(t, output, "Suggestion:")
+}
+
+func TestRenderTextError_WithDebug(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := &CLIError{
+		Message:    "failed",
+		Code:       CodeInternalError,
+		Suggestion: "retry",
+		Debug:      "stack trace",
+	}
+
+	RenderTextError(&buf, cliErr, true)
+
+	output := buf.String()
+	assert.Contains(t, output, "Debug: stack trace")
+}
+
+func TestRenderTextError_DebugHidden(t *testing.T) {
+	var buf bytes.Buffer
+	cliErr := &CLIError{
+		Message:    "failed",
+		Code:       CodeInternalError,
+		Suggestion: "retry",
+		Debug:      "stack trace",
+	}
+
+	RenderTextError(&buf, cliErr, false)
+
+	output := buf.String()
+	assert.NotContains(t, output, "Debug:")
+}
+
+func TestErrorClassToCode(t *testing.T) {
+	tests := []struct {
+		class recovery.ErrorClass
+		want  string
+	}{
+		{recovery.ClassContractValidation, CodeContractViolation},
+		{recovery.ClassPreflight, CodePreflightFailed},
+		{recovery.ClassSecurityViolation, CodeSecurityViolation},
+		{recovery.ClassRuntimeError, CodeInternalError},
+		{recovery.ClassUnknown, CodeInternalError},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.class), func(t *testing.T) {
+			assert.Equal(t, tt.want, ErrorClassToCode(tt.class))
+		})
+	}
+}

--- a/cmd/wave/commands/list.go
+++ b/cmd/wave/commands/list.go
@@ -137,6 +137,7 @@ For 'list runs', additional flags are available:
 			if len(args) > 0 {
 				filter = args[0]
 			}
+			opts.Format = ResolveFormat(cmd, opts.Format)
 			return runList(opts, filter)
 		},
 	}

--- a/cmd/wave/commands/logs.go
+++ b/cmd/wave/commands/logs.go
@@ -72,6 +72,7 @@ Examples:
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			}
+			opts.Format = ResolveFormat(cmd, opts.Format)
 			return runLogs(opts)
 		},
 	}
@@ -557,19 +558,19 @@ func renderPerformanceSummary(db *sql.DB, runID string) {
 		return
 	}
 
-	fmt.Println("\n--- Performance Summary ---")
-	fmt.Printf("Total Steps: %d\n", totalEvents)
+	fmt.Fprintln(os.Stderr, "\n--- Performance Summary ---")
+	fmt.Fprintf(os.Stderr, "Total Steps: %d\n", totalEvents)
 
 	if totalTokens > 0 {
-		fmt.Printf("Total Tokens: %s\n", formatTokens(totalTokens))
+		fmt.Fprintf(os.Stderr, "Total Tokens: %s\n", formatTokens(totalTokens))
 	}
 
 	if avgDuration.Valid && avgDuration.Float64 > 0 {
-		fmt.Printf("Avg Duration: %.1fs\n", avgDuration.Float64/1000.0)
+		fmt.Fprintf(os.Stderr, "Avg Duration: %.1fs\n", avgDuration.Float64/1000.0)
 	}
 
 	if minDuration.Valid && maxDuration.Valid && minDuration.Float64 > 0 {
-		fmt.Printf("Duration Range: %.1fs - %.1fs\n",
+		fmt.Fprintf(os.Stderr, "Duration Range: %.1fs - %.1fs\n",
 			minDuration.Float64/1000.0,
 			maxDuration.Float64/1000.0)
 	}
@@ -579,7 +580,7 @@ func renderPerformanceSummary(db *sql.DB, runID string) {
 		totalDuration := avgDuration.Float64 * float64(totalEvents)
 		burnRate := float64(totalTokens) / (totalDuration / 1000.0)
 		if burnRate >= 1.0 {
-			fmt.Printf("Token Burn Rate: %.1f tokens/s\n", burnRate)
+			fmt.Fprintf(os.Stderr, "Token Burn Rate: %.1f tokens/s\n", burnRate)
 		}
 	}
 }

--- a/cmd/wave/commands/output.go
+++ b/cmd/wave/commands/output.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/recinq/wave/internal/display"
@@ -23,13 +25,138 @@ const (
 type OutputConfig struct {
 	Format  string
 	Verbose bool
+	NoColor bool
+	Debug   bool
 }
 
-// GetOutputConfig reads the -o/--output and -v/--verbose persistent flags from the command.
+// resolvedFlagsKey is the context key for storing ResolvedFlags.
+type resolvedFlagsKey struct{}
+
+// ResolvedFlags captures the full resolved state from PersistentPreRunE.
+// Stored in cobra.Command context for downstream access.
+type ResolvedFlags struct {
+	Output OutputConfig
+	NoTUI  bool
+}
+
+// ResolveOutputConfig reads all root flag states, detects conflicts, and returns
+// the resolved output configuration. It should be called from PersistentPreRunE.
+func ResolveOutputConfig(cmd *cobra.Command) (*ResolvedFlags, error) {
+	root := cmd.Root()
+	flags := root.PersistentFlags()
+
+	jsonFlag := flags.Changed("json")
+	quietFlag := flags.Changed("quiet")
+	outputFlag := flags.Changed("output")
+	noColorFlag := flags.Changed("no-color")
+	verboseFlag := flags.Changed("verbose")
+	debugFlag, _ := flags.GetBool("debug")
+	noTUIFlag, _ := flags.GetBool("no-tui")
+
+	outputVal, _ := flags.GetString("output")
+	verbose, _ := flags.GetBool("verbose")
+	noColor, _ := flags.GetBool("no-color")
+
+	// Detect conflicts: --json + --output non-json
+	if jsonFlag && outputFlag && outputVal != OutputFormatJSON {
+		return nil, NewCLIError(CodeFlagConflict,
+			fmt.Sprintf("conflicting flags: --json and --output %s", outputVal),
+			"Use either --json or --output, not both")
+	}
+
+	// Detect conflicts: --quiet + --output non-quiet
+	if quietFlag && outputFlag && outputVal != OutputFormatQuiet {
+		return nil, NewCLIError(CodeFlagConflict,
+			fmt.Sprintf("conflicting flags: --quiet and --output %s", outputVal),
+			"Use either --quiet or --output, not both")
+	}
+
+	// --quiet + --verbose: quiet wins, warn
+	if quietFlag && verboseFlag {
+		fmt.Fprintln(os.Stderr, "warning: --quiet and --verbose both set; --quiet takes precedence")
+		verbose = false
+	}
+
+	// Resolve format: --json > --quiet > --output > default
+	format := outputVal
+	if jsonFlag {
+		format = OutputFormatJSON
+	} else if quietFlag {
+		format = OutputFormatQuiet
+	}
+
+	// Resolve NoTUI
+	noTUI := noTUIFlag
+	if jsonFlag || quietFlag {
+		noTUI = true
+	}
+
+	return &ResolvedFlags{
+		Output: OutputConfig{
+			Format:  format,
+			Verbose: verbose,
+			NoColor: noColor || noColorFlag,
+			Debug:   debugFlag,
+		},
+		NoTUI: noTUI,
+	}, nil
+}
+
+// GetOutputConfig reads the resolved output configuration.
+// It first checks the command context for ResolvedFlags (set by PersistentPreRunE),
+// falling back to direct flag reading for backward compatibility.
 func GetOutputConfig(cmd *cobra.Command) OutputConfig {
+	if ctx := cmd.Context(); ctx != nil {
+		if rf, ok := ctx.Value(resolvedFlagsKey{}).(*ResolvedFlags); ok {
+			return rf.Output
+		}
+	}
+	// Fallback: read flags directly
 	format, _ := cmd.Root().PersistentFlags().GetString("output")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
-	return OutputConfig{Format: format, Verbose: verbose}
+	debug, _ := cmd.Root().PersistentFlags().GetBool("debug")
+	return OutputConfig{Format: format, Verbose: verbose, Debug: debug}
+}
+
+// ResolveFormat resolves the effective output format for a subcommand.
+// If a root-level output flag (--json, --quiet, --output) was explicitly set,
+// the root value takes precedence. Otherwise, the local format is preserved.
+func ResolveFormat(cmd *cobra.Command, localFormat string) string {
+	root := cmd.Root()
+	flags := root.PersistentFlags()
+
+	// If --json was explicitly set, override
+	if flags.Changed("json") {
+		return "json"
+	}
+	// If --quiet was explicitly set, override
+	if flags.Changed("quiet") {
+		return "quiet"
+	}
+	// If --output was explicitly set, map to subcommand format
+	if flags.Changed("output") {
+		outputVal, _ := flags.GetString("output")
+		switch outputVal {
+		case OutputFormatJSON:
+			return "json"
+		case OutputFormatQuiet:
+			return "quiet"
+		case OutputFormatText:
+			return "table"
+		default:
+			return localFormat
+		}
+	}
+	return localFormat
+}
+
+// StoreResolvedFlags stores the resolved flags in the command context.
+func StoreResolvedFlags(cmd *cobra.Command, rf *ResolvedFlags) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd.SetContext(context.WithValue(ctx, resolvedFlagsKey{}, rf))
 }
 
 // EmitterResult holds the emitter, progress display, and cleanup function

--- a/cmd/wave/commands/output_test.go
+++ b/cmd/wave/commands/output_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,4 +170,180 @@ func TestCreateEmitter_JSONFormatNoThrottle(t *testing.T) {
 	if result.Progress != nil {
 		t.Errorf("json format should have nil Progress, got %T", result.Progress)
 	}
+}
+
+func TestResolveOutputConfig_JsonAlone(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("json", "true")
+
+	rf, err := ResolveOutputConfig(root)
+	require.NoError(t, err)
+	assert.Equal(t, OutputFormatJSON, rf.Output.Format)
+	assert.True(t, rf.NoTUI, "json implies no TUI")
+}
+
+func TestResolveOutputConfig_QuietAlone(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("quiet", "true")
+
+	rf, err := ResolveOutputConfig(root)
+	require.NoError(t, err)
+	assert.Equal(t, OutputFormatQuiet, rf.Output.Format)
+	assert.True(t, rf.NoTUI, "quiet implies no TUI")
+}
+
+func TestResolveOutputConfig_JsonOutputConflict(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("json", "true")
+	root.PersistentFlags().Set("output", "text")
+
+	_, err := ResolveOutputConfig(root)
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, CodeFlagConflict, cliErr.Code)
+}
+
+func TestResolveOutputConfig_QuietOutputConflict(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("quiet", "true")
+	root.PersistentFlags().Set("output", "json")
+
+	_, err := ResolveOutputConfig(root)
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, CodeFlagConflict, cliErr.Code)
+}
+
+func TestResolveOutputConfig_JsonQuietNoConflict(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("json", "true")
+	root.PersistentFlags().Set("quiet", "true")
+
+	rf, err := ResolveOutputConfig(root)
+	require.NoError(t, err)
+	assert.Equal(t, OutputFormatJSON, rf.Output.Format, "json takes precedence over quiet")
+}
+
+func TestResolveOutputConfig_NoColor(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("no-color", "true")
+
+	rf, err := ResolveOutputConfig(root)
+	require.NoError(t, err)
+	assert.True(t, rf.Output.NoColor)
+}
+
+func TestResolveOutputConfig_QuietVerbose(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().Bool("no-color", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+	root.PersistentFlags().BoolP("verbose", "v", false, "")
+	root.PersistentFlags().BoolP("debug", "d", false, "")
+	root.PersistentFlags().Bool("no-tui", false, "")
+
+	root.PersistentFlags().Set("quiet", "true")
+	root.PersistentFlags().Set("verbose", "true")
+
+	rf, err := ResolveOutputConfig(root)
+	require.NoError(t, err)
+	assert.Equal(t, OutputFormatQuiet, rf.Output.Format)
+	assert.False(t, rf.Output.Verbose, "quiet should win over verbose")
+}
+
+func TestResolveFormat_RootJsonOverridesLocal(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+
+	root.PersistentFlags().Set("json", "true")
+
+	result := ResolveFormat(root, "table")
+	assert.Equal(t, "json", result)
+}
+
+func TestResolveFormat_RootQuietOverridesLocal(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+
+	root.PersistentFlags().Set("quiet", "true")
+
+	result := ResolveFormat(root, "json")
+	assert.Equal(t, "quiet", result)
+}
+
+func TestResolveFormat_DefaultPreservesLocal(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+
+	result := ResolveFormat(root, "table")
+	assert.Equal(t, "table", result)
+}
+
+func TestResolveFormat_OutputTextMapsToTable(t *testing.T) {
+	root := &cobra.Command{Use: "wave"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.PersistentFlags().StringP("output", "o", "auto", "")
+
+	root.PersistentFlags().Set("output", "text")
+
+	result := ResolveFormat(root, "json")
+	assert.Equal(t, "table", result)
 }

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -118,7 +118,9 @@ func runRun(opts RunOptions, debug bool) error {
 	// Gate on onboarding completion — skip when --force is set
 	if !opts.Force {
 		if err := checkOnboarding(); err != nil {
-			return err
+			return NewCLIError(CodeOnboardingRequired,
+				"onboarding not complete",
+				"Run 'wave init' to complete setup before running pipelines")
 		}
 	}
 
@@ -134,12 +136,16 @@ func runRun(opts RunOptions, debug bool) error {
 
 	manifestData, err := os.ReadFile(opts.Manifest)
 	if err != nil {
-		return fmt.Errorf("failed to read manifest: %w", err)
+		return NewCLIError(CodeManifestMissing,
+			fmt.Sprintf("manifest file not found: %s", opts.Manifest),
+			"Run 'wave init' to create a manifest")
 	}
 
 	var m manifest.Manifest
 	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return fmt.Errorf("failed to parse manifest: %w", err)
+		return NewCLIError(CodeManifestInvalid,
+			fmt.Sprintf("failed to parse manifest: %s", err),
+			"Check wave.yaml syntax — run 'wave validate' to diagnose")
 	}
 
 	p, err := loadPipeline(opts.Pipeline, &m)
@@ -156,10 +162,14 @@ func runRun(opts RunOptions, debug bool) error {
 			applySelection(&opts, sel, &debug)
 			p, err = loadPipeline(opts.Pipeline, &m)
 			if err != nil {
-				return fmt.Errorf("failed to load pipeline: %w", err)
+				return NewCLIError(CodePipelineNotFound,
+					fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
+					"Run 'wave list pipelines' to see available pipelines")
 			}
 		} else {
-			return fmt.Errorf("failed to load pipeline: %w", err)
+			return NewCLIError(CodePipelineNotFound,
+				fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
+				"Run 'wave list pipelines' to see available pipelines")
 		}
 	}
 
@@ -499,63 +509,63 @@ func applySelection(opts *RunOptions, sel *tui.Selection, debug *bool) {
 }
 
 func performDryRun(p *pipeline.Pipeline, m *manifest.Manifest) error {
-	fmt.Printf("Dry run for pipeline: %s\n", p.Metadata.Name)
-	fmt.Printf("Description: %s\n", p.Metadata.Description)
-	fmt.Printf("Steps: %d\n\n", len(p.Steps))
-	fmt.Printf("Execution plan:\n")
+	fmt.Fprintf(os.Stderr, "Dry run for pipeline: %s\n", p.Metadata.Name)
+	fmt.Fprintf(os.Stderr, "Description: %s\n", p.Metadata.Description)
+	fmt.Fprintf(os.Stderr, "Steps: %d\n\n", len(p.Steps))
+	fmt.Fprintf(os.Stderr, "Execution plan:\n")
 
 	for i, step := range p.Steps {
-		fmt.Printf("  %d. %s (persona: %s)\n", i+1, step.ID, step.Persona)
+		fmt.Fprintf(os.Stderr, "  %d. %s (persona: %s)\n", i+1, step.ID, step.Persona)
 
 		if len(step.Dependencies) > 0 {
-			fmt.Printf("     Dependencies: %v\n", step.Dependencies)
+			fmt.Fprintf(os.Stderr, "     Dependencies: %v\n", step.Dependencies)
 		}
 
 		persona := m.GetPersona(step.Persona)
 		if persona != nil {
-			fmt.Printf("     Adapter: %s  Temp: %.1f\n", persona.Adapter, persona.Temperature)
-			fmt.Printf("     System prompt: %s\n", persona.SystemPromptFile)
+			fmt.Fprintf(os.Stderr, "     Adapter: %s  Temp: %.1f\n", persona.Adapter, persona.Temperature)
+			fmt.Fprintf(os.Stderr, "     System prompt: %s\n", persona.SystemPromptFile)
 			if len(persona.Permissions.AllowedTools) > 0 {
-				fmt.Printf("     Allowed tools: %v\n", persona.Permissions.AllowedTools)
+				fmt.Fprintf(os.Stderr, "     Allowed tools: %v\n", persona.Permissions.AllowedTools)
 			}
 			if len(persona.Permissions.Deny) > 0 {
-				fmt.Printf("     Denied tools: %v\n", persona.Permissions.Deny)
+				fmt.Fprintf(os.Stderr, "     Denied tools: %v\n", persona.Permissions.Deny)
 			}
 		}
 
 		if len(step.Workspace.Mount) > 0 {
 			for _, mount := range step.Workspace.Mount {
-				fmt.Printf("     Mount: %s → %s (%s)\n", mount.Source, mount.Target, mount.Mode)
+				fmt.Fprintf(os.Stderr, "     Mount: %s → %s (%s)\n", mount.Source, mount.Target, mount.Mode)
 			}
 		}
 
-		fmt.Printf("     Workspace: .wave/workspaces/%s/%s/\n", p.Metadata.Name, step.ID)
+		fmt.Fprintf(os.Stderr, "     Workspace: .wave/workspaces/%s/%s/\n", p.Metadata.Name, step.ID)
 
 		if step.Memory.Strategy != "" {
-			fmt.Printf("     Memory: %s\n", step.Memory.Strategy)
+			fmt.Fprintf(os.Stderr, "     Memory: %s\n", step.Memory.Strategy)
 		}
 
 		if len(step.Memory.InjectArtifacts) > 0 {
 			for _, art := range step.Memory.InjectArtifacts {
-				fmt.Printf("     Inject: %s:%s as %s\n", art.Step, art.Artifact, art.As)
+				fmt.Fprintf(os.Stderr, "     Inject: %s:%s as %s\n", art.Step, art.Artifact, art.As)
 			}
 		}
 
 		if len(step.OutputArtifacts) > 0 {
 			for _, art := range step.OutputArtifacts {
-				fmt.Printf("     Output: %s → %s (%s)\n", art.Name, art.Path, art.Type)
+				fmt.Fprintf(os.Stderr, "     Output: %s → %s (%s)\n", art.Name, art.Path, art.Type)
 			}
 		}
 
 		if step.Handover.Contract.Type != "" {
-			fmt.Printf("     Contract: %s", step.Handover.Contract.Type)
+			fmt.Fprintf(os.Stderr, "     Contract: %s", step.Handover.Contract.Type)
 			if step.Handover.Contract.OnFailure != "" {
-				fmt.Printf(" (on_failure: %s, max_retries: %d)", step.Handover.Contract.OnFailure, step.Handover.Contract.MaxRetries)
+				fmt.Fprintf(os.Stderr, " (on_failure: %s, max_retries: %d)", step.Handover.Contract.OnFailure, step.Handover.Contract.MaxRetries)
 			}
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
 		}
 
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 	}
 
 	return nil

--- a/cmd/wave/commands/status.go
+++ b/cmd/wave/commands/status.go
@@ -43,14 +43,14 @@ type StatusRunInfo struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// ANSI color codes for terminal output.
-const (
-	colorReset  = "\033[0m"
-	colorRed    = "\033[31m"
-	colorGreen  = "\033[32m"
-	colorYellow = "\033[33m"
-	colorGray   = "\033[90m"
-)
+// conditionalColor returns the ANSI color code if NO_COLOR is not set,
+// or an empty string when colors are disabled.
+func conditionalColor(code string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return ""
+	}
+	return code
+}
 
 // NewStatusCmd creates the status command.
 func NewStatusCmd() *cobra.Command {
@@ -75,6 +75,7 @@ Examples:
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			}
+			opts.Format = ResolveFormat(cmd, opts.Format)
 			return runStatus(opts)
 		},
 	}
@@ -95,7 +96,7 @@ func runStatus(opts StatusOptions) error {
 			fmt.Println(`{"runs":[]}`)
 			return nil
 		}
-		fmt.Println("No pipelines found")
+		fmt.Fprintln(os.Stderr, "No pipelines found")
 		return nil
 	}
 
@@ -147,7 +148,7 @@ func showRunDetails(db *sql.DB, opts StatusOptions) error {
 	// Detailed table view for single run
 	fmt.Printf("Run ID:     %s\n", run.RunID)
 	fmt.Printf("Pipeline:   %s\n", run.Pipeline)
-	fmt.Printf("Status:     %s%s%s\n", statusColor(run.Status), run.Status, colorReset)
+	fmt.Printf("Status:     %s%s%s\n", statusColor(run.Status), run.Status, conditionalColor("\033[0m"))
 	if run.CurrentStep != "" {
 		fmt.Printf("Step:       %s\n", run.CurrentStep)
 	}
@@ -184,7 +185,7 @@ func showRunningRuns(db *sql.DB, opts StatusOptions) error {
 			fmt.Println(`{"runs":[]}`)
 			return nil
 		}
-		fmt.Println("No running pipelines")
+		fmt.Fprintln(os.Stderr, "No running pipelines")
 		return nil
 	}
 
@@ -203,7 +204,7 @@ func showAllRuns(db *sql.DB, opts StatusOptions, limit int) error {
 			fmt.Println(`{"runs":[]}`)
 			return nil
 		}
-		fmt.Println("No pipelines found")
+		fmt.Fprintln(os.Stderr, "No pipelines found")
 		return nil
 	}
 
@@ -276,7 +277,7 @@ func outputRuns(runs []StatusRunInfo, opts StatusOptions) error {
 			step = step[:stepWidth-3] + "..."
 		}
 
-		statusColored := fmt.Sprintf("%s%-*s%s", statusColor(run.Status), statusWidth, run.Status, colorReset)
+		statusColored := fmt.Sprintf("%s%-*s%s", statusColor(run.Status), statusWidth, run.Status, conditionalColor("\033[0m"))
 
 		fmt.Printf("%-*s %-*s %s %-*s %-*s %s\n",
 			runIDWidth, runID, pipelineWidth, pipeline, statusColored,
@@ -448,13 +449,13 @@ func scanRuns(rows *sql.Rows) ([]StatusRunInfo, error) {
 func statusColor(status string) string {
 	switch status {
 	case "running":
-		return colorYellow
+		return conditionalColor("\033[33m")
 	case "completed":
-		return colorGreen
+		return conditionalColor("\033[32m")
 	case "failed":
-		return colorRed
+		return conditionalColor("\033[31m")
 	case "cancelled":
-		return colorGray
+		return conditionalColor("\033[90m")
 	default:
 		return ""
 	}

--- a/cmd/wave/commands/status_test.go
+++ b/cmd/wave/commands/status_test.go
@@ -136,15 +136,25 @@ func executeStatusCmd(args ...string) (stdout, stderr string, err error) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
+	// Capture stderr since informational messages now go to os.Stderr
+	oldStderr := os.Stderr
+	re, we, _ := os.Pipe()
+	os.Stderr = we
+
 	err = cmd.Execute()
 
 	w.Close()
 	os.Stdout = oldStdout
+	we.Close()
+	os.Stderr = oldStderr
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)
 
-	return buf.String(), errBuf.String(), err
+	var stderrBuf bytes.Buffer
+	stderrBuf.ReadFrom(re)
+
+	return buf.String(), stderrBuf.String(), err
 }
 
 // TestStatusCmd_NoDatabase tests when no state database exists.
@@ -156,9 +166,9 @@ func TestStatusCmd_NoDatabase(t *testing.T) {
 	// Remove the database
 	os.RemoveAll(filepath.Join(h.tmpDir, ".wave"))
 
-	stdout, _, err := executeStatusCmd()
+	_, stderr, err := executeStatusCmd()
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "No pipelines found")
+	assert.Contains(t, stderr, "No pipelines found")
 }
 
 // TestStatusCmd_NoRunningPipelines tests when no pipelines are running.
@@ -171,9 +181,9 @@ func TestStatusCmd_NoRunningPipelines(t *testing.T) {
 	completed := time.Now().Add(-1 * time.Minute)
 	h.createRun("test-run-001", "test-pipeline", "completed", "", 1000, completed.Add(-2*time.Minute), &completed)
 
-	stdout, _, err := executeStatusCmd()
+	_, stderr, err := executeStatusCmd()
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "No running pipelines")
+	assert.Contains(t, stderr, "No running pipelines")
 }
 
 // TestStatusCmd_RunningPipeline tests showing a running pipeline.
@@ -482,4 +492,19 @@ func TestStatusCmd_TruncatesLongRunID(t *testing.T) {
 	require.NoError(t, err)
 	// Should contain truncated version with ...
 	assert.Contains(t, stdout, "...")
+}
+
+// TestStatusCmd_NoColor tests that NO_COLOR suppresses ANSI escape sequences.
+func TestStatusCmd_NoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	// The conditionalColor function should return empty strings when NO_COLOR is set
+	result := conditionalColor("\033[32m")
+	assert.Equal(t, "", result, "NO_COLOR should suppress ANSI codes")
+
+	// statusColor should return empty when NO_COLOR is set
+	assert.Equal(t, "", statusColor("running"))
+	assert.Equal(t, "", statusColor("completed"))
+	assert.Equal(t, "", statusColor("failed"))
+	assert.Equal(t, "", statusColor("cancelled"))
 }

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -32,6 +32,25 @@ var rootCmd = &cobra.Command{
   Wave coordinates multiple AI personas through structured pipelines,
   enforcing permissions, contracts, and workspace isolation at every step.`,
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		rf, err := commands.ResolveOutputConfig(cmd)
+		if err != nil {
+			return err
+		}
+		commands.StoreResolvedFlags(cmd, rf)
+
+		// --no-color sets NO_COLOR env var for downstream code
+		if rf.Output.NoColor {
+			os.Setenv("NO_COLOR", "1")
+		}
+
+		// TERM=dumb implies --no-color and --no-tui
+		if os.Getenv("TERM") == "dumb" {
+			os.Setenv("NO_COLOR", "1")
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if shouldLaunchTUI(cmd) {
 			deps := tui.LaunchDependencies{}
@@ -73,6 +92,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("output", "o", "auto", "Output format: auto, json, text, quiet")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Include real-time tool activity")
 	rootCmd.PersistentFlags().Bool("no-tui", false, "Disable TUI and print help text")
+	rootCmd.PersistentFlags().Bool("json", false, "Output in JSON format (equivalent to --output json)")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output (equivalent to --output quiet)")
+	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
 
 	rootCmd.AddCommand(commands.NewInitCmd())
 	rootCmd.AddCommand(commands.NewValidateCmd())
@@ -97,6 +119,16 @@ func shouldLaunchTUI(cmd *cobra.Command) bool {
 		return false
 	}
 
+	// --json and --quiet suppress TUI
+	jsonFlag, _ := cmd.Root().PersistentFlags().GetBool("json")
+	if jsonFlag {
+		return false
+	}
+	quietFlag, _ := cmd.Root().PersistentFlags().GetBool("quiet")
+	if quietFlag {
+		return false
+	}
+
 	// Check WAVE_FORCE_TTY override
 	if forceTTY := os.Getenv("WAVE_FORCE_TTY"); forceTTY != "" {
 		switch strings.ToLower(forceTTY) {
@@ -117,7 +149,16 @@ func shouldLaunchTUI(cmd *cobra.Command) bool {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// Determine output mode from root flags for error rendering
+		debug, _ := rootCmd.PersistentFlags().GetBool("debug")
+		jsonMode, _ := rootCmd.PersistentFlags().GetBool("json")
+		outputMode, _ := rootCmd.PersistentFlags().GetString("output")
+
+		if jsonMode || outputMode == "json" {
+			commands.RenderJSONError(os.Stderr, err, debug)
+		} else {
+			commands.RenderTextError(os.Stderr, err, debug)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/wave/main_test.go
+++ b/cmd/wave/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +61,32 @@ func TestNoTUIFlag_IsPersistent(t *testing.T) {
 	flag := rootCmd.PersistentFlags().Lookup("no-tui")
 	assert.NotNil(t, flag, "--no-tui should be registered as a persistent flag")
 	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestAllSubcommands_ShowPersistentFlags(t *testing.T) {
+	expectedFlags := []string{
+		"--json",
+		"--quiet",
+		"--no-color",
+		"--debug",
+		"--verbose",
+		"--no-tui",
+		"--output",
+	}
+
+	// Get all registered subcommands
+	subcommands := rootCmd.Commands()
+	assert.NotEmpty(t, subcommands, "root command should have subcommands")
+
+	for _, subcmd := range subcommands {
+		t.Run(subcmd.Name(), func(t *testing.T) {
+			// Get the help text
+			help := subcmd.UsageString()
+
+			for _, flag := range expectedFlags {
+				assert.True(t, strings.Contains(help, flag),
+					"subcommand %q help should contain %q", subcmd.Name(), flag)
+			}
+		})
+	}
 }

--- a/specs/260-tui-cli-compliance/checklists/error-handling.md
+++ b/specs/260-tui-cli-compliance/checklists/error-handling.md
@@ -1,0 +1,32 @@
+# Error Handling Quality Checklist
+
+**Feature**: #260 — CLI Compliance Polish (clig.dev)  
+**Date**: 2026-03-07  
+**Scope**: Quality of structured error output and actionable error message specifications
+
+## Error Code Taxonomy
+
+- [ ] CHK201 - Is every error code in the data model reachable from at least one concrete code path identified in the plan or tasks? [Coverage]
+- [ ] CHK202 - Are the error codes exhaustive — does the taxonomy cover ALL possible failure modes in the current codebase, or just the ones listed? [Completeness]
+- [ ] CHK203 - Is the `internal_error` catch-all code documented as a fallback — is there guidance on when a specific code should be added vs. when `internal_error` is acceptable? [Clarity]
+- [ ] CHK204 - Are error codes stable identifiers that can be relied upon by external tooling, or are they subject to change? Is this contract documented? [Completeness]
+
+## Actionable Suggestions
+
+- [ ] CHK205 - Does every error code have a corresponding suggestion string defined in the spec or plan? [Completeness]
+- [ ] CHK206 - Are suggestions context-aware — does `pipeline_not_found` list available pipelines dynamically, or just suggest a static `wave list pipelines` command? [Clarity]
+- [ ] CHK207 - Is the suggestion format specified — plain text sentence, shell command with backticks, or mixed? Is it consistent across all error codes? [Consistency]
+- [ ] CHK208 - Does the spec define whether suggestions are shown in BOTH JSON and text error modes, or only in text mode? [Completeness]
+
+## JSON Error Schema
+
+- [ ] CHK209 - Is the JSON error output schema versioned or otherwise forward-compatible — can new fields be added without breaking existing consumers? [Coverage]
+- [ ] CHK210 - Does the spec define whether the JSON error object is emitted as a single line (for NDJSON compatibility) or pretty-printed? [Clarity]
+- [ ] CHK211 - Is the JSON error output on stderr validated by the same contract mechanism as stdout JSON output, or is it informal? [Consistency]
+- [ ] CHK212 - Does the spec define the behavior when JSON marshaling of the error itself fails — is there a fallback plain-text error? [Coverage]
+
+## Debug Context
+
+- [ ] CHK213 - Is the `debug` field content specified — does it contain the Go error chain (`%+v`), stack trace, or structured context? [Clarity]
+- [ ] CHK214 - Does the spec define whether debug information appears in BOTH JSON and text error rendering, or only in one mode? [Completeness]
+- [ ] CHK215 - Is there a security review requirement for the debug field — could it leak sensitive information (file paths, credentials, env vars)? [Coverage]

--- a/specs/260-tui-cli-compliance/checklists/flag-semantics.md
+++ b/specs/260-tui-cli-compliance/checklists/flag-semantics.md
@@ -1,0 +1,26 @@
+# Flag Semantics Quality Checklist
+
+**Feature**: #260 — CLI Compliance Polish (clig.dev)  
+**Date**: 2026-03-07  
+**Scope**: Quality of flag interaction, conflict detection, and resolution specifications
+
+## Flag Interaction Matrix
+
+- [ ] CHK101 - Is every pairwise combination of the 3 new flags (`--json`, `--quiet`, `--no-color`) explicitly classified as either "conflict", "orthogonal", or "override" in the spec? [Completeness]
+- [ ] CHK102 - Does the spec define the full interaction matrix between new flags and ALL existing flags (`--output`, `--debug`, `--verbose`, `--no-tui`), not just the conflict cases? [Completeness]
+- [ ] CHK103 - Is the `--json` + `--debug` combination specified — does `--debug` add extra fields to JSON output, or only affect text mode? [Completeness]
+- [ ] CHK104 - Is the behavior of `--no-color` + `--json` specified — JSON output has no ANSI codes regardless, so is `--no-color` redundant in JSON mode? [Clarity]
+
+## Conflict Detection
+
+- [ ] CHK105 - Is the conflict detection rule for `--quiet` + `--output json` justified — why is this a conflict when `--json` + `--quiet` is orthogonal? [Clarity]
+- [ ] CHK106 - Does the conflict error message format include BOTH conflicting flag names and their values, so the user knows exactly what to fix? [Completeness]
+- [ ] CHK107 - Is the conflict detection timing specified — does it happen in `PersistentPreRunE` before any subcommand logic, or could a subcommand override it? [Clarity]
+- [ ] CHK108 - Are the conflict detection rules testable without executing actual subcommands — is `ResolveOutputConfig` a pure function of flag values? [Coverage]
+
+## Flag Persistence and Scope
+
+- [ ] CHK109 - Is the persistent flag inheritance model clear — do persistent root flags propagate to ALL subcommands including `cobra.Command` children added by plugins or future commands? [Clarity]
+- [ ] CHK110 - Does the spec address whether `--json` applies to the `help` subcommand output — should `wave --json help` produce JSON-formatted help? [Coverage]
+- [ ] CHK111 - Is the `--no-color` flag scope defined for child processes — when Wave launches adapter subprocesses, does `NO_COLOR=1` propagate through the environment? [Coverage]
+- [ ] CHK112 - Does the spec address the case where a user sets `--output json` via a shell alias or config file — does `--json` conflict with a config-sourced `--output json`, or only with explicit CLI flags? [Coverage]

--- a/specs/260-tui-cli-compliance/checklists/requirements.md
+++ b/specs/260-tui-cli-compliance/checklists/requirements.md
@@ -1,0 +1,67 @@
+# Requirements Checklist: CLI Compliance Polish
+
+**Purpose**: Validate that the spec for issue #260 covers all acceptance criteria from the GitHub issue and clig.dev compliance requirements.
+**Created**: 2026-03-06
+**Feature**: [spec.md](../spec.md)
+
+## Flag Consistency
+
+- [x] CHK001 Spec defines `--json` as a persistent root flag (convenience alias for `--output json`) — FR-001, US1-AS2
+- [x] CHK002 Spec defines `-q`/`--quiet` as a persistent root flag (convenience alias for `--output quiet`) — FR-002, US1-AS3
+- [x] CHK003 Spec defines `--no-color` as a persistent root flag — FR-003, US3
+- [x] CHK004 Spec covers all standard flags listed in issue: `-h`/`--help`, `-v`/`--verbose`, `-q`/`--quiet`, `--debug`, `--version`, `--json`, `--no-tui` — FR-015, US1-AS1, SC-001
+- [x] CHK005 Spec addresses flag conflict resolution (e.g. `--json` + `--output text`) — FR-014, US1-AS4, Edge Cases
+- [x] CHK006 Spec addresses interaction between root `--json` and subcommand `--format` — FR-006, US1-AS5, Edge Cases
+
+## JSON Output
+
+- [x] CHK007 Spec requires `--json` support on ALL subcommands (`run`, `status`, `list`, `logs`, `artifacts`, `cancel`) — FR-005, US2, SC-002
+- [x] CHK008 Spec requires valid, machine-parseable JSON output — FR-005, US2-AS1 through AS5, SC-003
+- [x] CHK009 Spec addresses JSON error output format (structured error objects) — FR-013, US5-AS6, US2-AS6
+- [x] CHK010 Spec addresses empty result sets in JSON mode (e.g. empty array `[]`) — Edge Cases
+
+## Color Control
+
+- [x] CHK011 Spec requires `NO_COLOR` env var support (already implemented, verified in spec) — Context section, US3-AS2, FR-004
+- [x] CHK012 Spec requires `--no-color` flag with identical behavior to `NO_COLOR` — FR-003, FR-004, US3-AS1
+- [x] CHK013 Spec addresses `--no-color` in TUI mode (monochrome rendering) — US3-AS5, Edge Cases
+- [x] CHK014 Spec addresses `TERM=dumb` behavior — Edge Cases
+
+## Quiet Mode
+
+- [x] CHK015 Spec requires `--quiet` suppresses progress indicators and spinners — FR-007, US4-AS1
+- [x] CHK016 Spec requires `--quiet` prevents TUI launch (non-interactive) — FR-008, US4-AS2
+- [x] CHK017 Spec addresses `--quiet` + `--json` interaction — US4-AS3
+- [x] CHK018 Spec addresses `--quiet` + `--verbose` conflict — Edge Cases
+
+## Error Messages
+
+- [x] CHK019 Spec requires actionable error messages with suggested fixes — FR-009, US5
+- [x] CHK020 Spec requires stack traces only with `--debug` — FR-010, US5-AS4, US5-AS5
+- [x] CHK021 Spec requires JSON error format when `--json` is set — FR-013, US5-AS6
+- [x] CHK022 Spec covers at least 3 specific error scenarios with expected messages — US5-AS1 (missing pipeline), US5-AS2 (missing manifest), US5-AS3 (contract violation)
+
+## Output Stream Discipline
+
+- [x] CHK023 Spec requires progress indicators to stderr (never stdout) — FR-011, US6-AS2
+- [x] CHK024 Spec requires important info at end of output — FR-012, US6-AS3
+- [x] CHK025 Spec requires clean JSON on stdout when `--json` set (no interleaved text) — US6-AS1, SC-003
+- [x] CHK026 Spec requires verbose output to stderr — US6-AS4
+
+## Spec Quality
+
+- [x] CHK027 Every user story has acceptance scenarios with Given/When/Then format — all 6 user stories verified
+- [x] CHK028 Every user story has an independent test description — all 6 user stories verified
+- [x] CHK029 Edge cases section covers at least 5 boundary conditions — 7 edge cases listed
+- [x] CHK030 Success criteria are measurable with concrete commands/metrics — SC-001 through SC-008 all have specific commands
+- [x] CHK031 Maximum 3 `[NEEDS CLARIFICATION]` markers (preferably zero) — zero markers present
+- [x] CHK032 No implementation details (focuses on WHAT and WHY, not HOW) — spec avoids implementation details, references existing infra only as context
+- [x] CHK033 Requirements are testable and unambiguous — 15 FRs all use MUST with specific conditions
+- [x] CHK034 Spec acknowledges existing implementation (NO_COLOR, --output, etc.) as context — Context section enumerates existing infrastructure
+
+## Notes
+
+- All 34 checklist items PASS
+- Zero `[NEEDS CLARIFICATION]` markers in the spec
+- Spec builds on Wave's existing CLI infrastructure rather than starting from scratch
+- Self-validation: 3 iterations not needed — all items passed on first review

--- a/specs/260-tui-cli-compliance/checklists/review.md
+++ b/specs/260-tui-cli-compliance/checklists/review.md
@@ -1,0 +1,45 @@
+# Requirements Quality Review Checklist
+
+**Feature**: #260 — CLI Compliance Polish (clig.dev)  
+**Date**: 2026-03-07  
+**Scope**: Overall requirements quality validation across spec.md, plan.md, tasks.md
+
+## Completeness
+
+- [ ] CHK001 - Are all 7 persistent root flags (`--json`, `-q`/`--quiet`, `--no-color`, `--debug`, `--verbose`, `--no-tui`, `--output`) explicitly listed with their type, default value, and short-form alias? [Completeness]
+- [ ] CHK002 - Does the spec define behavior for every subcommand under `--json` mode, including subcommands beyond the 5 listed (e.g., `wave init`, `wave clean`, `wave run`, `wave validate`)? [Completeness]
+- [ ] CHK003 - Are all 13 error codes in the data model mapped to at least one trigger scenario in the spec or plan's actionable error messages? [Completeness]
+- [ ] CHK004 - Does the spec define what JSON output looks like for `wave cancel --json` when there is nothing to cancel? [Completeness]
+- [ ] CHK005 - Is the quiet mode behavior defined for ALL subcommands, not just `wave run` and `wave status`? (e.g., `wave init -q`, `wave clean -q`, `wave validate -q`) [Completeness]
+- [ ] CHK006 - Does the spec define the exit code semantics — which exit codes map to which error categories (flag conflict, pipeline failure, contract violation)? [Completeness]
+- [ ] CHK007 - Are requirements defined for `--json` interaction with interactive prompts (e.g., `wave init`, `wave clean` confirmation)? Interactive commands must either skip prompts or error in JSON mode. [Completeness]
+- [ ] CHK008 - Does the spec cover the `--json` output schema for each subcommand, or are formats left implicit? [Completeness]
+
+## Clarity
+
+- [ ] CHK009 - Is the resolution precedence between `--json`, `--quiet`, `--output`, and subcommand `--format` unambiguously defined with a single ordered rule? [Clarity]
+- [ ] CHK010 - Is the distinction between "structured JSON" (single document) and "NDJSON" (line-delimited) clearly associated with specific commands, or could a developer misinterpret which format applies? [Clarity]
+- [ ] CHK011 - Is the `--quiet` + `--json` combination semantics clear enough that two independent implementers would produce the same behavior? [Clarity]
+- [ ] CHK012 - Is the term "non-essential output" in FR-007 precisely defined — is a completion summary "essential" or "non-essential"? [Clarity]
+- [ ] CHK013 - Does C5 (subcommand `--format` coexistence) clearly define what "explicitly set" means — does `--output auto` count as explicitly set, or only non-default values? [Clarity]
+- [ ] CHK014 - Is the `ErrorResponse` debug field requirement clear — does "only when `--debug` is set" mean the field is omitted from JSON, or present with null/empty value? [Clarity]
+
+## Consistency
+
+- [ ] CHK015 - Is the naming convention for the `--json` flag consistent with `--output json` — does `--json` set Format to exactly "json" (same string), or a different internal value? [Consistency]
+- [ ] CHK016 - Are the error code strings in the data model (`pipeline_not_found`, `manifest_missing`) consistent with the recovery package's `ErrorClass` enum values, or is a mapping layer needed? [Consistency]
+- [ ] CHK017 - Is the `--no-color` flag behavior consistent with the existing `NO_COLOR` env var detection in `display.SelectColorPalette()` — do both code paths converge at the same point? [Consistency]
+- [ ] CHK018 - Are the FR numbers (FR-001 through FR-015) consistently referenced in tasks, plan phases, and success criteria, or are some requirements orphaned from tasks? [Consistency]
+- [ ] CHK019 - Is the `CLIError` JSON field naming (`"error"` not `"message"`) consistent with the clig.dev recommendation and common CLI tools like `gh` and `kubectl`? [Consistency]
+- [ ] CHK020 - Are the task priority labels ([P1], [P2], [P3]) consistent with the user story priorities they reference? [Consistency]
+
+## Coverage
+
+- [ ] CHK021 - Does the spec address backward compatibility for existing scripts that parse `wave status --format json` output — will the output schema change when using root `--json` vs subcommand `--format json`? [Coverage]
+- [ ] CHK022 - Are the interactions between `--no-color` and the TUI's Lipgloss renderer covered beyond the high-level "monochrome mode" description — is there a specific Lipgloss API call or color profile specified? [Coverage]
+- [ ] CHK023 - Does the spec address what happens when `--json` is passed to a command that currently produces no structured output (e.g., `wave validate`, `wave init`)? [Coverage]
+- [ ] CHK024 - Is the `TERM=dumb` edge case fully covered — does it trigger both `--no-color` and `--no-tui`, and is this documented in the spec or only in the plan? [Coverage]
+- [ ] CHK025 - Does the spec cover signal handling (SIGINT, SIGTERM) in JSON mode — should interrupted pipelines still emit a final JSON error object? [Coverage]
+- [ ] CHK026 - Are the stream discipline requirements (FR-011, FR-012) covered by specific task items for ALL commands, not just the 5 explicitly listed in Phase 7? [Coverage]
+- [ ] CHK027 - Does the spec define whether `--json` affects the TUI web dashboard output (`internal/webui/`), or is it scoped strictly to CLI stdout? [Coverage]
+- [ ] CHK028 - Is there coverage for the case where `NO_COLOR` env var is set AND `--no-color` flag is passed — are they idempotent or could double-application cause issues? [Coverage]

--- a/specs/260-tui-cli-compliance/checklists/stream-discipline.md
+++ b/specs/260-tui-cli-compliance/checklists/stream-discipline.md
@@ -1,0 +1,26 @@
+# Output Stream Discipline Quality Checklist
+
+**Feature**: #260 — CLI Compliance Polish (clig.dev)  
+**Date**: 2026-03-07  
+**Scope**: Quality of stdout/stderr separation and output format specifications
+
+## Stream Assignment Rules
+
+- [ ] CHK301 - Is there a complete taxonomy of output categories (data, progress, warnings, errors, summaries, debug) with their stream assignments (stdout vs stderr) defined in one place? [Completeness]
+- [ ] CHK302 - Does the spec define stream assignment for output produced by adapter subprocesses — is adapter stdout forwarded to Wave's stdout, or captured and re-emitted? [Completeness]
+- [ ] CHK303 - Is the "summary at END of stderr" requirement (FR-012) precisely defined — what constitutes "end"? After all NDJSON events? After all progress? [Clarity]
+- [ ] CHK304 - Does the stream discipline apply uniformly to all output modes (auto, text, json, quiet), or only to json mode? [Completeness]
+
+## JSON Output Guarantees
+
+- [ ] CHK305 - Is there a guarantee that stdout in `--json` mode contains ONLY valid JSON with no interleaved whitespace, prompts, or library output (e.g., cobra usage strings)? [Coverage]
+- [ ] CHK306 - Does the spec define whether cobra's default error/usage output (which goes to stderr) is also JSON-formatted in `--json` mode? [Coverage]
+- [ ] CHK307 - Is the NDJSON format for streaming commands fully specified — is there a defined event schema, or just "one JSON object per line"? [Clarity]
+- [ ] CHK308 - Does the spec address buffering behavior — are JSON lines flushed immediately, or could they be buffered and arrive in bursts? [Coverage]
+
+## Quiet Mode Output
+
+- [ ] CHK309 - Is the quiet mode output for non-streaming commands specified per-subcommand — what is the "essential" output for `wave status -q`, `wave list -q`, `wave artifacts -q`? [Completeness]
+- [ ] CHK310 - Does the spec define whether quiet mode affects exit codes — should a quiet success be distinguishable from a quiet failure by exit code alone? [Completeness]
+- [ ] CHK311 - Is the "final summary line" format for `wave run -q` specified — what fields does it contain (status, duration, step count)? [Clarity]
+- [ ] CHK312 - Does the spec address `--quiet` behavior for commands that only produce stderr output (e.g., `wave clean`) — is there ANY output at all? [Completeness]

--- a/specs/260-tui-cli-compliance/data-model.md
+++ b/specs/260-tui-cli-compliance/data-model.md
@@ -1,0 +1,168 @@
+# Data Model: CLI Compliance Polish
+
+## Entities
+
+### OutputConfig (Modified)
+
+**Location**: `cmd/wave/commands/output.go`
+
+Current:
+```go
+type OutputConfig struct {
+    Format  string
+    Verbose bool
+}
+```
+
+Updated:
+```go
+type OutputConfig struct {
+    Format   string // "auto", "json", "text", "quiet"
+    Verbose  bool
+    NoColor  bool   // NEW — true when --no-color flag or NO_COLOR env var is set
+    Debug    bool   // NEW — true when --debug flag is set (for error detail inclusion)
+}
+```
+
+**Changes**: Add `NoColor` and `Debug` fields to carry resolved flag state through command execution. This avoids each command re-reading root flags independently.
+
+### CLIError (New)
+
+**Location**: `cmd/wave/commands/errors.go` (new file)
+
+```go
+// CLIError represents a structured error for CLI output.
+// In JSON mode, this is rendered as a JSON object to stderr.
+// In text mode, it renders as a human-readable error with suggestion.
+type CLIError struct {
+    Message    string `json:"error"`
+    Code       string `json:"code"`
+    Suggestion string `json:"suggestion"`
+    Debug      string `json:"debug,omitempty"` // Only populated when --debug is set
+}
+
+func (e *CLIError) Error() string {
+    return e.Message
+}
+```
+
+**Error Codes** (machine-parseable classification):
+| Code | Trigger |
+|------|---------|
+| `pipeline_not_found` | Pipeline name doesn't match any in `.wave/pipelines/` |
+| `manifest_missing` | `wave.yaml` file not found |
+| `manifest_invalid` | YAML parse error in wave.yaml |
+| `contract_violation` | Step output fails contract validation |
+| `adapter_not_found` | Adapter binary not on PATH |
+| `flag_conflict` | Conflicting flags (e.g., `--json` + `--output text`) |
+| `onboarding_required` | `wave init` not completed |
+| `step_not_found` | `--from-step` references unknown step |
+| `run_not_found` | `wave status <run-id>` with invalid ID |
+| `preflight_failed` | Required skills/tools missing |
+| `timeout` | Step or pipeline exceeds configured timeout |
+| `cancelled` | Pipeline was cancelled by user |
+| `internal_error` | Unexpected internal error |
+
+### ResolvedFlags (New — Internal)
+
+**Location**: `cmd/wave/commands/output.go` (added to existing file)
+
+```go
+// ResolvedFlags captures the full resolved state from PersistentPreRunE.
+// Stored in cobra.Command context for downstream access.
+type ResolvedFlags struct {
+    Output  OutputConfig
+    NoTUI   bool
+}
+```
+
+This is computed once in `PersistentPreRunE` and stored in the command context. All subcommands read from this instead of re-parsing root flags.
+
+## Data Flow
+
+### Flag Resolution (PersistentPreRunE on rootCmd)
+
+```
+User Input: --json --quiet --no-color --output <val> --verbose --debug --no-tui
+                |       |        |          |          |         |        |
+                v       v        v          v          v         v        v
+         ┌─────────────────────────────────────────────────────────────────────┐
+         │                    ResolveOutputConfig()                            │
+         │                                                                     │
+         │  1. Check conflicts:                                                │
+         │     --json + --output text → error "flag_conflict"                  │
+         │     --json + --quiet (OK — orthogonal)                              │
+         │     --quiet + --verbose → warn stderr, quiet wins                   │
+         │                                                                     │
+         │  2. Resolve Format:                                                 │
+         │     if --json explicitly set → Format = "json"                      │
+         │     else if --quiet explicitly set → Format = "quiet"               │
+         │     else → Format = --output value (default "auto")                 │
+         │                                                                     │
+         │  3. Resolve NoColor:                                                │
+         │     if --no-color flag → os.Setenv("NO_COLOR", "1")                │
+         │     (NO_COLOR env already handled by display package)               │
+         │                                                                     │
+         │  4. Resolve NoTUI:                                                  │
+         │     if --quiet → noTUI = true (quiet implies non-interactive)       │
+         │     if --json → noTUI = true (json output excludes TUI)             │
+         │                                                                     │
+         └─────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      v
+                              ResolvedFlags stored
+                              in cmd context
+                                      │
+                     ┌────────────────┼────────────────┐
+                     │                │                │
+                     v                v                v
+              Subcommand RunE   Error Handler    TUI Decision
+              reads config      renders JSON     shouldLaunchTUI()
+```
+
+### Subcommand Format Resolution
+
+```
+For subcommands with local --format flag (status, list, logs, artifacts, cancel):
+
+  ResolveFormat(rootConfig, localFormat) → string
+    │
+    ├── if rootConfig.Format explicitly changed (--json, --quiet, --output)
+    │   └── return rootConfig.Format mapping:
+    │       "json" → "json"
+    │       "quiet" → (suppress decorations, minimal output)
+    │       "text" → "table"
+    │
+    └── else (root at default "auto")
+        └── return localFormat as-is
+```
+
+### Error Rendering
+
+```
+Error occurs in any command
+         │
+         v
+  main.go catches error
+         │
+         ├── Is it a *CLIError?
+         │   ├── JSON mode → json.Marshal to stderr
+         │   └── Text mode → "Error: <msg>\n  Suggestion: <suggestion>"
+         │
+         └── Is it a plain error?
+             ├── JSON mode → wrap as CLIError{Message: err.Error(), Code: "internal_error"}
+             └── Text mode → existing behavior (fmt.Fprintln(os.Stderr, err))
+```
+
+## Relationship to Existing Entities
+
+| Existing Entity | Interaction |
+|----------------|-------------|
+| `OutputConfig` | Extended with `NoColor`, `Debug` fields |
+| `SelectColorPalette()` | No change — already handles `NO_COLOR` env var |
+| `CreateEmitter()` | No change — already handles all format modes |
+| `shouldLaunchTUI()` | Add `--quiet` and `--json` as TUI disablers |
+| `recovery.ErrorClass` | Maps to `CLIError.Code` for pipeline errors |
+| `recovery.RecoveryBlock` | Recovery hints map to `CLIError.Suggestion` |
+| `display.ANSICodec` | No change — already respects `colorMode` |
+| `status.statusColor()` | Must check `NO_COLOR` before emitting ANSI codes |

--- a/specs/260-tui-cli-compliance/plan.md
+++ b/specs/260-tui-cli-compliance/plan.md
@@ -1,0 +1,241 @@
+# Implementation Plan: CLI Compliance Polish
+
+**Branch**: `260-tui-cli-compliance` | **Date**: 2026-03-06 | **Spec**: `specs/260-tui-cli-compliance/spec.md`
+**Input**: Feature specification from `/specs/260-tui-cli-compliance/spec.md`
+
+## Summary
+
+Standardize Wave's CLI surface for clig.dev compliance by adding `--json`, `-q`/`--quiet`, and `--no-color` as persistent root flag aliases, implementing flag conflict detection in `PersistentPreRunE`, structured JSON error responses with error codes and suggestions, and enforcing output stream discipline (data→stdout, progress→stderr). This builds on the existing `--output` flag infrastructure and `NO_COLOR` env var support.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (existing project)
+**Primary Dependencies**: `github.com/spf13/cobra` (CLI), `gopkg.in/yaml.v3` (config) — all existing
+**Storage**: SQLite via `modernc.org/sqlite` (existing, for error context)
+**Testing**: `go test` with `testify/assert`, `testify/require`
+**Target Platform**: Linux/macOS terminal
+**Project Type**: Single Go binary — changes in `cmd/wave/` and `internal/display/`
+**Constraints**: No new external dependencies; must not break existing tests (`go test -race ./...`)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | ✅ Pass | No new runtime dependencies. All changes use existing stdlib and cobra. |
+| P2: Manifest as SSOT | ✅ Pass | No new config files. Flag resolution is pure CLI logic. |
+| P3: Persona-Scoped Execution | N/A | CLI flag handling, not pipeline execution. |
+| P4: Fresh Memory at Step Boundary | N/A | CLI flag handling, not pipeline steps. |
+| P5: Navigator-First Architecture | N/A | CLI command infrastructure, not pipeline. |
+| P6: Contracts at Every Handover | N/A | No pipeline step handovers. |
+| P7: Relay via Dedicated Summarizer | N/A | CLI command infrastructure. |
+| P8: Ephemeral Workspaces | N/A | No workspace changes. |
+| P9: Credentials Never Touch Disk | ✅ Pass | No credential handling. |
+| P10: Observable Progress | ✅ Pass | Progress output correctly routed to stderr. JSON error output enhances observability. |
+| P11: Bounded Recursion | N/A | No pipeline execution changes. |
+| P12: Minimal Step State Machine | N/A | No step state changes. |
+| P13: Test Ownership | ✅ Pass | All new code will have tests; existing tests must continue to pass. |
+
+No violations. No complexity tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/260-tui-cli-compliance/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```
+cmd/wave/
+├── main.go                          # MODIFY — add PersistentPreRunE, JSON error handler
+└── commands/
+    ├── output.go                    # MODIFY — extend OutputConfig, add ResolveOutputConfig(), ResolveFormat()
+    ├── output_test.go               # MODIFY — tests for conflict detection, resolution logic
+    ├── errors.go                    # NEW — CLIError type, error code constants, formatters
+    ├── errors_test.go               # NEW — tests for error formatting in JSON/text modes
+    ├── run.go                       # MODIFY — use resolved config instead of GetOutputConfig()
+    ├── status.go                    # MODIFY — use NO_COLOR-aware color, use ResolveFormat()
+    ├── status_test.go               # MODIFY — add JSON format and --no-color tests
+    ├── list.go                      # MODIFY — use ResolveFormat() for root flag precedence
+    ├── list_test.go                 # MODIFY — add root --json override test
+    ├── logs.go                      # MODIFY — use ResolveFormat(), move summary to stderr
+    ├── logs_test.go                 # MODIFY — add format resolution tests
+    ├── artifacts.go                 # MODIFY — use ResolveFormat()
+    ├── artifacts_test.go            # MODIFY — add format resolution tests
+    ├── cancel.go                    # MODIFY — use ResolveFormat()
+    ├── cancel_test.go               # MODIFY — add format resolution tests
+    ├── clean.go                     # MODIFY — move progress to stderr, check root --quiet
+    └── clean_test.go                # MODIFY — add stderr output verification
+```
+
+**Structure Decision**: All changes are within existing `cmd/wave/` structure. One new file (`errors.go`) for the `CLIError` type and error code constants. No new packages.
+
+## Implementation Approach
+
+### Phase 1: Root Flag Registration and Conflict Detection
+
+**Files**: `cmd/wave/main.go` (MODIFY), `cmd/wave/commands/output.go` (MODIFY), `cmd/wave/commands/output_test.go` (MODIFY)
+
+1. **Register new persistent root flags** in `main.go init()`:
+   - `--json` (bool): shorthand for `--output json`
+   - `-q`/`--quiet` (bool): shorthand for `--output quiet`
+   - `--no-color` (bool): disables all ANSI color and styling
+
+2. **Add `PersistentPreRunE`** to `rootCmd` in `main.go`:
+   - Call `commands.ResolveOutputConfig(cmd)` which:
+     a. Reads all flag states using `cmd.Root().PersistentFlags()`
+     b. Uses `.Changed()` to detect explicit flags
+     c. Detects conflicts:
+        - `--json` + `--output` (with non-default, non-json value) → `CLIError{Code: "flag_conflict"}`
+        - `--quiet` + `--output` (with non-default, non-quiet value) → `CLIError{Code: "flag_conflict"}`
+        - `--json` + `--quiet` → OK (orthogonal: json=stdout format, quiet=stderr verbosity)
+        - `--quiet` + `--verbose` → log warning to stderr, quiet wins
+     d. Resolves final `OutputConfig`:
+        - If `--json` → Format = "json"
+        - Else if `--quiet` → Format = "quiet"
+        - Else → Format = `--output` value (default "auto")
+     e. If `--no-color` → `os.Setenv("NO_COLOR", "1")`
+     f. If `--json` or `--quiet` → set `shouldLaunchTUI` override (noTUI = true)
+   - Store resolved config in cmd context (via `cmd.SetContext()`)
+
+3. **Update `GetOutputConfig()`** in `output.go`:
+   - Read resolved config from cmd context first
+   - Fall back to existing flag reading if context is empty (for tests)
+
+4. **Tests** (SC-008, FR-014):
+   - `--json` alone → Format = "json"
+   - `--quiet` alone → Format = "quiet"
+   - `--json` + `--output text` → error with code "flag_conflict"
+   - `--quiet` + `--output json` → error with code "flag_conflict"
+   - `--json` + `--quiet` → no error, Format = "json" (json wins for format, quiet for stderr)
+   - `--no-color` → `NO_COLOR` env var set
+   - `--quiet` + `--verbose` → quiet wins with warning
+
+### Phase 2: CLIError Type and JSON Error Rendering
+
+**Files**: `cmd/wave/commands/errors.go` (NEW), `cmd/wave/commands/errors_test.go` (NEW), `cmd/wave/main.go` (MODIFY)
+
+1. **Create `CLIError`** in `errors.go`:
+   - Fields: `Message string`, `Code string`, `Suggestion string`, `Debug string`
+   - Implements `error` interface
+   - Constructor: `NewCLIError(code, message, suggestion string) *CLIError`
+   - JSON rendering: `RenderJSONError(w io.Writer, err error, debug bool)` — handles both `*CLIError` and plain `error`
+   - Error code constants matching data model
+
+2. **Update main.go error handler**:
+   - After `rootCmd.Execute()` returns error:
+     a. Read resolved output format from root flags
+     b. If JSON mode: call `RenderJSONError(os.Stderr, err, debug)`
+     c. Else: existing behavior + append suggestion if `*CLIError`
+   - Replace plain `fmt.Fprintln(os.Stderr, err)` with format-aware rendering
+
+3. **Tests** (FR-013, SC-006):
+   - `CLIError` renders as valid JSON with error/code/suggestion fields
+   - Plain error wraps as `CLIError{Code: "internal_error"}`
+   - Debug details included only when `--debug` is set
+   - JSON output on stderr, not stdout
+
+### Phase 3: Actionable Error Messages
+
+**Files**: `cmd/wave/commands/run.go` (MODIFY), `cmd/wave/commands/status.go` (MODIFY), `cmd/wave/commands/list.go` (MODIFY), various command files
+
+1. **Wrap key error paths** with `CLIError`:
+   - `loadPipeline()`: pipeline not found → `CLIError{Code: "pipeline_not_found", Suggestion: "Run 'wave list pipelines' to see available pipelines"}`
+   - Manifest read error → `CLIError{Code: "manifest_missing", Suggestion: "Run 'wave init' to create a manifest"}`
+   - Manifest parse error → `CLIError{Code: "manifest_invalid", Suggestion: "Check wave.yaml syntax"}`
+   - Onboarding check → `CLIError{Code: "onboarding_required", Suggestion: "Run 'wave init'"}`
+   - `--from-step` with unknown step → `CLIError{Code: "step_not_found", Suggestion: "Run 'wave run <pipeline> --dry-run' to see available steps"}`
+
+2. **Enhance recovery hints** to populate `CLIError.Suggestion` when in JSON mode (integrate with existing `recovery.BuildRecoveryBlock()`)
+
+3. **Tests** (FR-009, FR-010, SC-006):
+   - Each error path returns actionable suggestion
+   - `--debug` includes error chain, without `--debug` it's hidden
+   - JSON errors parse as valid JSON with required fields
+
+### Phase 4: Subcommand Format Resolution and `--no-color` for Status
+
+**Files**: `cmd/wave/commands/output.go` (MODIFY), `cmd/wave/commands/status.go` (MODIFY), `cmd/wave/commands/list.go` (MODIFY), `cmd/wave/commands/logs.go` (MODIFY), `cmd/wave/commands/artifacts.go` (MODIFY), `cmd/wave/commands/cancel.go` (MODIFY)
+
+1. **Add `ResolveFormat()`** in `output.go`:
+   ```go
+   func ResolveFormat(cmd *cobra.Command, localFormat string) string
+   ```
+   - If root `--json` was explicitly set → return "json"
+   - If root `--quiet` was explicitly set → return "quiet" (mapped to minimal output)
+   - If root `--output` was explicitly set to non-default → return its value
+   - Otherwise → return `localFormat` unchanged
+
+2. **Update each subcommand** with local `--format`:
+   - `status.go`: Replace `opts.Format` reads with `ResolveFormat(cmd, opts.Format)` call in RunE
+   - `list.go`: Same pattern
+   - `logs.go`: Same pattern
+   - `artifacts.go`: Same pattern
+   - `cancel.go`: Same pattern
+
+3. **Fix `status.go` hardcoded ANSI colors**:
+   - Replace `colorReset`, `colorRed`, etc. constants with calls that check `NO_COLOR` env var
+   - Use existing `display.ANSICodec` or gate colors on `os.Getenv("NO_COLOR") == ""`
+   - Move status table header to use conditional color
+
+4. **Tests** (FR-006, SC-001, SC-004):
+   - Root `--json` overrides subcommand `--format table`
+   - Root `--quiet` overrides subcommand `--format json`
+   - Default root → subcommand `--format` preserved
+   - `--no-color` produces zero ANSI escapes in status output
+
+### Phase 5: Output Stream Discipline
+
+**Files**: `cmd/wave/commands/clean.go` (MODIFY), `cmd/wave/commands/logs.go` (MODIFY), `cmd/wave/commands/artifacts.go` (MODIFY), `cmd/wave/commands/status.go` (MODIFY)
+
+1. **Route progress/informational messages to stderr**:
+   - `clean.go`: Change `fmt.Printf("Nothing to clean\n")` → `fmt.Fprintf(os.Stderr, ...)`
+   - `clean.go`: Change all progress messages (removed, failed, progress) → stderr
+   - `logs.go`: Move performance summary rendering → stderr
+   - `artifacts.go`: Move "No artifacts found", "Artifacts for run:" messages → stderr when not in JSON mode
+   - `status.go`: Move "No pipelines found", "No running pipelines" → stderr
+
+2. **Keep data output on stdout**:
+   - JSON output from all commands → stdout (already correct)
+   - Table data → stdout (already correct)
+
+3. **Ensure quiet mode suppresses non-essential output**:
+   - When format is "quiet", skip headers, decorations, and informational messages
+   - Only emit essential data (error messages, final result line)
+
+4. **Tests** (FR-011, FR-012, SC-003, SC-005):
+   - `wave status --json | jq .` succeeds (no non-JSON on stdout)
+   - Progress messages not on stdout
+   - Quiet mode suppresses all non-essential stderr
+
+### Phase 6: shouldLaunchTUI Updates and Edge Cases
+
+**Files**: `cmd/wave/main.go` (MODIFY)
+
+1. **Update `shouldLaunchTUI()`**:
+   - Add check: if `--json` → return false
+   - Add check: if `--quiet` → return false
+   - Existing checks: `--no-tui`, `WAVE_FORCE_TTY`, `TERM=dumb`, TTY detection
+
+2. **Edge cases**:
+   - `TERM=dumb`: Already handled for TUI. Color already handled via `DetectANSISupport()`. No additional changes needed.
+   - Empty output in JSON mode: Commands must output `[]` or `{}`, never empty string (already handled by most commands)
+   - `clean --quiet` coexistence: Root `--quiet` sets output format; `clean --quiet` boolean is a separate flag. Both paths lead to suppressed output. No conflict.
+
+3. **Tests** (edge cases from spec):
+   - `--json` prevents TUI launch
+   - `--quiet` prevents TUI launch
+   - `TERM=dumb` prevents TUI and color
+
+## Complexity Tracking
+
+_No constitution violations. No complexity tracking entries needed._

--- a/specs/260-tui-cli-compliance/research.md
+++ b/specs/260-tui-cli-compliance/research.md
@@ -1,0 +1,102 @@
+# Research: CLI Compliance Polish
+
+## R1: Current Flag Architecture — How Persistent Flags Propagate in Cobra
+
+**Decision**: Use Cobra's `PersistentFlags()` on rootCmd for `--json`, `--quiet`, `--no-color` as shorthand aliases that set existing internal state.
+
+**Rationale**: Cobra's `PersistentFlags` are inherited by all subcommands automatically and appear in `--help` output for every subcommand. This is exactly what clig.dev requires. The existing `--output`, `--debug`, `--verbose`, `--no-tui` flags already use this mechanism successfully.
+
+**Alternatives Rejected**:
+- Per-subcommand flags: Would require duplication across 13+ subcommands, easy to forget one.
+- Middleware/PersistentPreRunE: Not needed for flag registration, but we will use `PersistentPreRunE` for conflict detection.
+
+**Key Finding**: Cobra persistent flags ARE inherited and visible in subcommand `--help`. Verified by inspecting current `--output`, `--verbose` behavior. The `cmd.Flags().Changed("flagname")` method distinguishes explicit user flags from defaults — critical for conflict detection.
+
+## R2: Flag Conflict Detection — `--json` + `--output text`
+
+**Decision**: Add a `ResolveOutputConfig()` function called in `PersistentPreRunE` on the root command that detects flag conflicts before command execution.
+
+**Rationale**: The resolution must happen early and universally, not per-command. Using `PersistentPreRunE` ensures:
+1. All subcommands get conflict detection without modification
+2. Errors are reported before any execution begins
+3. The resolution order is explicit: conflicts → `--json` → `--quiet` → `--output` → default
+
+**Alternatives Rejected**:
+- Per-command validation: Would miss new subcommands, duplicates logic.
+- Silent precedence (last-flag-wins): clig.dev recommends explicit errors for conflicts.
+
+**Key Finding**: `cmd.Flags().Changed("flagname")` on `cmd.Root().PersistentFlags()` detects whether the user explicitly passed a flag vs the flag taking its default value. This is how we detect `--json` + `--output text` conflicts.
+
+## R3: `--no-color` Implementation — Interaction with Lipgloss and Existing NO_COLOR
+
+**Decision**: `--no-color` sets `os.Setenv("NO_COLOR", "1")` early in `PersistentPreRunE`, feeding into the existing `SelectColorPalette`/`DetectANSISupport` code paths. For TUI, lipgloss reads `NO_COLOR` natively.
+
+**Rationale**: The `internal/display/capability.go` already handles `NO_COLOR` env var by returning `AsciiOnlyColorScheme`. Adding `--no-color` is a single flag that converts to the same env var. Lipgloss v1.0+ reads `NO_COLOR` automatically — structural formatting (borders, padding, alignment) remains intact.
+
+**Alternatives Rejected**:
+- Custom color stripping middleware: Over-engineered; lipgloss and ANSICodec already respect `NO_COLOR`.
+- New `ColorConfig` struct: Unnecessary abstraction — the existing `colorMode string` parameter handles it.
+
+**Key Finding**: `SelectColorPalette` with `colorMode="auto"` already checks `os.Getenv("NO_COLOR")`. Setting the env var in `PersistentPreRunE` ensures all downstream code (display, TUI, lipgloss) sees it. TUI monochrome mode preserves layout because lipgloss separates color attributes from structural formatting.
+
+## R4: Subcommand `--format` vs Root `--json` Precedence
+
+**Decision**: Introduce a `ResolveFormat()` helper that each subcommand calls. If root `--json`/`--quiet`/`--output` was explicitly changed (via `cmd.Root().PersistentFlags().Changed()`), the root flag wins. Otherwise, local `--format` applies.
+
+**Rationale**: Five subcommands have local `--format` flags: `status`, `list`, `logs`, `artifacts`, `cancel`. Each reads `opts.Format` directly. The fix: each command calls `ResolveFormat(cmd, localFormat)` which checks root flag priority.
+
+**Alternatives Rejected**:
+- Removing `--format` from subcommands: Breaking change for existing scripts.
+- Making subcommand `--format` override root: Violates the "global policy wins" pattern.
+
+**Key Finding**: The five subcommands with `--format` all use the same conditional: `opts.Format == "json"`. Updating them to call a shared resolver is mechanical and low-risk.
+
+## R5: Error Response Structure — `ErrorResponse` JSON
+
+**Decision**: Introduce a `CLIError` type with `Error`, `Code`, `Suggestion`, and optional `Debug` fields. Render as JSON to stderr when `--json` is active.
+
+**Rationale**: Currently, errors are rendered by Cobra's default handler or `fmt.Errorf`. For JSON mode:
+1. Define `CLIError` struct with JSON tags in a new `cmd/wave/commands/errors.go`
+2. In main.go's error handler, detect JSON mode → format as JSON on stderr
+3. Map known error types to error codes using the existing `recovery.ErrorClass` types
+
+**Alternatives Rejected**:
+- Per-command JSON error formatting: Would miss errors from Cobra itself (flag parsing errors).
+- Go error wrapping chains: Too generic; need structured codes and suggestions.
+
+**Key Finding**: The `recovery` package already has `ErrorClass` types (`contract_validation`, `security_violation`, `preflight`, `runtime_error`) that map directly to error codes. Extending this with CLI-specific codes (`pipeline_not_found`, `manifest_missing`, `flag_conflict`) provides complete coverage.
+
+## R6: Output Stream Discipline — stdout vs stderr Audit
+
+**Decision**: Audit all `fmt.Printf`/`fmt.Println` calls in commands package; route progress/informational output to stderr, keep data output on stdout.
+
+**Rationale**: 188 print calls across 12 command files. Key findings:
+- `run.go`: Already correct — NDJSON on stdout, progress on stderr
+- `status.go`: Table output on stdout (correct for data), hardcoded ANSI color codes need `--no-color` respect
+- `list.go`: Table output on stdout (correct)
+- `clean.go`: Progress messages use `fmt.Printf` to stdout — should be stderr
+- `artifacts.go`: Table output on stdout (correct), informational messages should be stderr
+- `logs.go`: Performance summary uses stdout — should be stderr
+- `cancel.go`: Result output on stdout (correct for data)
+
+The fix is targeted, not wholesale — move progress/informational messages to stderr.
+
+**Key Finding**: `status.go` has hardcoded ANSI color constants (`colorReset`, `colorRed`, `colorGreen`, `colorYellow`, `colorGray`). These bypass the `SelectColorPalette`/`NO_COLOR` system and need to use the shared color infrastructure or be gated on `NO_COLOR`.
+
+## R7: `--quiet` as Root Persistent Flag
+
+**Decision**: Add `-q`/`--quiet` as persistent root flag equivalent to `--output quiet`. For non-streaming commands, quiet mode shows only essential data (no headers, no decorations).
+
+**Rationale**: `clean --quiet` is command-local. The root `--quiet` maps to `--output quiet` which already has full emitter support. Combined with `--json`, `--quiet` only suppresses stderr (orthogonal concerns per spec clarification C3).
+
+**Alternatives Rejected**:
+- Keeping `--quiet` per-command: Inconsistent with clig.dev.
+- Making `--quiet` suppress all output: Would be useless — equivalent to `>/dev/null`.
+
+## R8: `TERM=dumb` and Quiet+Verbose Conflict
+
+**Decision**: `TERM=dumb` triggers `--no-color --no-tui` equivalence. `--quiet` + `--verbose` → quiet wins, log warning.
+
+**Rationale**: `shouldLaunchTUI()` already handles `TERM=dumb`. `DetectANSISupport()` returns false for `TERM=dumb`. Color is already disabled via this path. Gap: ensure explicit `NO_COLOR` is set for downstream code. For `--quiet` + `--verbose` conflict: spec says quiet wins with a warning.
+
+**Key Finding**: Current code handles TERM=dumb correctly for both TUI and color (via `DetectANSISupport`). Only gap is ensuring `--quiet` + `--verbose` warning is logged.

--- a/specs/260-tui-cli-compliance/spec.md
+++ b/specs/260-tui-cli-compliance/spec.md
@@ -1,0 +1,221 @@
+# Feature Specification: CLI Compliance Polish
+
+**Feature Branch**: `260-tui-cli-compliance`  
+**Created**: 2026-03-06  
+**Status**: Draft  
+**Input**: [GitHub Issue #260](https://github.com/re-cinq/wave/issues/260) — CLI compliance polish per clig.dev guidelines: `--json`, `NO_COLOR`, `--no-color`, `--quiet`, error messages, output stream discipline, flag consistency.
+
+## Context
+
+Wave already has substantial CLI infrastructure:
+- Root persistent flags: `--output` (auto/json/text/quiet), `--debug`, `--verbose`, `--no-tui`
+- Per-subcommand `--format` flags on `status`, `logs`, `list`, `artifacts`, `cancel`
+- `NO_COLOR` env var support in `internal/display/capability.go`
+- `clean --quiet` for scripting
+- Progress emitters directing output to stderr in text/quiet modes
+- NDJSON event emitter for `--output json`
+
+This issue is about **standardizing and polishing** the existing CLI surface to comply with [clig.dev](https://clig.dev) guidelines by adding convenience aliases, enforcing consistency across all subcommands, and improving error message quality.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Consistent Flag Surface Across All Subcommands (Priority: P1)
+
+A user who frequently works with different `wave` subcommands expects the same standard flags to be available everywhere. Currently, `--json` does not exist as a standalone flag (users must use `--output json`), `--quiet`/`-q` is only on `clean`, and `--no-color` exists only as the `NO_COLOR` env var. This story unifies the flag surface.
+
+**Why this priority**: Flag consistency is the foundation — every other story depends on flags working uniformly. Without this, users must memorize different flag combinations per subcommand.
+
+**Independent Test**: Run `wave <any-subcommand> --help` and verify standard flags (`-q`/`--quiet`, `--json`, `--no-color`, `--debug`, `--verbose`, `--no-tui`) appear in the output.
+
+**Acceptance Scenarios**:
+
+1. **Given** any wave subcommand, **When** the user runs `wave <cmd> --help`, **Then** the help output lists all standard persistent flags: `-v`/`--verbose`, `-q`/`--quiet`, `--debug`, `--json`, `--no-color`, `--no-tui`, and `-o`/`--output`.
+2. **Given** the root command, **When** `--json` is passed, **Then** it behaves identically to `--output json` — producing JSON on stdout with no TUI, no progress spinners, and no color. For streaming commands (`run`), this means NDJSON (one event per line); for non-streaming commands (`status`, `list`, etc.), this means structured JSON output.
+3. **Given** the root command, **When** `-q`/`--quiet` is passed, **Then** it behaves identically to `--output quiet` — suppressing non-essential output.
+4. **Given** both `--json` and `--output text` are passed, **Then** the CLI reports a conflict error and exits with a non-zero code and actionable message.
+5. **Given** a subcommand with a local `--format` flag (e.g. `status --format json`), **When** the root `--json` flag is also passed, **Then** the root `--json` flag takes precedence and the subcommand's `--format` value is ignored.
+
+---
+
+### User Story 2 — Machine-Readable JSON Output (Priority: P1)
+
+A CI/CD pipeline or script author pipes `wave` output into `jq` or another JSON parser. They need valid, parseable JSON from every subcommand when `--json` is specified — not just from `wave run`.
+
+**Why this priority**: Machine-readable output enables automation and is a core clig.dev compliance requirement. Tied with flag consistency as the most impactful change.
+
+**Independent Test**: Run `wave status --json`, `wave list --json`, `wave artifacts --json`, and pipe each through `jq .` — all must succeed without parse errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** `wave status --json`, **When** output is piped through `jq`, **Then** the output is a single valid JSON object (structured, not NDJSON).
+2. **Given** `wave list pipelines --json`, **When** the pipeline list is rendered, **Then** it emits a JSON array of pipeline objects (not table rows).
+3. **Given** `wave artifacts --json <run-id>`, **When** artifacts exist, **Then** the output is a JSON array of artifact metadata objects.
+4. **Given** `wave run --json <pipeline>`, **When** the pipeline runs, **Then** stdout contains only NDJSON events (one JSON object per line) and stderr contains only error messages (no progress text).
+5. **Given** `wave logs --json <run-id>`, **When** logs are retrieved, **Then** each log entry is a JSON object on its own line (NDJSON).
+6. **Given** any subcommand with `--json`, **When** the command fails, **Then** stderr contains a JSON object with `"error"`, `"code"`, and `"suggestion"` fields.
+
+---
+
+### User Story 3 — Color and Styling Control (Priority: P2)
+
+A user on a terminal that does not support ANSI colors (or who prefers plain text for readability/accessibility) wants to disable all color output via a flag or environment variable without affecting functionality.
+
+**Why this priority**: Color control is a clig.dev and NO_COLOR.org standard. The `NO_COLOR` env var is already implemented; this story adds the `--no-color` flag as an explicit alternative.
+
+**Independent Test**: Run `wave status --no-color` and verify the output contains zero ANSI escape sequences.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `--no-color` flag is passed, **When** any output is rendered (CLI or TUI), **Then** no ANSI escape sequences are present in stdout or stderr.
+2. **Given** the `NO_COLOR` env var is set (to any non-empty value), **When** any command runs, **Then** color is disabled identically to `--no-color`.
+3. **Given** `--no-color` is passed alongside `--no-tui`, **When** `wave run` executes, **Then** progress text renders without color codes.
+4. **Given** `--no-color` is NOT passed and `NO_COLOR` is unset, **When** the terminal supports ANSI, **Then** colored output is rendered as normal.
+5. **Given** `--no-color` is passed, **When** the TUI is active, **Then** the TUI renders without color attributes but preserves structural formatting (borders, layout, spacing). Lipgloss styles are applied with empty color values, maintaining the TUI structure in monochrome.
+
+---
+
+### User Story 4 — Quiet Mode for Scripting (Priority: P2)
+
+A script author embedding `wave` in a larger automation wants to suppress all non-essential output (spinners, progress bars, status lines) and only see errors and final results.
+
+**Why this priority**: Quiet mode is essential for CI/CD integration and piping. The `-o quiet` mode exists but lacks the `-q`/`--quiet` shorthand expected by clig.dev.
+
+**Independent Test**: Run `wave run -q <pipeline>` and verify that only the final result (or error) appears in stderr, with no intermediate progress.
+
+**Acceptance Scenarios**:
+
+1. **Given** `-q` or `--quiet` is passed, **When** a pipeline runs, **Then** only the final completion/failure summary is emitted to stderr.
+2. **Given** `--quiet` is passed, **When** the TUI would normally launch, **Then** the TUI is NOT launched (quiet implies non-interactive).
+3. **Given** `--quiet` and `--json` are both passed, **When** a pipeline runs, **Then** `--json` controls stdout format (NDJSON events for streaming commands, structured JSON for non-streaming) while `--quiet` suppresses all non-essential stderr output (progress, warnings). Only fatal errors appear on stderr.
+4. **Given** `--quiet` is passed to `wave status`, **When** the status is retrieved, **Then** only the essential status line is emitted (no table headers, no decorations).
+
+---
+
+### User Story 5 — Actionable Error Messages (Priority: P3)
+
+A user encounters a failure (missing manifest, invalid pipeline name, adapter not found, contract violation). Instead of a cryptic error, they receive a clear message explaining what went wrong and what to do next.
+
+**Why this priority**: Good error messages reduce support burden and improve developer experience. Less urgent than output mode mechanics but critical for polish.
+
+**Independent Test**: Deliberately trigger known error conditions and verify each error message includes a suggestion.
+
+**Acceptance Scenarios**:
+
+1. **Given** `wave run nonexistent-pipeline`, **When** the pipeline is not found, **Then** the error message includes the pipeline name, lists available pipelines, and suggests `wave list pipelines`.
+2. **Given** `wave run --manifest missing.yaml`, **When** the manifest file does not exist, **Then** the error message includes the file path and suggests `wave init`.
+3. **Given** a pipeline step fails contract validation, **When** the error is reported, **Then** the message includes the step name, contract type, and a description of what was expected.
+4. **Given** any error, **When** `--debug` is NOT set, **Then** no stack traces or internal Go error chains are shown.
+5. **Given** any error with `--debug` set, **When** the error is displayed, **Then** it includes the full error chain and relevant debug context.
+6. **Given** any error with `--json` set, **When** the error is emitted, **Then** it is a valid JSON object on stderr with `"error"`, `"code"`, and `"suggestion"` fields.
+
+---
+
+### User Story 6 — Output Stream Discipline (Priority: P3)
+
+A user pipes `wave run --json <pipeline>` to `jq` and expects only clean JSON on stdout. Progress indicators, warnings, and informational messages must not pollute stdout.
+
+**Why this priority**: Correct stream separation is required for reliable piping and is a clig.dev mandate. Most of this is already implemented; this story ensures completeness.
+
+**Independent Test**: Run `wave run --json <pipeline> 2>/dev/null | jq .` and verify all lines parse as valid JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** any command with `--json`, **When** output is produced, **Then** stdout contains ONLY valid JSON (one object per line for streaming commands, a single JSON document for non-streaming commands), with no interleaved text.
+2. **Given** any command without `--json`, **When** progress spinners or bars render, **Then** they render to stderr, never stdout.
+3. **Given** `wave run` completes, **When** the final summary is shown, **Then** it appears at the END of stderr output (not buried in the middle).
+4. **Given** `--verbose` is active, **When** tool call activity is logged, **Then** it goes to stderr.
+
+---
+
+### Edge Cases
+
+- **Conflicting flags**: `--json` + `--output text` should produce a clear conflict error, not undefined behavior.
+- **Piped stdout with no flags**: When stdout is not a TTY and no explicit output flag is set, the auto mode should fall back to text (not TUI) — this is already handled by TTY detection.
+- **`TERM=dumb`**: Should disable both color and TUI, behaving as `--no-color --no-tui`.
+- **`--no-color` in TUI mode**: TUI should still launch but render in monochrome (no color attributes, but structural formatting preserved).
+- **Empty pipeline list in `--json` mode**: Should output `[]`, not an empty string or nothing.
+- **Subcommand `--format` vs root `--json`**: Root `--json` takes precedence when both are present. Subcommand `--format` flags are retained for backward compatibility but are overridden by root-level output flags.
+- **`--quiet` + `--verbose`**: `--quiet` wins — suppresses verbose output. If the user passes both, log a warning to stderr.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST provide `--json` as a persistent root flag that is equivalent to `--output json`.
+- **FR-002**: The CLI MUST provide `-q`/`--quiet` as a persistent root flag that is equivalent to `--output quiet`.
+- **FR-003**: The CLI MUST provide `--no-color` as a persistent root flag that disables all ANSI color and styling.
+- **FR-004**: The `--no-color` flag MUST have identical behavior to setting the `NO_COLOR` environment variable. Implementation: `--no-color` sets the internal `colorMode` to `"off"`, which is the same code path as `NO_COLOR` detection in `SelectColorPalette`.
+- **FR-005**: When `--json` is passed, every subcommand MUST produce valid, parseable JSON output on stdout. For streaming commands (`run`), this is NDJSON (one JSON object per line). For non-streaming commands (`status`, `list`, `logs`, `artifacts`, `cancel`), this is a single structured JSON document.
+- **FR-006**: Subcommands that currently use `--format json` for local table/JSON toggling MUST respect the root `--json` flag as an override. The subcommand `--format` flags are retained for backward compatibility but are superseded when `--json` (or any root `--output` variant) is set. Both root `--json` and subcommand `--format json` produce the same structured JSON for non-streaming commands.
+- **FR-007**: When `--quiet` is passed, all non-essential output (progress indicators, spinners, decorative formatting) MUST be suppressed.
+- **FR-008**: When `--quiet` is passed, the TUI MUST NOT launch (quiet implies non-interactive).
+- **FR-009**: Error messages MUST be actionable — every error MUST include a suggested next step or remediation.
+- **FR-010**: Stack traces and internal error chains MUST only appear when `--debug` is set.
+- **FR-011**: Progress indicators (spinners, bars, live updates) MUST render to stderr, never stdout.
+- **FR-012**: Important summary information (completion status, timing, token usage) MUST appear at the END of output, not buried in the middle.
+- **FR-013**: When `--json` is set and an error occurs, the error MUST be emitted as a JSON object to stderr with `"error"`, `"code"`, and `"suggestion"` fields. The `"code"` field provides a machine-parseable error classification (e.g. `"pipeline_not_found"`, `"manifest_missing"`, `"contract_violation"`).
+- **FR-014**: When conflicting flags are passed (e.g. `--json` + `--output text`), the CLI MUST report a clear conflict error and exit with non-zero status.
+- **FR-015**: All standard flags MUST be consistent and visible in `--help` output for every subcommand.
+
+### Key Entities
+
+- **OutputMode**: The resolved output behavior (auto, json, text, quiet) after considering `--output`, `--json`, `--quiet`, and their interactions. Resolution order: (1) check for conflicts, (2) `--json` sets json, (3) `--quiet` sets quiet, (4) `--output` value, (5) default auto.
+- **ColorMode**: The resolved color behavior (auto, on, off) after considering `--no-color`, `NO_COLOR` env var, and terminal capabilities. `--no-color` flag maps to `colorMode = "off"`, which follows the existing `SelectColorPalette` code path.
+- **ErrorResponse**: A structured error containing the error message (`"error"`), a machine-parseable error code (`"code"`), a human-readable suggestion (`"suggestion"`), and optionally debug details (`"debug"`, only when `--debug` is set).
+
+## Clarifications
+
+The following ambiguities were identified and resolved during the clarify step:
+
+### C1: JSON Output Format for Non-Streaming vs Streaming Commands
+
+**Ambiguity**: The spec originally described `--json` as producing "NDJSON" uniformly, but `wave status`, `wave list`, etc. are request-response commands where NDJSON (one event per line) doesn't apply. The existing `--format json` on these commands produces structured JSON (e.g., `{"runs": [...]}` for status).
+
+**Resolution**: `--json` produces **structured JSON** for non-streaming commands and **NDJSON** for streaming commands (`wave run`). This matches the existing `--format json` behavior on subcommands and aligns with clig.dev's recommendation that JSON output be parseable by `jq`. Streaming commands naturally produce line-delimited events; non-streaming commands produce a single JSON document.
+
+**Rationale**: NDJSON for `wave status` would break `jq .` compatibility (which expects a single document). The clig.dev spec says "if the output is primarily for machines, JSON" — it doesn't mandate NDJSON for all commands.
+
+### C2: Error Response `code` Field
+
+**Ambiguity**: FR-013 originally specified only `"error"` + `"suggestion"` fields, but US5-S6 referenced `"error"` + `"code"` + `"suggestion"`. The `code` field was inconsistently specified.
+
+**Resolution**: The `"code"` field is **required** in structured JSON error responses. It provides a machine-parseable error classification string (e.g., `"pipeline_not_found"`, `"manifest_missing"`, `"contract_violation"`, `"flag_conflict"`, `"adapter_not_found"`). FR-013 and the ErrorResponse entity definition have been updated to include `"code"`.
+
+**Rationale**: Machine consumers need stable error codes to programmatically handle different failure modes. This aligns with clig.dev's guidance on structured error output and follows patterns in tools like `gh` and `kubectl`.
+
+### C3: `--quiet` + `--json` Combination Semantics
+
+**Ambiguity**: US4-S3 described `--quiet` + `--json` but the semantics were unclear — if `--json` produces output on stdout, what does "quiet" suppress?
+
+**Resolution**: `--json` and `--quiet` control **orthogonal concerns**. `--json` controls the **stdout format** (JSON output). `--quiet` controls **stderr verbosity** (suppresses progress, warnings, informational messages). When combined: stdout gets JSON output as normal, stderr is silent except for fatal errors. This is **not** a conflict — the combination is valid and useful for CI/CD scripts that want structured output with minimal noise.
+
+**Rationale**: This follows the Unix convention where stdout is for data and stderr is for diagnostics. `--quiet` reduces diagnostic noise; `--json` structures the data channel. Tools like `curl -s -o - | jq` demonstrate this pattern.
+
+### C4: `--no-color` Effect on TUI Rendering (Monochrome Mode)
+
+**Ambiguity**: US3-S5 said "no lipgloss color styles applied" but lipgloss handles both color attributes and structural formatting (borders, padding, alignment). Stripping all lipgloss styling would destroy the TUI layout.
+
+**Resolution**: "Monochrome mode" means **no color attributes** but **preserved structural formatting**. Lipgloss styles continue to apply borders, padding, width, and alignment, but all `Foreground()`, `Background()`, and `ColorProfile()` color values are cleared/empty. This is implemented by passing `colorMode = "off"` through to lipgloss renderers, which use `lipgloss.NoColor{}` as the color profile.
+
+**Rationale**: This is the standard approach used by Charm ecosystem tools (e.g., `glow`, `soft-serve`). The lipgloss `HasDarkBackground` detection and `ColorProfile()` already support this via `lipgloss.Ascii` profile. Destroying layout would make the TUI unusable.
+
+### C5: Subcommand `--format` Flag Coexistence with Root Flags
+
+**Ambiguity**: The spec said root `--json` "overrides" subcommand `--format`, but didn't specify whether `--format` should be deprecated, removed, or continue to coexist.
+
+**Resolution**: Subcommand `--format` flags are **retained for backward compatibility** and continue to work as before. When a root-level output flag (`--json`, `--quiet`, `--output`) is explicitly set, it takes precedence over the subcommand's `--format`. When no root output flag is set (i.e., `--output` remains at its default `auto`), the subcommand's `--format` controls output as it does today. No deprecation warnings are added in this iteration.
+
+**Rationale**: Removing `--format` would be a breaking change for existing scripts. The precedence rule is simple: root flags are "global policy" and subcommand flags are "local preference" — global wins when explicitly set. This is the same pattern used by `kubectl` (`-o json` vs subcommand-specific flags).
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Running `wave <subcommand> --help` for ALL subcommands shows the standard persistent flag set (`--json`, `-q`/`--quiet`, `--no-color`, `--debug`, `--verbose`, `--no-tui`, `--output`).
+- **SC-002**: `wave status --json | jq .` succeeds for every subcommand that produces output (`status`, `list`, `logs`, `artifacts`, `cancel`, `run`).
+- **SC-003**: `wave run --json <pipeline> 2>/dev/null | jq -c .` parses every line — zero non-JSON lines on stdout.
+- **SC-004**: `wave status --no-color | grep -P '\x1b\[' | wc -l` returns 0 — no ANSI escape sequences present.
+- **SC-005**: `wave run -q <pipeline>` produces no output on stdout and only a final summary line on stderr.
+- **SC-006**: Every error path tested includes a `"suggestion"` or human-readable remediation hint.
+- **SC-007**: All existing tests pass with no regressions (`go test -race ./...`).
+- **SC-008**: Flag conflict detection (`--json` + `--output text`) produces a non-zero exit code and clear message.

--- a/specs/260-tui-cli-compliance/tasks.md
+++ b/specs/260-tui-cli-compliance/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: CLI Compliance Polish
+
+**Feature Branch**: `260-tui-cli-compliance`
+**Generated**: 2026-03-07
+**Spec**: `specs/260-tui-cli-compliance/spec.md`
+**Plan**: `specs/260-tui-cli-compliance/plan.md`
+
+## Phase 1: Setup & Foundation
+
+- [X] T001 [P1] [Setup] Create `cmd/wave/commands/errors.go` with `CLIError` type implementing `error` interface, JSON tags (`error`, `code`, `suggestion`, `debug`), constructor `NewCLIError(code, message, suggestion)`, and error code constants (`pipeline_not_found`, `manifest_missing`, `manifest_invalid`, `contract_violation`, `adapter_not_found`, `flag_conflict`, `onboarding_required`, `step_not_found`, `run_not_found`, `preflight_failed`, `timeout`, `cancelled`, `internal_error`) per data-model.md
+- [X] T002 [P1] [Setup] Create `cmd/wave/commands/errors_test.go` with table-driven tests: `CLIError.Error()` returns message, JSON marshaling produces `{"error":..,"code":..,"suggestion":..}`, `debug` field omitted when empty, included when set
+
+## Phase 2: Root Flag Registration & Conflict Detection (US1 — Consistent Flag Surface)
+
+- [X] T003 [P1] [US1] Register `--json` (bool), `-q`/`--quiet` (bool), and `--no-color` (bool) as persistent root flags in `cmd/wave/main.go` `init()` function, alongside existing `--output`, `--debug`, `--verbose`, `--no-tui`
+- [X] T004 [P1] [US1] Add `ResolvedFlags` struct and `ResolveOutputConfig(cmd *cobra.Command) (*ResolvedFlags, error)` function to `cmd/wave/commands/output.go` that: reads all root flag states via `.Changed()`, detects conflicts (`--json` + `--output` non-json → `CLIError{Code: "flag_conflict"}`; `--quiet` + `--output` non-quiet → error; `--quiet` + `--verbose` → warn stderr, quiet wins), resolves final `OutputConfig{Format, Verbose, NoColor, Debug}`, and returns `ResolvedFlags{Output, NoTUI}`
+- [X] T005 [P1] [US1] Extend `OutputConfig` struct in `cmd/wave/commands/output.go` with `NoColor bool` and `Debug bool` fields per data-model.md
+- [X] T006 [P1] [US1] Add `PersistentPreRunE` to `rootCmd` in `cmd/wave/main.go` that calls `commands.ResolveOutputConfig(cmd)`, stores result in cmd context via `cmd.SetContext()`, sets `os.Setenv("NO_COLOR", "1")` when `--no-color` is true, and sets `noTUI` override when `--json` or `--quiet`
+- [X] T007 [P1] [US1] Update `GetOutputConfig()` in `cmd/wave/commands/output.go` to first check cmd context for `ResolvedFlags`, falling back to existing flag reading for backward compatibility
+- [X] T008 [P1] [US1] Add conflict detection and resolution tests to `cmd/wave/commands/output_test.go`: `--json` alone → Format="json"; `--quiet` alone → Format="quiet"; `--json`+`--output text` → error "flag_conflict"; `--quiet`+`--output json` → error; `--json`+`--quiet` → no error, Format="json"; `--no-color` → NoColor=true; `--quiet`+`--verbose` → quiet wins with warning
+
+## Phase 3: JSON Error Rendering (US2 — Machine-Readable Output, US5 — Actionable Errors)
+
+- [X] T009 [P1] [US2] Add `RenderJSONError(w io.Writer, err error, debug bool)` function to `cmd/wave/commands/errors.go` that marshals `*CLIError` as JSON to writer, or wraps plain `error` as `CLIError{Code: "internal_error"}` before marshaling
+- [X] T010 [P1] [US2] Update `main()` error handler in `cmd/wave/main.go` to: read resolved output format from root flags, if JSON mode call `RenderJSONError(os.Stderr, err, debug)`, else render text error with suggestion if `*CLIError`
+- [X] T011 [P1] [US5] Add `RenderTextError(w io.Writer, err error, debug bool)` function to `cmd/wave/commands/errors.go` that formats `*CLIError` as `"Error: <message>\n  Suggestion: <suggestion>"` and includes debug chain only when debug=true
+- [X] T012 [P1] [US2,US5] Add tests to `cmd/wave/commands/errors_test.go` for: `RenderJSONError` produces valid JSON with error/code/suggestion fields on stderr, plain error wraps as `CLIError{Code: "internal_error"}`, debug details included only when debug=true, `RenderTextError` shows suggestion line
+
+## Phase 4: Actionable Error Messages (US5)
+
+- [X] T013 [P3] [US5] Wrap `loadPipeline()` error in `cmd/wave/commands/run.go` with `CLIError{Code: "pipeline_not_found", Suggestion: "Run 'wave list pipelines' to see available pipelines"}`
+- [X] T014 [P3] [US5] Wrap manifest read error in `cmd/wave/commands/run.go` `runRun()` with `CLIError{Code: "manifest_missing", Suggestion: "Run 'wave init' to create a manifest"}`
+- [X] T015 [P3] [US5] Wrap manifest parse error in `cmd/wave/commands/run.go` `runRun()` with `CLIError{Code: "manifest_invalid", Suggestion: "Check wave.yaml syntax — run 'wave validate' to diagnose"}`
+- [X] T016 [P3] [US5] Wrap onboarding check error in `cmd/wave/commands/run.go` `checkOnboarding()` return with `CLIError{Code: "onboarding_required", Suggestion: "Run 'wave init'"}`
+- [X] T017 [P] [P3] [US5] Add integration between `recovery.ErrorClass` and `CLIError.Code` — add `ErrorClassToCode(class recovery.ErrorClass) string` mapper function to `cmd/wave/commands/errors.go` that maps `ClassContractValidation` → `"contract_violation"`, `ClassPreflight` → `"preflight_failed"`, `ClassSecurityViolation` → `"security_violation"`, etc.
+
+## Phase 5: Subcommand Format Resolution (US1, US2)
+
+- [X] T018 [P1] [US1] Add `ResolveFormat(cmd *cobra.Command, localFormat string) string` function to `cmd/wave/commands/output.go` that returns root `--json`→"json" / `--quiet`→"quiet" / `--output` value if explicitly set, otherwise returns `localFormat` unchanged
+- [X] T019 [P] [P1] [US1] Update `cmd/wave/commands/status.go` `NewStatusCmd` RunE to call `ResolveFormat(cmd, opts.Format)` before passing format to `runStatus`
+- [X] T020 [P] [P1] [US1] Update `cmd/wave/commands/list.go` — in each list subcommand's RunE (`pipelines`, `personas`, `adapters`, `runs`, `contracts`, `skills`), call `ResolveFormat(cmd, format)` before format-conditional logic
+- [X] T021 [P] [P1] [US1] Update `cmd/wave/commands/logs.go` `NewLogsCmd` RunE to call `ResolveFormat(cmd, opts.Format)` before passing format to `runLogs`
+- [X] T022 [P] [P1] [US1] Update `cmd/wave/commands/artifacts.go` `NewArtifactsCmd` RunE to call `ResolveFormat(cmd, opts.Format)` before passing format to `runArtifacts`
+- [X] T023 [P] [P1] [US1] Update `cmd/wave/commands/cancel.go` `NewCancelCmd` RunE to call `ResolveFormat(cmd, opts.Format)` before passing format to `runCancel`
+- [X] T024 [P1] [US1] Add `ResolveFormat` tests to `cmd/wave/commands/output_test.go`: root `--json` overrides local "table", root `--quiet` overrides local "json", default root → local preserved
+
+## Phase 6: Color Control (US3)
+
+- [X] T025 [P2] [US3] Replace hardcoded ANSI color constants in `cmd/wave/commands/status.go` (`colorReset`, `colorRed`, `colorGreen`, `colorYellow`, `colorGray`) with a `conditionalColor(code string) string` helper that returns empty string when `os.Getenv("NO_COLOR") != ""`
+- [X] T026 [P2] [US3] Add `--no-color` test to `cmd/wave/commands/status_test.go` that sets `NO_COLOR=1`, runs status output, and verifies zero ANSI escape sequences in output
+
+## Phase 7: Output Stream Discipline (US6)
+
+- [X] T027 [P] [P3] [US6] Update `cmd/wave/commands/clean.go` — change all `fmt.Printf` progress/informational messages to `fmt.Fprintf(os.Stderr, ...)`: "Nothing to clean", "Removed %s", "Failed to remove %s", "Cleaned %d item(s)", "Progress: %d/%d", confirmation prompts, and dry-run output
+- [X] T028 [P] [P3] [US6] Update `cmd/wave/commands/logs.go` `renderPerformanceSummary()` — change all `fmt.Println`/`fmt.Printf` to `fmt.Fprintf(os.Stderr, ...)` for the "--- Performance Summary ---" block
+- [X] T029 [P] [P3] [US6] Update `cmd/wave/commands/artifacts.go` `outputArtifactsTable()` — move "Artifacts for run:" header and "No artifacts found" message to stderr; keep table data rows on stdout
+- [X] T030 [P] [P3] [US6] Update `cmd/wave/commands/status.go` `showRunningRuns()` and `showAllRuns()` — move "No running pipelines" and "No pipelines found" informational messages to stderr; keep table data on stdout
+- [X] T031 [P] [P3] [US6] Update `cmd/wave/commands/run.go` `performDryRun()` — route dry-run output to stderr since it's informational, not data
+
+## Phase 8: Quiet Mode & TUI Integration (US4)
+
+- [X] T032 [P2] [US4] Update `shouldLaunchTUI()` in `cmd/wave/main.go` — add checks: if `--json` flag set → return false; if `--quiet` flag set → return false (before existing TTY check)
+- [X] T033 [P2] [US4] Handle `clean --quiet` coexistence with root `--quiet` in `cmd/wave/commands/clean.go` — ensure both `opts.Quiet` (local flag) and root `--quiet` produce suppressed output without conflict
+
+## Phase 9: Edge Cases & Polish
+
+- [X] T034 [P2] [US1] Ensure `TERM=dumb` triggers `--no-color` equivalence in `cmd/wave/main.go` `PersistentPreRunE` — when `os.Getenv("TERM") == "dumb"`, set `NO_COLOR=1` and `noTUI=true`
+- [X] T035 [P] [P3] [US2] Verify empty-list JSON output in subcommands — ensure `wave list pipelines --json` outputs `[]`, `wave status --json` outputs `{"runs":[]}`, not empty string, when no data exists (audit existing code in `list.go`, `status.go`)
+
+## Phase 10: Test Verification & Cross-Cutting
+
+- [X] T036 [P1] [SC-007] Run `go test -race ./...` and fix any regressions introduced by flag changes, ensuring all existing tests pass
+- [X] T037 [P1] [SC-001] Add test that verifies `wave <subcommand> --help` for ALL subcommands shows standard persistent flags (`--json`, `-q`/`--quiet`, `--no-color`, `--debug`, `--verbose`, `--no-tui`, `--output`) — can be implemented as table-driven test in `cmd/wave/commands/output_test.go` or a new `cmd/wave/main_test.go`
+
+---
+
+## Task Summary
+
+| Phase | Tasks | Priority | User Story |
+|-------|-------|----------|------------|
+| 1: Setup | T001-T002 | P1 | Foundation |
+| 2: Root Flags | T003-T008 | P1 | US1 |
+| 3: JSON Errors | T009-T012 | P1 | US2, US5 |
+| 4: Actionable Errors | T013-T017 | P3 | US5 |
+| 5: Format Resolution | T018-T024 | P1 | US1, US2 |
+| 6: Color Control | T025-T026 | P2 | US3 |
+| 7: Stream Discipline | T027-T031 | P3 | US6 |
+| 8: Quiet/TUI | T032-T033 | P2 | US4 |
+| 9: Edge Cases | T034-T035 | P2-P3 | Cross-cutting |
+| 10: Verification | T036-T037 | P1 | SC-001, SC-007 |
+
+**Total Tasks**: 37
+**Parallelizable**: T019-T023, T027-T031, T035 (marked with [P])
+
+## Dependency Graph
+
+```
+T001 ──┬──> T004 ──> T006 ──> T007
+       │              ↑
+T005 ──┘              │
+       ├──> T009 ──> T010
+       └──> T011      │
+                       │
+T003 ──────────────> T006
+                       │
+T002, T008, T012 ──> (tests, parallel with implementation)
+                       │
+T006 ──> T018 ──> T019,T020,T021,T022,T023 (parallel)
+                       │
+T001 ──> T013,T014,T015,T016,T017 (parallel after T001)
+                       │
+T006 ──> T025 ──> T026
+T006 ──> T027,T028,T029,T030,T031 (parallel)
+T006 ──> T032,T033,T034
+                       │
+T036,T037 ──> (final gate, all other tasks complete)
+```


### PR DESCRIPTION
## Summary

Standardizes and polishes the Wave CLI surface for [clig.dev](https://clig.dev) compliance (#260). Part 9 of the TUI epic (#251).

- Add `--json`, `-q`/`--quiet`, `--no-color` as persistent root flag aliases (`--output json`, `--output quiet`, `NO_COLOR=1` respectively)
- Introduce structured JSON error output with actionable messages via new `errors.go` module
- Enforce output stream discipline: human text → stderr, machine-parseable data → stdout
- Add `--json` support to `status`, `artifacts`, and `clean` subcommands with proper JSON output formatting
- Detect and reject conflicting flags (e.g. `--json` + `--output text`) with clear error messages

## Spec

See [`specs/260-tui-cli-compliance/spec.md`](specs/260-tui-cli-compliance/spec.md) for the full specification.

## Test Plan

- `go test -race ./...` passes (all 28 packages)
- New test files: `errors_test.go` (structured error output), `output_test.go` (JSON output formatting, flag conflict detection), `main_test.go` (persistent flag registration)
- Updated tests: `artifacts_test.go`, `clean_test.go`, `status_test.go` adapted for stderr/stdout stream discipline
- Verified flag help output includes all standard persistent flags across subcommands

## Known Limitations

- `wave logs --json` not yet implemented (logs are inherently streaming text)
- `wave run --json` already produces NDJSON via event emitters — no changes needed

Closes #260