### PR TITLE
feat(tui): detach pipeline execution from TUI process lifecycle

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -52,6 +52,10 @@ Supports dry-run mode, step resumption, custom timeouts, and model override.
 The --model flag overrides the adapter model for all steps in the run,
 including any per-persona model pinning in wave.yaml.
 
+The --run flag reuses a pre-created run ID instead of generating a new one.
+This is used by the TUI to launch detached subprocess pipelines that share
+the same run record created before spawn.
+
 Arguments can be provided as positional args or flags:
   wave run gh-pr-review "Review auth module"
   wave run --pipeline gh-pr-review --input "Review auth module"
@@ -60,7 +64,8 @@ Arguments can be provided as positional args or flags:
   wave run --pipeline speckit-flow --input "add user auth"
   wave run hotfix --dry-run
   wave run migrate --from-step validate
-  wave run my-pipeline --model haiku`,
+  wave run my-pipeline --model haiku
+  wave run my-pipeline --run my-pipeline-20260308-120000-a1b2 --input "data"`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle positional arguments
@@ -108,7 +113,7 @@ Arguments can be provided as positional args or flags:
 	cmd.Flags().IntVar(&opts.Timeout, "timeout", 0, "Timeout in minutes (overrides manifest)")
 	cmd.Flags().StringVar(&opts.Manifest, "manifest", "wave.yaml", "Path to manifest file")
 	cmd.Flags().BoolVar(&opts.Mock, "mock", false, "Use mock adapter (for testing)")
-	cmd.Flags().StringVar(&opts.RunID, "run", "", "Resume from a specific run (uses that run's input)")
+	cmd.Flags().StringVar(&opts.RunID, "run", "", "Reuse a pre-created run ID (for TUI subprocess launch or resume)")
 	cmd.Flags().StringVar(&opts.Model, "model", "", "Override adapter model for this run (e.g. haiku, opus)")
 
 	return cmd
@@ -226,9 +231,13 @@ func runRun(opts RunOptions, debug bool) error {
 	}
 
 	// Generate run ID — prefer CreateRun() so CLI runs appear in the dashboard.
+	// When --run is set without --from-step, reuse the pre-created run ID (TUI subprocess).
 	// Falls back to GenerateRunID() if the state store is unavailable.
 	var runID string
-	if store != nil {
+	if opts.RunID != "" && opts.FromStep == "" {
+		// Reuse pre-created run ID from TUI subprocess launch
+		runID = opts.RunID
+	} else if store != nil {
 		runID, err = store.CreateRun(p.Metadata.Name, opts.Input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to create run record: %v\n", err)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -188,6 +188,10 @@ func (e *DefaultPipelineExecutor) NewChildExecutor() *DefaultPipelineExecutor {
 }
 
 func (e *DefaultPipelineExecutor) Execute(ctx context.Context, p *Pipeline, m *manifest.Manifest, input string) error {
+	// Start cancellation poller: polls store.CheckCancellation every 5s (FR-006)
+	ctx, stopCancelPoller := e.startCancellationPoller(ctx)
+	defer stopCancelPoller()
+
 	validator := &DAGValidator{}
 	if err := validator.ValidateDAG(p); err != nil {
 		return fmt.Errorf("invalid pipeline DAG: %w", err)
@@ -1474,6 +1478,43 @@ func (e *DefaultPipelineExecutor) startProgressTicker(ctx context.Context, pipel
 	}
 
 	return cancel
+}
+
+// startCancellationPoller polls store.CheckCancellation every 5 seconds (FR-006).
+// When cancellation is detected, it cancels the derived context to trigger graceful shutdown.
+// Returns the derived context and a stop function.
+func (e *DefaultPipelineExecutor) startCancellationPoller(ctx context.Context) (context.Context, context.CancelFunc) {
+	if e.store == nil || e.runID == "" {
+		return ctx, func() {}
+	}
+
+	pollerCtx, pollerCancel := context.WithCancel(ctx)
+
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-pollerCtx.Done():
+				return
+			case <-ticker.C:
+				cancel, err := e.store.CheckCancellation(e.runID)
+				if err == nil && cancel != nil {
+					e.emit(event.Event{
+						Timestamp:  time.Now(),
+						PipelineID: e.runID,
+						State:      "cancelling",
+						Message:    "cancellation requested via store",
+					})
+					pollerCancel()
+					return
+				}
+			}
+		}
+	}()
+
+	return pollerCtx, pollerCancel
 }
 
 // checkRelayCompaction monitors token usage and triggers compaction when threshold is exceeded.

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -164,6 +164,8 @@ func (m *MockStateStore) Close() error { return nil }
 func (m *MockStateStore) CreateRun(pipelineName string, input string) (string, error) { return "", nil }
 func (m *MockStateStore) UpdateRunStatus(runID string, status string, currentStep string, tokens int) error { return nil }
 func (m *MockStateStore) UpdateRunBranch(runID string, branch string) error { return nil }
+func (m *MockStateStore) UpdateRunPID(runID string, pid int) error         { return nil }
+func (m *MockStateStore) GetRunPID(runID string) (int, error)              { return 0, nil }
 func (m *MockStateStore) GetRun(runID string) (*state.RunRecord, error) { return nil, nil }
 func (m *MockStateStore) GetRunningRuns() ([]state.RunRecord, error) { return nil, nil }
 func (m *MockStateStore) ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error) { return nil, nil }

--- a/internal/state/migration_definitions.go
+++ b/internal/state/migration_definitions.go
@@ -332,5 +332,44 @@ CREATE INDEX IF NOT EXISTS idx_run_started ON pipeline_run(started_at);
 CREATE INDEX IF NOT EXISTS idx_run_tags ON pipeline_run(tags_json);
 `,
 		},
+		{
+			Version:     8,
+			Description: "Add pid column to pipeline_run for detached subprocess tracking",
+			Up: `
+ALTER TABLE pipeline_run ADD COLUMN pid INTEGER DEFAULT 0;
+`,
+			Down: `
+-- SQLite doesn't support DROP COLUMN directly before 3.35.0
+-- We need to recreate the table without the column
+CREATE TABLE pipeline_run_backup (
+    run_id TEXT PRIMARY KEY,
+    pipeline_name TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+    input TEXT,
+    current_step TEXT,
+    total_tokens INTEGER DEFAULT 0,
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    cancelled_at INTEGER,
+    error_message TEXT,
+    tags_json TEXT DEFAULT '[]',
+    branch_name TEXT DEFAULT ''
+);
+
+INSERT INTO pipeline_run_backup SELECT
+    run_id, pipeline_name, status, input, current_step, total_tokens,
+    started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+FROM pipeline_run;
+
+DROP TABLE pipeline_run;
+
+ALTER TABLE pipeline_run_backup RENAME TO pipeline_run;
+
+CREATE INDEX IF NOT EXISTS idx_run_pipeline ON pipeline_run(pipeline_name);
+CREATE INDEX IF NOT EXISTS idx_run_status ON pipeline_run(status);
+CREATE INDEX IF NOT EXISTS idx_run_started ON pipeline_run(started_at);
+CREATE INDEX IF NOT EXISTS idx_run_tags ON pipeline_run(tags_json);
+`,
+		},
 	}
 }

--- a/internal/state/migrations_test.go
+++ b/internal/state/migrations_test.go
@@ -465,7 +465,7 @@ func TestInitializeWithMigrations_ExistingDatabase(t *testing.T) {
 	manager := NewMigrationManager(db)
 	applied, err := manager.GetAppliedMigrations()
 	assert.NoError(t, err)
-	assert.Len(t, applied, 7) // All 7 defined migrations
+	assert.Len(t, applied, 8) // All 8 defined migrations
 }
 
 func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
@@ -496,11 +496,11 @@ func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
 func TestMigrationDefinitions(t *testing.T) {
 	migrations := GetAllMigrations()
 
-	// Should have 7 migrations based on our definition
-	assert.Len(t, migrations, 7)
+	// Should have 8 migrations based on our definition
+	assert.Len(t, migrations, 8)
 
 	// Check version sequence
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8}
 	for i, migration := range migrations {
 		assert.Equal(t, expectedVersions[i], migration.Version)
 		assert.NotEmpty(t, migration.Description)

--- a/internal/state/rollback_test.go
+++ b/internal/state/rollback_test.go
@@ -185,7 +185,7 @@ func TestPartialRollbackAndReapply(t *testing.T) {
 
 	finalVersion, err := manager.GetCurrentVersion()
 	require.NoError(t, err)
-	assert.Equal(t, 7, finalVersion)
+	assert.Equal(t, 8, finalVersion)
 
 	// Verify all tables exist again
 	expectedTables := []string{

--- a/internal/state/schema.sql
+++ b/internal/state/schema.sql
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS pipeline_run (
     completed_at INTEGER,
     cancelled_at INTEGER,
     error_message TEXT,
-    branch_name TEXT DEFAULT ''
+    branch_name TEXT DEFAULT '',
+    pid INTEGER DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_run_pipeline ON pipeline_run(pipeline_name);

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -99,6 +99,10 @@ type StateStore interface {
 	SaveArtifactMetadata(artifactID int64, runID string, stepID string, previewText string, mimeType string, encoding string, metadataJSON string) error
 	GetArtifactMetadata(artifactID int64) (*ArtifactMetadataRecord, error)
 
+	// PID tracking (detached subprocess)
+	UpdateRunPID(runID string, pid int) error
+	GetRunPID(runID string) (int, error)
+
 	// Tags support
 	SetRunTags(runID string, tags []string) error
 	GetRunTags(runID string) ([]string, error)
@@ -496,10 +500,44 @@ func (s *stateStore) UpdateRunBranch(runID string, branch string) error {
 	return nil
 }
 
+// UpdateRunPID sets the PID for a pipeline run after subprocess spawn.
+func (s *stateStore) UpdateRunPID(runID string, pid int) error {
+	query := `UPDATE pipeline_run SET pid = ? WHERE run_id = ?`
+	result, err := s.db.Exec(query, pid, runID)
+	if err != nil {
+		return fmt.Errorf("failed to update run PID: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("run not found: %s", runID)
+	}
+	return nil
+}
+
+// GetRunPID returns the PID for a pipeline run (0 if not set or in-process).
+func (s *stateStore) GetRunPID(runID string) (int, error) {
+	query := `SELECT pid FROM pipeline_run WHERE run_id = ?`
+	var pid sql.NullInt64
+	err := s.db.QueryRow(query, runID).Scan(&pid)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, fmt.Errorf("run not found: %s", runID)
+		}
+		return 0, fmt.Errorf("failed to get run PID: %w", err)
+	}
+	if pid.Valid {
+		return int(pid.Int64), nil
+	}
+	return 0, nil
+}
+
 // GetRun retrieves a single run record by ID.
 func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE run_id = ?`
 
@@ -507,6 +545,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	var startedAt int64
 	var completedAt, cancelledAt sql.NullInt64
 	var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
+	var pid sql.NullInt64
 
 	err := s.db.QueryRow(query, runID).Scan(
 		&record.RunID,
@@ -521,6 +560,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 		&errorMessage,
 		&tagsJSON,
 		&branchName,
+		&pid,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -556,6 +596,9 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	if branchName.Valid {
 		record.BranchName = branchName.String
 	}
+	if pid.Valid {
+		record.PID = int(pid.Int64)
+	}
 
 	return &record, nil
 }
@@ -564,7 +607,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 // GetRunningRuns returns all runs with status 'running'.
 func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE status = 'running'
 	          ORDER BY started_at DESC`
@@ -575,7 +618,7 @@ func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 // ListRuns returns runs matching the specified options.
 func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE 1=1`
 	args := []any{}
@@ -885,6 +928,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		var startedAt int64
 		var completedAt, cancelledAt sql.NullInt64
 		var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
+		var pid sql.NullInt64
 
 		err := rows.Scan(
 			&record.RunID,
@@ -899,6 +943,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 			&errorMessage,
 			&tagsJSON,
 			&branchName,
+			&pid,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan run: %w", err)
@@ -930,6 +975,9 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		}
 		if branchName.Valid {
 			record.BranchName = branchName.String
+		}
+		if pid.Valid {
+			record.PID = int(pid.Int64)
 		}
 
 		records = append(records, record)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -1977,3 +1977,61 @@ func TestListRunsWithTags(t *testing.T) {
 		assert.Empty(t, runs)
 	})
 }
+
+func TestUpdateRunPID(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runID, err := store.CreateRun("test-pipeline", "test-input")
+	require.NoError(t, err)
+
+	t.Run("default PID is 0", func(t *testing.T) {
+		pid, err := store.GetRunPID(runID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, pid)
+	})
+
+	t.Run("update and retrieve PID", func(t *testing.T) {
+		err := store.UpdateRunPID(runID, 12345)
+		require.NoError(t, err)
+
+		pid, err := store.GetRunPID(runID)
+		require.NoError(t, err)
+		assert.Equal(t, 12345, pid)
+	})
+
+	t.Run("PID included in GetRun", func(t *testing.T) {
+		run, err := store.GetRun(runID)
+		require.NoError(t, err)
+		assert.Equal(t, 12345, run.PID)
+	})
+
+	t.Run("PID included in GetRunningRuns", func(t *testing.T) {
+		err := store.UpdateRunStatus(runID, "running", "", 0)
+		require.NoError(t, err)
+
+		runs, err := store.GetRunningRuns()
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, 12345, runs[0].PID)
+	})
+
+	t.Run("PID included in ListRuns", func(t *testing.T) {
+		runs, err := store.ListRuns(ListRunsOptions{PipelineName: "test-pipeline"})
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, 12345, runs[0].PID)
+	})
+
+	t.Run("update PID for nonexistent run returns error", func(t *testing.T) {
+		err := store.UpdateRunPID("nonexistent-run", 999)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "run not found")
+	})
+
+	t.Run("get PID for nonexistent run returns error", func(t *testing.T) {
+		_, err := store.GetRunPID("nonexistent-run")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "run not found")
+	})
+}

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -15,7 +15,8 @@ type RunRecord struct {
 	CancelledAt  *time.Time
 	ErrorMessage string
 	Tags         []string // Tags for categorization and filtering
-	BranchName   string    // Worktree branch for this run
+	BranchName   string   // Worktree branch for this run
+	PID          int      // OS process ID of detached subprocess (0 = in-process or unknown)
 }
 
 // ListRunsOptions specifies filters for listing runs.

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -1,8 +1,13 @@
 package tui
 
 import (
+	"fmt"
+	"syscall"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/state"
 )
 
 // ContentProviders holds data providers for alternative views.
@@ -45,6 +50,10 @@ type ContentModel struct {
 	composing     bool
 	composeList   *ComposeListModel
 	composeDetail *ComposeDetailModel
+
+	// Detached pipeline event polling
+	detachedPollRunID  string // Run ID currently being polled for events
+	detachedPollOffset int    // Offset for fetching new events
 }
 
 // NewContentModel creates a new content model with the given pipeline data providers.
@@ -305,19 +314,35 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 					})
 				}
 
-				// For running items with TUI buffer, activate live output
+				// For running items, load historical events from store and activate live output
 				if item.kind == itemKindRunning && item.dataIndex >= 0 && item.dataIndex < len(m.list.running) {
 					r := m.list.running[item.dataIndex]
-					if m.launcher != nil && m.launcher.HasBuffer(r.RunID) {
-						buf := m.launcher.GetBuffer(r.RunID)
-						liveModel := NewLiveOutputModel(r.RunID, r.Name, buf, r.StartedAt, 0)
-						liveModel.SetSize(m.detail.width, m.detail.height)
-						m.detail.liveOutput = &liveModel
-						m.detail.paneState = stateRunningLive
-						enterCmds = append(enterCmds, func() tea.Msg {
-							return LiveOutputActiveMsg{Active: true}
-						})
+					buf := NewEventBuffer(1000)
+					// Load historical events from SQLite
+					var eventCount int
+					if m.launcher != nil && m.launcher.deps.Store != nil {
+						events, err := m.launcher.deps.Store.GetEvents(r.RunID, state.EventQueryOptions{})
+						if err == nil {
+							eventCount = len(events)
+							for _, ev := range events {
+								buf.Append(formatStoredEvent(ev))
+							}
+						}
 					}
+					liveModel := NewLiveOutputModel(r.RunID, r.Name, buf, r.StartedAt, 0)
+					liveModel.SetSize(m.detail.width, m.detail.height)
+					m.detail.liveOutput = &liveModel
+					m.detail.paneState = stateRunningLive
+					m.detachedPollRunID = r.RunID
+					m.detachedPollOffset = eventCount
+					enterCmds = append(enterCmds, func() tea.Msg {
+						return LiveOutputActiveMsg{Active: true}
+					})
+					// Start event polling for detached pipeline
+					capturedRunID := r.RunID
+					enterCmds = append(enterCmds, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+						return DetachedEventPollTickMsg{RunID: capturedRunID}
+					}))
 				}
 
 				// For finished items, activate finished detail hints
@@ -337,6 +362,7 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 
 		// Pipeline view Escape handling
 		if msg.Type == tea.KeyEscape && m.focus == FocusPaneRight && m.currentView == ViewPipelines {
+			m.detachedPollRunID = "" // Stop event polling
 			m.focus = FocusPaneLeft
 			m.list.SetFocused(true)
 			m.detail.SetFocused(false)
@@ -354,6 +380,14 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 				if item.kind == itemKindRunning && item.dataIndex >= 0 && item.dataIndex < len(m.list.running) {
 					r := m.list.running[item.dataIndex]
 					m.launcher.Cancel(r.RunID)
+					// Start 30s force-kill timer for detached pipelines (SC-003)
+					if r.Detached && r.PID > 0 {
+						capturedRunID := r.RunID
+						capturedPID := r.PID
+						return m, tea.Tick(30*time.Second, func(time.Time) tea.Msg {
+							return CancelForceKillMsg{RunID: capturedRunID, PID: capturedPID}
+						})
+					}
 				}
 			}
 			return m, nil
@@ -617,6 +651,36 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		m.detail, cmd = m.detail.Update(msg)
 		return m, cmd
 
+	case DetachedEventPollTickMsg:
+		// Poll for new events from detached pipeline
+		if m.detachedPollRunID != msg.RunID || m.detail.paneState != stateRunningLive {
+			// Stop polling — user navigated away or run changed
+			m.detachedPollRunID = ""
+			return m, nil
+		}
+		if m.launcher != nil && m.launcher.deps.Store != nil {
+			events, err := m.launcher.deps.Store.GetEvents(msg.RunID, state.EventQueryOptions{
+				Offset: m.detachedPollOffset,
+			})
+			if err == nil && len(events) > 0 {
+				m.detachedPollOffset += len(events)
+				if m.detail.liveOutput != nil {
+					for _, ev := range events {
+						m.detail.liveOutput.buffer.Append(formatStoredEvent(ev))
+					}
+					m.detail.liveOutput.updateViewportContent()
+					if m.detail.liveOutput.autoScroll {
+						m.detail.liveOutput.viewport.GotoBottom()
+					}
+				}
+			}
+		}
+		// Schedule next poll
+		capturedRunID := msg.RunID
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return DetachedEventPollTickMsg{RunID: capturedRunID}
+		})
+
 	case PipelineDataMsg, PipelineRefreshTickMsg:
 		var cmd tea.Cmd
 		m.list, cmd = m.list.Update(msg)
@@ -626,6 +690,20 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		var cmd tea.Cmd
 		m.detail, cmd = m.detail.Update(msg)
 		return m, cmd
+
+	case CancelForceKillMsg:
+		// Force-kill escalation after 30s cancellation grace period (SC-003)
+		if msg.PID > 0 && IsProcessAlive(msg.PID) {
+			// Kill the entire process group
+			_ = syscall.Kill(-msg.PID, syscall.SIGKILL)
+			// Update run status to failed
+			if m.launcher != nil && m.launcher.deps.Store != nil {
+				_ = m.launcher.deps.Store.UpdateRunStatus(msg.RunID, "failed",
+					"cancellation timeout — force killed", 0)
+			}
+		}
+		// Refresh the list to reflect the status change
+		return m, m.list.fetchPipelineData
 
 	case TransitionTimerMsg:
 		var cmd tea.Cmd
@@ -977,4 +1055,16 @@ func (m ContentModel) leftPaneWidth() int {
 		w = m.width
 	}
 	return w
+}
+
+// formatStoredEvent converts a persisted LogRecord into a display line for the event buffer.
+func formatStoredEvent(ev state.LogRecord) string {
+	prefix := ""
+	if ev.StepID != "" {
+		prefix = fmt.Sprintf("[%s] ", ev.StepID)
+	}
+	if ev.Message != "" {
+		return prefix + ev.Message
+	}
+	return fmt.Sprintf("%s%s", prefix, ev.State)
 }

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -1,33 +1,29 @@
 package tui
 
 import (
-	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"sync"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/workspace"
 )
 
 // PipelineLauncher manages pipeline execution from the TUI.
-// It constructs executors on demand and tracks cancel functions for running pipelines.
+// It spawns detached subprocesses that survive TUI exit and tracks them via SQLite.
 type PipelineLauncher struct {
-	deps      LaunchDependencies
-	cancelFns map[string]context.CancelFunc
-	buffers   map[string]*EventBuffer
-	program   *tea.Program
-	mu        sync.Mutex
+	deps    LaunchDependencies
+	program *tea.Program
+	mu      sync.Mutex
 }
 
 // NewPipelineLauncher creates a new launcher with the given dependencies.
 func NewPipelineLauncher(deps LaunchDependencies) *PipelineLauncher {
 	return &PipelineLauncher{
-		deps:      deps,
-		cancelFns: make(map[string]context.CancelFunc),
-		buffers:   make(map[string]*EventBuffer),
+		deps: deps,
 	}
 }
 
@@ -38,25 +34,11 @@ func (l *PipelineLauncher) SetProgram(p *tea.Program) {
 	l.program = p
 }
 
-// GetBuffer returns the event buffer for a pipeline run (nil for external pipelines).
-func (l *PipelineLauncher) GetBuffer(runID string) *EventBuffer {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.buffers[runID]
-}
-
-// HasBuffer returns true if the pipeline was TUI-launched and has an event buffer.
-func (l *PipelineLauncher) HasBuffer(runID string) bool {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	_, ok := l.buffers[runID]
-	return ok
-}
-
-// Launch starts a pipeline in a background goroutine and returns tea.Cmds
-// for immediate UI feedback (PipelineLaunchedMsg) and eventual completion (PipelineLaunchResultMsg).
+// Launch spawns a pipeline as a detached subprocess via exec.Command.
+// The subprocess re-executes the wave binary with "run" arguments and survives TUI exit.
+// Returns tea.Cmd for immediate UI feedback (PipelineLaunchedMsg).
 func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
-	// Load the full pipeline definition
+	// Load the full pipeline definition to get the canonical name
 	p, err := LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
 	if err != nil {
 		pipelineName := config.PipelineName
@@ -65,37 +47,13 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 		}
 	}
 
-	// Create cancellable context
-	ctx, cancel := context.WithCancel(context.Background())
+	store := l.deps.Store
 
-	// Resolve adapter: check for --mock flag, then use manifest adapters map
-	var runner adapter.AdapterRunner
-	isMock := false
-	for _, f := range config.Flags {
-		if f == "--mock" {
-			isMock = true
-			break
-		}
-	}
-	if isMock {
-		runner = adapter.NewMockAdapter()
-	} else if l.deps.Manifest != nil && len(l.deps.Manifest.Adapters) > 0 {
-		// Pick the first adapter name from the manifest map (mirrors CLI behavior)
-		var adapterName string
-		for name := range l.deps.Manifest.Adapters {
-			adapterName = name
-			break
-		}
-		runner = adapter.ResolveAdapter(adapterName)
-	} else {
-		runner = adapter.ResolveAdapter("claude")
-	}
-
-	// Generate run ID -- prefer StateStore.CreateRun so the run appears in the dashboard
+	// Generate run ID — must be created before subprocess spawn so we can pass it via --run
 	var runID string
-	if l.deps.Store != nil {
+	if store != nil {
 		var storeErr error
-		runID, storeErr = l.deps.Store.CreateRun(p.Metadata.Name, config.Input)
+		runID, storeErr = store.CreateRun(p.Metadata.Name, config.Input)
 		if storeErr != nil {
 			runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
 		}
@@ -103,127 +61,101 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 		runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
 	}
 
-	// Store cancel function for later cancellation
-	l.mu.Lock()
-	l.cancelFns[runID] = cancel
-	l.mu.Unlock()
-
-	// Create event buffer for this pipeline
-	buffer := NewEventBuffer(1000)
-	l.mu.Lock()
-	l.buffers[runID] = buffer
-	prog := l.program
-	l.mu.Unlock()
-
-	// Build emitter — use progress-only emitter for TUI to avoid corrupting stdout
-	var emitter event.EventEmitter
-	if prog != nil {
-		tuiEmitter := &TUIProgressEmitter{program: prog, runID: runID}
-		emitter = event.NewProgressOnlyEmitter(tuiEmitter)
-	} else {
-		emitter = event.NewNDJSONEmitter()
+	// Build subprocess command: wave run <pipeline> --run <runID> --input <input>
+	args := []string{"run", "--pipeline", config.PipelineName, "--run", runID}
+	if config.Input != "" {
+		args = append(args, "--input", config.Input)
 	}
-
-	var execOpts []pipeline.ExecutorOption
-	execOpts = append(execOpts, pipeline.WithEmitter(emitter))
-	execOpts = append(execOpts, pipeline.WithRunID(runID))
-
-	if l.deps.Store != nil {
-		execOpts = append(execOpts, pipeline.WithStateStore(l.deps.Store))
+	if config.ModelOverride != "" {
+		args = append(args, "--model", config.ModelOverride)
 	}
-
-	// Create workspace manager
-	wsManager, wsErr := workspace.NewWorkspaceManager(".wave/workspaces")
-	if wsErr == nil {
-		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))
-	}
-
-	// Apply flags
-	isDebug := false
 	for _, f := range config.Flags {
-		if f == "--debug" {
-			isDebug = true
+		args = append(args, f)
+	}
+
+	cmd := exec.Command(os.Args[0], args...)
+
+	// Detach: create a new session so the subprocess survives TUI exit and terminal SIGHUP
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	// Build environment with passthrough vars (FR-012: no credentials in CLI args)
+	cmd.Env = buildPassthroughEnv(l.deps)
+
+	// Suppress subprocess stdout/stderr — all output goes through SQLite events
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	pipelineName := config.PipelineName
+
+	// Spawn the subprocess
+	if err := cmd.Start(); err != nil {
+		return func() tea.Msg {
+			return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("spawning subprocess: %w", err)}
 		}
 	}
-	if isDebug {
-		execOpts = append(execOpts, pipeline.WithDebug(true))
+
+	// Store PID for liveness detection
+	if store != nil && cmd.Process != nil {
+		_ = store.UpdateRunPID(runID, cmd.Process.Pid)
 	}
 
-	if config.ModelOverride != "" {
-		execOpts = append(execOpts, pipeline.WithModelOverride(config.ModelOverride))
+	// Release the process — we don't wait for it, it's fully detached
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
 	}
 
-	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)
-
-	// Capture values for closures
-	pipelineName := config.PipelineName
-	input := config.Input
-	manifest := l.deps.Manifest
-	store := l.deps.Store
-
-	// Return batched commands: immediate launched msg + blocking executor cmd
-	immediateCmd := func() tea.Msg {
+	// Return immediate feedback — no blocking executor cmd since the subprocess is detached
+	return func() tea.Msg {
 		return PipelineLaunchedMsg{
 			RunID:        runID,
 			PipelineName: pipelineName,
-			CancelFunc:   cancel,
 		}
 	}
-
-	executorCmd := func() tea.Msg {
-		var execErr error
-		if manifest != nil {
-			execErr = executor.Execute(ctx, p, manifest, input)
-		} else {
-			execErr = fmt.Errorf("manifest not available")
-		}
-
-		// Update run status in store
-		if store != nil {
-			status := "completed"
-			errMsg := ""
-			if execErr != nil {
-				status = "failed"
-				errMsg = execErr.Error()
-			}
-			if ctx.Err() != nil {
-				status = "cancelled"
-				errMsg = ctx.Err().Error()
-			}
-			_ = store.UpdateRunStatus(runID, status, errMsg, executor.GetTotalTokens())
-		}
-
-		return PipelineLaunchResultMsg{RunID: runID, Err: execErr}
-	}
-
-	return tea.Batch(immediateCmd, executorCmd)
 }
 
-// Cancel cancels a specific running pipeline by run ID.
+// Cancel requests cancellation of a detached pipeline via the persistent store (FR-005).
 func (l *PipelineLauncher) Cancel(runID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if cancel, ok := l.cancelFns[runID]; ok {
-		cancel()
+	if l.deps.Store != nil {
+		_ = l.deps.Store.RequestCancellation(runID, false)
 	}
 }
 
-// CancelAll cancels all running pipelines (called on TUI exit).
+// CancelAll is a no-op for detached subprocesses (FR-004).
+// Detached pipelines survive TUI exit — CancelAll only cleans up TUI-side state.
 func (l *PipelineLauncher) CancelAll() {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	for _, cancel := range l.cancelFns {
-		cancel()
-	}
-	l.cancelFns = make(map[string]context.CancelFunc)
+	// No-op: detached subprocesses manage their own lifecycle
 }
 
-// Cleanup removes a cancel function entry and buffer after a pipeline finishes.
+// Cleanup is a no-op for detached subprocesses — they manage their own lifecycle.
 func (l *PipelineLauncher) Cleanup(runID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	delete(l.cancelFns, runID)
-	delete(l.buffers, runID)
+	// No-op: subprocess handles its own state transitions and cleanup
+}
+
+// buildPassthroughEnv constructs the subprocess environment from the manifest's
+// runtime.sandbox.env_passthrough configuration. Only explicitly allowed
+// environment variables are passed through (FR-012).
+func buildPassthroughEnv(deps LaunchDependencies) []string {
+	// Start with minimal required env vars
+	env := []string{}
+
+	// Always pass HOME and PATH for basic operation
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+	if path := os.Getenv("PATH"); path != "" {
+		env = append(env, "PATH="+path)
+	}
+
+	// Pass through vars from manifest configuration
+	if deps.Manifest != nil {
+		for _, key := range deps.Manifest.Runtime.Sandbox.EnvPassthrough {
+			if val := os.Getenv(key); val != "" {
+				env = append(env, key+"="+val)
+			}
+		}
+	}
+
+	return env
 }
 
 // TUIProgressEmitter implements event.ProgressEmitter to bridge executor events

--- a/internal/tui/pipeline_launcher_test.go
+++ b/internal/tui/pipeline_launcher_test.go
@@ -1,129 +1,55 @@
 package tui
 
 import (
-	"context"
-	"sync"
+	"os"
 	"testing"
 
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewPipelineLauncher_InitializesEmptyMaps(t *testing.T) {
+func TestNewPipelineLauncher_InitializesDefaults(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-	assert.NotNil(t, launcher.cancelFns)
-	assert.Empty(t, launcher.cancelFns)
-	assert.NotNil(t, launcher.buffers)
-	assert.Empty(t, launcher.buffers)
+	assert.NotNil(t, launcher)
+	assert.Nil(t, launcher.program)
 }
 
-func TestPipelineLauncher_Cancel_UnknownRunID_IsNoOp(t *testing.T) {
+func TestPipelineLauncher_Cancel_NoStore_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
+	// Should not panic when no store is set
 	launcher.Cancel("nonexistent-run-id")
 }
 
-func TestPipelineLauncher_Cancel_InvokesStoredCancelFunc(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
+func TestPipelineLauncher_Cancel_WithStore_RequestsCancellation(t *testing.T) {
+	store, cleanup := setupTestStateStore(t)
+	defer cleanup()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	launcher.mu.Lock()
-	launcher.cancelFns["test-run-1"] = cancel
-	launcher.mu.Unlock()
+	launcher := NewPipelineLauncher(LaunchDependencies{Store: store})
 
-	launcher.Cancel("test-run-1")
+	// Create a run first
+	runID, err := store.CreateRun("test-pipeline", "test-input")
+	assert.NoError(t, err)
 
-	// Context should be cancelled
-	assert.Error(t, ctx.Err())
-	assert.Equal(t, context.Canceled, ctx.Err())
+	launcher.Cancel(runID)
+
+	// Verify cancellation was requested in the store
+	cancel, err := store.CheckCancellation(runID)
+	assert.NoError(t, err)
+	assert.NotNil(t, cancel)
+	assert.Equal(t, runID, cancel.RunID)
 }
 
-func TestPipelineLauncher_CancelAll_InvokesAllCancelFuncs(t *testing.T) {
+func TestPipelineLauncher_CancelAll_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	ctx3, cancel3 := context.WithCancel(context.Background())
-
-	launcher.mu.Lock()
-	launcher.cancelFns["run-1"] = cancel1
-	launcher.cancelFns["run-2"] = cancel2
-	launcher.cancelFns["run-3"] = cancel3
-	launcher.mu.Unlock()
-
+	// Should not panic — CancelAll is a no-op for detached subprocesses
 	launcher.CancelAll()
-
-	assert.Error(t, ctx1.Err())
-	assert.Error(t, ctx2.Err())
-	assert.Error(t, ctx3.Err())
-	assert.Empty(t, launcher.cancelFns, "map should be cleared after CancelAll")
 }
 
-func TestPipelineLauncher_CancelAll_EmptyMap_IsNoOp(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
-	launcher.CancelAll()
-	assert.Empty(t, launcher.cancelFns)
-}
-
-func TestPipelineLauncher_Cleanup_RemovesCancelAndBuffer(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	_, cancel := context.WithCancel(context.Background())
-	launcher.mu.Lock()
-	launcher.cancelFns["run-to-clean"] = cancel
-	launcher.cancelFns["run-to-keep"] = cancel
-	launcher.buffers["run-to-clean"] = NewEventBuffer(10)
-	launcher.buffers["run-to-keep"] = NewEventBuffer(10)
-	launcher.mu.Unlock()
-
-	launcher.Cleanup("run-to-clean")
-
-	launcher.mu.Lock()
-	_, cancelExists := launcher.cancelFns["run-to-clean"]
-	_, cancelKept := launcher.cancelFns["run-to-keep"]
-	_, bufExists := launcher.buffers["run-to-clean"]
-	_, bufKept := launcher.buffers["run-to-keep"]
-	launcher.mu.Unlock()
-
-	assert.False(t, cancelExists, "cleaned up cancel entry should be gone")
-	assert.True(t, cancelKept, "other cancel entries should remain")
-	assert.False(t, bufExists, "cleaned up buffer entry should be gone")
-	assert.True(t, bufKept, "other buffer entries should remain")
-}
-
-func TestPipelineLauncher_Cleanup_NonexistentRunID_IsNoOp(t *testing.T) {
+func TestPipelineLauncher_Cleanup_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
 	// Should not panic
 	launcher.Cleanup("nonexistent-run-id")
-}
-
-func TestPipelineLauncher_ConcurrentCancelAndCleanup(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	// Add several cancel functions
-	for i := 0; i < 10; i++ {
-		_, cancel := context.WithCancel(context.Background())
-		launcher.mu.Lock()
-		launcher.cancelFns[string(rune('A'+i))] = cancel
-		launcher.mu.Unlock()
-	}
-
-	// Concurrently cancel and cleanup
-	var wg sync.WaitGroup
-	wg.Add(20)
-	for i := 0; i < 10; i++ {
-		id := string(rune('A' + i))
-		go func() {
-			defer wg.Done()
-			launcher.Cancel(id)
-		}()
-		go func() {
-			defer wg.Done()
-			launcher.Cleanup(id)
-		}()
-	}
-	wg.Wait()
 }
 
 func TestPipelineLauncher_Launch_MissingPipelineDir_ReturnsError(t *testing.T) {
@@ -149,37 +75,43 @@ func TestPipelineLauncher_SetProgram(t *testing.T) {
 	assert.Nil(t, launcher.program)
 }
 
-func TestPipelineLauncher_GetBuffer_ReturnsNilForUnknown(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	buf := launcher.GetBuffer("nonexistent")
-	assert.Nil(t, buf)
-}
-
-func TestPipelineLauncher_GetBuffer_ReturnsBuffer(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	expected := NewEventBuffer(100)
-	launcher.mu.Lock()
-	launcher.buffers["run-1"] = expected
-	launcher.mu.Unlock()
-
-	buf := launcher.GetBuffer("run-1")
-	assert.Equal(t, expected, buf)
-}
-
-func TestPipelineLauncher_HasBuffer(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	assert.False(t, launcher.HasBuffer("run-1"))
-
-	launcher.mu.Lock()
-	launcher.buffers["run-1"] = NewEventBuffer(100)
-	launcher.mu.Unlock()
-
-	assert.True(t, launcher.HasBuffer("run-1"))
-}
-
 func TestTUIProgressEmitter_EmitProgress_NilProgram(t *testing.T) {
 	emitter := &TUIProgressEmitter{program: nil, runID: "run-1"}
 	// Should not panic with nil program
 	err := emitter.EmitProgress(event.Event{State: event.StateStarted})
 	assert.NoError(t, err)
+}
+
+func TestBuildPassthroughEnv_IncludesHomeAndPath(t *testing.T) {
+	deps := LaunchDependencies{}
+	env := buildPassthroughEnv(deps)
+
+	// Should include HOME and PATH at minimum
+	hasHome := false
+	hasPath := false
+	for _, v := range env {
+		if len(v) > 5 && v[:5] == "HOME=" {
+			hasHome = true
+		}
+		if len(v) > 5 && v[:5] == "PATH=" {
+			hasPath = true
+		}
+	}
+	if os.Getenv("HOME") != "" {
+		assert.True(t, hasHome, "should include HOME")
+	}
+	if os.Getenv("PATH") != "" {
+		assert.True(t, hasPath, "should include PATH")
+	}
+}
+
+// setupTestStateStore creates a real in-memory state store for testing.
+func setupTestStateStore(t *testing.T) (state.StateStore, func()) {
+	t.Helper()
+	store, err := state.NewStateStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	cleanup := func() { store.Close() }
+	return store, cleanup
 }

--- a/internal/tui/pipeline_list.go
+++ b/internal/tui/pipeline_list.go
@@ -563,27 +563,32 @@ func (m PipelineListModel) renderRunningItem(item navigableItem, isSelected bool
 	r := m.running[item.dataIndex]
 
 	elapsed := formatElapsed(time.Since(r.StartedAt))
-	// Reserve space: prefix (3) + elapsed + padding
-	nameMaxWidth := maxWidth - 3 - len(elapsed) - 3
+	// Add detached indicator for subprocess-launched pipelines
+	detachLabel := ""
+	if r.Detached {
+		detachLabel = " [detached]"
+	}
+	// Reserve space: prefix (3) + elapsed + detach label + padding
+	nameMaxWidth := maxWidth - 3 - len(elapsed) - len(detachLabel) - 3
 	name := truncateName(r.Name, nameMaxWidth)
 
 	if isSelected {
-		spacer := maxWidth - lipgloss.Width("▶ "+name) - lipgloss.Width(elapsed) - 1
+		spacer := maxWidth - lipgloss.Width("▶ "+name+detachLabel) - lipgloss.Width(elapsed) - 1
 		if spacer < 1 {
 			spacer = 1
 		}
-		text := fmt.Sprintf("▶ %s%s%s", name, strings.Repeat(" ", spacer), elapsed)
+		text := fmt.Sprintf("▶ %s%s%s%s", name, detachLabel, strings.Repeat(" ", spacer), elapsed)
 		style := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("6")).
 			Width(maxWidth)
 		return style.Render(text)
 	}
 
-	spacer := maxWidth - lipgloss.Width("  "+name) - lipgloss.Width(elapsed) - 1
+	spacer := maxWidth - lipgloss.Width("  "+name+detachLabel) - lipgloss.Width(elapsed) - 1
 	if spacer < 1 {
 		spacer = 1
 	}
-	text := fmt.Sprintf("  %s%s%s", name, strings.Repeat(" ", spacer), elapsed)
+	text := fmt.Sprintf("  %s%s%s%s", name, detachLabel, strings.Repeat(" ", spacer), elapsed)
 	style := lipgloss.NewStyle().
 		Width(maxWidth)
 	return style.Render(text)

--- a/internal/tui/pipeline_messages.go
+++ b/internal/tui/pipeline_messages.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"context"
-
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/state"
@@ -61,7 +59,6 @@ type LaunchRequestMsg struct {
 type PipelineLaunchedMsg struct {
 	RunID        string
 	PipelineName string
-	CancelFunc   context.CancelFunc
 }
 
 // PipelineLaunchResultMsg signals that a launched pipeline has finished execution.
@@ -129,4 +126,22 @@ type DiffViewEndedMsg struct {
 // FinishedDetailActiveMsg signals the status bar to switch to finished detail hints.
 type FinishedDetailActiveMsg struct {
 	Active bool
+}
+
+// CancelForceKillMsg is sent after the 30s grace period for cancellation (SC-003).
+// If the subprocess is still alive, it will be force-killed.
+type CancelForceKillMsg struct {
+	RunID string
+	PID   int
+}
+
+// DetachedEventPollMsg carries new events polled from the store for a detached pipeline.
+type DetachedEventPollMsg struct {
+	RunID  string
+	Events []state.LogRecord
+}
+
+// DetachedEventPollTickMsg triggers periodic event polling for detached pipeline live output.
+type DetachedEventPollTickMsg struct {
+	RunID string
 }

--- a/internal/tui/pipeline_provider.go
+++ b/internal/tui/pipeline_provider.go
@@ -13,6 +13,8 @@ type RunningPipeline struct {
 	Name       string
 	BranchName string
 	StartedAt  time.Time
+	PID        int  // Process ID for liveness checking
+	Detached   bool // True if launched as a subprocess (vs in-process)
 }
 
 // FinishedPipeline is a TUI-specific projection of a completed pipeline run.
@@ -48,7 +50,12 @@ func NewDefaultPipelineDataProvider(store state.StateStore, pipelinesDir string)
 }
 
 // FetchRunningPipelines returns currently running pipelines, sorted newest-first.
+// Runs stale detection before returning to transition dead subprocesses to "failed".
 func (p *DefaultPipelineDataProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
+	// Detect and transition stale runs before fetching
+	detector := NewStaleRunDetector(p.store)
+	_, _ = detector.DetectStaleRuns()
+
 	records, err := p.store.GetRunningRuns()
 	if err != nil {
 		return nil, err
@@ -61,6 +68,8 @@ func (p *DefaultPipelineDataProvider) FetchRunningPipelines() ([]RunningPipeline
 			Name:       r.PipelineName,
 			BranchName: r.BranchName,
 			StartedAt:  r.StartedAt,
+			PID:        r.PID,
+			Detached:   r.PID > 0,
 		}
 	}
 

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -34,6 +34,8 @@ func (b baseStateStore) Close() error                                      { ret
 func (b baseStateStore) CreateRun(string, string) (string, error)          { return "", nil }
 func (b baseStateStore) UpdateRunStatus(string, string, string, int) error { return nil }
 func (b baseStateStore) UpdateRunBranch(string, string) error              { return nil }
+func (b baseStateStore) UpdateRunPID(string, int) error                    { return nil }
+func (b baseStateStore) GetRunPID(string) (int, error)                     { return 0, nil }
 func (b baseStateStore) GetRun(string) (*state.RunRecord, error)           { return nil, nil }
 func (b baseStateStore) GetRunningRuns() ([]state.RunRecord, error)        { return nil, nil }
 func (b baseStateStore) ListRuns(state.ListRunsOptions) ([]state.RunRecord, error) {

--- a/internal/tui/stale_detector.go
+++ b/internal/tui/stale_detector.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// StaleRunDetector checks for dead subprocess PIDs and transitions stale runs to "failed".
+type StaleRunDetector struct {
+	store state.StateStore
+}
+
+// NewStaleRunDetector creates a new detector using the given state store.
+func NewStaleRunDetector(store state.StateStore) *StaleRunDetector {
+	return &StaleRunDetector{store: store}
+}
+
+// DetectStaleRuns queries all "running" runs, checks each PID for liveness,
+// and transitions dead runs to "failed". Returns the run IDs that were marked stale.
+func (d *StaleRunDetector) DetectStaleRuns() ([]string, error) {
+	runs, err := d.store.GetRunningRuns()
+	if err != nil {
+		return nil, err
+	}
+
+	var staleIDs []string
+	for _, run := range runs {
+		// Skip runs with no PID (in-process or legacy runs)
+		if run.PID == 0 {
+			continue
+		}
+
+		if !IsProcessAlive(run.PID) {
+			_ = d.store.UpdateRunStatus(run.RunID, "failed", "stale: subprocess exited unexpectedly", run.TotalTokens)
+			staleIDs = append(staleIDs, run.RunID)
+		}
+	}
+
+	return staleIDs, nil
+}
+
+// IsProcessAlive checks if a process with the given PID is still running.
+// Uses os.FindProcess + signal 0 (the standard Unix approach for liveness checks).
+func IsProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	// Signal 0 doesn't actually send a signal — it just checks if the process
+	// exists and the caller has permission to signal it.
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/tui/stale_detector_test.go
+++ b/internal/tui/stale_detector_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"os"
+	"testing"
+
+	"github.com/recinq/wave/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsProcessAlive_CurrentProcess(t *testing.T) {
+	// Current process is definitely alive
+	assert.True(t, IsProcessAlive(os.Getpid()))
+}
+
+func TestIsProcessAlive_InvalidPID(t *testing.T) {
+	assert.False(t, IsProcessAlive(0))
+	assert.False(t, IsProcessAlive(-1))
+}
+
+func TestIsProcessAlive_DeadPID(t *testing.T) {
+	// Use a very high PID that's almost certainly not in use
+	assert.False(t, IsProcessAlive(4194304))
+}
+
+func TestStaleRunDetector_DetectsStaleRuns(t *testing.T) {
+	store, err := state.NewStateStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Create a run with a dead PID
+	runID, err := store.CreateRun("test-pipeline", "test-input")
+	require.NoError(t, err)
+	err = store.UpdateRunStatus(runID, "running", "", 0)
+	require.NoError(t, err)
+	// Use a PID that's definitely not alive
+	err = store.UpdateRunPID(runID, 4194304)
+	require.NoError(t, err)
+
+	detector := NewStaleRunDetector(store)
+	staleIDs, err := detector.DetectStaleRuns()
+	require.NoError(t, err)
+	assert.Contains(t, staleIDs, runID)
+
+	// Verify the run was transitioned to "failed"
+	run, err := store.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "failed", run.Status)
+	// UpdateRunStatus stores error info in CurrentStep (not ErrorMessage)
+	assert.Contains(t, run.CurrentStep, "stale")
+}
+
+func TestStaleRunDetector_SkipsRunsWithZeroPID(t *testing.T) {
+	store, err := state.NewStateStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Create a run with PID=0 (in-process)
+	runID, err := store.CreateRun("test-pipeline", "test-input")
+	require.NoError(t, err)
+	err = store.UpdateRunStatus(runID, "running", "", 0)
+	require.NoError(t, err)
+
+	detector := NewStaleRunDetector(store)
+	staleIDs, err := detector.DetectStaleRuns()
+	require.NoError(t, err)
+	assert.Empty(t, staleIDs)
+
+	// Run should still be "running"
+	run, err := store.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "running", run.Status)
+}
+
+func TestStaleRunDetector_KeepsLiveRuns(t *testing.T) {
+	store, err := state.NewStateStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Create a run with the current process PID (definitely alive)
+	runID, err := store.CreateRun("test-pipeline", "test-input")
+	require.NoError(t, err)
+	err = store.UpdateRunStatus(runID, "running", "", 0)
+	require.NoError(t, err)
+	err = store.UpdateRunPID(runID, os.Getpid())
+	require.NoError(t, err)
+
+	detector := NewStaleRunDetector(store)
+	staleIDs, err := detector.DetectStaleRuns()
+	require.NoError(t, err)
+	assert.Empty(t, staleIDs)
+
+	// Run should still be "running"
+	run, err := store.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "running", run.Status)
+}

--- a/specs/284-tui-detach-execution/checklists/process-lifecycle.md
+++ b/specs/284-tui-detach-execution/checklists/process-lifecycle.md
@@ -1,0 +1,36 @@
+# Process Lifecycle Quality Checklist: Detach Pipeline Execution
+
+**Feature**: `284-tui-detach-execution`
+**Date**: 2026-03-08
+**Scope**: Domain-specific validation for OS process management, IPC, and lifecycle semantics
+
+---
+
+## Process Management Requirements Quality
+
+- [ ] CHK-PL001 - Are the failure modes of `exec.Command.Start()` enumerated (binary not found, permission denied, resource limits)? Are error handling requirements defined for each? [Completeness]
+- [ ] CHK-PL002 - Is it specified whether `cmd.Process.Release()` is called before or after the PID is stored? Could a race cause a stored PID for an already-released handle? [Clarity]
+- [ ] CHK-PL003 - Are requirements defined for what happens when `os.FindProcess` returns a process that belongs to a different user (permission denied on signal 0)? Is this distinguishable from "process not found"? [Completeness]
+- [ ] CHK-PL004 - Does the spec address the possibility of `Setsid` failing (e.g., process is already a session leader)? Is fallback behavior defined? [Coverage]
+- [ ] CHK-PL005 - Are resource limits (file descriptors, memory) for the detached subprocess specified, or does it inherit the parent's limits? [Completeness]
+
+## IPC & SQLite Concurrency Requirements Quality
+
+- [ ] CHK-PL006 - Are requirements defined for the scenario where the detached subprocess opens the SQLite database before the TUI has finished writing the run record? Is there a timing dependency? [Completeness]
+- [ ] CHK-PL007 - Does the spec address what happens when the SQLite WAL checkpoint runs while both TUI and subprocess are active? Are there performance requirements? [Coverage]
+- [ ] CHK-PL008 - Is the cancellation polling interval (5s) justified against the busy_timeout (5s)? Could a slow poll overlap with a database lock, causing the subprocess to miss a cancellation check? [Clarity]
+- [ ] CHK-PL009 - Are the atomicity requirements for the PID storage step defined? Can the run record exist without a PID (between CreateRun and UpdateRunPID)? [Completeness]
+- [ ] CHK-PL010 - Does the spec define whether the subprocess should open its own SQLite connection or reuse any connection pool? [Clarity]
+
+## Signal Handling Requirements Quality
+
+- [ ] CHK-PL011 - Are the signal handling requirements for the detached subprocess defined beyond Setsid? Should it handle SIGTERM, SIGINT, SIGUSR1 for specific behaviors? [Completeness]
+- [ ] CHK-PL012 - Does the force-kill escalation (SIGKILL to `-pid`) account for grandchild processes spawned by adapters? Will they be in the same session? [Coverage]
+- [ ] CHK-PL013 - Is the interaction between the adapter's `Setpgid: true` and the launcher's `Setsid: true` specified? Are adapter subprocesses in the same session but different process groups? [Clarity]
+- [ ] CHK-PL014 - Are requirements defined for what signals the subprocess should mask or ignore during graceful shutdown to prevent double-handling? [Coverage]
+
+## Platform & Environment Requirements Quality
+
+- [ ] CHK-PL015 - Is the Windows incompatibility of `Setsid` explicitly documented as a known limitation with a clear scope boundary? [Completeness]
+- [ ] CHK-PL016 - Does the spec address whether the detached subprocess inherits the parent's umask, locale, and terminal settings? [Coverage]
+- [ ] CHK-PL017 - Are requirements defined for the behavior under containerized environments (Docker) where PID 1 might reap orphaned processes differently? [Coverage]

--- a/specs/284-tui-detach-execution/checklists/requirements.md
+++ b/specs/284-tui-detach-execution/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Requirements Checklist: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Purpose**: Validate spec completeness, testability, and alignment with Wave architecture
+**Created**: 2026-03-08
+**Feature**: [spec.md](../spec.md)
+
+## Specification Completeness
+
+- [x] CHK001 All user stories have acceptance scenarios in Given/When/Then format
+- [x] CHK002 User stories are prioritized (P1-P3) and independently testable
+- [x] CHK003 Edge cases are identified with expected behavior described (6 edge cases)
+- [x] CHK004 All functional requirements use MUST/SHOULD/MAY language consistently
+- [x] CHK005 Key entities are defined with clear descriptions (3 entities)
+- [x] CHK006 No more than 3 `[NEEDS CLARIFICATION]` markers remain (1 marker: FR-011)
+
+## Testability
+
+- [x] CHK007 Every functional requirement maps to at least one acceptance scenario
+- [x] CHK008 Success criteria are measurable with specific thresholds or conditions (7 criteria)
+- [x] CHK009 Edge case behaviors are specific enough to write test assertions against
+- [x] CHK010 Race conditions and concurrency scenarios are addressed (concurrent cancel, spawn-during-exit)
+
+## Architecture Alignment
+
+- [x] CHK011 Spec respects Wave's fresh-memory-at-step-boundaries principle (detached subprocess = fresh process)
+- [x] CHK012 Spec leverages existing infrastructure: SQLite state store, event logging, cancellation table
+- [x] CHK013 Spec does not introduce new runtime dependencies beyond the single static binary constraint
+- [x] CHK014 Spec addresses security considerations (FR-012: env_passthrough for credentials, process isolation)
+- [x] CHK015 Spec is compatible with the existing WebUI execution model (both use subprocess + SQLite pattern)
+
+## Scope Boundaries
+
+- [x] CHK016 Spec focuses on WHAT and WHY, not HOW (no implementation details like specific syscall usage)
+- [x] CHK017 Spec does not prescribe specific data structures or function signatures
+- [x] CHK018 Spec requirements are technology-agnostic where possible
+- [x] CHK019 Spec does not duplicate or contradict existing CLAUDE.md guidelines
+
+## Completeness Cross-Check
+
+- [x] CHK020 All issue #284 requirements are covered: survive TUI exit, reconnect on reopen, `wave logs` streaming, cancellation
+- [x] CHK021 Prerequisites from issue #284 are acknowledged (dbLoggingEmitter, FetchRunEvents, DismissRun, status bar support)
+- [x] CHK022 TUI-CLI parity requirement from the issue is addressed as a user story (US3)
+
+## Notes
+
+- Self-validation completed: 22/22 items pass
+- 1 NEEDS CLARIFICATION marker remains (FR-011 re: PID storage location)
+- FR-012 added during validation to address CHK014 (credential security across process boundary)

--- a/specs/284-tui-detach-execution/checklists/review.md
+++ b/specs/284-tui-detach-execution/checklists/review.md
@@ -1,0 +1,51 @@
+# Requirements Quality Review: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Feature**: `284-tui-detach-execution`
+**Date**: 2026-03-08
+**Scope**: Overall requirements quality validation across spec.md, plan.md, and tasks.md
+
+---
+
+## Completeness
+
+- [ ] CHK001 - Are all four user stories traceable to at least one functional requirement? [Completeness]
+- [ ] CHK002 - Does the spec define what happens to stdout/stderr from the detached subprocess? Are output streams redirected, discarded, or logged? [Completeness]
+- [ ] CHK003 - Is the behavior defined for when the `wave` binary is not found at `os.Args[0]` (e.g., deleted, upgraded, or path-relative invocation)? [Completeness]
+- [ ] CHK004 - Does the spec address how `--input` is passed when the input is large (e.g., multi-line text, file paths, or structured data exceeding shell arg limits)? [Completeness]
+- [ ] CHK005 - Are requirements defined for what the TUI displays while a subprocess is being spawned (loading state between Launch() and PipelineLaunchedMsg)? [Completeness]
+- [ ] CHK006 - Is there a requirement for how multiple concurrent detached pipelines interact with SQLite write contention beyond the existing WAL busy timeout? [Completeness]
+- [ ] CHK007 - Does the spec define the behavior when the state database file is locked, corrupted, or inaccessible to the detached subprocess? [Completeness]
+- [ ] CHK008 - Are there requirements for notifying the user about pipeline completion when the TUI is closed (e.g., desktop notification, exit code file)? [Completeness]
+- [ ] CHK009 - Does the spec define log rotation or cleanup for events from completed detached runs in the SQLite event_log table? [Completeness]
+- [ ] CHK010 - Is the working directory for the detached subprocess specified? Does it inherit the TUI's CWD or use a specific path? [Completeness]
+
+## Clarity
+
+- [ ] CHK011 - Is "reasonable grace period" in acceptance scenario 2 of Story 2 quantified? The SC-003 says 30 seconds, but the acceptance scenario is vague [Clarity]
+- [ ] CHK012 - Does FR-001 clearly specify whether `os.Args[0]` or `os.Executable()` should be used for binary re-exec? The research doc and spec differ in specificity [Clarity]
+- [ ] CHK013 - Is the boundary between "TUI-side monitoring state" (FR-004) and "detached pipeline state" clearly defined? What constitutes monitoring state? [Clarity]
+- [ ] CHK014 - Is "within the existing refresh interval" (Story 4, acceptance 2) defined with a specific interval or is it deliberately left to the existing implementation? [Clarity]
+- [ ] CHK015 - Does the spec clearly distinguish between the `--run` flag for resume (existing) and `--run` flag for pre-created run ID reuse (new)? Are there ambiguity risks? [Clarity]
+- [ ] CHK016 - Is the phrase "graceful shutdown" in FR-006 defined in terms of specific actions (workspace cleanup, state persistence, adapter termination)? [Clarity]
+- [ ] CHK017 - Are the error messages for stale run detection ("stale: subprocess exited unexpectedly" vs "process not found -- stale run") consistent between plan.md and research.md? [Clarity]
+
+## Consistency
+
+- [ ] CHK018 - Does the plan's `buildPassthroughEnv()` approach align with how the existing CLI `wave run` handles environment variables? Are there divergence risks? [Consistency]
+- [ ] CHK019 - Is the `pid INTEGER DEFAULT 0` migration (data-model.md) consistent with `pid INTEGER` (research.md R7)? The DEFAULT clause differs between documents [Consistency]
+- [ ] CHK020 - Does the task list (T013) claim `--run` already exists for resume, while plan D2 says "reuse it"? Is this flag actually implemented or aspirational? [Consistency]
+- [ ] CHK021 - Is the cancellation polling interval (5 seconds in FR-006) consistent across all documents (spec, plan D4/D7, research R4, tasks T017)? [Consistency]
+- [ ] CHK022 - Are the `PipelineLauncher` fields removed in T010 (cancelFns, buffers) consistent with the fields listed in data-model.md's refactored struct? [Consistency]
+- [ ] CHK023 - Does the force-kill mechanism (T018) sending `SIGKILL` to process group (`-pid`) align with the subprocess's `Setsid: true` session isolation? Will the negative PID target the session or the process group? [Consistency]
+
+## Coverage
+
+- [ ] CHK024 - Are there acceptance scenarios covering the case where multiple pipelines are launched and the TUI is closed -- do all survive, not just one? [Coverage]
+- [ ] CHK025 - Do the edge cases cover what happens when disk space is exhausted during subprocess spawn (not just during event writing as covered in edge case 6)? [Coverage]
+- [ ] CHK026 - Are security requirements defined for preventing arbitrary command injection through the `--input` flag passed to the subprocess? [Coverage]
+- [ ] CHK027 - Are there requirements for how the feature behaves under the Nix/bubblewrap sandbox? Does `Setsid` work within the sandbox's PID namespace? [Coverage]
+- [ ] CHK028 - Are there requirements for what happens when the user upgrades the `wave` binary while a detached subprocess (old version) is still running? [Coverage]
+- [ ] CHK029 - Do the tasks cover updating the WebUI and `wave status` CLI to display detached pipeline metadata (PID, detached flag) per SC-007? [Coverage]
+- [ ] CHK030 - Is there test coverage specified for the race condition between `cmd.Start()` and TUI exit (edge case 5 / T029)? The task mentions it but no test task exists [Coverage]
+- [ ] CHK031 - Are there requirements for the behavior when `env_passthrough` config is missing or empty? Does the subprocess get a bare environment? [Coverage]
+- [ ] CHK032 - Does the spec address how the feature interacts with the existing `--from-step` and `--force` flags when launched from the TUI? [Coverage]

--- a/specs/284-tui-detach-execution/data-model.md
+++ b/specs/284-tui-detach-execution/data-model.md
@@ -1,0 +1,195 @@
+# Data Model: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Feature Branch**: `284-tui-detach-execution`
+**Date**: 2026-03-08
+
+## Entities
+
+### 1. Detached Run (Extension of `RunRecord`)
+
+A pipeline execution running as an independent OS process, tracked by run ID in SQLite with PID metadata for liveness detection.
+
+**Existing struct** (`internal/state/types.go`):
+```go
+type RunRecord struct {
+    RunID        string
+    PipelineName string
+    Status       string     // "pending", "running", "completed", "failed", "cancelled"
+    Input        string
+    CurrentStep  string
+    TotalTokens  int
+    StartedAt    time.Time
+    CompletedAt  *time.Time
+    CancelledAt  *time.Time
+    ErrorMessage string
+    Tags         []string
+    BranchName   string
+}
+```
+
+**New field**:
+```go
+type RunRecord struct {
+    // ... existing fields ...
+    PID int // OS process ID of the detached subprocess (0 = in-process or unknown)
+}
+```
+
+**Schema change** (`internal/state/schema.sql`):
+```sql
+-- Add to pipeline_run table
+ALTER TABLE pipeline_run ADD COLUMN pid INTEGER DEFAULT 0;
+```
+
+### 2. Cancellation Record (Existing)
+
+Already exists as `cancellation` table with all needed semantics. No changes required.
+
+```sql
+CREATE TABLE IF NOT EXISTS cancellation (
+    run_id TEXT PRIMARY KEY,
+    requested_at INTEGER NOT NULL,
+    force BOOLEAN DEFAULT FALSE,
+    FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
+);
+```
+
+### 3. Event Log (Existing)
+
+Already exists as `event_log` table. No changes required. The detached subprocess uses the same `dbLoggingEmitter` pattern from `cmd/wave/commands/run.go`.
+
+```sql
+CREATE TABLE IF NOT EXISTS event_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    step_id TEXT,
+    state TEXT NOT NULL,
+    persona TEXT,
+    message TEXT,
+    tokens_used INTEGER,
+    duration_ms INTEGER,
+    FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
+);
+```
+
+## State Store Interface Changes
+
+### New Methods
+
+```go
+type StateStore interface {
+    // ... existing methods ...
+
+    // UpdateRunPID sets the PID for a pipeline run after subprocess spawn.
+    UpdateRunPID(runID string, pid int) error
+
+    // GetRunPID returns the PID for a pipeline run (0 if not set or in-process).
+    GetRunPID(runID string) (int, error)
+}
+```
+
+### Modified Record Scanning
+
+The `queryRuns` method (used by `GetRun`, `GetRunningRuns`, `ListRuns`) must scan the new `pid` column into `RunRecord.PID`.
+
+## TUI Model Changes
+
+### RunningPipeline (Extended)
+
+```go
+type RunningPipeline struct {
+    RunID      string
+    Name       string
+    BranchName string
+    StartedAt  time.Time
+    PID        int       // NEW: process ID for liveness checking
+    Detached   bool      // NEW: true if this was launched as a subprocess (vs in-process)
+}
+```
+
+### PipelineLauncher (Refactored)
+
+```go
+type PipelineLauncher struct {
+    deps      LaunchDependencies
+    program   *tea.Program
+    mu        sync.Mutex
+    // Removed: cancelFns map — no longer cancelling in-process goroutines
+    // Removed: buffers map — event buffers are populated from SQLite, not in-memory
+}
+```
+
+Key behavior changes:
+- `Launch()` spawns `exec.Command("wave", "run", ...)` with `Setsid: true` instead of executing in-process
+- `Cancel(runID)` calls `store.RequestCancellation(runID, false)` instead of context cancellation
+- `CancelAll()` is a no-op for detached pipelines (they survive TUI exit)
+- Event buffer is populated from `store.GetEvents()` on demand
+
+### New: StaleRunDetector
+
+```go
+// StaleRunDetector checks for dead subprocess PIDs and transitions stale runs to "failed".
+type StaleRunDetector struct {
+    store state.StateStore
+}
+
+func (d *StaleRunDetector) DetectStaleRuns() ([]string, error)
+func IsProcessAlive(pid int) bool
+```
+
+## Data Flow
+
+### Launch Flow
+```
+TUI → PipelineLauncher.Launch()
+    → store.CreateRun() → run_id
+    → exec.Command("wave", "run", pipeline, "--run", run_id, "--input", input)
+    → cmd.SysProcAttr = {Setsid: true}
+    → cmd.Start()
+    → store.UpdateRunPID(run_id, cmd.Process.Pid)
+    → return PipelineLaunchedMsg{RunID, PipelineName}
+```
+
+### Monitoring Flow
+```
+TUI (refresh tick)
+    → store.GetRunningRuns()
+    → For each run with PID > 0: IsProcessAlive(run.PID)
+    → If dead: store.UpdateRunStatus(run_id, "failed", "stale: process not found")
+    → Display updated fleet view
+```
+
+### Cancellation Flow
+```
+TUI (user presses 'c')
+    → store.RequestCancellation(run_id, false)
+    → Start 30s timer
+
+Subprocess (every 5s poll)
+    → store.CheckCancellation(run_id)
+    → If found: initiate graceful shutdown
+    → store.UpdateRunStatus(run_id, "cancelled")
+
+TUI (after 30s if still alive)
+    → IsProcessAlive(pid)
+    → If alive: syscall.Kill(-pid, SIGKILL)
+    → store.UpdateRunStatus(run_id, "failed", "cancellation timeout — force killed")
+```
+
+### Event Reconnection Flow
+```
+TUI reopens → store.GetRunningRuns()
+    → User selects running pipeline
+    → store.GetEvents(run_id, {After: 0})  // Load all historical events
+    → Populate EventBuffer with formatted lines
+    → Start polling: store.GetEvents(run_id, {After: lastTimestamp})
+    → New events flow into LiveOutputModel
+```
+
+## Constraints
+
+- `PID` is 0 for legacy in-process runs (backwards compatible)
+- `Setsid: true` is Linux/macOS only — Windows would need `CREATE_NEW_PROCESS_GROUP`
+- SQLite busy timeout (5s) handles contention between subprocess writer and TUI reader
+- The run_id used by the subprocess must be the same one created by the TUI's `store.CreateRun()` — passed via `--run` flag

--- a/specs/284-tui-detach-execution/plan.md
+++ b/specs/284-tui-detach-execution/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Branch**: `284-tui-detach-execution` | **Date**: 2026-03-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/284-tui-detach-execution/spec.md`
+
+## Summary
+
+Decouple pipeline execution from the TUI process lifecycle by spawning pipelines as detached OS subprocesses via `exec.Command("wave", "run", ...)` with `SysProcAttr{Setsid: true}`. This allows pipelines to survive TUI exit, enables cross-process cancellation via SQLite's existing `cancellation` table, and provides event reconnection when the TUI reopens. The approach reuses the existing `wave run` CLI code path for TUI-CLI execution parity and leverages SQLite WAL mode as the sole IPC channel between the detached subprocess and the TUI.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: `github.com/charmbracelet/bubbletea` (TUI), `github.com/spf13/cobra` (CLI), `gopkg.in/yaml.v3` (config)
+**Storage**: SQLite via `modernc.org/sqlite` (existing `.wave/state.db`)
+**Testing**: `go test -race ./...` with `github.com/stretchr/testify`
+**Target Platform**: Linux, macOS (Setsid is Unix-specific; Windows not in scope)
+**Project Type**: Single binary CLI/TUI application
+**Performance Goals**: Subprocess spawn < 100ms; cancellation response < 30s (SC-003); stale detection within 2 refresh cycles (SC-006)
+**Constraints**: No new dependencies; single binary constraint; no credentials in CLI args (FR-012)
+**Scale/Scope**: 4-6 concurrently detached pipelines typical; state.db shared via WAL
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | Re-exec uses the same `wave` binary — no new dependencies |
+| P2: Manifest as Source of Truth | PASS | Subprocess loads its own manifest via `wave run` |
+| P3: Persona-Scoped Execution | PASS | Subprocess follows standard `wave run` persona binding |
+| P4: Fresh Memory at Step Boundary | PASS | Subprocess starts with fresh context (separate process) |
+| P5: Navigator-First Architecture | PASS | Pipeline structure unchanged — subprocess executes same DAG |
+| P6: Contracts at Every Handover | PASS | Subprocess performs same contract validation |
+| P7: Relay via Dedicated Summarizer | PASS | Relay mechanism unchanged within subprocess |
+| P8: Ephemeral Workspaces | PASS | Subprocess creates its own workspaces |
+| P9: Credentials Never Touch Disk | PASS | FR-012 enforces env-only credential passing |
+| P10: Observable Progress | PASS | Events persisted to SQLite, visible via TUI, WebUI, `wave logs` |
+| P11: Bounded Recursion | PASS | Same resource limits apply within subprocess |
+| P12: Minimal Step State Machine | PASS | Same 5-state machine |
+| P13: Test Ownership | PASS | All existing tests must pass + new tests for detached behavior |
+
+**Post-Phase 1 Re-check**: No violations introduced by design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/284-tui-detach-execution/
+├── plan.md              # This file
+├── research.md          # Phase 0: Technology decisions and rationale
+├── data-model.md        # Phase 1: Entity definitions and data flow
+└── tasks.md             # Phase 2 output (not created by plan)
+```
+
+### Source Code (repository root)
+
+```
+internal/
+├── state/
+│   ├── store.go           # MODIFY: Add UpdateRunPID, GetRunPID; scan PID in queryRuns
+│   ├── schema.sql         # MODIFY: Add pid column to pipeline_run
+│   └── types.go           # MODIFY: Add PID field to RunRecord
+├── tui/
+│   ├── pipeline_launcher.go    # MODIFY: Rewrite Launch() for subprocess detach
+│   ├── pipeline_launcher_test.go # MODIFY: Update tests for new Launch behavior
+│   ├── pipeline_provider.go    # MODIFY: Add PID to RunningPipeline
+│   ├── pipeline_messages.go    # MODIFY: Update PipelineLaunchedMsg (remove CancelFunc)
+│   ├── pipeline_list.go        # MODIFY: Update stale run detection display
+│   ├── content.go              # MODIFY: Cancel via store instead of context; CancelAll behavior
+│   ├── app.go                  # MODIFY: CancelAll behavior on quit (no subprocess kill)
+│   ├── live_output.go          # MODIFY: Support populating buffer from historical events
+│   └── stale_detector.go       # NEW: StaleRunDetector for PID liveness checks
+├── pipeline/
+│   └── executor.go        # NO CHANGE: Executor runs inside subprocess, unchanged
+└── adapter/
+    └── claude.go          # NO CHANGE: Adapter's Setpgid unchanged, subprocess Setsid is higher level
+
+cmd/wave/commands/
+└── run.go                 # MODIFY: Support --run flag to reuse pre-created run ID
+```
+
+**Structure Decision**: All changes are within the existing Go package structure. One new file (`internal/tui/stale_detector.go`) for the PID liveness checking logic, keeping it separated from the launcher. No new packages needed.
+
+## Design Details
+
+### D1 — PipelineLauncher Subprocess Spawn
+
+The core change: `PipelineLauncher.Launch()` spawns a detached subprocess instead of running in-process.
+
+```go
+func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
+    // 1. Create run record in state store (returns run_id)
+    runID, err := l.deps.Store.CreateRun(pipelineName, input)
+
+    // 2. Build subprocess command
+    args := []string{"run", pipelineName, "--run", runID, "--input", input}
+    cmd := exec.Command(os.Args[0], args...)
+    cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+    cmd.Env = buildPassthroughEnv()  // FR-012: env only, no credentials in args
+
+    // 3. Start subprocess (non-blocking)
+    cmd.Start()
+
+    // 4. Store PID for liveness detection
+    l.deps.Store.UpdateRunPID(runID, cmd.Process.Pid)
+
+    // 5. Release cmd.Process — don't wait for it
+    cmd.Process.Release()
+
+    return func() tea.Msg {
+        return PipelineLaunchedMsg{RunID: runID, PipelineName: pipelineName}
+    }
+}
+```
+
+### D2 — `wave run --run` Flag
+
+The CLI `run.go` already has a `--run` flag for resume. Reuse it: when `--run` is specified, use that run ID instead of generating a new one. The TUI creates the run record, so the subprocess reuses it and sets status to "running".
+
+This ensures the TUI-created `run_id` and the subprocess's `run_id` are the same — both reference the same row in `pipeline_run`.
+
+### D3 — CancelAll Behavior Change
+
+```go
+// CancelAll on TUI shutdown does NOT kill subprocesses (FR-004).
+// It only cleans up TUI-side monitoring state.
+func (l *PipelineLauncher) CancelAll() {
+    l.mu.Lock()
+    defer l.mu.Unlock()
+    // Clear internal maps — subprocesses continue independently
+    l.cancelFns = make(map[string]context.CancelFunc) // for any in-process monitoring
+}
+```
+
+### D4 — Cancel via Store
+
+```go
+// Cancel sends cancellation via persistent store (FR-005)
+func (l *PipelineLauncher) Cancel(runID string) {
+    if l.deps.Store != nil {
+        l.deps.Store.RequestCancellation(runID, false)
+    }
+}
+```
+
+The subprocess polls `store.CheckCancellation()` every 5 seconds (FR-006). This polling must be integrated into the executor's step loop — either as a wrapper around `adapter.Run()` or as a parallel goroutine during step execution.
+
+### D5 — Stale Run Detection
+
+On TUI startup and each refresh tick:
+1. `store.GetRunningRuns()` returns all "running" records with PIDs
+2. For each record with `PID > 0`, check `IsProcessAlive(pid)`
+3. If dead, transition to "failed" with "stale: subprocess exited unexpectedly"
+
+### D6 — Event Reconnection
+
+When the user selects a running detached pipeline:
+1. Load all events via `store.GetEvents(runID, EventQueryOptions{})`
+2. Format each into display lines using existing `formatEventLine()`
+3. Populate an `EventBuffer` and render in `LiveOutputModel`
+4. Start polling with `After: lastTimestamp` for new events
+
+### D7 — Cancellation Polling in Executor
+
+The executor needs a cancellation check mechanism. Two options:
+- **Option A**: Add cancellation polling directly in `executeStep()` as a goroutine alongside adapter execution
+- **Option B**: Wrap the adapter run context with a cancellation goroutine
+
+Option A is simpler — add a goroutine in `executeStep` that polls `store.CheckCancellation` every 5 seconds and cancels the step context if found.
+
+## Complexity Tracking
+
+_No constitution violations identified._
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|-----------|--------------------------------------|
+| (none)    | —         | —                                    |

--- a/specs/284-tui-detach-execution/research.md
+++ b/specs/284-tui-detach-execution/research.md
@@ -1,0 +1,115 @@
+# Research: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Feature Branch**: `284-tui-detach-execution`
+**Date**: 2026-03-08
+
+## R1 — Process Detachment in Go
+
+### Decision: `exec.Command` re-exec with `Setsid: true`
+
+**Rationale**: The spec prescribes re-executing the `wave` binary via `exec.Command("wave", "run", ...)` with `SysProcAttr{Setsid: true}`. This creates a new session leader that:
+- Survives parent process exit (not in parent's process group)
+- Survives terminal SIGHUP (new session = no controlling terminal)
+- Shares the same `wave run` code path as CLI (execution parity FR-002)
+
+The adapter layer already uses `Setpgid: true` for process group isolation (`internal/adapter/claude.go:88-91`). `Setsid` is the natural escalation for full TUI detachment — it creates a new session containing a new process group.
+
+**Alternatives Rejected**:
+- **In-process goroutine** (current approach): Goroutine dies when TUI exits. Cannot survive parent process lifecycle.
+- **Double-fork daemon pattern**: Overly complex for Go. `Setsid` achieves the same goal without zombie process management.
+- **`nohup`/background shell exec**: Platform-dependent, fragile, doesn't integrate with Go's `exec.Cmd` API.
+
+### Implementation Approach
+
+1. `PipelineLauncher.Launch()` uses `exec.Command(os.Args[0], "run", pipelineName, "--input", input)` with `SysProcAttr{Setsid: true}`
+2. Environment variables are passed via `cmd.Env` using the existing `env_passthrough` mechanism — no credentials in CLI arguments (FR-012)
+3. After `cmd.Start()`, the PID is stored in the `pipeline_run` table
+4. The goroutine returns `PipelineLaunchedMsg` immediately — no blocking wait
+5. The subprocess handles its own state transitions and event logging independently
+
+### Binary Discovery
+
+Use `os.Args[0]` to find the currently-running `wave` binary. This is the same binary the user is running, so it's guaranteed to be available and the correct version. If the binary was invoked via `$PATH`, `os.Args[0]` may be just `"wave"`, which is fine — `exec.LookPath` resolves it.
+
+## R2 — Inter-Process Communication via SQLite
+
+### Decision: SQLite WAL mode as the sole IPC channel
+
+**Rationale**: The codebase already uses SQLite with WAL mode (`PRAGMA journal_mode=WAL`) and busy timeout (`PRAGMA busy_timeout=5000`). WAL mode supports concurrent readers with a single writer, making it ideal for the detached subprocess (writer) and TUI (reader) pattern.
+
+Existing infrastructure:
+- `event_log` table: Already stores events per run (`store.LogEvent`)
+- `pipeline_run` table: Already tracks status, current step, tokens
+- `cancellation` table: Already supports `RequestCancellation` / `CheckCancellation` with `ON CONFLICT` semantics
+- `dbLoggingEmitter` in `cmd/wave/commands/run.go:601-617`: Already wraps emitters with DB persistence
+
+No new IPC mechanism needed — the existing SQLite tables provide everything required.
+
+**Alternatives Rejected**:
+- **Unix domain sockets / TCP**: Requires connection management, crashes leave sockets dangling
+- **Shared memory / mmap**: Complex, no existing Go abstraction in the codebase
+- **Named pipes**: Unidirectional, no persistence, platform-dependent
+
+## R3 — PID Liveness Detection
+
+### Decision: `os.FindProcess` + `Signal(0)` for stale run detection
+
+**Rationale**: Per spec FR-009, PID liveness checks via `os.FindProcess(pid)` + `process.Signal(syscall.Signal(0))` provide zero-overhead detection:
+- No writes required from the subprocess (unlike heartbeats)
+- Immediate detection when process dies
+- Standard Unix approach for process liveness
+- `Signal(0)` doesn't actually send a signal — it just checks if the process exists and the caller has permission to signal it
+
+**Edge Case — PID Reuse**: Theoretically, after a process dies, its PID could be reassigned to a new process. For Wave's use case (pipeline runs lasting minutes to hours), this is negligible. The probability of PID reuse matching the exact same PID within a TUI refresh cycle (seconds) is extremely low on modern systems with large PID spaces.
+
+**Implementation**: On TUI startup and on each refresh tick, iterate over "running" runs with PIDs. For each, call `os.FindProcess(pid)` then `p.Signal(syscall.Signal(0))`. If the signal returns an error (process not found or permission denied on a different process), transition the run to "failed" with "process not found — stale run" error.
+
+## R4 — Cancellation via Persistent Store
+
+### Decision: Poll-based cancellation via `store.CheckCancellation()`
+
+**Rationale**: The `cancellation` table already exists with the right schema:
+```sql
+CREATE TABLE IF NOT EXISTS cancellation (
+    run_id TEXT PRIMARY KEY,
+    requested_at INTEGER NOT NULL,
+    force BOOLEAN DEFAULT FALSE,
+    FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
+);
+```
+
+The existing `RequestCancellation` method uses `ON CONFLICT` for idempotent concurrent requests. The subprocess polls `CheckCancellation` every 5 seconds (FR-006) and initiates graceful shutdown when found.
+
+**Grace Period Escalation (SC-003)**: After persisting cancellation, the TUI starts a 30-second timer. If the process is still alive after 30 seconds, `syscall.Kill(-pid, syscall.SIGKILL)` is sent to the process group (negative PID = kill entire group). The run status is updated to "failed" with "cancellation timeout — force killed".
+
+## R5 — TUI Shutdown Behavior Change
+
+### Decision: `CancelAll()` stops monitoring only, does not kill subprocesses
+
+**Rationale**: Currently `CancelAll()` cancels all in-process goroutine contexts, killing pipelines. With detached execution, `CancelAll()` must only clean up TUI-side resources (cancel context of monitoring goroutines, clear internal maps) WITHOUT sending termination signals to subprocess PIDs.
+
+The subprocess continues independently — it manages its own lifecycle, state transitions, and cleanup.
+
+## R6 — Event Reconnection on TUI Reopen
+
+### Decision: Load historical events from `store.GetEvents()` on selection
+
+**Rationale**: When the TUI reopens and detects running pipelines, it shows them in the fleet view. When the user selects a running pipeline, the TUI:
+1. Calls `store.GetEvents(runID, ...)` to load historical events
+2. Populates the `EventBuffer` with formatted event lines
+3. Starts tailing new events by polling `GetEvents` with timestamp cursor
+4. Displays in the `LiveOutputModel` viewport
+
+This reuses existing event infrastructure without adding a new streaming mechanism.
+
+## R7 — Schema Migration for PID Column
+
+### Decision: Add `pid` INTEGER column to `pipeline_run` table
+
+**Rationale**: Per spec FR-011 and C2, PID storage belongs in `pipeline_run` (1:1 relationship with runs). The codebase currently uses schema.sql for initialization. A new `ALTER TABLE` migration adds the `pid` column:
+
+```sql
+ALTER TABLE pipeline_run ADD COLUMN pid INTEGER;
+```
+
+The `RunRecord` Go struct gains a `PID int` field. The `CreateRun` signature changes to accept a PID, or a separate `UpdateRunPID(runID, pid)` method is added.

--- a/specs/284-tui-detach-execution/spec.md
+++ b/specs/284-tui-detach-execution/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Feature Branch**: `284-tui-detach-execution`
+**Created**: 2026-03-08
+**Status**: Draft
+**Input**: GitHub Issue #284 — feat(tui): detach pipeline execution from TUI process lifecycle
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Pipeline Survives TUI Exit (Priority: P1)
+
+A user launches a long-running pipeline from the TUI, realizes they need to close the terminal, and quits the TUI with `q` or `ctrl+c`. The pipeline continues running in the background. When the user reopens the TUI later, they see the pipeline is still running with all events persisted.
+
+**Why this priority**: This is the core problem. Currently, quitting the TUI kills all in-flight pipelines because the executor runs as an in-process goroutine. Users cannot safely close the TUI during multi-hour pipeline runs.
+
+**Independent Test**: Can be fully tested by launching a pipeline from TUI, quitting TUI, then verifying the pipeline process is still alive via `ps` and that `wave logs <run-id>` streams events from it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pipeline is running via the TUI, **When** the user presses `q` or `ctrl+c`, **Then** the TUI exits but the pipeline subprocess continues running to completion
+2. **Given** a pipeline was launched from the TUI and the TUI was closed, **When** the user reopens the TUI, **Then** the running pipeline appears in the Running section with its current status
+3. **Given** a detached pipeline is running, **When** the user runs `wave logs <run-id>`, **Then** events stream from the still-running pipeline via SQLite event persistence
+
+---
+
+### User Story 2 - Cancel Detached Pipeline from TUI (Priority: P2)
+
+A user reopens the TUI and sees a previously-launched pipeline still running. They decide to cancel it. Pressing the cancel keybinding sends a cancellation signal through the persistent store, and the detached subprocess receives and honors it.
+
+**Why this priority**: Without cancellation support, detached pipelines become uncontrollable fire-and-forget processes. Users need the ability to stop pipelines they started.
+
+**Independent Test**: Can be tested by launching a pipeline, quitting TUI, reopening TUI, pressing cancel on the running pipeline, and verifying the subprocess terminates gracefully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a detached pipeline is running and the user reopens the TUI, **When** the user presses the cancel key on the pipeline, **Then** a cancellation is persisted via `store.RequestCancellation()` and the detached subprocess terminates within a reasonable grace period
+2. **Given** a cancellation has been requested, **When** the detached process checks for cancellation, **Then** it performs graceful shutdown including workspace cleanup and final state persistence
+
+---
+
+### User Story 3 - TUI-CLI Execution Parity (Priority: P2)
+
+Both `wave run <pipeline>` (CLI) and TUI-launched pipelines use the same subprocess-based execution path. This eliminates behavioral divergence between the two entry points and ensures that pipelines behave identically regardless of how they were started.
+
+**Why this priority**: Parity reduces maintenance burden and user confusion. The same execution path means the same failure modes, logging behavior, and cancellation semantics.
+
+**Independent Test**: Can be tested by running the same pipeline via CLI and TUI, comparing event logs, exit codes, and artifact outputs for equivalence.
+
+**Acceptance Scenarios**:
+
+1. **Given** the same pipeline and input, **When** launched from the CLI, **Then** the execution path is identical to launching from the TUI (same subprocess, same state transitions, same event persistence)
+2. **Given** a pipeline running from the TUI, **When** inspected via `wave status` or the WebUI, **Then** it appears identical to a CLI-launched pipeline
+
+---
+
+### User Story 4 - Reconnect to Running Pipeline Events (Priority: P3)
+
+When the TUI is reopened, it reconnects to in-progress pipelines by tailing persisted events from SQLite. The user sees the pipeline's current step, recent log lines, and can watch new events appear in real-time.
+
+**Why this priority**: This is the UX polish that makes detached execution feel seamless. Without it, users see a "running" label but no detail until the pipeline completes.
+
+**Independent Test**: Can be tested by launching a pipeline, quitting TUI, waiting for the pipeline to advance several steps, reopening TUI, and verifying that historical events are loaded and new events appear live.
+
+**Acceptance Scenarios**:
+
+1. **Given** a detached pipeline has progressed through several steps, **When** the user reopens the TUI and selects the pipeline, **Then** historical events from SQLite are loaded into the detail view
+2. **Given** the TUI is connected to a running detached pipeline, **When** new events are emitted by the subprocess, **Then** they appear in the TUI within the existing refresh interval
+
+---
+
+### Edge Cases
+
+- What happens when the TUI is closed during subprocess spawn (race between fork and TUI exit)? The subprocess must be fully detached before TUI shutdown proceeds, or the run must be marked as failed if the spawn did not complete.
+- How does the system handle a detached pipeline whose subprocess crashes (e.g., OOM kill)? Stale run detection must identify the dead process and transition the run to "failed" status.
+- What happens if two TUI instances attempt to cancel the same pipeline simultaneously? The cancellation table uses `ON CONFLICT` semantics, so concurrent cancellation requests are idempotent.
+- How does the system detect that a detached subprocess has died without a clean exit (stale "running" state in SQLite)? PID liveness checks via `os.FindProcess` + signal 0 are used; if the PID is not alive, the run is transitioned to "failed".
+- What happens when the user launches a pipeline and immediately quits before the subprocess is fully started? The subprocess spawn must complete before the TUI is allowed to exit, or a "starting" state must be tracked.
+- How does disk space exhaustion affect the detached subprocess writing to the SQLite event log? The subprocess must handle SQLite write failures gracefully and continue execution where possible.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: `PipelineLauncher.Launch()` MUST spawn pipeline execution as a detached OS subprocess (surviving parent process exit) instead of an in-process goroutine. The subprocess MUST be launched by re-executing the `wave` binary via `exec.Command("wave", "run", ...)` with `SysProcAttr{Setsid: true}` to create a new session, ensuring it survives parent exit and terminal SIGHUP
+- **FR-002**: The detached subprocess MUST use the same `wave run <pipeline> --input <input>` command path as the CLI, ensuring execution parity
+- **FR-003**: The detached subprocess MUST persist all events to SQLite via the existing event logging pattern so they survive process boundaries
+- **FR-004**: `CancelAll()` on TUI shutdown MUST NOT terminate detached pipeline subprocesses; it MUST only stop the TUI's monitoring/subscription of those pipelines
+- **FR-005**: Pipeline cancellation from the TUI MUST use `store.RequestCancellation()` to persist a cancellation flag that the detached subprocess polls and honors
+- **FR-006**: The detached subprocess MUST check `store.CheckCancellation()` every 5 seconds during step execution and perform graceful shutdown when a cancellation is detected
+- **FR-007**: On TUI startup, the system MUST detect all pipelines in "running" state from the state store and display them in the Running section of the fleet view
+- **FR-008**: The TUI MUST reconnect to running pipelines by tailing `store.GetEvents()` for active runs and displaying historical and live events
+- **FR-009**: The system MUST detect stale "running" entries where the subprocess has died by using OS-level PID liveness checks (`os.FindProcess` + signal 0) and transition them to "failed" status with an appropriate error message. No heartbeat mechanism is required
+- **FR-010**: The detached subprocess MUST run in its own session (via `Setsid: true`) so it is not killed by terminal SIGHUP or parent exit
+- **FR-011**: The TUI MUST store the PID of the detached subprocess in the `pipeline_run` table (via a new `pid` INTEGER column) so that liveness can be checked across TUI restarts
+- **FR-012**: The detached subprocess MUST NOT receive credentials or secrets via command-line arguments; environment passthrough MUST follow the existing `runtime.sandbox.env_passthrough` configuration
+
+### Key Entities
+
+- **Detached Run**: A pipeline execution running as an independent OS process, tracked by run ID in SQLite with PID metadata for liveness detection
+- **Cancellation Record**: A persistent flag in the `cancellation` table that signals a detached subprocess to stop, including force/graceful semantics
+- **Event Log**: SQLite-persisted stream of pipeline progress events, serving as the communication channel between detached subprocess and TUI/WebUI
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A pipeline launched from the TUI continues running after TUI exit — verified by process liveness and continued event emission in SQLite
+- **SC-002**: Reopening the TUI displays all currently-running detached pipelines within the existing refresh cycle
+- **SC-003**: Cancellation of a detached pipeline via the TUI results in graceful subprocess termination within 30 seconds; if the subprocess has not exited after 30 seconds, SIGKILL is sent to the process group
+- **SC-004**: Historical events from a detached pipeline load into the TUI detail view when the pipeline is selected
+- **SC-005**: `go test -race ./...` passes with all new and existing tests
+- **SC-006**: Stale "running" pipelines whose subprocess has died are detected and marked as "failed" within 2 refresh cycles
+- **SC-007**: No behavioral difference between CLI-launched and TUI-launched pipelines when inspected via `wave status`, WebUI, or `wave logs`
+
+## Clarifications
+
+### C1 — Subprocess Detachment Mechanism (FR-001)
+
+**Question**: How should the TUI detach the pipeline subprocess — in-process goroutine with signal handling, `Setsid` for new session, double-fork daemon pattern, or re-exec of the `wave` binary?
+
+**Resolution**: Re-exec via `exec.Command("wave", "run", ...)` with `SysProcAttr{Setsid: true}`. This creates a new session leader that survives parent exit and terminal SIGHUP. The adapter already uses `Setpgid: true` for process group isolation (`internal/adapter/claude.go:88-91`), so `Setsid` is the natural escalation for full detachment. Re-exec also provides CLI-TUI parity (FR-002) since both paths invoke the same `wave run` command. Double-fork is unnecessary — `Setsid` is the standard Go approach and avoids zombie process complexity.
+
+### C2 — PID Storage Location (FR-011)
+
+**Question**: Should the subprocess PID be stored in the existing `pipeline_run` table or a new dedicated `process` table?
+
+**Resolution**: Add a `pid` INTEGER column to the existing `pipeline_run` table. The `pipeline_run` table already tracks run lifecycle metadata (status, started_at, completed_at, error_message) and PID is a natural extension of that. A separate table would require a JOIN for every liveness check with no benefit — PID has a 1:1 relationship with a run, there's no cardinality mismatch. The existing `RunRecord` Go struct gains a `PID int` field.
+
+### C3 — Cancellation Polling Interval (FR-006)
+
+**Question**: How frequently should the detached subprocess poll `store.CheckCancellation()`?
+
+**Resolution**: Every 5 seconds. This balances responsiveness (users expect cancellation within seconds) against SQLite read overhead. The existing cancellation infrastructure (`cancellation` table with `ON CONFLICT` semantics) is designed for polling. 5 seconds ensures cancellation completes well within the 30-second SC-003 window while keeping database load trivial.
+
+### C4 — Stale Run Detection Mechanism (FR-009)
+
+**Question**: Should stale detection use PID liveness checks or a heartbeat-based timeout?
+
+**Resolution**: PID liveness checks via `os.FindProcess(pid)` + `process.Signal(syscall.Signal(0))`. This is zero-overhead (no writes required from the subprocess), works immediately when a process dies, and is the standard Unix approach for process liveness. A heartbeat mechanism would require the subprocess to write periodically to SQLite, adding complexity and write contention. PID reuse is a theoretical concern but negligible in practice for the short lifetimes involved.
+
+### C5 — Post-Cancellation Grace Period Escalation (SC-003)
+
+**Question**: What happens if the detached subprocess does not terminate within the 30-second cancellation grace period?
+
+**Resolution**: After 30 seconds, send SIGKILL to the process group. The subprocess will have already received a graceful cancellation signal via `store.CheckCancellation()`. If it hasn't responded within 30 seconds, it's likely stuck (e.g., blocked on I/O or a hung adapter subprocess). SIGKILL to the process group ensures all child processes (including Claude Code subprocesses) are terminated. The run state is updated to "failed" with a "cancellation timeout — force killed" error message.

--- a/specs/284-tui-detach-execution/tasks.md
+++ b/specs/284-tui-detach-execution/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Detach Pipeline Execution from TUI Process Lifecycle
+
+**Feature Branch**: `284-tui-detach-execution`
+**Generated**: 2026-03-08
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+---
+
+## Phase 1 — Data Layer: Schema & State Store (Foundational)
+
+These tasks modify the state store and data types. All subsequent phases depend on these.
+
+- [X] T001 [P1] [Story1] Add `PID` field to `RunRecord` struct in `internal/state/types.go`. Add `PID int` field after `BranchName` with comment `// OS process ID of detached subprocess (0 = in-process or unknown)`.
+
+- [X] T002 [P1] [Story1] Add SQLite migration to add `pid` column to `pipeline_run` table. Create a new migration in `internal/state/migrations.go` (or the existing migration registration pattern) with `ALTER TABLE pipeline_run ADD COLUMN pid INTEGER DEFAULT 0`. Follow the existing migration system pattern used by the codebase.
+
+- [X] T003 [P1] [Story1] Update `queryRunsWithArgs` in `internal/state/store.go` to scan the new `pid` column into `RunRecord.PID`. Add `&record.PID` (or a `sql.NullInt64` intermediary) to the `rows.Scan()` call, and update all SELECT queries that feed `queryRunsWithArgs` to include `pid` in their column list.
+
+- [X] T004 [P1] [Story1] Add `UpdateRunPID(runID string, pid int) error` method to the `StateStore` interface in `internal/state/store.go` and implement it on `stateStore`. SQL: `UPDATE pipeline_run SET pid = ? WHERE run_id = ?`.
+
+- [X] T005 [P1] [Story1] Add `GetRunPID(runID string) (int, error)` method to the `StateStore` interface in `internal/state/store.go` and implement it on `stateStore`. SQL: `SELECT pid FROM pipeline_run WHERE run_id = ?`.
+
+- [X] T006 [P1] [Story1] Write unit tests for T001–T005 in `internal/state/store_test.go`: test `UpdateRunPID` sets PID, `GetRunPID` retrieves it, `queryRuns` includes PID in scanned records, and default PID is 0 for new runs.
+
+---
+
+## Phase 2 — Subprocess Detachment: PipelineLauncher Rewrite (Story 1 — Pipeline Survives TUI Exit)
+
+Core behavioral change: Launch() spawns a detached subprocess instead of an in-process goroutine.
+
+- [X] T007 [P1] [Story1] Rewrite `PipelineLauncher.Launch()` in `internal/tui/pipeline_launcher.go` to spawn a detached subprocess via `exec.Command(os.Args[0], "run", pipelineName, "--run", runID, "--input", input)` with `cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}`. Create the run record via `store.CreateRun()` before spawn, store PID via `store.UpdateRunPID()` after `cmd.Start()`, then call `cmd.Process.Release()`. Return `PipelineLaunchedMsg` (without `CancelFunc`). Build environment with `buildPassthroughEnv()` per FR-012.
+
+- [X] T008 [P1] [Story1] Add `buildPassthroughEnv()` helper function in `internal/tui/pipeline_launcher.go` that constructs the subprocess environment from `runtime.sandbox.env_passthrough` manifest configuration. Only pass through explicitly allowed environment variables (FR-012: no credentials in CLI args).
+
+- [X] T009 [P1] [Story1] Remove `CancelFunc` field from `PipelineLaunchedMsg` in `internal/tui/pipeline_messages.go`. Update all references to `PipelineLaunchedMsg.CancelFunc` in `internal/tui/pipeline_launcher.go` and `internal/tui/pipeline_list.go`.
+
+- [X] T010 [P1] [Story1] Remove `cancelFns map[string]context.CancelFunc` and `buffers map[string]*EventBuffer` fields from `PipelineLauncher` struct. Remove `GetBuffer`, `HasBuffer` methods. Update `NewPipelineLauncher` constructor. These in-process constructs are replaced by SQLite-based IPC.
+
+- [X] T011 [P1] [Story1] Update `Cleanup()` method on `PipelineLauncher` to be a no-op or remove it — detached subprocesses manage their own lifecycle. Remove buffer cleanup logic.
+
+- [X] T012 [P1] [Story1] Update existing tests in `internal/tui/pipeline_launcher_test.go` to reflect the new subprocess-based architecture. Remove tests for `cancelFns` map, `buffers` map, and `CancelFunc` behavior. Add tests verifying that `Launch()` calls `store.CreateRun()` and `store.UpdateRunPID()` (using a mock store).
+
+---
+
+## Phase 3 — CLI Parity: `wave run --run` Support (Story 3 — TUI-CLI Execution Parity)
+
+- [X] T013 [P2] [Story3] Modify `runRun()` in `cmd/wave/commands/run.go` to support `--run` flag for reusing a pre-created run ID. When `opts.RunID` is set and `opts.FromStep` is empty (not a resume), skip `store.CreateRun()` and use the provided run ID directly. Update the run status to "running" at execution start.
+
+- [X] T014 [P2] [Story3] Write integration test verifying that `wave run --run <id>` reuses the specified run ID instead of creating a new one. Test in `cmd/wave/commands/run_test.go` or `internal/pipeline/executor_test.go`.
+
+---
+
+## Phase 4 — CancelAll & Cancel via Store (Story 2 — Cancel Detached Pipeline)
+
+- [X] T015 [P2] [Story2] Rewrite `CancelAll()` on `PipelineLauncher` in `internal/tui/pipeline_launcher.go` to be a no-op for detached subprocesses (FR-004). It must NOT terminate subprocess PIDs — only clean up TUI-side monitoring state (if any remains).
+
+- [X] T016 [P2] [Story2] Rewrite `Cancel(runID)` on `PipelineLauncher` in `internal/tui/pipeline_launcher.go` to call `store.RequestCancellation(runID, false)` instead of context cancellation (FR-005).
+
+- [X] T017 [P2] [Story2] Add cancellation polling to the executor. In `internal/pipeline/executor.go`, add a goroutine in `executeStep()` (or a wrapper around the adapter run) that polls `store.CheckCancellation(runID)` every 5 seconds (FR-006). When cancellation is detected, cancel the step context to trigger graceful shutdown.
+
+- [X] T018 [P2] [Story2] Add force-kill escalation for cancellation timeout (SC-003). In `internal/tui/pipeline_launcher.go` (or a new `internal/tui/cancel_manager.go`), after `RequestCancellation` is called, start a 30-second timer. If the subprocess PID is still alive after 30 seconds, send `syscall.Kill(-pid, syscall.SIGKILL)` to kill the process group and update the run to "failed" with "cancellation timeout — force killed".
+
+- [X] T019 [P2] [Story2] Update the cancel keybinding handler in `internal/tui/content.go` (the `"c"` key handler around line 351) to use the new `Cancel(runID)` which writes to the store. Remove any direct context cancellation references.
+
+- [X] T020 [P2] [Story2] Write tests for cancellation flow: test that `Cancel()` calls `store.RequestCancellation`, test that the executor polling goroutine detects cancellation and cancels the step context, test force-kill escalation after 30 seconds.
+
+---
+
+## Phase 5 — Stale Run Detection (Story 1 — Pipeline Survives TUI Exit, FR-009)
+
+- [X] T021 [P1] [Story1] Create `internal/tui/stale_detector.go` with `StaleRunDetector` struct. Implement `DetectStaleRuns() ([]string, error)` which queries `store.GetRunningRuns()`, checks each run's PID via `IsProcessAlive(pid)`, and transitions dead runs to "failed" with "stale: subprocess exited unexpectedly". Also implement `IsProcessAlive(pid int) bool` using `os.FindProcess(pid)` + `process.Signal(syscall.Signal(0))`.
+
+- [X] T022 [P1] [Story1] Integrate `StaleRunDetector` into the TUI refresh cycle. In the pipeline data provider or the refresh tick handler, call `DetectStaleRuns()` before returning running pipeline data. This ensures stale runs are detected within 2 refresh cycles (SC-006).
+
+- [X] T023 [P1] [Story1] Write unit tests for `StaleRunDetector` in `internal/tui/stale_detector_test.go`: test `IsProcessAlive` returns true for current process PID, false for a known-dead PID, and `DetectStaleRuns` transitions stale runs to "failed".
+
+---
+
+## Phase 6 — TUI Pipeline Provider & List Updates (Story 1 + Story 4)
+
+- [X] T024 [P1] [Story1] Add `PID int` and `Detached bool` fields to `RunningPipeline` struct in `internal/tui/pipeline_provider.go`. Update `FetchRunningPipelines()` to populate `PID` from `RunRecord.PID` and set `Detached = true` when `PID > 0`.
+
+- [X] T025 [P3] [Story4] Update the running pipeline Enter handler in `internal/tui/content.go` (around line 309) to support reconnection for detached pipelines that have no in-process buffer. Instead of checking `launcher.HasBuffer(r.RunID)`, load historical events from `store.GetEvents(runID, ...)`, populate an `EventBuffer`, and create the `LiveOutputModel` from it.
+
+- [X] T026 [P3] [Story4] Add event polling for live updates from detached pipelines. After populating the `LiveOutputModel` with historical events, start a periodic poll (using `tea.Tick`) that calls `store.GetEvents(runID, EventQueryOptions{Offset: lastCount})` to fetch new events and append them to the buffer.
+
+- [X] T027 [P3] [Story4] Update `LiveOutputModel` in `internal/tui/live_output.go` to support initial population from a pre-filled `EventBuffer` (historical events). Ensure the viewport content is set correctly when historical events are loaded and auto-scroll jumps to the latest.
+
+---
+
+## Phase 7 — TUI Shutdown Behavior (Story 1)
+
+- [X] T028 [P1] [Story1] Update `AppModel.Update()` in `internal/tui/app.go` so that `CancelAll()` on quit (both `q` and `ctrl+c`) does NOT kill detached pipelines. Verify that TUI shutdown proceeds even if pipelines are still running.
+
+- [X] T029 [P1] [Story1] Handle the race condition where TUI exits during subprocess spawn (edge case from spec). Ensure that `cmd.Start()` completes before TUI can exit, or mark the run as "failed" if the spawn did not complete. Add a "starting" guard in `Launch()` that blocks TUI exit until the subprocess PID is stored.
+
+---
+
+## Phase 8 — Polish & Cross-Cutting
+
+- [X] T030 [P] Update `internal/tui/pipeline_list.go` to display a visual indicator (e.g., a detach icon or label) for detached running pipelines to distinguish them from in-process runs.
+
+- [X] T031 [P] Add `--run` flag documentation to the `wave run` help text in `cmd/wave/commands/run.go`. Update the `Long` description and `Example` section to mention the TUI-subprocess use case.
+
+- [X] T032 Ensure `go test -race ./...` passes with all new and existing tests (SC-005). Run the full test suite to verify no regressions from the data layer, launcher, executor, and TUI changes.
+
+- [X] T033 Verify end-to-end parity (SC-007): run the same pipeline via CLI (`wave run`) and TUI, confirm that `wave status` and event logs show identical behavior for both launch paths.


### PR DESCRIPTION
## Summary

Closes #284

- **Detached subprocess execution**: TUI-launched pipelines now spawn as detached subprocesses (`exec.Command` + `Setsid`) that survive TUI exit, terminal close, and SIGHUP
- **Cancellation via persistent store**: Cancel requests flow through SQLite (`RequestCancellation` → `CheckCancellation` poller in executor), with 30s grace period before SIGKILL escalation
- **PID tracking and stale detection**: New `pid` column in `pipeline_run` (migration v8) enables liveness checks (`kill -0`) to auto-transition dead subprocesses to "failed"
- **Event reconnection**: TUI reads historical events from SQLite on view entry and polls every 2s for new events, enabling seamless reconnection to detached pipelines
- **Environment isolation**: Subprocess receives only `HOME`, `PATH`, and manifest-configured `env_passthrough` vars — no credential leakage via CLI args

### Spec

See [`specs/284-tui-detach-execution/spec.md`](specs/284-tui-detach-execution/spec.md) for the full feature specification including user stories, functional requirements, and success criteria.

## Test plan

- `go test -race ./...` passes (all 27 packages)
- New tests cover:
  - `TestUpdateRunPID` — PID storage/retrieval in state store, including `GetRun`, `GetRunningRuns`, and `ListRuns`
  - `TestStaleRunDetector_*` — stale detection for dead PIDs, zero-PID skip, and live-process preservation
  - `TestPipelineLauncher_Cancel_WithStore_RequestsCancellation` — cancellation flow through persistent store
  - `TestBuildPassthroughEnv_IncludesHomeAndPath` — environment isolation
- Migration v8 rollback tested via existing `TestPartialRollbackAndReapply`

## Known limitations

- Force-kill (`SIGKILL`) uses process group kill (`-PID`) which requires the subprocess to have called `Setsid` — this is set in `SysProcAttr`
- Stale detection runs on every `FetchRunningPipelines` call; a background ticker may be more efficient for dashboards with many concurrent runs