### PR TITLE
feat(tui): rich live output parity with CLI handover tree

### DIFF
--- a/internal/display/progress.go
+++ b/internal/display/progress.go
@@ -697,8 +697,10 @@ func (bpd *BasicProgressDisplay) renderHandoverMetadata(timestamp, stepID string
 	}
 }
 
-// buildHandoverLines constructs the tree-formatted handover metadata lines.
-func (bpd *BasicProgressDisplay) buildHandoverLines(stepID string, info *HandoverInfo) []string {
+// BuildHandoverLines constructs tree-formatted handover metadata lines.
+// stepID is the completing step, stepOrder is the ordered list of step IDs
+// seen so far (used to resolve handover targets when info.TargetStep is empty).
+func BuildHandoverLines(stepID string, info *HandoverInfo, stepOrder []string) []string {
 	var items []string
 
 	// Artifact lines
@@ -726,16 +728,16 @@ func (bpd *BasicProgressDisplay) buildHandoverLines(stepID string, info *Handove
 	targetStepNum := 0
 	if targetStep == "" {
 		// Determine from step order
-		for i, sid := range bpd.stepOrder {
-			if sid == stepID && i+1 < len(bpd.stepOrder) {
-				targetStep = bpd.stepOrder[i+1]
+		for i, sid := range stepOrder {
+			if sid == stepID && i+1 < len(stepOrder) {
+				targetStep = stepOrder[i+1]
 				targetStepNum = i + 2 // 1-based, and it's the next step
 				break
 			}
 		}
 	} else {
 		// Find targetStep's position in stepOrder
-		for i, sid := range bpd.stepOrder {
+		for i, sid := range stepOrder {
 			if sid == targetStep {
 				targetStepNum = i + 1 // 1-based
 				break
@@ -756,6 +758,11 @@ func (bpd *BasicProgressDisplay) buildHandoverLines(stepID string, info *Handove
 		lines = append(lines, fmt.Sprintf("%s %s", connector, item))
 	}
 	return lines
+}
+
+// buildHandoverLines delegates to the shared BuildHandoverLines function.
+func (bpd *BasicProgressDisplay) buildHandoverLines(stepID string, info *HandoverInfo) []string {
+	return BuildHandoverLines(stepID, info, bpd.stepOrder)
 }
 
 // QuietProgressDisplay only renders pipeline-level completed/failed events.

--- a/internal/tui/live_output.go
+++ b/internal/tui/live_output.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 )
 
@@ -335,6 +336,10 @@ type LiveOutputModel struct {
 
 	completed         bool
 	completionPending bool
+
+	// Handover tracking for rich output (tree-formatted metadata on step completion)
+	handoverInfo map[string]*display.HandoverInfo
+	stepOrder    []string
 }
 
 const (
@@ -352,6 +357,7 @@ func NewLiveOutputModel(runID, pipelineName string, buffer *EventBuffer, started
 		autoScroll:   true,
 		startedAt:    startedAt,
 		totalSteps:   totalSteps,
+		handoverInfo: make(map[string]*display.HandoverInfo),
 	}
 }
 
@@ -395,6 +401,14 @@ func (m *LiveOutputModel) rebuildBuffer() {
 			} else {
 				m.buffer.Append(formatEventLine(evt))
 			}
+			// Re-inject handover tree lines after step completion
+			if evt.State == event.StateCompleted && evt.StepID != "" {
+				if info, exists := m.handoverInfo[evt.StepID]; exists {
+					for _, hl := range display.BuildHandoverLines(evt.StepID, info, m.stepOrder) {
+						m.buffer.Append("  " + hl)
+					}
+				}
+			}
 		}
 	}
 	m.updateViewportContent()
@@ -419,6 +433,43 @@ func (m LiveOutputModel) Update(msg tea.Msg) (LiveOutputModel, tea.Cmd) {
 				if evt.Model != "" {
 					m.model = evt.Model
 				}
+				// Track step order for handover target resolution
+				found := false
+				for _, sid := range m.stepOrder {
+					if sid == evt.StepID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					m.stepOrder = append(m.stepOrder, evt.StepID)
+				}
+			}
+		}
+
+		// Accumulate handover metadata from contract events
+		if evt.StepID != "" {
+			switch evt.State {
+			case event.StateContractValidating:
+				if _, exists := m.handoverInfo[evt.StepID]; !exists {
+					m.handoverInfo[evt.StepID] = &display.HandoverInfo{}
+				}
+				m.handoverInfo[evt.StepID].ContractSchema = evt.ValidationPhase
+			case "contract_passed":
+				if _, exists := m.handoverInfo[evt.StepID]; !exists {
+					m.handoverInfo[evt.StepID] = &display.HandoverInfo{}
+				}
+				m.handoverInfo[evt.StepID].ContractStatus = "passed"
+			case "contract_failed":
+				if _, exists := m.handoverInfo[evt.StepID]; !exists {
+					m.handoverInfo[evt.StepID] = &display.HandoverInfo{}
+				}
+				m.handoverInfo[evt.StepID].ContractStatus = "failed"
+			case "contract_soft_failure":
+				if _, exists := m.handoverInfo[evt.StepID]; !exists {
+					m.handoverInfo[evt.StepID] = &display.HandoverInfo{}
+				}
+				m.handoverInfo[evt.StepID].ContractStatus = "soft_failure"
 			}
 		}
 
@@ -483,6 +534,22 @@ func (m LiveOutputModel) Update(msg tea.Msg) (LiveOutputModel, tea.Cmd) {
 				line := formatEventLine(evt)
 				m.buffer.Append(line)
 			}
+
+			// On step completion, capture artifacts and render handover tree
+			if evt.State == event.StateCompleted && evt.StepID != "" {
+				if len(evt.Artifacts) > 0 {
+					if _, exists := m.handoverInfo[evt.StepID]; !exists {
+						m.handoverInfo[evt.StepID] = &display.HandoverInfo{}
+					}
+					m.handoverInfo[evt.StepID].ArtifactPaths = evt.Artifacts
+				}
+				if info, exists := m.handoverInfo[evt.StepID]; exists {
+					for _, hl := range display.BuildHandoverLines(evt.StepID, info, m.stepOrder) {
+						m.buffer.Append("  " + hl)
+					}
+				}
+			}
+
 			m.updateViewportContent()
 			if m.autoScroll {
 				m.viewport.GotoBottom()

--- a/internal/tui/live_output_test.go
+++ b/internal/tui/live_output_test.go
@@ -658,3 +658,141 @@ func TestLiveOutputModel_RawEvents_StoredForAllEvents(t *testing.T) {
 	// All raw events should be stored regardless of flags
 	assert.Equal(t, 4, len(m.rawEvents), "all events should be stored in rawEvents")
 }
+
+func TestLiveOutputModel_HandoverMetadata_OnStepCompletion(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	defer os.Unsetenv("NO_COLOR")
+
+	buf := NewEventBuffer(100)
+	m := NewLiveOutputModel("run-1", "pipe", buf, time.Now(), 3)
+	m.SetSize(120, 40)
+
+	// Step 1 starts
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "specify", State: event.StateStarted, Persona: "navigator"},
+	})
+
+	// Step 2 starts (so handover target can be resolved)
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "plan", State: event.StateStarted, Persona: "navigator"},
+	})
+
+	// Contract validation for step 1
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "specify", State: event.StateContractValidating, ValidationPhase: "json_schema"},
+	})
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "specify", State: "contract_passed"},
+	})
+
+	// Step 1 completes with artifacts
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{
+			StepID:     "specify",
+			State:      event.StateCompleted,
+			DurationMs: 42000,
+			Artifacts:  []string{".wave/artifacts/spec.md"},
+		},
+	})
+
+	// Verify handover info was accumulated
+	assert.Contains(t, m.handoverInfo, "specify")
+	assert.Equal(t, "passed", m.handoverInfo["specify"].ContractStatus)
+	assert.Equal(t, "json_schema", m.handoverInfo["specify"].ContractSchema)
+
+	// Verify tree lines were appended to buffer
+	lines := buf.Lines()
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "artifact:") && strings.Contains(line, "spec.md") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected artifact tree line in buffer, got: %v", lines)
+
+	// Check for contract line
+	contractFound := false
+	for _, line := range lines {
+		if strings.Contains(line, "contract:") && strings.Contains(line, "valid") {
+			contractFound = true
+			break
+		}
+	}
+	assert.True(t, contractFound, "Expected contract tree line in buffer, got: %v", lines)
+
+	// Check for handover line
+	handoverFound := false
+	for _, line := range lines {
+		if strings.Contains(line, "handover") && strings.Contains(line, "plan") {
+			handoverFound = true
+			break
+		}
+	}
+	assert.True(t, handoverFound, "Expected handover tree line in buffer, got: %v", lines)
+}
+
+func TestLiveOutputModel_HandoverMetadata_ContractFailed(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	defer os.Unsetenv("NO_COLOR")
+
+	buf := NewEventBuffer(100)
+	m := NewLiveOutputModel("run-1", "pipe", buf, time.Now(), 2)
+	m.SetSize(120, 40)
+
+	// Step starts
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "implement", State: event.StateStarted},
+	})
+
+	// Contract fails
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "implement", State: "contract_failed"},
+	})
+
+	// Step completes
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "implement", State: event.StateCompleted, DurationMs: 5000},
+	})
+
+	// Verify failed contract shows in output
+	lines := buf.Lines()
+	failedFound := false
+	for _, line := range lines {
+		if strings.Contains(line, "failed") && strings.Contains(line, "contract") {
+			failedFound = true
+			break
+		}
+	}
+	assert.True(t, failedFound, "Expected contract failed line in buffer, got: %v", lines)
+}
+
+func TestLiveOutputModel_StepOrder_TracksCorrectly(t *testing.T) {
+	buf := NewEventBuffer(100)
+	m := NewLiveOutputModel("run-1", "pipe", buf, time.Now(), 3)
+
+	// Three steps start in order
+	for _, step := range []string{"specify", "plan", "implement"} {
+		m, _ = m.Update(PipelineEventMsg{
+			RunID: "run-1",
+			Event: event.Event{StepID: step, State: event.StateStarted},
+		})
+	}
+
+	assert.Equal(t, []string{"specify", "plan", "implement"}, m.stepOrder)
+
+	// Duplicate start should not add again
+	m, _ = m.Update(PipelineEventMsg{
+		RunID: "run-1",
+		Event: event.Event{StepID: "specify", State: event.StateStarted},
+	})
+	assert.Equal(t, []string{"specify", "plan", "implement"}, m.stepOrder)
+}


### PR DESCRIPTION
## Summary

Adds rich handover metadata (artifact paths, contract validation, handover arrows) to TUI live output, matching CLI's `wave run -v` output format.

**Before:**
```
[specify] Starting...
[specify] Completed (42s)
```

**After:**
```
[specify] Completed (42s)
  ├─ artifact: file:///path/to/spec.md (written)
  ├─ contract: json_schema ✓ valid
  └─ handover → step 2: plan
```

## Changes

| File | Change |
|------|--------|
| `internal/display/progress.go` | Extract `BuildHandoverLines()` as public shared function |
| `internal/tui/live_output.go` | Add handover tracking (`handoverInfo`, `stepOrder`), accumulate contract events, render tree on step completion, include in buffer rebuild |
| `internal/tui/live_output_test.go` | 3 new tests: handover metadata, contract failed, step order tracking |

## Implementation

- `BuildHandoverLines()` extracted from `BasicProgressDisplay.buildHandoverLines()` into a standalone function accepting `stepOrder []string` parameter
- `LiveOutputModel` accumulates contract validation status from `contract_passed`/`contract_failed`/`contract_soft_failure` events
- On step completion, captures artifacts from event and renders tree-formatted lines (`├─`/`└─`) into the ring buffer
- `rebuildBuffer()` also re-injects handover lines on flag toggle rebuilds

## Test plan

- [x] `TestLiveOutputModel_HandoverMetadata_OnStepCompletion` — full flow with artifacts + contract + handover
- [x] `TestLiveOutputModel_HandoverMetadata_ContractFailed` — contract failure display
- [x] `TestLiveOutputModel_StepOrder_TracksCorrectly` — step order deduplication
- [x] All existing `BuildHandoverLines` tests still pass (delegation)
- [x] `go test -race ./...` passes (all 28 packages)

Closes #289