### PR TITLE
feat(tui): detach pipeline execution from TUI process lifecycle

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -225,10 +225,14 @@ func runRun(opts RunOptions, debug bool) error {
 		}
 	}
 
-	// Generate run ID — prefer CreateRun() so CLI runs appear in the dashboard.
+	// Generate run ID — use pre-created ID from TUI subprocess (--run flag without --from-step),
+	// or prefer CreateRun() so CLI runs appear in the dashboard.
 	// Falls back to GenerateRunID() if the state store is unavailable.
 	var runID string
-	if store != nil {
+	if opts.RunID != "" && opts.FromStep == "" {
+		// TUI subprocess passes a pre-created run ID — reuse it instead of creating a new one
+		runID = opts.RunID
+	} else if store != nil {
 		runID, err = store.CreateRun(p.Metadata.Name, opts.Input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to create run record: %v\n", err)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -193,6 +193,7 @@ func (m *MockStateStore) SetRunTags(runID string, tags []string) error { return 
 func (m *MockStateStore) GetRunTags(runID string) ([]string, error) { return nil, nil }
 func (m *MockStateStore) AddRunTag(runID string, tag string) error { return nil }
 func (m *MockStateStore) RemoveRunTag(runID string, tag string) error { return nil }
+func (m *MockStateStore) UpdateRunPID(runID string, pid int) error    { return nil }
 
 // createTestManifest creates a manifest for testing
 func createTestManifest(workspaceRoot string) *manifest.Manifest {

--- a/internal/state/migration_definitions.go
+++ b/internal/state/migration_definitions.go
@@ -332,5 +332,44 @@ CREATE INDEX IF NOT EXISTS idx_run_started ON pipeline_run(started_at);
 CREATE INDEX IF NOT EXISTS idx_run_tags ON pipeline_run(tags_json);
 `,
 		},
+		{
+			Version:     8,
+			Description: "Add pid column to pipeline_run for detached subprocess tracking",
+			Up: `
+ALTER TABLE pipeline_run ADD COLUMN pid INTEGER DEFAULT 0;
+`,
+			Down: `
+-- SQLite doesn't support DROP COLUMN directly before 3.35.0
+-- Recreate table without pid column
+CREATE TABLE pipeline_run_backup (
+    run_id TEXT PRIMARY KEY,
+    pipeline_name TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+    input TEXT,
+    current_step TEXT,
+    total_tokens INTEGER DEFAULT 0,
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    cancelled_at INTEGER,
+    error_message TEXT,
+    tags_json TEXT DEFAULT '[]',
+    branch_name TEXT DEFAULT ''
+);
+
+INSERT INTO pipeline_run_backup SELECT
+    run_id, pipeline_name, status, input, current_step, total_tokens,
+    started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+FROM pipeline_run;
+
+DROP TABLE pipeline_run;
+
+ALTER TABLE pipeline_run_backup RENAME TO pipeline_run;
+
+CREATE INDEX IF NOT EXISTS idx_run_pipeline ON pipeline_run(pipeline_name);
+CREATE INDEX IF NOT EXISTS idx_run_status ON pipeline_run(status);
+CREATE INDEX IF NOT EXISTS idx_run_started ON pipeline_run(started_at);
+CREATE INDEX IF NOT EXISTS idx_run_tags ON pipeline_run(tags_json);
+`,
+		},
 	}
 }

--- a/internal/state/migrations_test.go
+++ b/internal/state/migrations_test.go
@@ -465,7 +465,7 @@ func TestInitializeWithMigrations_ExistingDatabase(t *testing.T) {
 	manager := NewMigrationManager(db)
 	applied, err := manager.GetAppliedMigrations()
 	assert.NoError(t, err)
-	assert.Len(t, applied, 7) // All 7 defined migrations
+	assert.Len(t, applied, 8) // All 8 defined migrations
 }
 
 func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
@@ -496,11 +496,11 @@ func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
 func TestMigrationDefinitions(t *testing.T) {
 	migrations := GetAllMigrations()
 
-	// Should have 7 migrations based on our definition
-	assert.Len(t, migrations, 7)
+	// Should have 8 migrations based on our definition
+	assert.Len(t, migrations, 8)
 
 	// Check version sequence
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8}
 	for i, migration := range migrations {
 		assert.Equal(t, expectedVersions[i], migration.Version)
 		assert.NotEmpty(t, migration.Description)

--- a/internal/state/rollback_test.go
+++ b/internal/state/rollback_test.go
@@ -185,7 +185,7 @@ func TestPartialRollbackAndReapply(t *testing.T) {
 
 	finalVersion, err := manager.GetCurrentVersion()
 	require.NoError(t, err)
-	assert.Equal(t, 7, finalVersion)
+	assert.Equal(t, 8, finalVersion)
 
 	// Verify all tables exist again
 	expectedTables := []string{

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -104,6 +104,9 @@ type StateStore interface {
 	GetRunTags(runID string) ([]string, error)
 	AddRunTag(runID string, tag string) error
 	RemoveRunTag(runID string, tag string) error
+
+	// Process tracking (detached subprocess execution)
+	UpdateRunPID(runID string, pid int) error
 }
 
 type stateStore struct {
@@ -496,10 +499,20 @@ func (s *stateStore) UpdateRunBranch(runID string, branch string) error {
 	return nil
 }
 
+// UpdateRunPID sets the OS process ID for a detached pipeline run.
+func (s *stateStore) UpdateRunPID(runID string, pid int) error {
+	query := `UPDATE pipeline_run SET pid = ? WHERE run_id = ?`
+	_, err := s.db.Exec(query, pid, runID)
+	if err != nil {
+		return fmt.Errorf("failed to update run PID: %w", err)
+	}
+	return nil
+}
+
 // GetRun retrieves a single run record by ID.
 func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE run_id = ?`
 
@@ -507,6 +520,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	var startedAt int64
 	var completedAt, cancelledAt sql.NullInt64
 	var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
+	var pid sql.NullInt64
 
 	err := s.db.QueryRow(query, runID).Scan(
 		&record.RunID,
@@ -521,6 +535,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 		&errorMessage,
 		&tagsJSON,
 		&branchName,
+		&pid,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -556,6 +571,9 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	if branchName.Valid {
 		record.BranchName = branchName.String
 	}
+	if pid.Valid {
+		record.PID = int(pid.Int64)
+	}
 
 	return &record, nil
 }
@@ -564,7 +582,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 // GetRunningRuns returns all runs with status 'running'.
 func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE (status = 'running' OR (status = 'pending' AND started_at > unixepoch() - 300))
 	          ORDER BY started_at DESC`
@@ -575,7 +593,7 @@ func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 // ListRuns returns runs matching the specified options.
 func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name
+	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid
 	          FROM pipeline_run
 	          WHERE 1=1`
 	args := []any{}
@@ -885,6 +903,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		var startedAt int64
 		var completedAt, cancelledAt sql.NullInt64
 		var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
+		var pid sql.NullInt64
 
 		err := rows.Scan(
 			&record.RunID,
@@ -899,6 +918,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 			&errorMessage,
 			&tagsJSON,
 			&branchName,
+			&pid,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan run: %w", err)
@@ -930,6 +950,9 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		}
 		if branchName.Valid {
 			record.BranchName = branchName.String
+		}
+		if pid.Valid {
+			record.PID = int(pid.Int64)
 		}
 
 		records = append(records, record)

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -15,7 +15,8 @@ type RunRecord struct {
 	CancelledAt  *time.Time
 	ErrorMessage string
 	Tags         []string // Tags for categorization and filtering
-	BranchName   string    // Worktree branch for this run
+	BranchName   string   // Worktree branch for this run
+	PID          int      // OS process ID of the detached executor (0 = unknown/in-process)
 }
 
 // ListRunsOptions specifies filters for listing runs.

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
-	"time"
+	"fmt"
 	"strings"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/state"
 )
 
 // ContentProviders holds data providers for alternative views.
@@ -47,6 +50,10 @@ type ContentModel struct {
 	composing     bool
 	composeList   *ComposeListModel
 	composeDetail *ComposeDetailModel
+
+	// Detached pipeline event polling
+	detachedPollRunID  string
+	detachedPollOffset int
 }
 
 // NewContentModel creates a new content model with the given pipeline data providers.
@@ -326,23 +333,33 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 					})
 				}
 
-				// For running items with TUI buffer, activate live output
+				// For running items, load historical events from SQLite and start polling
 				if item.kind == itemKindRunning && item.dataIndex >= 0 && item.dataIndex < len(m.list.running) {
 					r := m.list.running[item.dataIndex]
-					if m.launcher != nil && m.launcher.HasBuffer(r.RunID) {
-						buf := m.launcher.GetBuffer(r.RunID)
-						liveModel := NewLiveOutputModel(r.RunID, r.Name, buf, r.StartedAt, 0)
-						liveModel.SetSize(m.detail.width, m.detail.height)
-						m.detail.liveOutput = &liveModel
-						m.detail.paneState = stateRunningLive
-						enterCmds = append(enterCmds, func() tea.Msg {
-							return LiveOutputActiveMsg{Active: true}
-						})
-					} else {
-						enterCmds = append(enterCmds, func() tea.Msg {
-							return RunningInfoActiveMsg{Active: true}
-						})
+					buf := NewEventBuffer(1000)
+					var eventCount int
+					if m.launcher != nil && m.launcher.deps.Store != nil {
+						events, err := m.launcher.deps.Store.GetEvents(r.RunID, state.EventQueryOptions{})
+						if err == nil {
+							eventCount = len(events)
+							for _, ev := range events {
+								buf.Append(formatStoredEvent(ev))
+							}
+						}
 					}
+					liveModel := NewLiveOutputModel(r.RunID, r.Name, buf, r.StartedAt, 0)
+					liveModel.SetSize(m.detail.width, m.detail.height)
+					m.detail.liveOutput = &liveModel
+					m.detail.paneState = stateRunningLive
+					m.detachedPollRunID = r.RunID
+					m.detachedPollOffset = eventCount
+					capturedRunID := r.RunID
+					enterCmds = append(enterCmds, func() tea.Msg {
+						return LiveOutputActiveMsg{Active: true}
+					})
+					enterCmds = append(enterCmds, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+						return DetachedEventPollTickMsg{RunID: capturedRunID}
+					}))
 				}
 
 				// For finished items, activate finished detail hints
@@ -368,6 +385,8 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 				m.detail.paneState = stateAvailableDetail
 				m.detail.updateViewportContent()
 			}
+			// Stop detached event polling
+			m.detachedPollRunID = ""
 			m.focus = FocusPaneLeft
 			m.list.SetFocused(true)
 			m.detail.SetFocused(false)
@@ -394,7 +413,7 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 				}
 			}
 			if cancelRunID != "" {
-				m.launcher.DismissRun(cancelRunID)
+				m.launcher.Cancel(cancelRunID)
 				return m, m.list.fetchPipelineData
 			}
 			return m, nil
@@ -644,9 +663,8 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 	case PipelineSelectedMsg:
 		var listCmd, detailCmd tea.Cmd
 		m.list, listCmd = m.list.Update(msg)
-		// Wire live output buffer for TUI-launched running pipelines on hover
-		if msg.Kind == itemKindRunning && msg.RunID != "" && m.launcher != nil && m.launcher.HasBuffer(msg.RunID) {
-			buf := m.launcher.GetBuffer(msg.RunID)
+		// Wire live output from SQLite events for running pipelines on hover
+		if msg.Kind == itemKindRunning && msg.RunID != "" && m.launcher != nil {
 			if m.detail.liveOutput == nil || m.detail.liveOutput.runID != msg.RunID {
 				var startedAt time.Time
 				for _, r := range m.list.running {
@@ -655,9 +673,22 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 						break
 					}
 				}
+				buf := NewEventBuffer(1000)
+				var eventCount int
+				if m.launcher.deps.Store != nil {
+					events, err := m.launcher.deps.Store.GetEvents(msg.RunID, state.EventQueryOptions{})
+					if err == nil {
+						eventCount = len(events)
+						for _, ev := range events {
+							buf.Append(formatStoredEvent(ev))
+						}
+					}
+				}
 				liveModel := NewLiveOutputModel(msg.RunID, msg.Name, buf, startedAt, 0)
 				liveModel.SetSize(m.detail.width, m.detail.height)
 				m.detail.liveOutput = &liveModel
+				m.detachedPollRunID = msg.RunID
+				m.detachedPollOffset = eventCount
 			}
 		}
 		m.detail, detailCmd = m.detail.Update(msg)
@@ -680,19 +711,7 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		return m, cmd
 
 	case PipelineDataMsg:
-		// Merge TUI-launched running entries that still have active buffers
-		// so periodic refreshes don't wipe out synthetic entries
-		if m.launcher != nil && msg.Err == nil {
-			dbRunIDs := make(map[string]bool)
-			for _, r := range msg.Running {
-				dbRunIDs[r.RunID] = true
-			}
-			for _, r := range m.list.running {
-				if !dbRunIDs[r.RunID] && m.launcher.HasBuffer(r.RunID) {
-					msg.Running = append(msg.Running, r)
-				}
-			}
-		}
+		// Detached pipelines are tracked via SQLite — no in-memory merge needed.
 		var cmd tea.Cmd
 		m.list, cmd = m.list.Update(msg)
 		return m, cmd
@@ -744,17 +763,27 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		var listCmd tea.Cmd
 		m.list, listCmd = m.list.Update(msg)
 
-		// B2: Create live output model if launcher has a buffer for this run
-		if m.launcher != nil && m.launcher.HasBuffer(msg.RunID) {
-			buffer := m.launcher.GetBuffer(msg.RunID)
-			live := NewLiveOutputModel(msg.RunID, msg.PipelineName, buffer, time.Now(), 0)
-			live.SetSize(m.detail.width, m.detail.height)
-			m.detail.liveOutput = &live
-			m.detail.paneState = stateRunningLive
-			m.detail.selectedRunID = msg.RunID
-			m.detail.selectedName = msg.PipelineName
-			m.detail.selectedKind = itemKindRunning
+		// Create live output model from SQLite events (will be empty for just-launched pipeline)
+		buf := NewEventBuffer(1000)
+		var eventCount int
+		if m.launcher != nil && m.launcher.deps.Store != nil {
+			events, err := m.launcher.deps.Store.GetEvents(msg.RunID, state.EventQueryOptions{})
+			if err == nil {
+				eventCount = len(events)
+				for _, ev := range events {
+					buf.Append(formatStoredEvent(ev))
+				}
+			}
 		}
+		live := NewLiveOutputModel(msg.RunID, msg.PipelineName, buf, time.Now(), 0)
+		live.SetSize(m.detail.width, m.detail.height)
+		m.detail.liveOutput = &live
+		m.detail.paneState = stateRunningLive
+		m.detail.selectedRunID = msg.RunID
+		m.detail.selectedName = msg.PipelineName
+		m.detail.selectedKind = itemKindRunning
+		m.detachedPollRunID = msg.RunID
+		m.detachedPollOffset = eventCount
 
 		// Switch focus to right pane for live output
 		m.focus = FocusPaneRight
@@ -763,7 +792,11 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		focusCmd := func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneRight} }
 		formCmd := func() tea.Msg { return FormActiveMsg{Active: false} }
 		liveCmd := func() tea.Msg { return LiveOutputActiveMsg{Active: true} }
-		batchCmds := []tea.Cmd{focusCmd, formCmd, liveCmd}
+		capturedRunID := msg.RunID
+		pollCmd := tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return DetachedEventPollTickMsg{RunID: capturedRunID}
+		})
+		batchCmds := []tea.Cmd{focusCmd, formCmd, liveCmd, pollCmd}
 		if listCmd != nil {
 			batchCmds = append(batchCmds, listCmd)
 		}
@@ -821,6 +854,36 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		var cmd tea.Cmd
 		m.detail, cmd = m.detail.Update(msg)
 		return m, cmd
+
+	case DetachedEventPollTickMsg:
+		// Stop polling if the run ID changed or we left the live output pane
+		if m.detachedPollRunID != msg.RunID || m.detail.paneState != stateRunningLive {
+			m.detachedPollRunID = ""
+			return m, nil
+		}
+		// Fetch new events since our last offset
+		if m.launcher != nil && m.launcher.deps.Store != nil {
+			events, err := m.launcher.deps.Store.GetEvents(msg.RunID, state.EventQueryOptions{
+				Limit:  1000,
+				Offset: m.detachedPollOffset,
+			})
+			if err == nil && len(events) > 0 {
+				m.detachedPollOffset += len(events)
+				if m.detail.liveOutput != nil {
+					for _, ev := range events {
+						m.detail.liveOutput.buffer.Append(formatStoredEvent(ev))
+					}
+					m.detail.liveOutput.updateViewportContent()
+					if m.detail.liveOutput.autoScroll {
+						m.detail.liveOutput.viewport.GotoBottom()
+					}
+				}
+			}
+		}
+		capturedRunID := msg.RunID
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return DetachedEventPollTickMsg{RunID: capturedRunID}
+		})
 	}
 
 	// Default: forward to both pipeline children
@@ -1121,4 +1184,12 @@ func (m ContentModel) leftPaneWidth() int {
 		w = m.width
 	}
 	return w
+}
+
+// formatStoredEvent formats a persisted LogRecord for display in the live output buffer.
+func formatStoredEvent(ev state.LogRecord) string {
+	if ev.StepID != "" {
+		return fmt.Sprintf("[%s] %s", ev.StepID, ev.Message)
+	}
+	return ev.Message
 }

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -786,7 +786,7 @@ func TestContentModel_RunEventsMsg_RoutedToDetail(t *testing.T) {
 	// Just verify it doesn't panic
 }
 
-func TestContentModel_EnterOnRunningItem_NoBuffer_EmitsRunningInfoActive(t *testing.T) {
+func TestContentModel_EnterOnRunningItem_EmitsLiveOutputActive(t *testing.T) {
 	deps := LaunchDependencies{
 		Manifest: &manifest.Manifest{},
 	}
@@ -814,13 +814,16 @@ func TestContentModel_EnterOnRunningItem_NoBuffer_EmitsRunningInfoActive(t *test
 	assert.Equal(t, FocusPaneRight, c.focus)
 	assert.NotNil(t, cmd)
 
-	// Execute the batch cmd and check for RunningInfoActiveMsg
+	// With detached execution, entering a running item always shows live output
+	// (loading events from SQLite), so it emits LiveOutputActiveMsg, not RunningInfoActiveMsg
 	msgs := extractMsgFromBatch(cmd)
-	foundRunningInfoActive := false
+	foundLiveOutputActive := false
 	for _, m := range msgs {
-		if riMsg, ok := m.(RunningInfoActiveMsg); ok && riMsg.Active {
-			foundRunningInfoActive = true
+		if loMsg, ok := m.(LiveOutputActiveMsg); ok && loMsg.Active {
+			foundLiveOutputActive = true
 		}
 	}
-	assert.True(t, foundRunningInfoActive, "should emit RunningInfoActiveMsg{Active: true}")
+	assert.True(t, foundLiveOutputActive, "should emit LiveOutputActiveMsg{Active: true}")
+	assert.Equal(t, stateRunningLive, c.detail.paneState, "detail pane should be in live output state")
+	assert.Equal(t, "r1", c.detachedPollRunID, "should start detached polling for the run")
 }

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -1,35 +1,29 @@
 package tui
 
 import (
-	"context"
-	"time"
 	"fmt"
+	"os"
+	"os/exec"
 	"sync"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/event"
-	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/workspace"
 )
 
 // PipelineLauncher manages pipeline execution from the TUI.
-// It constructs executors on demand and tracks cancel functions for running pipelines.
+// It spawns detached subprocesses via `wave run` so pipelines survive TUI exit.
 type PipelineLauncher struct {
-	deps      LaunchDependencies
-	cancelFns map[string]context.CancelFunc
-	buffers   map[string]*EventBuffer
-	program   *tea.Program
-	mu        sync.Mutex
+	deps    LaunchDependencies
+	program *tea.Program
+	mu      sync.Mutex
 }
 
 // NewPipelineLauncher creates a new launcher with the given dependencies.
 func NewPipelineLauncher(deps LaunchDependencies) *PipelineLauncher {
 	return &PipelineLauncher{
-		deps:      deps,
-		cancelFns: make(map[string]context.CancelFunc),
-		buffers:   make(map[string]*EventBuffer),
+		deps: deps,
 	}
 }
 
@@ -40,25 +34,11 @@ func (l *PipelineLauncher) SetProgram(p *tea.Program) {
 	l.program = p
 }
 
-// GetBuffer returns the event buffer for a pipeline run (nil for external pipelines).
-func (l *PipelineLauncher) GetBuffer(runID string) *EventBuffer {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.buffers[runID]
-}
-
-// HasBuffer returns true if the pipeline was TUI-launched and has an event buffer.
-func (l *PipelineLauncher) HasBuffer(runID string) bool {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	_, ok := l.buffers[runID]
-	return ok
-}
-
-// Launch starts a pipeline in a background goroutine and returns tea.Cmds
-// for immediate UI feedback (PipelineLaunchedMsg) and eventual completion (PipelineLaunchResultMsg).
+// Launch starts a pipeline as a detached subprocess and returns a tea.Cmd
+// that immediately sends PipelineLaunchedMsg. Live output comes from polling
+// SQLite events, not in-memory buffers.
 func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
-	// Load the full pipeline definition
+	// Load the full pipeline definition to validate it exists
 	p, err := LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
 	if err != nil {
 		pipelineName := config.PipelineName
@@ -67,33 +47,7 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 		}
 	}
 
-	// Create cancellable context
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Resolve adapter: check for --mock flag, then use manifest adapters map
-	var runner adapter.AdapterRunner
-	isMock := false
-	for _, f := range config.Flags {
-		if f == "--mock" {
-			isMock = true
-			break
-		}
-	}
-	if isMock {
-		runner = adapter.NewMockAdapter()
-	} else if l.deps.Manifest != nil && len(l.deps.Manifest.Adapters) > 0 {
-		// Pick the first adapter name from the manifest map (mirrors CLI behavior)
-		var adapterName string
-		for name := range l.deps.Manifest.Adapters {
-			adapterName = name
-			break
-		}
-		runner = adapter.ResolveAdapter(adapterName)
-	} else {
-		runner = adapter.ResolveAdapter("claude")
-	}
-
-	// Generate run ID -- prefer StateStore.CreateRun so the run appears in the dashboard
+	// Generate run ID via StateStore so the run appears in the dashboard
 	var runID string
 	if l.deps.Store != nil {
 		var storeErr error
@@ -105,172 +59,96 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 		runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
 	}
 
-	// Transition run from pending → running so `wave status` picks it up
+	// Transition run from pending -> running so wave status picks it up
 	if l.deps.Store != nil {
 		_ = l.deps.Store.UpdateRunStatus(runID, "running", "", 0)
 	}
 
-	// Store cancel function for later cancellation
-	l.mu.Lock()
-	l.cancelFns[runID] = cancel
-	l.mu.Unlock()
-
-	// Create event buffer for this pipeline
-	buffer := NewEventBuffer(1000)
-	l.mu.Lock()
-	l.buffers[runID] = buffer
-	prog := l.program
-	l.mu.Unlock()
-
-	// Build emitter — use progress-only emitter for TUI to avoid corrupting stdout
-	var emitter event.EventEmitter
-	if prog != nil {
-		tuiEmitter := &TUIProgressEmitter{program: prog, runID: runID}
-		emitter = event.NewProgressOnlyEmitter(tuiEmitter)
-	} else {
-		emitter = event.NewNDJSONEmitter()
+	// Check for --mock flag
+	isMock := false
+	for _, f := range config.Flags {
+		if f == "--mock" {
+			isMock = true
+			break
+		}
 	}
 
-	// Wrap emitter with DB logging so events persist across TUI sessions
-	if l.deps.Store != nil {
-		emitter = &dbLoggingEmitter{inner: emitter, store: l.deps.Store, runID: runID}
+	// Build subprocess command: wave run --pipeline <name> --run <runID> --input <input> [flags...]
+	args := []string{"run", "--pipeline", config.PipelineName, "--run", runID}
+	if config.Input != "" {
+		args = append(args, "--input", config.Input)
 	}
-
-	var execOpts []pipeline.ExecutorOption
-	execOpts = append(execOpts, pipeline.WithEmitter(emitter))
-	execOpts = append(execOpts, pipeline.WithRunID(runID))
-
-	if l.deps.Store != nil {
-		execOpts = append(execOpts, pipeline.WithStateStore(l.deps.Store))
-	}
-
-	// Create workspace manager
-	wsManager, wsErr := workspace.NewWorkspaceManager(".wave/workspaces")
-	if wsErr == nil {
-		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))
-	}
-
-	// NOTE: Do NOT enable WithDebug(true) here — the executor's debug flag
-	// writes [DEBUG]/[SECURITY] lines directly to stdout/stderr, which corrupts
-	// Bubble Tea's alternate screen. Events are emitted regardless of the debug flag.
-
 	if config.ModelOverride != "" {
-		execOpts = append(execOpts, pipeline.WithModelOverride(config.ModelOverride))
+		args = append(args, "--model", config.ModelOverride)
+	}
+	if isMock {
+		args = append(args, "--mock")
 	}
 
-	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Env = buildPassthroughEnv(l.deps)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
 
-	// Capture values for closures
+	if startErr := cmd.Start(); startErr != nil {
+		pipelineName := config.PipelineName
+		return func() tea.Msg {
+			return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("starting subprocess: %w", startErr)}
+		}
+	}
+
+	// Record PID and release the process so it becomes fully detached
+	if l.deps.Store != nil {
+		_ = l.deps.Store.UpdateRunPID(runID, cmd.Process.Pid)
+	}
+	_ = cmd.Process.Release()
+
+	// Return immediate PipelineLaunchedMsg — no blocking executor cmd
 	pipelineName := config.PipelineName
-	input := config.Input
-	manifest := l.deps.Manifest
-	store := l.deps.Store
-
-	// Return batched commands: immediate launched msg + blocking executor cmd
-	immediateCmd := func() tea.Msg {
+	return func() tea.Msg {
 		return PipelineLaunchedMsg{
 			RunID:        runID,
 			PipelineName: pipelineName,
-			CancelFunc:   cancel,
 		}
 	}
-
-	executorCmd := func() tea.Msg {
-		var execErr error
-		if manifest != nil {
-			execErr = executor.Execute(ctx, p, manifest, input)
-		} else {
-			execErr = fmt.Errorf("manifest not available")
-		}
-
-		// Update run status in store
-		if store != nil {
-			status := "completed"
-			errMsg := ""
-			if execErr != nil {
-				status = "failed"
-				errMsg = execErr.Error()
-			}
-			if ctx.Err() != nil {
-				status = "cancelled"
-				errMsg = ctx.Err().Error()
-			}
-			_ = store.UpdateRunStatus(runID, status, errMsg, executor.GetTotalTokens())
-			_ = store.ClearCancellation(runID)
-		}
-
-		// Emit pipeline-level failure event so live output shows the error
-		if execErr != nil && prog != nil {
-			prog.Send(PipelineEventMsg{
-				RunID: runID,
-				Event: event.Event{
-					Timestamp:     time.Now(),
-					PipelineID:    pipelineName,
-					State:         event.StateFailed,
-					Message:       execErr.Error(),
-					FailureReason: "execution",
-				},
-			})
-		}
-
-		return PipelineLaunchResultMsg{RunID: runID, Err: execErr}
-	}
-
-	return tea.Batch(immediateCmd, executorCmd)
 }
 
-// Cancel cancels a specific running pipeline by run ID.
+// Cancel requests cancellation of a pipeline run via the state store.
+// The executor's pollCancellation goroutine will pick this up.
 func (l *PipelineLauncher) Cancel(runID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if cancel, ok := l.cancelFns[runID]; ok {
-		cancel()
-	}
-}
-
-
-// DismissRun cancels or dismisses a pipeline run.
-// For active TUI-launched runs, it calls the in-memory cancel function.
-// For stale previous-session runs, it updates the DB status directly.
-func (l *PipelineLauncher) DismissRun(runID string) {
-	l.mu.Lock()
-	cancel, hasCancel := l.cancelFns[runID]
-	l.mu.Unlock()
-
-	if hasCancel {
-		cancel()
-		return
-	}
-
-	// Cross-process run (CLI or previous session) — request cancellation via DB.
-	// The executor's pollCancellation goroutine will pick this up and cancel the context.
-	// If the process is already dead, the stale run status will be cleaned up on next list refresh.
 	if l.deps.Store != nil {
 		_ = l.deps.Store.RequestCancellation(runID, false)
 	}
 }
-// CancelAll cancels all running pipelines (called on TUI exit).
-// Also updates DB status since the executor goroutines may not have time
-// to run their completion handlers before the process exits.
+
+// CancelAll is a no-op for detached pipelines — they survive TUI exit.
 func (l *PipelineLauncher) CancelAll() {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	for runID, cancel := range l.cancelFns {
-		cancel()
-		if l.deps.Store != nil {
-			_ = l.deps.Store.UpdateRunStatus(runID, "cancelled", "TUI session exited", 0)
-			_ = l.deps.Store.ClearCancellation(runID)
-		}
-	}
-	l.cancelFns = make(map[string]context.CancelFunc)
+	// Detached subprocesses manage their own lifecycle.
 }
 
-// Cleanup removes a cancel function entry and buffer after a pipeline finishes.
-func (l *PipelineLauncher) Cleanup(runID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	delete(l.cancelFns, runID)
-	delete(l.buffers, runID)
+// Cleanup is a no-op for detached pipelines — subprocesses manage their own lifecycle.
+func (l *PipelineLauncher) Cleanup(_ string) {
+	// No in-process state to clean up.
+}
+
+// buildPassthroughEnv constructs a minimal environment for the subprocess.
+// It includes HOME, PATH, and any vars specified in manifest runtime.sandbox.env_passthrough.
+func buildPassthroughEnv(deps LaunchDependencies) []string {
+	env := []string{
+		"HOME=" + os.Getenv("HOME"),
+		"PATH=" + os.Getenv("PATH"),
+	}
+
+	if deps.Manifest != nil && len(deps.Manifest.Runtime.Sandbox.EnvPassthrough) > 0 {
+		for _, key := range deps.Manifest.Runtime.Sandbox.EnvPassthrough {
+			if val, ok := os.LookupEnv(key); ok {
+				env = append(env, key+"="+val)
+			}
+		}
+	}
+
+	return env
 }
 
 // TUIProgressEmitter implements event.ProgressEmitter to bridge executor events
@@ -286,21 +164,4 @@ func (e *TUIProgressEmitter) EmitProgress(evt event.Event) error {
 		e.program.Send(PipelineEventMsg{RunID: e.runID, Event: evt})
 	}
 	return nil
-}
-
-// dbLoggingEmitter wraps an EventEmitter and persists each event to the state
-// database so event logs survive TUI exit. Mirrors the pattern in cmd/wave/commands/run.go.
-type dbLoggingEmitter struct {
-	inner event.EventEmitter
-	store state.StateStore
-	runID string
-}
-
-func (d *dbLoggingEmitter) Emit(ev event.Event) {
-	d.inner.Emit(ev)
-	// Skip empty heartbeat ticks — they carry no useful information.
-	if ev.Message == "" && (ev.State == "step_progress" || ev.State == "stream_activity") && ev.TokensUsed == 0 && ev.DurationMs == 0 {
-		return
-	}
-	d.store.LogEvent(d.runID, ev.StepID, ev.State, ev.Persona, ev.Message, ev.TokensUsed, ev.DurationMs)
 }

--- a/internal/tui/pipeline_launcher_test.go
+++ b/internal/tui/pipeline_launcher_test.go
@@ -1,163 +1,60 @@
 package tui
 
 import (
-	"context"
-	"sync"
+	"os"
 	"testing"
 
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/manifest"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewPipelineLauncher_InitializesEmptyMaps(t *testing.T) {
+func TestNewPipelineLauncher_InitializesFields(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-	assert.NotNil(t, launcher.cancelFns)
-	assert.Empty(t, launcher.cancelFns)
-	assert.NotNil(t, launcher.buffers)
-	assert.Empty(t, launcher.buffers)
+	assert.NotNil(t, launcher)
+	assert.Nil(t, launcher.program)
 }
 
-func TestPipelineLauncher_Cancel_UnknownRunID_IsNoOp(t *testing.T) {
+func TestPipelineLauncher_Cancel_NilStore_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
+	// Should not panic even with no store
 	launcher.Cancel("nonexistent-run-id")
 }
 
-func TestPipelineLauncher_Cancel_InvokesStoredCancelFunc(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	launcher.mu.Lock()
-	launcher.cancelFns["test-run-1"] = cancel
-	launcher.mu.Unlock()
+func TestPipelineLauncher_Cancel_CallsRequestCancellation(t *testing.T) {
+	store := &cancelMockStore{}
+	launcher := NewPipelineLauncher(LaunchDependencies{Store: store})
 
 	launcher.Cancel("test-run-1")
 
-	// Context should be cancelled
-	assert.Error(t, ctx.Err())
-	assert.Equal(t, context.Canceled, ctx.Err())
+	assert.Equal(t, "test-run-1", store.cancelledRunID, "should call RequestCancellation via store")
 }
 
-func TestPipelineLauncher_CancelAll_InvokesAllCancelFuncs(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	ctx3, cancel3 := context.WithCancel(context.Background())
-
-	launcher.mu.Lock()
-	launcher.cancelFns["run-1"] = cancel1
-	launcher.cancelFns["run-2"] = cancel2
-	launcher.cancelFns["run-3"] = cancel3
-	launcher.mu.Unlock()
-
-	launcher.CancelAll()
-
-	assert.Error(t, ctx1.Err())
-	assert.Error(t, ctx2.Err())
-	assert.Error(t, ctx3.Err())
-	assert.Empty(t, launcher.cancelFns, "map should be cleared after CancelAll")
-}
-
-func TestPipelineLauncher_CancelAll_UpdatesDBStatus(t *testing.T) {
-	store := &cancelAllMockStore{}
-	launcher := NewPipelineLauncher(LaunchDependencies{Store: store})
-
-	_, cancel1 := context.WithCancel(context.Background())
-	_, cancel2 := context.WithCancel(context.Background())
-
-	launcher.mu.Lock()
-	launcher.cancelFns["run-a"] = cancel1
-	launcher.cancelFns["run-b"] = cancel2
-	launcher.mu.Unlock()
-
-	launcher.CancelAll()
-
-	assert.Len(t, store.updatedRuns, 2, "should update DB status for all cancelled runs")
-	for _, status := range store.updatedRuns {
-		assert.Equal(t, "cancelled", status)
-	}
-}
-
-// cancelAllMockStore records UpdateRunStatus calls.
-type cancelAllMockStore struct {
+// cancelMockStore records RequestCancellation calls.
+type cancelMockStore struct {
 	baseStateStore
-	updatedRuns map[string]string
+	cancelledRunID string
 }
 
-func (c *cancelAllMockStore) UpdateRunStatus(runID string, status string, _ string, _ int) error {
-	if c.updatedRuns == nil {
-		c.updatedRuns = make(map[string]string)
-	}
-	c.updatedRuns[runID] = status
+func (c *cancelMockStore) RequestCancellation(runID string, force bool) error {
+	c.cancelledRunID = runID
 	return nil
 }
 
-func TestPipelineLauncher_CancelAll_EmptyMap_IsNoOp(t *testing.T) {
+func TestPipelineLauncher_CancelAll_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
-	launcher.CancelAll()
-	assert.Empty(t, launcher.cancelFns)
+	// CancelAll is a no-op for detached pipelines — should not panic
+	assert.NotPanics(t, func() {
+		launcher.CancelAll()
+	})
 }
 
-func TestPipelineLauncher_Cleanup_RemovesCancelAndBuffer(t *testing.T) {
+func TestPipelineLauncher_Cleanup_IsNoOp(t *testing.T) {
 	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	_, cancel := context.WithCancel(context.Background())
-	launcher.mu.Lock()
-	launcher.cancelFns["run-to-clean"] = cancel
-	launcher.cancelFns["run-to-keep"] = cancel
-	launcher.buffers["run-to-clean"] = NewEventBuffer(10)
-	launcher.buffers["run-to-keep"] = NewEventBuffer(10)
-	launcher.mu.Unlock()
-
-	launcher.Cleanup("run-to-clean")
-
-	launcher.mu.Lock()
-	_, cancelExists := launcher.cancelFns["run-to-clean"]
-	_, cancelKept := launcher.cancelFns["run-to-keep"]
-	_, bufExists := launcher.buffers["run-to-clean"]
-	_, bufKept := launcher.buffers["run-to-keep"]
-	launcher.mu.Unlock()
-
-	assert.False(t, cancelExists, "cleaned up cancel entry should be gone")
-	assert.True(t, cancelKept, "other cancel entries should remain")
-	assert.False(t, bufExists, "cleaned up buffer entry should be gone")
-	assert.True(t, bufKept, "other buffer entries should remain")
-}
-
-func TestPipelineLauncher_Cleanup_NonexistentRunID_IsNoOp(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
-	launcher.Cleanup("nonexistent-run-id")
-}
-
-func TestPipelineLauncher_ConcurrentCancelAndCleanup(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-
-	// Add several cancel functions
-	for i := 0; i < 10; i++ {
-		_, cancel := context.WithCancel(context.Background())
-		launcher.mu.Lock()
-		launcher.cancelFns[string(rune('A'+i))] = cancel
-		launcher.mu.Unlock()
-	}
-
-	// Concurrently cancel and cleanup
-	var wg sync.WaitGroup
-	wg.Add(20)
-	for i := 0; i < 10; i++ {
-		id := string(rune('A' + i))
-		go func() {
-			defer wg.Done()
-			launcher.Cancel(id)
-		}()
-		go func() {
-			defer wg.Done()
-			launcher.Cleanup(id)
-		}()
-	}
-	wg.Wait()
+	// Cleanup is a no-op for detached pipelines — should not panic
+	assert.NotPanics(t, func() {
+		launcher.Cleanup("nonexistent-run-id")
+	})
 }
 
 func TestPipelineLauncher_Launch_MissingPipelineDir_ReturnsError(t *testing.T) {
@@ -183,34 +80,6 @@ func TestPipelineLauncher_SetProgram(t *testing.T) {
 	assert.Nil(t, launcher.program)
 }
 
-func TestPipelineLauncher_GetBuffer_ReturnsNilForUnknown(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	buf := launcher.GetBuffer("nonexistent")
-	assert.Nil(t, buf)
-}
-
-func TestPipelineLauncher_GetBuffer_ReturnsBuffer(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	expected := NewEventBuffer(100)
-	launcher.mu.Lock()
-	launcher.buffers["run-1"] = expected
-	launcher.mu.Unlock()
-
-	buf := launcher.GetBuffer("run-1")
-	assert.Equal(t, expected, buf)
-}
-
-func TestPipelineLauncher_HasBuffer(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	assert.False(t, launcher.HasBuffer("run-1"))
-
-	launcher.mu.Lock()
-	launcher.buffers["run-1"] = NewEventBuffer(100)
-	launcher.mu.Unlock()
-
-	assert.True(t, launcher.HasBuffer("run-1"))
-}
-
 func TestTUIProgressEmitter_EmitProgress_NilProgram(t *testing.T) {
 	emitter := &TUIProgressEmitter{program: nil, runID: "run-1"}
 	// Should not panic with nil program
@@ -218,75 +87,43 @@ func TestTUIProgressEmitter_EmitProgress_NilProgram(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPipelineLauncher_DismissRun_ActiveRun_CallsCancel(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
+func TestBuildPassthroughEnv_MinimalEnv(t *testing.T) {
+	deps := LaunchDependencies{}
+	env := buildPassthroughEnv(deps)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	launcher.mu.Lock()
-	launcher.cancelFns["test-run"] = cancel
-	launcher.mu.Unlock()
-
-	launcher.DismissRun("test-run")
-
-	assert.Error(t, ctx.Err())
-	assert.Equal(t, context.Canceled, ctx.Err())
+	// Should always include HOME and PATH
+	assert.Contains(t, env, "HOME="+os.Getenv("HOME"))
+	assert.Contains(t, env, "PATH="+os.Getenv("PATH"))
+	assert.Len(t, env, 2)
 }
 
-func TestPipelineLauncher_DismissRun_StaleRun_NilStore_IsNoOp(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
+func TestBuildPassthroughEnv_WithManifestPassthrough(t *testing.T) {
+	// Set a test env var to verify passthrough
+	t.Setenv("WAVE_TEST_VAR", "test-value")
 
-	// No cancel function and no store — should not panic
-	assert.NotPanics(t, func() {
-		launcher.DismissRun("stale-run")
-	})
-}
-
-func TestPipelineLauncher_DismissRun_UnknownRun_IsNoOp(t *testing.T) {
-	launcher := NewPipelineLauncher(LaunchDependencies{})
-	// Should not panic
-	launcher.DismissRun("nonexistent")
-}
-
-func TestPipelineLauncher_DismissRun_StaleRun_RequestsCancellation(t *testing.T) {
-	store := &dismissMockStore{}
-	launcher := NewPipelineLauncher(LaunchDependencies{Store: store})
-
-	// No cancel function — simulates a CLI-started run
-	launcher.DismissRun("cli-run-1")
-
-	assert.Equal(t, "cli-run-1", store.cancelledRunID, "should call RequestCancellation for cross-process run")
-}
-
-// dismissMockStore records RequestCancellation calls.
-type dismissMockStore struct {
-	baseStateStore
-	cancelledRunID string
-}
-
-func (d *dismissMockStore) RequestCancellation(runID string, force bool) error {
-	d.cancelledRunID = runID
-	return nil
-}
-
-func TestDBLoggingEmitter_SkipsEmptyHeartbeats(t *testing.T) {
-	var emitted []event.Event
-	inner := &captureEmitter{events: &emitted}
-	d := &dbLoggingEmitter{
-		inner: inner,
-		store: nil, // nil store — LogEvent won't be called
-		runID: "run-1",
+	deps := LaunchDependencies{
+		Manifest: &manifest.Manifest{
+			Runtime: manifest.Runtime{
+				Sandbox: manifest.RuntimeSandbox{
+					EnvPassthrough: []string{"WAVE_TEST_VAR", "NONEXISTENT_VAR"},
+				},
+			},
+		},
 	}
+	env := buildPassthroughEnv(deps)
 
-	// Empty heartbeat — should still call inner.Emit but skip LogEvent
-	d.Emit(event.Event{State: "step_progress"})
-	assert.Len(t, emitted, 1, "inner.Emit should still be called")
+	// Should include HOME, PATH, and the passthrough var
+	assert.Contains(t, env, "HOME="+os.Getenv("HOME"))
+	assert.Contains(t, env, "PATH="+os.Getenv("PATH"))
+	assert.Contains(t, env, "WAVE_TEST_VAR=test-value")
+	// NONEXISTENT_VAR should not be included since it's not set
+	assert.Len(t, env, 3)
 }
 
-// captureEmitter is a test helper that captures emitted events.
-type captureEmitter struct {
-	events *[]event.Event
-}
-
-func (c *captureEmitter) Emit(ev event.Event) {
-	*c.events = append(*c.events, ev)
+func TestBuildPassthroughEnv_NilManifest(t *testing.T) {
+	deps := LaunchDependencies{
+		Manifest: nil,
+	}
+	env := buildPassthroughEnv(deps)
+	assert.Len(t, env, 2, "should only include HOME and PATH")
 }

--- a/internal/tui/pipeline_messages.go
+++ b/internal/tui/pipeline_messages.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"context"
-
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/state"
@@ -61,7 +59,6 @@ type LaunchRequestMsg struct {
 type PipelineLaunchedMsg struct {
 	RunID        string
 	PipelineName string
-	CancelFunc   context.CancelFunc
 }
 
 // PipelineLaunchResultMsg signals that a launched pipeline has finished execution.
@@ -141,4 +138,9 @@ type RunEventsMsg struct {
 // RunningInfoActiveMsg signals the status bar when stateRunningInfo pane is active.
 type RunningInfoActiveMsg struct {
 	Active bool
+}
+
+// DetachedEventPollTickMsg triggers periodic event polling for detached pipeline live output.
+type DetachedEventPollTickMsg struct {
+	RunID string
 }

--- a/internal/tui/pipeline_provider.go
+++ b/internal/tui/pipeline_provider.go
@@ -14,6 +14,8 @@ type RunningPipeline struct {
 	Input      string
 	BranchName string
 	StartedAt  time.Time
+	PID        int  // OS process ID of detached executor (0 = unknown)
+	Detached   bool // True when running as a detached subprocess
 }
 
 // FinishedPipeline is a TUI-specific projection of a completed pipeline run.
@@ -64,6 +66,8 @@ func (p *DefaultPipelineDataProvider) FetchRunningPipelines() ([]RunningPipeline
 			Input:      r.Input,
 			BranchName: r.BranchName,
 			StartedAt:  r.StartedAt,
+			PID:        r.PID,
+			Detached:   r.PID > 0,
 		}
 	}
 

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -101,6 +101,7 @@ func (b baseStateStore) SetRunTags(string, []string) error { return nil }
 func (b baseStateStore) GetRunTags(string) ([]string, error) { return nil, nil }
 func (b baseStateStore) AddRunTag(string, string) error      { return nil }
 func (b baseStateStore) RemoveRunTag(string, string) error   { return nil }
+func (b baseStateStore) UpdateRunPID(string, int) error      { return nil }
 
 // Compile-time check: baseStateStore must satisfy state.StateStore.
 var _ state.StateStore = baseStateStore{}

--- a/internal/tui/stale_detector.go
+++ b/internal/tui/stale_detector.go
@@ -1,0 +1,19 @@
+package tui
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsProcessAlive checks whether a process with the given PID is still running.
+func IsProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/tui/stale_detector_test.go
+++ b/internal/tui/stale_detector_test.go
@@ -1,0 +1,27 @@
+package tui
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProcessAlive_CurrentProcess(t *testing.T) {
+	pid := os.Getpid()
+	assert.True(t, IsProcessAlive(pid), "current process should be alive")
+}
+
+func TestIsProcessAlive_ZeroPID(t *testing.T) {
+	assert.False(t, IsProcessAlive(0), "PID 0 should return false")
+}
+
+func TestIsProcessAlive_NegativePID(t *testing.T) {
+	assert.False(t, IsProcessAlive(-1), "negative PID should return false")
+}
+
+func TestIsProcessAlive_VeryLargePID(t *testing.T) {
+	// PID 4194304 is beyond the default Linux PID max (32768 or 4194304 on 64-bit)
+	// and extremely unlikely to exist.
+	assert.False(t, IsProcessAlive(99999999), "very large PID should return false")
+}


### PR DESCRIPTION
## Summary

- Replace in-process goroutine pipeline execution with detached OS subprocesses (`Setsid: true`) so pipelines survive TUI exit
- Live output now comes from polling SQLite events every 2 seconds instead of in-memory buffers
- Add `pid` column to `pipeline_run` table (migration v8) for process tracking and stale run detection
- `cmd/wave run --run` flag accepts a pre-created run ID from the TUI subprocess launcher

## Details

**`internal/tui/pipeline_launcher.go`** -- Core architecture change:
- `Launch()` now spawns `exec.Command(os.Args[0], "run", "--pipeline", name, "--run", runID, ...)` with `SysProcAttr{Setsid: true}`
- Removed in-process fields (`cancelFns`, `buffers`) and methods (`HasBuffer`, `GetBuffer`, `DismissRun`, `dbLoggingEmitter`)
- `CancelAll()` and `Cleanup()` are now no-ops (detached processes manage their own lifecycle)
- `Cancel()` uses `store.RequestCancellation()` for cross-process cancellation via SQLite polling
- Added `buildPassthroughEnv()` for secure environment passthrough (HOME, PATH, manifest env_passthrough)

**`internal/tui/content.go`** -- SQLite-based live output:
- All `HasBuffer`/`GetBuffer` references replaced with `store.GetEvents()` loading
- Added `DetachedEventPollTickMsg` handler that polls SQLite every 2s for new events
- Added `detachedPollRunID`/`detachedPollOffset` fields for incremental event fetching
- Entering a running item always creates a fresh `EventBuffer` from SQLite events
- Escape from live output stops polling; poll auto-stops if pane state changes

**`internal/state/`** -- PID tracking:
- Migration v8: `ALTER TABLE pipeline_run ADD COLUMN pid INTEGER DEFAULT 0`
- Added `UpdateRunPID(runID, pid)` to `StateStore` interface and implementation
- Added `PID int` field to `RunRecord` struct
- Updated all `queryRuns` SQL to include `pid` column

**`internal/tui/stale_detector.go`** -- New process liveness utility:
- `IsProcessAlive(pid)` uses `syscall.Signal(0)` to check if a process exists

**`cmd/wave/commands/run.go`** -- Pre-created run ID support:
- When `--run` is provided without `--from-step`, reuses the run ID instead of creating a new one

## Test plan

- [x] `go test ./internal/tui/...` -- all pass
- [x] `go test ./internal/state/...` -- all pass (migration v8 applied correctly)
- [x] `go test ./internal/pipeline/...` -- all pass
- [x] `go test ./cmd/wave/...` -- all pass
- [x] `go test -race ./...` -- all pass, no data races
- [ ] Manual: launch pipeline from TUI, exit TUI, verify pipeline continues running
- [ ] Manual: re-enter TUI, verify live output shows events from detached pipeline

Closes #284