### PR TITLE
feat(tui): add issue browser and pipeline chooser dialog

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/recinq/wave/internal/github"
 	"github.com/recinq/wave/internal/state"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -144,6 +145,13 @@ func RunTUI(deps LaunchDependencies) error {
 	}
 	if deps.Manifest != nil || deps.Store != nil {
 		cp.HealthProvider = NewDefaultHealthDataProvider(deps.Manifest, deps.Store, deps.PipelinesDir)
+	}
+	if deps.Manifest != nil && deps.Manifest.Metadata.Repo != "" {
+		token := resolveGitHubToken()
+		if token != "" {
+			ghClient := github.NewClient(github.ClientConfig{Token: token})
+			cp.IssueProvider = NewDefaultIssueDataProvider(ghClient, deps.Manifest)
+		}
 	}
 
 	// Build pipeline and detail providers from dependencies

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -16,6 +16,7 @@ type ContentProviders struct {
 	ContractProvider ContractDataProvider
 	SkillProvider    SkillDataProvider
 	HealthProvider   HealthDataProvider
+	IssueProvider    IssueDataProvider
 }
 
 // ContentModel is the main content area component composing a left pipeline list pane and a right detail pane.
@@ -39,12 +40,15 @@ type ContentModel struct {
 	skillDetail    *SkillDetailModel
 	healthList     *HealthListModel
 	healthDetail   *HealthDetailModel
+	issueList      *IssueListModel
+	issueDetail    *IssueDetailModel
 
 	// Data providers for alternative views
 	personaProvider  PersonaDataProvider
 	contractProvider ContractDataProvider
 	skillProvider    SkillDataProvider
 	healthProvider   HealthDataProvider
+	issueProvider    IssueDataProvider
 
 	// Compose mode (nil when inactive)
 	composing     bool
@@ -77,6 +81,7 @@ func NewContentModel(provider PipelineDataProvider, detailProvider DetailDataPro
 		m.contractProvider = p.ContractProvider
 		m.skillProvider = p.SkillProvider
 		m.healthProvider = p.HealthProvider
+		m.issueProvider = p.IssueProvider
 	}
 
 	return m
@@ -93,6 +98,8 @@ func (m ContentModel) IsFiltering() bool {
 		return m.contractList != nil && m.contractList.filtering
 	case ViewSkills:
 		return m.skillList != nil && m.skillList.filtering
+	case ViewIssues:
+		return m.issueList != nil && m.issueList.filtering
 	}
 	return false
 }
@@ -153,6 +160,12 @@ func (m *ContentModel) SetSize(w, h int) {
 	if m.healthDetail != nil {
 		m.healthDetail.SetSize(rightWidth, m.childHeight())
 	}
+	if m.issueList != nil {
+		m.issueList.SetSize(leftWidth, m.childHeight())
+	}
+	if m.issueDetail != nil {
+		m.issueDetail.SetSize(rightWidth, m.childHeight())
+	}
 	if m.composeList != nil {
 		m.composeList.SetSize(leftWidth, m.childHeight())
 	}
@@ -163,7 +176,7 @@ func (m *ContentModel) SetSize(w, h int) {
 
 // cycleView moves to the next view and returns init commands if the view was just created.
 func (m *ContentModel) cycleView() tea.Cmd {
-	m.currentView = (m.currentView + 1) % 5
+	m.currentView = (m.currentView + 1) % 6
 	m.focus = FocusPaneLeft
 
 	var initCmd tea.Cmd
@@ -243,6 +256,27 @@ func (m *ContentModel) cycleView() tea.Cmd {
 		if m.healthDetail != nil {
 			m.healthDetail.SetFocused(false)
 		}
+
+	case ViewIssues:
+		if m.issueList == nil && m.issueProvider != nil {
+			il := NewIssueListModel(m.issueProvider)
+			il.SetSize(leftWidth, m.childHeight())
+			m.issueList = &il
+			id := NewIssueDetailModel()
+			id.SetSize(rightWidth, m.childHeight())
+			// Populate available pipelines for the chooser
+			if m.list.available != nil {
+				id.SetPipelines(m.list.available)
+			}
+			m.issueDetail = &id
+			initCmd = m.issueList.Init()
+		}
+		if m.issueList != nil {
+			m.issueList.SetFocused(true)
+		}
+		if m.issueDetail != nil {
+			m.issueDetail.SetFocused(false)
+		}
 	}
 
 	batchCmds := []tea.Cmd{
@@ -268,7 +302,7 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 				return m, nil
 			}
 			// Decrement twice: once to undo the +1 in cycleView, once for the actual back
-			m.currentView = (m.currentView + 3) % 5 // net effect: -1 after cycleView adds +1
+			m.currentView = (m.currentView + 4) % 6 // net effect: -1 after cycleView adds +1
 			cmd := m.cycleView()
 			return m, cmd
 		}
@@ -633,6 +667,50 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 
+	case IssueDataMsg:
+		if m.issueList != nil {
+			var cmd tea.Cmd
+			*m.issueList, cmd = m.issueList.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
+	case IssueSelectedMsg:
+		if m.issueList != nil {
+			var listCmd tea.Cmd
+			*m.issueList, listCmd = m.issueList.Update(msg)
+			if listCmd != nil {
+				cmds = append(cmds, listCmd)
+			}
+		}
+		if m.issueDetail != nil && m.issueList != nil {
+			if msg.Index >= 0 && msg.Index < len(m.issueList.navigable) {
+				issue := m.issueList.navigable[msg.Index]
+				m.issueDetail.SetIssue(&issue)
+			}
+		}
+		return m, tea.Batch(cmds...)
+
+	case IssueLaunchMsg:
+		// Convert to a LaunchRequestMsg and switch to Pipelines view
+		m.currentView = ViewPipelines
+		m.focus = FocusPaneLeft
+		m.list.SetFocused(true)
+		m.detail.SetFocused(false)
+		launchCmd := func() tea.Msg {
+			return LaunchRequestMsg{Config: LaunchConfig{
+				PipelineName: msg.PipelineName,
+				Input:        msg.IssueURL,
+			}}
+		}
+		viewCmd := func() tea.Msg {
+			return ViewChangedMsg{View: ViewPipelines}
+		}
+		focusCmd := func() tea.Msg {
+			return FocusChangedMsg{Pane: FocusPaneLeft}
+		}
+		return m, tea.Batch(launchCmd, viewCmd, focusCmd)
+
 	case HealthCheckResultMsg:
 		if m.healthList != nil {
 			var listCmd tea.Cmd
@@ -932,6 +1010,13 @@ func (m ContentModel) handleAlternativeViewEnter() (ContentModel, tea.Cmd) {
 		if m.healthDetail != nil {
 			m.healthDetail.SetFocused(true)
 		}
+	case ViewIssues:
+		if m.issueList != nil {
+			m.issueList.SetFocused(false)
+		}
+		if m.issueDetail != nil {
+			m.issueDetail.SetFocused(true)
+		}
 	}
 
 	return m, func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneRight} }
@@ -970,6 +1055,13 @@ func (m ContentModel) handleAlternativeViewEscape() (ContentModel, tea.Cmd) {
 		if m.healthDetail != nil {
 			m.healthDetail.SetFocused(false)
 		}
+	case ViewIssues:
+		if m.issueList != nil {
+			m.issueList.SetFocused(true)
+		}
+		if m.issueDetail != nil {
+			m.issueDetail.SetFocused(false)
+		}
 	}
 
 	return m, func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneLeft} }
@@ -1006,6 +1098,12 @@ func (m ContentModel) routeToActiveList(msg tea.Msg) (ContentModel, tea.Cmd) {
 			*m.healthList, cmd = m.healthList.Update(msg)
 			return m, cmd
 		}
+	case ViewIssues:
+		if m.issueList != nil {
+			var cmd tea.Cmd
+			*m.issueList, cmd = m.issueList.Update(msg)
+			return m, cmd
+		}
 	}
 	return m, nil
 }
@@ -1039,6 +1137,12 @@ func (m ContentModel) routeToActiveDetail(msg tea.Msg) (ContentModel, tea.Cmd) {
 		if m.healthDetail != nil {
 			var cmd tea.Cmd
 			*m.healthDetail, cmd = m.healthDetail.Update(msg)
+			return m, cmd
+		}
+	case ViewIssues:
+		if m.issueDetail != nil {
+			var cmd tea.Cmd
+			*m.issueDetail, cmd = m.issueDetail.Update(msg)
 			return m, cmd
 		}
 	}
@@ -1118,6 +1222,18 @@ func (m ContentModel) View() string {
 			rightView = m.healthDetail.View()
 		} else {
 			rightView = renderPlaceholder(m.width-m.leftPaneWidth()-3, m.height, "Select a health check to view details")
+		}
+
+	case ViewIssues:
+		if m.issueList != nil {
+			leftView = m.issueList.View()
+		} else {
+			leftView = renderPlaceholder(m.leftPaneWidth(), m.height, "No repository configured")
+		}
+		if m.issueDetail != nil {
+			rightView = m.issueDetail.View()
+		} else {
+			rightView = renderPlaceholder(m.width-m.leftPaneWidth()-3, m.height, "Select an issue to view details")
 		}
 	}
 

--- a/internal/tui/issue_detail.go
+++ b/internal/tui/issue_detail.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// IssueDetailModel is the right pane model for the Issues view.
+type IssueDetailModel struct {
+	width          int
+	height         int
+	focused        bool
+	viewport       viewport.Model
+	selected       *IssueData
+	pipelines      []PipelineInfo
+	chooserActive  bool
+	chooserCursor  int
+	pipelinesDir   string
+}
+
+// NewIssueDetailModel creates a new issue detail model.
+func NewIssueDetailModel() IssueDetailModel {
+	return IssueDetailModel{
+		viewport: viewport.New(0, 0),
+	}
+}
+
+// Init returns nil.
+func (m IssueDetailModel) Init() tea.Cmd {
+	return nil
+}
+
+// SetSize updates the model dimensions.
+func (m *IssueDetailModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+	m.viewport.Width = w
+	m.viewport.Height = h
+	if m.selected != nil {
+		m.updateContent()
+	}
+}
+
+// SetFocused updates the focused state.
+func (m *IssueDetailModel) SetFocused(focused bool) {
+	m.focused = focused
+}
+
+// SetIssue sets the selected issue and updates the viewport.
+func (m *IssueDetailModel) SetIssue(issue *IssueData) {
+	m.selected = issue
+	m.chooserActive = false
+	m.chooserCursor = 0
+	m.updateContent()
+	m.viewport.GotoTop()
+}
+
+// SetPipelines sets the available pipelines for the chooser.
+func (m *IssueDetailModel) SetPipelines(pipelines []PipelineInfo) {
+	m.pipelines = pipelines
+}
+
+// Update handles messages.
+func (m IssueDetailModel) Update(msg tea.Msg) (IssueDetailModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if !m.focused {
+			return m, nil
+		}
+
+		if m.chooserActive {
+			return m.handleChooserKey(msg)
+		}
+
+		// Enter activates the pipeline chooser when an issue is selected
+		if msg.Type == tea.KeyEnter && m.selected != nil && len(m.pipelines) > 0 {
+			m.chooserActive = true
+			m.chooserCursor = 0
+			m.updateContent()
+			return m, nil
+		}
+
+		// Default: scroll viewport
+		var cmd tea.Cmd
+		m.viewport, cmd = m.viewport.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m IssueDetailModel) handleChooserKey(msg tea.KeyMsg) (IssueDetailModel, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.chooserCursor > 0 {
+			m.chooserCursor--
+			m.updateContent()
+		}
+		return m, nil
+
+	case tea.KeyDown:
+		if m.chooserCursor < len(m.pipelines)-1 {
+			m.chooserCursor++
+			m.updateContent()
+		}
+		return m, nil
+
+	case tea.KeyEnter:
+		if m.chooserCursor < len(m.pipelines) && m.selected != nil {
+			pipeline := m.pipelines[m.chooserCursor]
+			issueURL := m.selected.HTMLURL
+			m.chooserActive = false
+			m.updateContent()
+			return m, func() tea.Msg {
+				return IssueLaunchMsg{
+					PipelineName: pipeline.Name,
+					IssueURL:     issueURL,
+				}
+			}
+		}
+		return m, nil
+
+	case tea.KeyEscape:
+		m.chooserActive = false
+		m.updateContent()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// View renders the detail pane.
+func (m IssueDetailModel) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+
+	if m.selected == nil {
+		content := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("244")).
+			Render("Select an issue to view details")
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	}
+
+	return m.viewport.View()
+}
+
+func (m *IssueDetailModel) updateContent() {
+	m.viewport.SetContent(m.renderIssueDetail())
+}
+
+func (m IssueDetailModel) renderIssueDetail() string {
+	if m.selected == nil {
+		return ""
+	}
+
+	issue := m.selected
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("7"))
+
+	var sb strings.Builder
+
+	// Title
+	sb.WriteString(titleStyle.Render(fmt.Sprintf("Issue #%d: %s", issue.Number, issue.Title)))
+	sb.WriteString("\n")
+
+	// Metadata
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("State:"), issue.State))
+	if issue.Author != "" {
+		sb.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Author:"), issue.Author))
+	}
+	if len(issue.Labels) > 0 {
+		sb.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Labels:"), strings.Join(issue.Labels, ", ")))
+	}
+	if len(issue.Assignees) > 0 {
+		sb.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Assignees:"), strings.Join(issue.Assignees, ", ")))
+	}
+	if !issue.CreatedAt.IsZero() {
+		sb.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Created:"), issue.CreatedAt.Format("2006-01-02")))
+	}
+	if issue.Comments > 0 {
+		sb.WriteString(fmt.Sprintf("%s %d\n", labelStyle.Render("Comments:"), issue.Comments))
+	}
+
+	// Body
+	if issue.Body != "" {
+		sb.WriteString("\n")
+		sb.WriteString(sectionStyle.Render("Body:"))
+		sb.WriteString("\n")
+		sb.WriteString(issue.Body)
+		sb.WriteString("\n")
+	}
+
+	// Pipeline chooser
+	if len(m.pipelines) > 0 {
+		sb.WriteString("\n")
+		dividerWidth := m.width - 2
+		if dividerWidth < 10 {
+			dividerWidth = 10
+		}
+		divider := strings.Repeat("\u2500", dividerWidth)
+		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(divider))
+		sb.WriteString("\n")
+		sb.WriteString(sectionStyle.Render("Launch Pipeline"))
+		sb.WriteString("\n\n")
+
+		for i, p := range m.pipelines {
+			if m.chooserActive && i == m.chooserCursor {
+				line := lipgloss.NewStyle().
+					Foreground(lipgloss.Color("6")).
+					Bold(true).
+					Render(fmt.Sprintf("  > %s", p.Name))
+				sb.WriteString(line)
+			} else {
+				sb.WriteString(fmt.Sprintf("    %s", p.Name))
+			}
+			sb.WriteString("\n")
+		}
+
+		sb.WriteString("\n")
+		if m.chooserActive {
+			sb.WriteString(labelStyle.Render("[Enter] Launch with issue URL  [Esc] Cancel"))
+		} else {
+			sb.WriteString(labelStyle.Render("[Enter] Open pipeline chooser"))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/internal/tui/issue_detail_test.go
+++ b/internal/tui/issue_detail_test.go
@@ -1,0 +1,282 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+// ===========================================================================
+// IssueDetailModel tests
+// ===========================================================================
+
+func TestIssueDetailModel_EmptyState(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+
+	view := m.View()
+	assert.Contains(t, view, "Select an issue to view details")
+}
+
+func TestIssueDetailModel_SetIssue(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+
+	issue := &IssueData{
+		Number:  123,
+		Title:   "Fix authentication bug",
+		State:   "open",
+		Author:  "testuser",
+		Labels:  []string{"bug", "P1"},
+		Body:    "The auth flow is broken",
+		HTMLURL: "https://github.com/org/repo/issues/123",
+	}
+	m.SetIssue(issue)
+
+	view := m.View()
+	assert.Contains(t, view, "#123")
+	assert.Contains(t, view, "Fix authentication bug")
+	assert.Contains(t, view, "open")
+	assert.Contains(t, view, "testuser")
+	assert.Contains(t, view, "bug, P1")
+	assert.Contains(t, view, "The auth flow is broken")
+}
+
+func TestIssueDetailModel_SetSize(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+
+	assert.Equal(t, 80, m.width)
+	assert.Equal(t, 40, m.height)
+}
+
+func TestIssueDetailModel_SelectionUpdatesContent(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+
+	// Set first issue
+	issue1 := &IssueData{
+		Number: 1,
+		Title:  "First issue",
+		State:  "open",
+		Body:   "First body",
+	}
+	m.SetIssue(issue1)
+
+	view := m.View()
+	assert.Contains(t, view, "First issue")
+
+	// Set second issue
+	issue2 := &IssueData{
+		Number: 2,
+		Title:  "Second issue",
+		State:  "closed",
+		Body:   "Second body",
+	}
+	m.SetIssue(issue2)
+
+	view = m.View()
+	assert.Contains(t, view, "Second issue")
+	assert.Contains(t, view, "closed")
+}
+
+func TestIssueDetailModel_PipelineChooser_Open(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(true)
+
+	m.SetPipelines([]PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-bugfix"},
+		{Name: "wave-review"},
+	})
+
+	issue := &IssueData{
+		Number:  1,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/1",
+	}
+	m.SetIssue(issue)
+
+	// Press Enter to open chooser
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, m.chooserActive)
+	assert.Equal(t, 0, m.chooserCursor)
+}
+
+func TestIssueDetailModel_PipelineChooser_Navigate(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(true)
+
+	m.SetPipelines([]PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-bugfix"},
+		{Name: "wave-review"},
+	})
+
+	issue := &IssueData{
+		Number:  1,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/1",
+	}
+	m.SetIssue(issue)
+
+	// Open chooser
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Navigate down
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 1, m.chooserCursor)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.chooserCursor)
+
+	// Can't go past end
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.chooserCursor)
+
+	// Navigate up
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 1, m.chooserCursor)
+}
+
+func TestIssueDetailModel_PipelineChooser_Launch(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(true)
+
+	m.SetPipelines([]PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-bugfix"},
+	})
+
+	issue := &IssueData{
+		Number:  42,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/42",
+	}
+	m.SetIssue(issue)
+
+	// Open chooser
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Navigate to wave-bugfix
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 1, m.chooserCursor)
+
+	// Press Enter to launch
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.False(t, m.chooserActive)
+	assert.NotNil(t, cmd)
+
+	// Verify the launched message
+	msg := cmd()
+	launchMsg, ok := msg.(IssueLaunchMsg)
+	assert.True(t, ok)
+	assert.Equal(t, "wave-bugfix", launchMsg.PipelineName)
+	assert.Equal(t, "https://github.com/org/repo/issues/42", launchMsg.IssueURL)
+}
+
+func TestIssueDetailModel_PipelineChooser_Cancel(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(true)
+
+	m.SetPipelines([]PipelineInfo{
+		{Name: "speckit-flow"},
+	})
+
+	issue := &IssueData{
+		Number:  1,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/1",
+	}
+	m.SetIssue(issue)
+
+	// Open chooser
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, m.chooserActive)
+
+	// Press Escape to cancel
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	assert.False(t, m.chooserActive)
+}
+
+func TestIssueDetailModel_NoPipelines_NoChooser(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(true)
+
+	issue := &IssueData{
+		Number:  1,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/1",
+	}
+	m.SetIssue(issue)
+
+	// Press Enter with no pipelines configured
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.False(t, m.chooserActive) // Should not activate
+}
+
+func TestIssueDetailModel_UnfocusedIgnoresKeys(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+	m.SetFocused(false)
+
+	m.SetPipelines([]PipelineInfo{{Name: "speckit-flow"}})
+
+	issue := &IssueData{
+		Number:  1,
+		Title:   "Test issue",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/1",
+	}
+	m.SetIssue(issue)
+
+	// Press Enter while unfocused
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.False(t, m.chooserActive)
+}
+
+func TestIssueDetailModel_ViewShowsPipelineChooser(t *testing.T) {
+	m := NewIssueDetailModel()
+	m.SetSize(80, 40)
+
+	m.SetPipelines([]PipelineInfo{
+		{Name: "speckit-flow"},
+		{Name: "wave-bugfix"},
+	})
+
+	issue := &IssueData{
+		Number: 1,
+		Title:  "Test issue",
+		State:  "open",
+	}
+	m.SetIssue(issue)
+
+	view := m.View()
+	assert.Contains(t, view, "Launch Pipeline")
+	assert.Contains(t, view, "speckit-flow")
+	assert.Contains(t, view, "wave-bugfix")
+}
+
+// ===========================================================================
+// Mock provider for tests
+// ===========================================================================
+
+type mockIssueDataProvider struct {
+	issues []IssueData
+	err    error
+}
+
+func (m *mockIssueDataProvider) FetchIssues() ([]IssueData, error) {
+	return m.issues, m.err
+}

--- a/internal/tui/issue_list.go
+++ b/internal/tui/issue_list.go
@@ -1,0 +1,350 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// IssueListModel is the left pane model for the Issues view.
+type IssueListModel struct {
+	width        int
+	height       int
+	issues       []IssueData
+	cursor       int
+	navigable    []IssueData
+	filtering    bool
+	filterInput  textinput.Model
+	filterQuery  string
+	focused      bool
+	scrollOffset int
+	provider     IssueDataProvider
+	loaded       bool
+}
+
+// NewIssueListModel creates a new issue list model.
+func NewIssueListModel(provider IssueDataProvider) IssueListModel {
+	ti := textinput.New()
+	ti.Placeholder = "Filter issues..."
+	ti.CharLimit = 100
+
+	return IssueListModel{
+		provider:    provider,
+		filterInput: ti,
+		focused:     true,
+	}
+}
+
+// Init returns the command to fetch issue data.
+func (m IssueListModel) Init() tea.Cmd {
+	return m.fetchIssueData
+}
+
+// SetSize updates the list dimensions.
+func (m *IssueListModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// SetFocused updates the focused state.
+func (m *IssueListModel) SetFocused(focused bool) {
+	m.focused = focused
+}
+
+// IsFiltering returns true if the list is in filter mode.
+func (m IssueListModel) IsFiltering() bool {
+	return m.filtering
+}
+
+// Update handles messages to update list state.
+func (m IssueListModel) Update(msg tea.Msg) (IssueListModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case IssueDataMsg:
+		if msg.Err != nil {
+			return m, nil
+		}
+		m.issues = msg.Issues
+		m.loaded = true
+		m.buildNavigableItems()
+
+		if len(m.navigable) == 0 {
+			m.cursor = 0
+		} else if m.cursor >= len(m.navigable) {
+			m.cursor = len(m.navigable) - 1
+		}
+
+		// Emit initial selection
+		if cmd := m.emitSelectionMsg(); cmd != nil {
+			return m, cmd
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if !m.focused {
+			return m, nil
+		}
+		return m.handleKeyMsg(msg)
+	}
+
+	return m, nil
+}
+
+// View renders the issue list.
+func (m IssueListModel) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+
+	var lines []string
+	visibleHeight := m.height
+
+	if m.filtering {
+		filterLine := "/ " + m.filterInput.View()
+		lines = append(lines, filterLine)
+		visibleHeight--
+	}
+
+	if len(m.navigable) == 0 {
+		emptyMsg := "No issues found"
+		if m.filtering && m.filterQuery != "" {
+			emptyMsg = "No matching issues"
+		}
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("244")).
+			Width(m.width)
+		placeholder := style.Render(emptyMsg)
+
+		if m.filtering {
+			lines = append(lines, placeholder)
+		} else {
+			lines = append(lines, lipgloss.Place(m.width, visibleHeight, lipgloss.Center, lipgloss.Center, placeholder))
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	}
+
+	m.adjustScrollOffset(visibleHeight)
+
+	endOffset := m.scrollOffset + visibleHeight
+	if endOffset > len(m.navigable) {
+		endOffset = len(m.navigable)
+	}
+
+	for i := m.scrollOffset; i < endOffset; i++ {
+		issue := m.navigable[i]
+		isSelected := i == m.cursor
+
+		line := m.renderIssueLine(issue, isSelected)
+		lines = append(lines, line)
+	}
+
+	for len(lines) < m.height {
+		lines = append(lines, strings.Repeat(" ", m.width))
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+func (m IssueListModel) renderIssueLine(issue IssueData, isSelected bool) string {
+	prefix := "  "
+	if isSelected {
+		prefix = "▶ "
+	}
+
+	// Build the number prefix
+	number := fmt.Sprintf("#%d", issue.Number)
+
+	// Build label badges
+	var labelBadges string
+	if len(issue.Labels) > 0 {
+		badges := make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			badges = append(badges, "["+l+"]")
+		}
+		labelBadges = strings.Join(badges, " ")
+	}
+
+	// Build comment indicator
+	var commentStr string
+	if issue.Comments > 0 {
+		commentStr = fmt.Sprintf("  %d", issue.Comments)
+	}
+
+	// Calculate space for the title
+	rightSide := ""
+	if labelBadges != "" {
+		rightSide += " " + labelBadges
+	}
+	if commentStr != "" {
+		rightSide += commentStr
+	}
+
+	usedWidth := len(prefix) + len(number) + 1 + len(rightSide) // +1 for space after number
+	titleMaxWidth := m.width - usedWidth
+	if titleMaxWidth < 0 {
+		titleMaxWidth = 0
+	}
+	title := truncateName(issue.Title, titleMaxWidth)
+
+	// Assemble the line parts
+	leftPart := prefix + number + " " + title
+
+	// Calculate spacer
+	spacerWidth := m.width - lipgloss.Width(leftPart) - lipgloss.Width(rightSide)
+	if spacerWidth < 1 {
+		spacerWidth = 1
+	}
+
+	text := leftPart + strings.Repeat(" ", spacerWidth) + rightSide
+
+	if isSelected {
+		style := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("6")).
+			Width(m.width)
+		return style.Render(text)
+	}
+
+	style := lipgloss.NewStyle().
+		Width(m.width)
+	return style.Render(text)
+}
+
+func (m IssueListModel) handleKeyMsg(msg tea.KeyMsg) (IssueListModel, tea.Cmd) {
+	if m.filtering {
+		switch msg.Type {
+		case tea.KeyEscape:
+			m.filtering = false
+			m.filterQuery = ""
+			m.filterInput.SetValue("")
+			m.buildNavigableItems()
+			m.cursor = 0
+			return m, nil
+
+		case tea.KeyUp, tea.KeyDown:
+			return m.handleNavigation(msg)
+
+		case tea.KeyEnter:
+			m.filtering = false
+			return m, nil
+
+		default:
+			var cmd tea.Cmd
+			m.filterInput, cmd = m.filterInput.Update(msg)
+			newQuery := m.filterInput.Value()
+			if newQuery != m.filterQuery {
+				m.filterQuery = newQuery
+				oldCursor := m.cursor
+				m.buildNavigableItems()
+				if oldCursor >= len(m.navigable) {
+					m.cursor = 0
+				}
+			}
+			return m, cmd
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyUp, tea.KeyDown:
+		return m.handleNavigation(msg)
+	default:
+		if msg.String() == "/" {
+			m.filtering = true
+			m.filterInput.SetValue("")
+			m.filterQuery = ""
+			m.filterInput.Focus()
+			return m, m.filterInput.Cursor.BlinkCmd()
+		}
+	}
+
+	return m, nil
+}
+
+func (m IssueListModel) handleNavigation(msg tea.KeyMsg) (IssueListModel, tea.Cmd) {
+	if len(m.navigable) == 0 {
+		return m, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case tea.KeyDown:
+		if m.cursor < len(m.navigable)-1 {
+			m.cursor++
+		}
+	}
+
+	return m, m.emitSelectionMsg()
+}
+
+func (m IssueListModel) emitSelectionMsg() tea.Cmd {
+	if len(m.navigable) == 0 || m.cursor >= len(m.navigable) {
+		return nil
+	}
+
+	issue := m.navigable[m.cursor]
+	return func() tea.Msg {
+		return IssueSelectedMsg{Number: issue.Number, Title: issue.Title, Index: m.cursor}
+	}
+}
+
+func (m *IssueListModel) buildNavigableItems() {
+	query := strings.ToLower(m.filterQuery)
+	m.navigable = nil
+
+	for _, issue := range m.issues {
+		if query == "" {
+			m.navigable = append(m.navigable, issue)
+			continue
+		}
+		// Match against title, number, and labels
+		if strings.Contains(strings.ToLower(issue.Title), query) {
+			m.navigable = append(m.navigable, issue)
+			continue
+		}
+		if strings.Contains(fmt.Sprintf("#%d", issue.Number), query) {
+			m.navigable = append(m.navigable, issue)
+			continue
+		}
+		for _, l := range issue.Labels {
+			if strings.Contains(strings.ToLower(l), query) {
+				m.navigable = append(m.navigable, issue)
+				break
+			}
+		}
+	}
+}
+
+func (m *IssueListModel) adjustScrollOffset(visibleHeight int) {
+	if visibleHeight <= 0 {
+		return
+	}
+	if m.cursor < m.scrollOffset {
+		m.scrollOffset = m.cursor
+	}
+	if m.cursor >= m.scrollOffset+visibleHeight {
+		m.scrollOffset = m.cursor - visibleHeight + 1
+	}
+	maxOffset := len(m.navigable) - visibleHeight
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.scrollOffset > maxOffset {
+		m.scrollOffset = maxOffset
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
+}
+
+func (m IssueListModel) fetchIssueData() tea.Msg {
+	if m.provider == nil {
+		return IssueDataMsg{Err: nil}
+	}
+
+	issues, err := m.provider.FetchIssues()
+	return IssueDataMsg{Issues: issues, Err: err}
+}

--- a/internal/tui/issue_list_test.go
+++ b/internal/tui/issue_list_test.go
@@ -1,0 +1,234 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+// ===========================================================================
+// IssueListModel tests
+// ===========================================================================
+
+func TestIssueListModel_Init_FetchesData(t *testing.T) {
+	provider := &mockIssueDataProvider{
+		issues: []IssueData{
+			{Number: 1, Title: "First issue"},
+		},
+	}
+	m := NewIssueListModel(provider)
+	cmd := m.Init()
+	assert.NotNil(t, cmd)
+
+	// Execute the command and verify it returns IssueDataMsg
+	msg := cmd()
+	dataMsg, ok := msg.(IssueDataMsg)
+	assert.True(t, ok)
+	assert.Nil(t, dataMsg.Err)
+	assert.Equal(t, 1, len(dataMsg.Issues))
+}
+
+func TestIssueListModel_DataLoading(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	msg := IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 123, Title: "Fix authentication bug", Labels: []string{"bug", "P1"}},
+			{Number: 120, Title: "Add dark mode support", Labels: []string{"enhancement"}},
+		},
+	}
+
+	m, _ = m.Update(msg)
+	assert.Equal(t, 2, len(m.issues))
+	assert.Equal(t, 2, len(m.navigable))
+	assert.True(t, m.loaded)
+}
+
+func TestIssueListModel_Navigation(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "First"},
+			{Number: 2, Title: "Second"},
+			{Number: 3, Title: "Third"},
+		},
+	})
+
+	assert.Equal(t, 0, m.cursor)
+
+	// Move down
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 1, m.cursor)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.cursor)
+
+	// Can't go past end
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, 2, m.cursor)
+
+	// Move up
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 1, m.cursor)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 0, m.cursor)
+
+	// Can't go before start
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	assert.Equal(t, 0, m.cursor)
+}
+
+func TestIssueListModel_Filtering(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "Fix authentication bug", Labels: []string{"bug"}},
+			{Number: 2, Title: "Add dark mode support", Labels: []string{"enhancement"}},
+			{Number: 3, Title: "Performance regression", Labels: []string{"bug"}},
+		},
+	})
+
+	assert.Equal(t, 3, len(m.navigable))
+
+	// Activate filter with '/'
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	assert.True(t, m.filtering)
+
+	// Type 'bug' to filter
+	for _, r := range "bug" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	// Filter matches: #1 by title ("Fix authentication bug"), #3 by label ("bug")
+	// #2 doesn't match title or labels
+	assert.Equal(t, 2, len(m.navigable))
+
+	// Clear filter with Escape
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	assert.False(t, m.filtering)
+	assert.Equal(t, 3, len(m.navigable))
+}
+
+func TestIssueListModel_FilterByTitle(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "Fix authentication bug"},
+			{Number: 2, Title: "Add dark mode support"},
+			{Number: 3, Title: "Performance regression"},
+		},
+	})
+
+	// Activate filter
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	// Type 'dark' to filter
+	for _, r := range "dark" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	assert.Equal(t, 1, len(m.navigable))
+	assert.Equal(t, "Add dark mode support", m.navigable[0].Title)
+}
+
+func TestIssueListModel_EmptyList(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+	m, _ = m.Update(IssueDataMsg{})
+
+	view := m.View()
+	assert.Contains(t, view, "No issues found")
+}
+
+func TestIssueListModel_EmptyFilterResult(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "Test issue"},
+		},
+	})
+
+	// Activate filter and type something that doesn't match
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range "zzzzz" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	view := m.View()
+	assert.Contains(t, view, "No matching issues")
+}
+
+func TestIssueListModel_ViewRendersIssues(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(80, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 123, Title: "Fix authentication bug", Labels: []string{"bug"}, Comments: 3},
+		},
+	})
+
+	view := m.View()
+	assert.Contains(t, view, "#123")
+	assert.Contains(t, view, "Fix authentication bug")
+	assert.Contains(t, view, "[bug]")
+}
+
+func TestIssueListModel_NavigationEmitsSelectionMsg(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "First"},
+			{Number: 2, Title: "Second"},
+		},
+	})
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	selMsg, ok := msg.(IssueSelectedMsg)
+	assert.True(t, ok)
+	assert.Equal(t, 2, selMsg.Number)
+	assert.Equal(t, "Second", selMsg.Title)
+}
+
+func TestIssueListModel_UnfocusedIgnoresKeys(t *testing.T) {
+	m := NewIssueListModel(&mockIssueDataProvider{})
+	m.SetSize(60, 20)
+	m.SetFocused(false)
+
+	m, _ = m.Update(IssueDataMsg{
+		Issues: []IssueData{
+			{Number: 1, Title: "First"},
+			{Number: 2, Title: "Second"},
+		},
+	})
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Nil(t, cmd)
+	assert.Equal(t, 0, m.cursor) // Cursor shouldn't move
+}
+
+func TestIssueListModel_NilProvider(t *testing.T) {
+	m := NewIssueListModel(nil)
+	cmd := m.Init()
+	assert.NotNil(t, cmd)
+
+	msg := cmd()
+	dataMsg, ok := msg.(IssueDataMsg)
+	assert.True(t, ok)
+	assert.Nil(t, dataMsg.Err)
+	assert.Nil(t, dataMsg.Issues)
+}

--- a/internal/tui/issue_messages.go
+++ b/internal/tui/issue_messages.go
@@ -1,0 +1,20 @@
+package tui
+
+// IssueDataMsg carries fetched issue data from the provider.
+type IssueDataMsg struct {
+	Issues []IssueData
+	Err    error
+}
+
+// IssueSelectedMsg signals that an issue was selected in the list.
+type IssueSelectedMsg struct {
+	Number int
+	Title  string
+	Index  int
+}
+
+// IssueLaunchMsg signals that the user wants to launch a pipeline against an issue.
+type IssueLaunchMsg struct {
+	PipelineName string
+	IssueURL     string
+}

--- a/internal/tui/issue_provider.go
+++ b/internal/tui/issue_provider.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/recinq/wave/internal/github"
+	"github.com/recinq/wave/internal/manifest"
+)
+
+// IssueData is a TUI-specific projection of a GitHub issue.
+type IssueData struct {
+	Number    int
+	Title     string
+	State     string
+	Author    string
+	Labels    []string
+	Assignees []string
+	Comments  int
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	Body      string
+	HTMLURL   string
+}
+
+// IssueDataProvider fetches issue data for the TUI.
+type IssueDataProvider interface {
+	FetchIssues() ([]IssueData, error)
+}
+
+// DefaultIssueDataProvider uses the GitHub client to fetch issues.
+type DefaultIssueDataProvider struct {
+	client   *github.Client
+	manifest *manifest.Manifest
+}
+
+// NewDefaultIssueDataProvider creates a new issue data provider.
+func NewDefaultIssueDataProvider(client *github.Client, m *manifest.Manifest) *DefaultIssueDataProvider {
+	return &DefaultIssueDataProvider{client: client, manifest: m}
+}
+
+// FetchIssues retrieves open issues from the configured repository.
+func (p *DefaultIssueDataProvider) FetchIssues() ([]IssueData, error) {
+	if p.manifest == nil || p.manifest.Metadata.Repo == "" {
+		return nil, nil
+	}
+	owner, repo, ok := strings.Cut(p.manifest.Metadata.Repo, "/")
+	if !ok {
+		return nil, nil
+	}
+	issues, err := p.client.ListIssues(context.Background(), owner, repo, github.ListIssuesOptions{
+		State:   "open",
+		PerPage: 50,
+		Sort:    "updated",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result []IssueData
+	for _, issue := range issues {
+		if issue.IsPullRequest() {
+			continue // Skip PRs
+		}
+		d := IssueData{
+			Number:    issue.Number,
+			Title:     issue.Title,
+			State:     issue.State,
+			Body:      issue.Body,
+			Comments:  issue.Comments,
+			CreatedAt: issue.CreatedAt,
+			UpdatedAt: issue.UpdatedAt,
+			HTMLURL:   issue.HTMLURL,
+		}
+		if issue.User != nil {
+			d.Author = issue.User.Login
+		}
+		for _, l := range issue.Labels {
+			d.Labels = append(d.Labels, l.Name)
+		}
+		for _, a := range issue.Assignees {
+			d.Assignees = append(d.Assignees, a.Login)
+		}
+		result = append(result, d)
+	}
+	return result, nil
+}
+
+// resolveGitHubToken returns a GitHub token from environment variables.
+func resolveGitHubToken() string {
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		return token
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -88,6 +88,10 @@ func (m StatusBarModel) View() string {
 		hintsText = "↑↓: scroll  Esc: back  q: quit  ctrl+c: exit"
 	} else if m.currentView == ViewHealth {
 		hintsText = "↑↓: navigate  r: recheck  Enter: view  Tab/Shift+Tab: views  q: quit"
+	} else if m.currentView == ViewIssues && m.focusPane == FocusPaneLeft {
+		hintsText = "↑↓: navigate  Enter: view  /: filter  Tab/Shift+Tab: views  q: quit"
+	} else if m.currentView == ViewIssues && m.focusPane == FocusPaneRight {
+		hintsText = "Enter: launch pipeline  ↑↓: scroll  Esc: back"
 	} else {
 		hintsText = "↑↓: navigate  Enter: view  /: filter  s: compose  c: cancel  Tab/Shift+Tab: views  q: quit"
 	}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -9,6 +9,7 @@ const (
 	ViewContracts
 	ViewSkills
 	ViewHealth
+	ViewIssues
 )
 
 // String returns the display name for the view (used as status bar label).
@@ -24,6 +25,8 @@ func (v ViewType) String() string {
 		return "Skills"
 	case ViewHealth:
 		return "Health"
+	case ViewIssues:
+		return "Issues"
 	default:
 		return "Unknown"
 	}

--- a/internal/tui/views_test.go
+++ b/internal/tui/views_test.go
@@ -22,6 +22,7 @@ func TestViewType_String(t *testing.T) {
 		{ViewContracts, "Contracts"},
 		{ViewSkills, "Skills"},
 		{ViewHealth, "Health"},
+		{ViewIssues, "Issues"},
 	}
 
 	for _, tt := range tests {
@@ -60,11 +61,12 @@ func TestContentModel_TabCyclesThroughAllViews(t *testing.T) {
 			ContractProvider: &mockContractDataProvider{},
 			SkillProvider:    &mockSkillDataProvider{},
 			HealthProvider:   &mockHealthDataProvider{},
+			IssueProvider:    &mockIssueDataProvider{},
 		},
 	)
 	c.SetSize(120, 40)
 
-	views := []ViewType{ViewPersonas, ViewContracts, ViewSkills, ViewHealth, ViewPipelines}
+	views := []ViewType{ViewPersonas, ViewContracts, ViewSkills, ViewHealth, ViewIssues, ViewPipelines}
 	msg := tea.KeyMsg{Type: tea.KeyTab}
 
 	for _, expected := range views {


### PR DESCRIPTION
## Summary
- Adds a new **Issues** tab to the TUI (6th view after Health) that fetches and displays open GitHub issues from the configured repository
- Left pane shows a filterable issue list with number, title, label badges, and comment counts
- Right pane shows full issue detail (metadata, body) with an integrated pipeline chooser -- pressing Enter opens a selection menu of all available pipelines, and selecting one emits a `LaunchRequestMsg` with the issue URL as input, switching back to the Pipelines view
- Issue data is fetched via the existing `internal/github` client using `GH_TOKEN` / `GITHUB_TOKEN` environment variables; the tab gracefully degrades when no repo is configured or no token is available

## New files
- `internal/tui/issue_messages.go` -- `IssueDataMsg`, `IssueSelectedMsg`, `IssueLaunchMsg` message types
- `internal/tui/issue_provider.go` -- `IssueData` struct, `IssueDataProvider` interface, `DefaultIssueDataProvider` implementation
- `internal/tui/issue_list.go` -- `IssueListModel` left pane with filtering, navigation, and scroll support
- `internal/tui/issue_detail.go` -- `IssueDetailModel` right pane with viewport and pipeline chooser overlay
- `internal/tui/issue_list_test.go` -- 12 tests covering data loading, navigation, filtering, rendering, and edge cases
- `internal/tui/issue_detail_test.go` -- 11 tests covering selection, pipeline chooser open/navigate/launch/cancel, and edge cases

## Modified files
- `internal/tui/views.go` -- added `ViewIssues` to the enum and `String()` method
- `internal/tui/content.go` -- wired issue models into lazy init, message routing, focus management, and view rendering (modulo 5 -> 6)
- `internal/tui/statusbar.go` -- added context-aware hints for the Issues view
- `internal/tui/app.go` -- wired `DefaultIssueDataProvider` creation in `RunTUI()` when repo and token are available
- `internal/tui/views_test.go` -- updated tab cycling and view string tests for the new view

## Test plan
- [x] `go test -race ./...` passes (all 28 packages)
- [x] New issue list tests verify: data loading, cursor navigation, filter activation/deactivation, filter-by-title matching, empty states, selection message emission, unfocused key suppression, nil provider
- [x] New issue detail tests verify: empty state rendering, issue content display, pipeline chooser open/navigate/launch/cancel, no-pipeline edge case, unfocused key suppression
- [x] Existing tab cycling test updated and passing with 6-view cycle
- [ ] Manual: run `wave tui` with `GH_TOKEN` set and verify Issues tab appears and fetches issues
- [ ] Manual: select an issue, open pipeline chooser, launch a pipeline and verify it switches to Pipelines view

Closes #283