### PR TITLE
fix(docs): correct inaccuracies found in review

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,10 @@ wave clean --all --keep-last 5
 personas:
   navigator:
     adapter: claude
-    #temperature: 0.1
+    #temperature: 0.3
     permissions:
-      allowed_tools: [Read, Glob, Grep]
-      deny: [Write(*), Edit(*)]
+      allowed_tools: [Read, Glob, Grep, "Bash(git log*)", "Bash(git status*)"]
+      deny: ["Write(*)", "Edit(*)", "Bash(git commit*)", "Bash(git push*)"]
 ```
 
 **30 built-in personas** including `navigator`, `craftsman`, `auditor`, `philosopher`, `debugger`, and more.
@@ -340,6 +340,7 @@ A selection of the 47 built-in pipelines:
 | Pipeline | Description |
 |----------|-------------|
 | `speckit-flow` | Specification-driven feature development |
+| `feature` | Feature planning and implementation |
 | `hotfix` | Quick investigation and fix for production issues |
 | `refactor` | Safe refactoring with comprehensive test coverage |
 | `prototype` | Prototype-driven development (spec → docs → dummy → implement → pr) |
@@ -358,16 +359,17 @@ A selection of the 47 built-in pipelines:
 |----------|-------------|
 | `plan` | Break down a feature into actionable tasks |
 | `doc-fix` | Generate or update documentation |
+| `doc-audit` | Documentation consistency gate |
 
 ### GitHub Automation
 
 | Pipeline | Description |
 |----------|-------------|
 | `gh-implement` | Implement a GitHub issue end-to-end |
-| `gh-pr-review` | Comprehensive code review for pull requests |
-| `doc-audit` | Documentation consistency gate |
+| `gh-scope` | Decompose epics into child issues |
+| `gh-research` | Research and report on issues |
 
-> **More pipelines:** `hello-world`, `smoke-test`, `explain`, `onboard`, `improve`, `dead-code`, `security-scan`, `changelog`, `adr`, `wave-land`, `recinq`, `supervise`, plus platform variants for GitLab (gl-*), Gitea (gt-*), and Bitbucket (bb-*)
+> **More pipelines:** `hello-world`, `smoke-test`, `explain`, `onboard`, `improve`, `dead-code`, `security-scan`, `changelog`, `adr`, `wave-land`, `recinq`, `supervise`, plus platform variants for GitHub (gh-\*), GitLab (gl-\*), Gitea (gt-\*), and Bitbucket (bb-\*)
 >
 > Explore all in [`.wave/pipelines/`](.wave/pipelines/)
 
@@ -383,7 +385,7 @@ A selection of the 30 built-in personas:
 | `philosopher` | Architecture & specs | Read, Write, Edit, Bash, Glob, Grep |
 | `planner` | Task breakdown | Read, Write, Edit, Bash, Glob, Grep |
 | `craftsman` | Implementation | Read, Write, Edit, Bash |
-| `debugger` | Root cause analysis | Read, Grep, Glob, go test, git bisect |
+| `debugger` | Root cause analysis | Read, Grep, Glob, go test, git log/diff/bisect |
 | `auditor` | Security review | Read, Grep, go vet, npm audit |
 | `summarizer` | Context compaction | Read, Write, Edit, Bash, Glob, Grep |
 
@@ -458,8 +460,8 @@ Persona permissions from `wave.yaml` are projected into Claude Code's `settings.
 personas:
   navigator:
     permissions:
-      allowed_tools: [Read, Glob, Grep]
-      deny: [Write(*), Edit(*)]
+      allowed_tools: [Read, Glob, Grep, "Bash(git log*)", "Bash(git status*)"]
+      deny: ["Write(*)", "Edit(*)", "Bash(git commit*)", "Bash(git push*)"]
     sandbox:
       allowed_domains: [api.anthropic.com]
 

--- a/docs/guide/contracts.md
+++ b/docs/guide/contracts.md
@@ -29,7 +29,7 @@ steps:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `type` | - | `json_schema`, `typescript_interface`, `test_suite`, `markdown_spec`, or `format` |
-| `schema` | - | Schema file path (for json_schema) |
+| `schema_path` | - | Schema file path (for json_schema) |
 | `source` | - | File to validate |
 | `command` | - | Test command (for test_suite) |
 | `dir` | workspace | Working directory for test_suite: `project_root`, absolute, or relative |

--- a/docs/guide/personas.md
+++ b/docs/guide/personas.md
@@ -19,9 +19,9 @@ Wave ships with 30 built-in personas:
 | `researcher` | Research & analysis | Read, Write, Edit, Bash, Glob, Grep, WebSearch, WebFetch |
 | `summarizer` | Context compaction | Read, Write, Edit, Bash, Glob, Grep (full access) |
 | `supervisor` | Work quality review | Read, Glob, Grep, Bash(git \*), Bash(go test\*) |
-| `validator` | Output validation | Read, Glob, Grep, Bash(wc \*), Bash(git log\*) |
-| `synthesizer` | Content synthesis | Read, Write, Edit, Bash, Glob, Grep (full access) |
-| `provocateur` | Critical analysis | Read, Glob, Grep, Bash(wc \*), Bash(git log\*) |
+| `validator` | Skeptical verification against source | Read, Glob, Grep, Bash(wc \*), Bash(git log\*) |
+| `synthesizer` | Structured synthesis into JSON proposals | Read, Write, Edit, Bash, Glob, Grep (full access) |
+| `provocateur` | Divergent thinking & complexity hunting | Read, Glob, Grep, Bash(wc \*), Bash(git log\*) |
 | `github-analyst` | GitHub issue analysis | Read, Bash(gh issue\*), Bash(gh pr\*), Bash(git log\*) |
 | `github-enhancer` | GitHub issue enhancement | Read, Bash(gh issue edit\*) |
 | `github-commenter` | GitHub commenting | Read, Bash(gh issue comment\*), Bash(gh pr\*), Bash(git push\*) |
@@ -48,9 +48,9 @@ Read-only codebase exploration. Finds files, analyzes patterns, maps architectur
 ```yaml
 navigator:
   adapter: claude
-  description: "Read-only codebase exploration"
+  description: "Read-only codebase exploration and analysis"
   system_prompt_file: .wave/personas/navigator.md
-  #temperature: 0.1
+  #temperature: 0.3
   permissions:
     allowed_tools:
       - Read

--- a/docs/guide/pipelines.md
+++ b/docs/guide/pipelines.md
@@ -349,7 +349,7 @@ steps:
       source: "Fix the issue with regression test"
 
   - id: verify
-    persona: auditor
+    persona: reviewer
     dependencies: [fix]
     exec:
       source: "Verify fix is safe for production"

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -9,11 +9,12 @@ The TUI is enabled by default when running in an interactive terminal. Wave auto
 ### Detection Logic
 
 1. **`--no-tui` flag** (highest priority) — disables the TUI
-2. **`WAVE_FORCE_TTY` env var** — override TTY detection:
+2. **`--json` or `--quiet` flags** — suppress TUI in favor of structured/minimal output
+3. **`WAVE_FORCE_TTY` env var** — override TTY detection:
    - `"1"` or `"true"` → force TUI on
    - `"0"` or `"false"` → force TUI off
-3. **Dumb terminals** — TUI disabled when `TERM=dumb`
-4. **TTY check** — TUI enabled only when stdout is a terminal
+4. **Dumb terminals** — TUI disabled when `TERM=dumb`
+5. **TTY check** — TUI enabled only when stdout is a terminal
 
 ### Examples
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ Wave CLI commands for pipeline orchestration.
 | `wave validate` | Validate configuration |
 | `wave clean` | Clean up workspaces |
 | `wave serve` | Start the web dashboard server |
+| `wave chat` | Interactive chat session with a persona |
 | `wave migrate` | Database migrations |
 
 ---
@@ -614,12 +615,8 @@ All commands support:
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | General error |
-| 2 | Usage error |
-| 3 | Pipeline failed |
-| 4 | Validation error |
-| 5 | Timeout |
-| 130 | Interrupted (Ctrl+C) |
+| 1 | General error (includes pipeline failures, timeouts, validation errors) |
+| 2 | Usage error (invalid arguments or configuration) |
 
 ---
 

--- a/docs/reference/contract-types.md
+++ b/docs/reference/contract-types.md
@@ -335,29 +335,35 @@ Production-ready format validation for domain-specific outputs like GitHub issue
 handover:
   contract:
     type: format
-    source: .wave/output/issue.md
+    source: .wave/output/issue.json
+    schema_path: .wave/contracts/github-issue-analysis.schema.json
 ```
 
-**Use when:** Validating that generated content matches expected domain formats (e.g., GitHub issue structure, PR descriptions).
+**Use when:** Validating that generated JSON content matches expected domain formats (e.g., GitHub issue structure, PR descriptions).
 
-**Status:** Experimental. Infers format type from content and applies domain-specific validation rules including placeholder detection.
+**Status:** Experimental. Infers format type from `schema_path` filename and applies domain-specific validation rules including placeholder detection. Source file must be valid JSON.
 
 ### Fields
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `source` | **yes** | - | Path to file to validate |
+| `source` | **yes** | - | Path to JSON file to validate |
+| `schema_path` | no | - | Schema path used to infer format type (e.g., `github-issue-analysis.schema.json` → `github_issue`) |
 | `must_pass` | no | `true` | Whether failure blocks progression |
 | `on_failure` | no | `retry` | `retry` or `halt` |
 | `max_retries` | no | `2` | Maximum retry attempts |
 
 ### Supported Formats
 
-The format validator auto-detects content type and applies domain-specific rules:
-- **GitHub issues** — checks for title, body, labels structure
-- **Pull requests** — validates description, linked issues
-- **Analysis outputs** — ensures structured sections are present
-- **Placeholder detection** — flags unfilled template placeholders
+The format validator infers the format type from the `schema_path` filename and applies domain-specific rules. Without a `schema_path`, it falls back to generic validation.
+
+| Schema name pattern | Format type | Validation |
+|---------------------|-------------|------------|
+| `github-issue-*` | `github_issue` | Title length/quality, body structure, labels, placeholder detection |
+| `github-pr-*` | `github_pr` | Description quality, linked issues, placeholder detection |
+| `implementation-results` | `implementation_results` | Structured result sections |
+| `analysis`, `findings` | `analysis` | Structured analysis sections |
+| _(other)_ | `generic` | Basic structure and placeholder detection |
 
 ---
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -12,7 +12,7 @@ Reference for all environment variables that control Wave behavior, and the cred
 | `WAVE_AUTO_MIGRATE` | `bool` | `true` | Automatically apply pending migrations on startup. |
 | `WAVE_SKIP_MIGRATION_VALIDATION` | `bool` | `false` | Skip migration checksum validation (development only). |
 | `WAVE_MAX_MIGRATION_VERSION` | `int` | `0` | Limit migrations to this version (0 = unlimited). Useful for gradual rollout. |
-| `NO_COLOR` | `bool` | `false` | Disable colored output. Follows the [NO_COLOR](https://no-color.org) standard. |
+| `NO_COLOR` | `string` | _(unset)_ | Disable colored output. Any non-empty value disables color. Follows the [NO_COLOR](https://no-color.org) standard. |
 
 ### Precedence Order
 
@@ -99,13 +99,16 @@ The Claude adapter constructs a curated environment for each subprocess. Only ba
 
 Audit logs automatically redact values for environment variables matching these patterns:
 
-| Pattern | Examples |
+| Pattern (regex) | Examples |
 |---------|----------|
-| `*_KEY` | `ANTHROPIC_API_KEY`, `AWS_ACCESS_KEY` |
-| `*_TOKEN` | `GITHUB_TOKEN`, `NPM_TOKEN` |
-| `*_SECRET` | `AWS_SECRET_ACCESS_KEY`, `JWT_SECRET` |
-| `*_PASSWORD` | `DATABASE_PASSWORD`, `SMTP_PASSWORD` |
-| `*_CREDENTIAL*` | `GCP_CREDENTIAL_FILE` |
+| `API[_-]?KEY` | `ANTHROPIC_API_KEY`, `OPENAI_APIKEY` |
+| `TOKEN` | `GITHUB_TOKEN`, `NPM_TOKEN` |
+| `SECRET` | `AWS_SECRET_ACCESS_KEY`, `JWT_SECRET` |
+| `PASSWORD` | `DATABASE_PASSWORD`, `SMTP_PASSWORD` |
+| `CREDENTIAL` | `GCP_CREDENTIAL_FILE` |
+| `AUTH` | `BASIC_AUTH`, `AUTH_TOKEN` |
+| `PRIVATE[_-]?KEY` | `SSH_PRIVATE_KEY` |
+| `ACCESS[_-]?KEY` | `AWS_ACCESS_KEY` |
 
 Redacted values appear as `[REDACTED]` in audit logs.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -12,7 +12,7 @@ Every event contains these fields:
 | `pipeline_id` | `string` | **yes** | UUID for this pipeline execution instance. |
 | `step_id` | `string` | no | Step identifier within the pipeline. |
 | `state` | `string` | **yes** | Event state (see Event States below). |
-| `duration_ms` | `int` | no | Milliseconds elapsed since step started. |
+| `duration_ms` | `int64` | no | Milliseconds elapsed since step started. |
 | `message` | `string` | no | Human-readable status message. |
 | `persona` | `string` | no | Persona executing the step. |
 | `artifacts` | `[]string` | when completed | List of output artifact paths. |
@@ -23,7 +23,7 @@ Every event contains these fields:
 | `current_action` | `string` | no | Current action description. |
 | `total_steps` | `int` | when started | Total pipeline steps. |
 | `completed_steps` | `int` | no | Number of completed steps. |
-| `estimated_time_ms` | `int` | no | Estimated remaining time in milliseconds. |
+| `estimated_time_ms` | `int64` | **yes** (0 = no estimate) | Estimated remaining time in milliseconds. |
 | `validation_phase` | `string` | no | Current contract validation phase. |
 | `compaction_stats` | `string` | no | Relay compaction statistics. |
 | `failure_reason` | `string` | when failed | Detailed failure reason. |
@@ -50,6 +50,7 @@ Every event contains these fields:
 | `contract_validating` | Contract validation is in progress. |
 | `compaction_progress` | Relay compaction is in progress. |
 | `stream_activity` | Real-time tool activity from the adapter. |
+| `skipped` | Step was skipped (condition not met or dependency failed). |
 
 ## Event Examples
 
@@ -86,7 +87,7 @@ wave run flow "task" 2>/dev/null
 Human-friendly format with color and formatting.
 
 ```bash
-WAVE_LOG_FORMAT=text wave run flow "task"
+wave run flow "task" -o text
 ```
 
 Text output example:


### PR DESCRIPTION
## Summary

Review fixes for PR #273. Systematic file-by-file verification against the codebase found these inaccuracies:

### Critical fixes
- **events.md**: Removed fabricated `WAVE_LOG_FORMAT` env var (doesn't exist)
- **cli.md**: Removed non-existent exit codes 3/4/5/130 (codebase only uses 0/1/2)
- **contract-types.md**: Fixed `format` type docs — requires JSON input (not markdown), infers format from `schema_path` filename (not content)

### Moderate fixes
- **events.md**: Added missing `skipped` state, fixed `duration_ms`/`estimated_time_ms` types (`int` → `int64`), fixed `estimated_time_ms` always-present column
- **pipelines.md**: Fixed hotfix example persona (`auditor` → `reviewer`)
- **personas.md + README.md**: Fixed navigator temperature (`0.1` → `0.3`), description, and permissions to match wave.yaml
- **tui.md**: Added `--json`/`--quiet` flags to TUI detection logic (they suppress TUI before `WAVE_FORCE_TTY` is checked)
- **environment.md**: Fixed credential scrubbing patterns to match actual regex in `internal/audit/logger.go`, fixed `NO_COLOR` type/default
- **cli.md**: Added missing `wave chat` command to quick reference
- **README.md**: Added `feature` pipeline, fixed gh-* catch-all, moved `doc-audit` to correct section, removed `gh-pr-review` duplicate

### Minor fixes
- **contracts.md**: Fixed `schema` → `schema_path` field name
- **personas.md**: Improved purpose descriptions for `provocateur`/`validator`/`synthesizer` to match wave.yaml

## Test plan
- [x] `go test ./...` passes (docs-only changes + existing code change in run.go)