### PR TITLE
fix(tui): prevent issue view display corruption when scrolling

### DIFF
--- a/internal/tui/issue_detail.go
+++ b/internal/tui/issue_detail.go
@@ -152,7 +152,13 @@ func (m IssueDetailModel) View() string {
 }
 
 func (m *IssueDetailModel) updateContent() {
-	m.viewport.SetContent(m.renderIssueDetail())
+	content := m.renderIssueDetail()
+	// Wrap content to viewport width to prevent horizontal overflow
+	// that corrupts the split-pane layout when joined horizontally.
+	if m.width > 0 {
+		content = lipgloss.NewStyle().Width(m.width).Render(content)
+	}
+	m.viewport.SetContent(content)
 }
 
 func (m IssueDetailModel) renderIssueDetail() string {

--- a/internal/tui/issue_list.go
+++ b/internal/tui/issue_list.go
@@ -161,8 +161,8 @@ func (m IssueListModel) renderIssueLine(issue IssueData, isSelected bool) string
 		commentStr = fmt.Sprintf(" %d", issue.Comments)
 	}
 
-	// Fixed portions: prefix + number + space + commentStr
-	fixedWidth := len(prefix) + len(number) + 1 + len(commentStr)
+	// Fixed portions: prefix + number + space + commentStr (visual widths)
+	fixedWidth := lipgloss.Width(prefix) + lipgloss.Width(number) + 1 + lipgloss.Width(commentStr)
 	availableWidth := m.width - fixedWidth
 	if availableWidth < 0 {
 		availableWidth = 0
@@ -182,7 +182,7 @@ func (m IssueListModel) renderIssueLine(issue IssueData, isSelected bool) string
 		used := 0
 		for _, l := range issue.Labels {
 			badge := "[" + l + "]"
-			need := len(badge)
+			need := lipgloss.Width(badge)
 			if used > 0 {
 				need++ // space between badges
 			}
@@ -198,7 +198,7 @@ func (m IssueListModel) renderIssueLine(issue IssueData, isSelected bool) string
 	}
 
 	// Calculate actual title width now that we know label width
-	labelWidth := len(labelBadges)
+	labelWidth := lipgloss.Width(labelBadges)
 	if labelWidth > 0 {
 		labelWidth++ // leading space
 	}
@@ -223,13 +223,14 @@ func (m IssueListModel) renderIssueLine(issue IssueData, isSelected bool) string
 
 	text := leftPart + strings.Repeat(" ", spacerWidth) + rightPart
 
-	// Enforce single-line by truncating if still too wide
-	if lipgloss.Width(text) > m.width && m.width > 0 {
-		text = text[:m.width]
+	// Pad to full width if needed (for consistent highlight background)
+	if pad := m.width - lipgloss.Width(text); pad > 0 {
+		text += strings.Repeat(" ", pad)
 	}
 
+	// Use only MaxWidth (truncates without wrapping) to prevent multi-line output.
+	// Width() wraps text and can produce 2+ lines that corrupt the split-pane layout.
 	style := lipgloss.NewStyle().
-		Width(m.width).
 		MaxWidth(m.width)
 	if isSelected {
 		style = style.Foreground(lipgloss.Color("6"))

--- a/internal/tui/pipeline_list.go
+++ b/internal/tui/pipeline_list.go
@@ -738,18 +738,29 @@ func (m PipelineListModel) renderFinishedItem(item navigableItem, isSelected boo
 	return style.Render(text)
 }
 
-// truncateName truncates a name with ellipsis if it exceeds maxWidth.
+// truncateName truncates a name with ellipsis if it exceeds maxWidth visual columns.
 func truncateName(name string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
-	if len(name) <= maxWidth {
+	if lipgloss.Width(name) <= maxWidth {
 		return name
 	}
 	if maxWidth <= 1 {
 		return "…"
 	}
-	return name[:maxWidth-1] + "…"
+	// Walk rune by rune, tracking visual width, to find the longest
+	// prefix that fits within (maxWidth - 1) columns (reserving 1 for …).
+	target := maxWidth - 1
+	w := 0
+	for i, r := range name {
+		rw := lipgloss.Width(string(r))
+		if w+rw > target {
+			return name[:i] + "…"
+		}
+		w += rw
+	}
+	return name + "…"
 }
 
 // formatDuration wraps display.FormatDuration converting time.Duration to milliseconds.


### PR DESCRIPTION
## Summary
- Issue detail pane rendered long titles and bodies without width constraints, producing lines wider than the terminal when joined horizontally with the left pane — causing terminal wrapping that corrupted the entire split-pane layout
- Fixed by wrapping detail content to viewport width, switching from `Width()` (wraps) to `MaxWidth()` (truncates) in issue line rendering, and fixing `truncateName` and width calculations to use visual width instead of byte count

## Changes
- **`issue_detail.go`**: Wrap rendered content with `lipgloss.Width(m.width)` before setting viewport content
- **`issue_list.go`**: Use `lipgloss.Width()` for fixedWidth/label calculations; replace `Width()+MaxWidth()` with `MaxWidth()` only to prevent multi-line wrapping
- **`pipeline_list.go`**: Fix `truncateName` to walk runes by visual width instead of byte count

## Test plan
- [x] All TUI tests pass (`go test ./internal/tui/...`)
- [x] Verified `renderIssueLine` produces single-line output across widths 40-80
- [x] Manual verification: scroll issues list up/down, verify no display corruption