### PR TITLE
feat(pipeline): add wave-audit pipeline for implementation fidelity auditing

### DIFF
--- a/.wave/contracts/audit-findings.schema.json
+++ b/.wave/contracts/audit-findings.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Findings",
+  "description": "Output from the audit-items step: per-item fidelity classification with evidence",
+  "type": "object",
+  "required": ["findings", "summary", "timestamp"],
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["item_number", "item_type", "item_url", "title", "category", "evidence"],
+        "properties": {
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "item_type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether the source item is an issue or PR"
+          },
+          "item_url": {
+            "type": "string",
+            "description": "Full GitHub URL for reference"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Item title for readability"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+            "description": "Fidelity classification"
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "File paths, code references, and commit SHAs supporting the classification"
+          },
+          "unmet_criteria": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Specific acceptance criteria not satisfied (for partial/regressed)"
+          },
+          "remediation": {
+            "type": "string",
+            "description": "Actionable description of what needs to change (empty for verified/obsolete)"
+          }
+        }
+      },
+      "description": "Per-item audit findings"
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_audited"],
+      "properties": {
+        "total_audited": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of items audited"
+        },
+        "by_category": {
+          "type": "object",
+          "properties": {
+            "verified": { "type": "integer", "minimum": 0 },
+            "partial": { "type": "integer", "minimum": 0 },
+            "regressed": { "type": "integer", "minimum": 0 },
+            "obsolete": { "type": "integer", "minimum": 0 },
+            "unverifiable": { "type": "integer", "minimum": 0 }
+          },
+          "description": "Count of findings per fidelity category"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the audit was performed"
+    }
+  }
+}

--- a/.wave/contracts/audit-inventory.schema.json
+++ b/.wave/contracts/audit-inventory.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Inventory",
+  "description": "Output from the collect-inventory step: all closed issues and merged PRs with extracted metadata",
+  "type": "object",
+  "required": ["scope", "items", "timestamp"],
+  "properties": {
+    "scope": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["full", "time_range", "label"],
+          "description": "How the inventory was scoped"
+        },
+        "filter": {
+          "type": "string",
+          "description": "The filter expression applied (e.g., 'last 30 days', 'label:enhancement')"
+        },
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "Repository full name (owner/repo)"
+        }
+      }
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "type", "title", "url", "close_reason", "closed_at"],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub issue or PR number"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether this is an issue or pull request"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Issue or PR title"
+          },
+          "url": {
+            "type": "string",
+            "description": "Full GitHub URL"
+          },
+          "body": {
+            "type": "string",
+            "description": "Full issue/PR body text"
+          },
+          "labels": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Associated labels"
+          },
+          "close_reason": {
+            "type": "string",
+            "description": "Why the item was closed (completed, merged, not_planned)"
+          },
+          "closed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the item was closed"
+          },
+          "linked_prs": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "description": "PR numbers linked to this issue"
+          },
+          "linked_commits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Commit SHAs associated with this item"
+          },
+          "acceptance_criteria": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Extracted acceptance criteria from the body"
+          }
+        }
+      },
+      "description": "All inventory items to audit"
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_issues": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of closed issues in inventory"
+        },
+        "total_prs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of merged PRs in inventory"
+        },
+        "excluded_not_planned": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of issues excluded due to not_planned close reason"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the inventory was collected"
+    }
+  }
+}

--- a/.wave/contracts/audit-publish-result.schema.json
+++ b/.wave/contracts/audit-publish-result.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Publish Result",
+  "description": "Output from the publish step: GitHub issue creation results for actionable findings",
+  "type": "object",
+  "required": ["success", "repository", "timestamp"],
+  "properties": {
+    "success": {
+      "type": "boolean",
+      "description": "Whether the publish operation completed successfully"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$",
+      "description": "Repository full name (owner/repo)"
+    },
+    "issues_created": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "url", "source_item", "category"],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Created GitHub issue number"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to the created issue"
+          },
+          "source_item": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Original issue/PR number that this finding references"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["partial", "regressed"],
+            "description": "Fidelity category of the finding"
+          }
+        }
+      },
+      "description": "List of GitHub issues created for fixable gaps"
+    },
+    "issues_skipped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of findings skipped (verified, obsolete, unverifiable, or no remediation)"
+    },
+    "skipped": {
+      "type": "boolean",
+      "description": "True if no issues were created because all findings are verified/obsolete"
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": ["authentication_failed", "rate_limit_exceeded", "permission_denied", "network_error", "api_error", "unknown_error"],
+          "description": "Error code"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message"
+        },
+        "retryable": {
+          "type": "boolean",
+          "description": "Whether the operation can be retried"
+        }
+      },
+      "description": "Error details (only present if success=false)"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Operation timestamp"
+    }
+  }
+}

--- a/.wave/contracts/audit-triage-report.schema.json
+++ b/.wave/contracts/audit-triage-report.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Triage Report",
+  "description": "Output from the compose-triage step: aggregated findings with prioritized action list",
+  "type": "object",
+  "required": ["metadata", "summary", "findings", "prioritized_actions"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["scope", "timestamp", "repository", "total_items_audited"],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Audit scope description (e.g., 'full', 'last 30 days', 'label:enhancement')"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the triage report was composed"
+        },
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "Repository full name (owner/repo)"
+        },
+        "total_items_audited": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of items that were audited"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+      "properties": {
+        "verified": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items fully implemented and intact"
+        },
+        "partial": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items with some acceptance criteria unmet"
+        },
+        "regressed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items that were implemented but later broken"
+        },
+        "obsolete": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items no longer applicable to current codebase"
+        },
+        "unverifiable": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items with no traceable implementation artifacts"
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["item_number", "item_type", "item_url", "title", "category", "evidence"],
+        "properties": {
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "item_type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether the source item is an issue or PR"
+          },
+          "item_url": {
+            "type": "string",
+            "description": "Full GitHub URL"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Item title"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+            "description": "Fidelity classification"
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Supporting evidence (file paths, code refs, commit SHAs)"
+          },
+          "remediation": {
+            "type": "string",
+            "description": "Actionable fix description"
+          }
+        }
+      },
+      "description": "All findings grouped by category (regressed first, then partial, then unverifiable, then obsolete, then verified)"
+    },
+    "prioritized_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["priority", "item_number", "action_description"],
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Priority rank (1 = highest)"
+          },
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "action_description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "What needs to be done to resolve this finding"
+          }
+        }
+      },
+      "description": "Prioritized list of remediation actions (regressed first, then partial)"
+    }
+  }
+}

--- a/.wave/pipelines/wave-audit.yaml
+++ b/.wave/pipelines/wave-audit.yaml
@@ -1,0 +1,353 @@
+kind: WavePipeline
+metadata:
+  name: wave-audit
+  description: Zero-trust implementation fidelity audit — verifies all closed issues and merged PRs against the current codebase, classifies gaps, and optionally creates remediation issues
+  release: false
+
+requires:
+  tools:
+    - gh
+
+input:
+  source: cli
+  example: "last 30 days -- audit only recent work"
+  schema:
+    type: string
+    description: "Audit scope: empty for full audit, time range ('last 30 days', 'since 2026-01-01'), or label filter ('label:enhancement')"
+
+steps:
+  - id: collect-inventory
+    persona: github-analyst
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source: |
+        Collect a complete inventory of closed issues and merged PRs for auditing.
+
+        ## Detect Repository
+
+        Run: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+
+        ## Parse Scope
+
+        Input: {{ input }}
+
+        Determine the scope mode from the input:
+
+        - **Empty or blank input**: Full audit — fetch ALL closed issues and merged PRs
+        - **Time range** (e.g., "last 30 days", "last 7 days", "since 2026-01-01"):
+          - For "last N days": calculate the date N days ago, use `closed:>YYYY-MM-DD` / `merged:>YYYY-MM-DD`
+          - For "since YYYY-MM-DD": use `closed:>YYYY-MM-DD` / `merged:>YYYY-MM-DD`
+        - **Label filter** (e.g., "label:enhancement", "label:bug"):
+          - Extract the label name after "label:"
+          - Add `--label <name>` to both issue and PR queries
+
+        ## Fetch Closed Issues
+
+        ```bash
+        gh issue list --state closed --json number,title,body,labels,closedAt,stateReason,url \
+          --limit 500 [--search "closed:>YYYY-MM-DD"] [--label <name>]
+        ```
+
+        Filter out issues where `stateReason` is `NOT_PLANNED` — these represent intentional non-implementation and should be excluded.
+
+        If the result count equals the limit (500), make additional paginated calls to fetch remaining items.
+
+        ## Fetch Merged PRs
+
+        ```bash
+        gh pr list --state merged --json number,title,body,files,mergeCommit,closedAt,url \
+          --limit 500 [--search "merged:>YYYY-MM-DD"] [--label <name>]
+        ```
+
+        If the result count equals the limit, paginate for more.
+
+        ## Rate Limit Awareness
+
+        The `gh` CLI handles rate limits automatically. If you see rate-limit errors, wait briefly and retry. For very large repositories, space out requests.
+
+        ## Build Inventory
+
+        For each item, extract:
+        - `number`, `type` (issue or pr), `title`, `url`, `body`, `labels`
+        - `close_reason`: "completed" for issues, "merged" for PRs
+        - `closed_at`: ISO 8601 timestamp
+        - `linked_prs`: For issues, search the body for "Fixes #N", "Closes #N", or PR cross-references
+        - `linked_commits`: For PRs, include the merge commit SHA
+        - `acceptance_criteria`: Extract from issue body by looking for checklist patterns (`- [ ]`, `- [x]`) or sections titled "Acceptance Criteria", "Requirements", or similar headers
+
+        ## Handle Empty Results
+
+        If no items match the scope filters, output a valid inventory JSON with an empty `items` array and a summary indicating zero results. This is not an error.
+
+        ## Output
+
+        Write the inventory as structured JSON to `.wave/output/inventory.json`.
+
+        The JSON must include:
+        - `scope`: object with `mode` ("full", "time_range", or "label"), `filter` (the raw scope expression), `repository` (owner/repo)
+        - `items`: array of inventory items
+        - `summary`: object with `total_issues`, `total_prs`, `excluded_not_planned` counts
+        - `timestamp`: current ISO 8601 timestamp
+    output_artifacts:
+      - name: inventory
+        path: .wave/output/inventory.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        source: .wave/output/inventory.json
+        schema_path: .wave/contracts/audit-inventory.schema.json
+        on_failure: retry
+        max_retries: 2
+
+  - id: audit-items
+    persona: navigator
+    dependencies: [collect-inventory]
+    memory:
+      inject_artifacts:
+        - step: collect-inventory
+          artifact: inventory
+          as: inventory
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source: |
+        Audit each inventory item against the current codebase to classify implementation fidelity.
+
+        ## Read Inventory
+
+        Read the injected inventory artifact to get the list of items to audit.
+
+        ## Verification Methodology
+
+        For each inventory item, perform static analysis verification:
+
+        1. **Read the item description** — identify what should exist in the codebase: specific functions, types, handlers, configuration options, CLI flags, test files, documentation
+        2. **Check file existence** — use Glob to verify that referenced files still exist at HEAD
+        3. **Search for key artifacts** — use Grep to find function names, type definitions, handler registrations, and other code artifacts mentioned in the issue/PR
+        4. **Read relevant code** — use Read to verify logic matches the described behavior
+        5. **Check test coverage** — verify related test files exist and contain assertions matching the acceptance criteria
+        6. **Detect regressions** — run `git log --oneline --all -- <file>` to check if key files were modified after the implementing PR merged. Run `git log --grep="Revert" --oneline` to find revert commits that may have undone the work
+
+        ## Classification Rules
+
+        Assign exactly ONE fidelity category per item:
+
+        - **verified**: All referenced files exist, key functions/types are present via Grep, logic reads match the described behavior, related tests exist
+        - **partial**: Some but not all acceptance criteria have matching code evidence. For each partial finding, list WHICH criteria passed and WHICH did not
+        - **regressed**: Was implemented but later broken or reverted. Include the revert commit SHAs and affected file paths as evidence. Use `git log --all --oneline -- <file>` and `git log --grep="Revert" --oneline` output
+        - **obsolete**: Referenced files have been deleted at HEAD, or the codebase has diverged significantly enough that the item no longer applies
+        - **unverifiable**: No linked PRs, no commit SHAs, no file references in the issue body — insufficient evidence to evaluate
+
+        ## Evidence Requirements
+
+        Every finding MUST include evidence:
+        - For **verified**: file paths confirming existence, Grep matches for key code artifacts
+        - For **partial**: which criteria passed (with file:line references) and which did not (what was searched for but not found)
+        - For **regressed**: revert commit SHAs, `git log` output showing modification/deletion after the implementing PR
+        - For **obsolete**: evidence that files no longer exist or architecture has changed
+        - For **unverifiable**: note the absence of linked PRs, commits, or traceable code changes
+
+        ## Edge Cases
+
+        - **Issues with no linked PRs or commits**: Mark as "unverifiable" with a note explaining the lack of traceable code changes
+        - **Issues referencing deleted files**: Mark as "obsolete" with evidence that the referenced code no longer exists at HEAD
+        - **Single issues spanning many files**: Summarize the scope, highlighting the 5-10 most important file paths rather than exhaustively listing every touched file
+        - **Large inventories**: Focus on the most impactful items first — non-trivial issues with acceptance criteria. If context limits approach, prioritize quality of analysis over quantity
+
+        ## Remediation Details
+
+        For **partial** items: describe specifically what needs to change — which criteria are unmet, which files need modification, what logic is missing
+        For **regressed** items: identify the reverting commit, the affected code locations, and what needs to be restored
+        For **verified** and **obsolete** items: remediation should be empty
+        For **unverifiable** items: suggest adding linked PRs or better traceability to the issue
+
+        ## Output
+
+        Write the findings as structured JSON to `.wave/output/audit-findings.json`.
+
+        The JSON must include:
+        - `findings`: array of finding objects, each with `item_number`, `item_type`, `item_url`, `title`, `category`, `evidence` (array of strings), `unmet_criteria` (array of strings for partial/regressed), `remediation` (string)
+        - `summary`: object with `total_audited` count and `by_category` breakdown (verified, partial, regressed, obsolete, unverifiable counts)
+        - `timestamp`: current ISO 8601 timestamp
+    output_artifacts:
+      - name: findings
+        path: .wave/output/audit-findings.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        source: .wave/output/audit-findings.json
+        schema_path: .wave/contracts/audit-findings.schema.json
+        on_failure: retry
+        max_retries: 2
+
+  - id: compose-triage
+    persona: navigator
+    dependencies: [audit-items]
+    memory:
+      inject_artifacts:
+        - step: collect-inventory
+          artifact: inventory
+          as: inventory
+        - step: audit-items
+          artifact: findings
+          as: findings
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source: |
+        Compose a triage report from the audit findings with prioritized remediation actions.
+
+        ## Read Inputs
+
+        Read the injected inventory artifact to get scope and repository metadata.
+        Read the injected findings artifact to get the per-item audit results.
+
+        ## Group Findings by Category
+
+        Organize all findings into groups by fidelity category, in this order:
+        1. **regressed** — highest priority, was working but now broken
+        2. **partial** — some criteria unmet
+        3. **unverifiable** — no traceable implementation
+        4. **obsolete** — no longer applicable
+        5. **verified** — fully intact (included for completeness)
+
+        ## Summary Statistics
+
+        Calculate counts for each fidelity category:
+        - `verified`: number of fully implemented items
+        - `partial`: number with some criteria unmet
+        - `regressed`: number that were broken or reverted
+        - `obsolete`: number no longer applicable
+        - `unverifiable`: number with no traceable evidence
+
+        ## Prioritized Actions
+
+        Generate an ordered list of remediation actions for non-verified items. Priority ranking:
+
+        1. **regressed** items (highest priority — was working, now broken)
+        2. **partial** items with many unmet criteria (sort by unmet count descending)
+        3. **partial** items with fewer unmet criteria
+        4. **unverifiable** items (lowest actionable priority)
+        5. **obsolete** items are EXCLUDED from actions — they are intentionally non-applicable
+
+        Each action MUST include:
+        - `priority`: integer rank (1 = highest)
+        - `item_number`: the original issue/PR number
+        - `action_description`: specific remediation describing what needs to change, referencing the original issue URL and the specific unmet criteria or reverted commits. Rank by severity (regressed > partial with many unmet > partial with few > unverifiable)
+
+        ## Output
+
+        Write the triage report as structured JSON to `.wave/output/triage-report.json`.
+
+        The JSON must include:
+        - `metadata`: object with `scope` (string describing audit scope), `timestamp` (ISO 8601), `repository` (owner/repo), `total_items_audited` (integer)
+        - `summary`: object with counts for verified, partial, regressed, obsolete, unverifiable
+        - `findings`: array of all findings (grouped by category: regressed first, then partial, unverifiable, obsolete, verified)
+        - `prioritized_actions`: array of action objects sorted by priority
+    output_artifacts:
+      - name: triage-report
+        path: .wave/output/triage-report.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        source: .wave/output/triage-report.json
+        schema_path: .wave/contracts/audit-triage-report.schema.json
+        on_failure: retry
+        max_retries: 2
+
+  - id: publish
+    persona: craftsman
+    dependencies: [compose-triage]
+    memory:
+      inject_artifacts:
+        - step: compose-triage
+          artifact: triage-report
+          as: triage-report
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source: |
+        Create GitHub issues for actionable audit findings (partial and regressed items).
+
+        ## Read Triage Report
+
+        Read the injected triage report artifact to get findings and prioritized actions.
+
+        ## Check for Actionable Findings
+
+        If all findings are verified, obsolete, or unverifiable (no partial or regressed items), skip issue creation:
+        - Write a publish result with `success: true`, `skipped: true`, empty `issues_created` array
+        - Exit early
+
+        ## Detect Repository
+
+        Run: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+
+        ## Create Issues for Fixable Gaps
+
+        For each finding with category "partial" or "regressed", create a GitHub issue:
+
+        ```bash
+        gh issue create \
+          --title "audit: <category> — <item title>" \
+          --body "<body with evidence and remediation details>" \
+          --label "audit"
+        ```
+
+        The issue body should include:
+        - Reference to the original issue/PR (number and URL)
+        - Fidelity category and explanation
+        - Evidence from the audit (file paths, code references)
+        - Specific remediation steps from the triage report
+        - Link back to the audit run for context
+
+        If the `audit` label doesn't exist, create without labels.
+        If any `gh issue create` command fails, log the error and continue with remaining items.
+
+        ## Capture Results
+
+        For each created issue, record:
+        - `number`: the new issue number
+        - `url`: the new issue URL
+        - `source_item`: the original issue/PR number this finding references
+        - `category`: the fidelity category (partial or regressed)
+
+        ## Output
+
+        Write the publish result as structured JSON to `.wave/output/publish-result.json`.
+
+        The JSON must include:
+        - `success`: boolean (true if all issue creations succeeded or were skipped)
+        - `repository`: owner/repo string
+        - `issues_created`: array of created issue objects
+        - `issues_skipped`: count of findings not turned into issues (verified, obsolete, unverifiable)
+        - `skipped`: boolean (true if no issues were created because no actionable findings)
+        - `timestamp`: current ISO 8601 timestamp
+    output_artifacts:
+      - name: publish-result
+        path: .wave/output/publish-result.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        source: .wave/output/publish-result.json
+        schema_path: .wave/contracts/audit-publish-result.schema.json
+        on_failure: retry
+        max_retries: 2
+    outcomes:
+      - type: issue
+        extract_from: .wave/output/publish-result.json
+        json_path: .issues_created[].url
+        label: "Audit Remediation Issue"

--- a/specs/305-audit-pipeline/checklists/contracts.md
+++ b/specs/305-audit-pipeline/checklists/contracts.md
@@ -1,0 +1,29 @@
+# Contract Schema Quality Review — Closed-Issue/PR Audit Pipeline (#305)
+
+**Feature**: `wave-audit` pipeline | **Date**: 2026-03-11
+
+This checklist validates the quality of the four JSON Schema contracts that govern inter-step data handoffs.
+
+## Schema Completeness
+
+- [ ] CHK101 - Does `audit-inventory.schema.json` require the `summary` object (with `total_issues`, `total_prs`, `excluded_not_planned`) or is it optional — and is this intentional given FR-004 requires a "structured JSON inventory"? [Completeness]
+- [ ] CHK102 - Does `audit-findings.schema.json` define the `unmet_criteria` and `remediation` fields as required for `partial`/`regressed` categories per FR-009, or are they globally optional? [Completeness]
+- [ ] CHK103 - Does `audit-triage-report.schema.json` enforce that `prioritized_actions` items reference only non-verified/non-obsolete findings, or is this a prompt-level concern only? [Completeness]
+- [ ] CHK104 - Does `audit-publish-result.schema.json` define the `issues_created` array as required when `success=true`, or can a successful publish have zero issues created? [Completeness]
+- [ ] CHK105 - Are `additionalProperties` constraints defined in all four schemas to prevent uncontrolled schema drift? [Completeness]
+
+## Schema-to-Spec Alignment
+
+- [ ] CHK106 - Does the inventory item schema include all fields from the data model's `InventoryItem` entity — specifically `body`, `labels`, `linked_prs`, `linked_commits`, and `acceptance_criteria`? [Consistency]
+- [ ] CHK107 - Does the findings schema's `category` enum match the five fidelity categories listed in FR-007 exactly (verified, partial, regressed, obsolete, unverifiable)? [Consistency]
+- [ ] CHK108 - Does the triage report schema's `metadata.repository` pattern (`^[^/]+/[^/]+$`) match the inventory schema's `scope.repository` pattern for consistency? [Consistency]
+- [ ] CHK109 - Does the publish result schema's `category` enum (`partial`, `regressed`) correctly reflect which categories produce publishable findings per FR-015? [Consistency]
+- [ ] CHK110 - Are the `timestamp` fields using consistent format (`date-time`) across all four schemas? [Consistency]
+
+## Schema Robustness
+
+- [ ] CHK111 - Do the schemas define minimum array lengths where empty arrays would indicate a problem (e.g., `findings` in the triage report should it allow empty)? [Coverage]
+- [ ] CHK112 - Are string fields that should never be empty protected with `minLength: 1` constraints (titles, descriptions, remediation text)? [Coverage]
+- [ ] CHK113 - Does the inventory schema validate URL format for the `url` field, or is any string accepted? [Coverage]
+- [ ] CHK114 - Are integer fields constrained with appropriate `minimum` values to prevent negative numbers (e.g., `item_number >= 1`, `total_audited >= 0`)? [Coverage]
+- [ ] CHK115 - Does the error object in `audit-publish-result.schema.json` have a clearly defined relationship with the `success` field — is the error required when `success=false`? [Coverage]

--- a/specs/305-audit-pipeline/checklists/pipeline-design.md
+++ b/specs/305-audit-pipeline/checklists/pipeline-design.md
@@ -1,0 +1,33 @@
+# Pipeline Design Quality Review — Closed-Issue/PR Audit Pipeline (#305)
+
+**Feature**: `wave-audit` pipeline | **Date**: 2026-03-11
+
+This checklist validates the quality of the pipeline architecture and step decomposition requirements.
+
+## Step Decomposition
+
+- [ ] CHK201 - Is the separation of concerns between `audit-items` and `compose-triage` justified — are the requirements clear about why aggregation cannot happen within the audit step itself? [Clarity]
+- [ ] CHK202 - Does the plan specify the exact artifact names and paths for inter-step communication (e.g., `inventory.json` → where exactly is it written and how is it injected)? [Completeness]
+- [ ] CHK203 - Is the DAG dependency chain fully specified — are there missing edges (e.g., should `publish` also depend on `collect-inventory` for repository metadata)? [Completeness]
+- [ ] CHK204 - Does the spec define whether the `publish` step is opt-in (requiring a flag to enable) or opt-out (running by default with a flag to skip)? [Clarity]
+
+## Persona-Step Alignment
+
+- [ ] CHK205 - Are the tool permissions required by each step documented against the actual persona definitions — does `navigator` have all tools needed for `audit-items` (specifically `Bash(git log*)`)? [Consistency]
+- [ ] CHK206 - Does the P5 deviation (github-analyst as first step) have a clear constitutional exception documented, or is it a silent violation? [Completeness]
+- [ ] CHK207 - Are the `craftsman` persona's permissions appropriate for the `publish` step — does it have `gh issue create` but not overly broad access? [Coverage]
+- [ ] CHK208 - Does the spec define what happens if a persona's tool permissions are insufficient at runtime — error handling for permission denials? [Coverage]
+
+## Prompt Engineering Requirements
+
+- [ ] CHK209 - Are the prompt requirements for scope parsing (C3) specific enough to produce consistent behavior — what if the persona misparses "last 30 days" as a label filter? [Clarity]
+- [ ] CHK210 - Does the spec define the expected prompt structure for handling inventory items that span the adapter's context window — is there a batching or prioritization strategy? [Completeness]
+- [ ] CHK211 - Are the verification instructions in the `audit-items` prompt specific enough for consistent classification — would two different navigators classify the same item identically? [Clarity]
+- [ ] CHK212 - Does the spec require prompt testing or validation beyond `go test ./...` — how is prompt quality assured for the four step prompts? [Coverage]
+
+## Resilience and Operability
+
+- [ ] CHK213 - Are retry semantics specified for each step — does the plan define `on_failure` and `max_retries` per step, and are these consistent with existing pipeline patterns? [Completeness]
+- [ ] CHK214 - Does the spec define observability requirements — what progress events should be emitted during long-running steps like `audit-items`? [Completeness]
+- [ ] CHK215 - Is the expected runtime performance characterized — what is the estimated token/time cost per inventory item during the audit step? [Completeness]
+- [ ] CHK216 - Does the spec address the workspace isolation model — are all steps using the same worktree, and is this documented as a deliberate choice? [Clarity]

--- a/specs/305-audit-pipeline/checklists/requirements.md
+++ b/specs/305-audit-pipeline/checklists/requirements.md
@@ -1,0 +1,53 @@
+# Quality Checklist: 305-audit-pipeline
+
+## Structure & Completeness
+
+- [x] Feature branch name matches convention (`NNN-short-name`)
+- [x] Created date is present
+- [x] Status is set (Draft)
+- [x] Input/source reference is present (GitHub issue URL)
+- [x] All mandatory sections present: User Scenarios, Requirements, Success Criteria
+
+## User Stories
+
+- [x] At least 3 user stories with distinct priorities (P1, P2, P3)
+- [x] Each story has: description, priority justification, independent test, acceptance scenarios
+- [x] P1 story represents a viable MVP (end-to-end audit flow)
+- [x] Stories are independently testable
+- [x] Acceptance scenarios use Given/When/Then format
+- [x] Edge cases section is populated with realistic scenarios (not placeholders)
+
+## Requirements
+
+- [x] All requirements use RFC 2119 language (MUST/SHOULD/MAY)
+- [x] Each requirement has a unique ID (FR-NNN)
+- [x] Requirements are testable and unambiguous
+- [x] No implementation details (technology choices, specific algorithms)
+- [x] Key entities defined with descriptions and relationships
+- [x] Maximum 3 `[NEEDS CLARIFICATION]` markers (currently: 1)
+- [x] Requirements trace back to user stories and issue acceptance criteria
+
+## Requirements Coverage (Issue #305 Acceptance Criteria)
+
+- [x] AC: Pipeline definition added to `.wave/pipelines/` → FR-001
+- [x] AC: Step 1 fetches closed issues and merged PRs → FR-002, FR-003, FR-004, FR-005
+- [x] AC: Step 2 audits each item against codebase → FR-006, FR-007
+- [x] AC: Step 3 produces triage report with categories → FR-008, FR-009
+- [x] AC: Handles rate limits and large repos → FR-005, FR-012
+- [x] AC: Results are actionable with file paths and remediation → FR-009
+- [x] AC: Pipeline can be resumed → FR-013
+
+## Success Criteria
+
+- [x] At least 4 measurable success criteria
+- [x] Criteria are technology-agnostic
+- [x] Criteria are quantifiable or objectively verifiable
+- [x] Criteria cover: correctness (SC-002), actionability (SC-003), reliability (SC-001, SC-004), performance (SC-005, SC-007), and resumability (SC-006)
+
+## Quality Gates
+
+- [x] No placeholder text remaining (all `[FEATURE NAME]`, `[DATE]`, etc. replaced)
+- [x] No template comments remaining (HTML comments with ACTION REQUIRED)
+- [x] Focuses on WHAT and WHY, not HOW
+- [x] Edge cases address error scenarios, boundary conditions, and scale concerns
+- [x] Specification is self-consistent (no contradictions between sections)

--- a/specs/305-audit-pipeline/checklists/review.md
+++ b/specs/305-audit-pipeline/checklists/review.md
@@ -1,0 +1,43 @@
+# Requirements Quality Review — Closed-Issue/PR Audit Pipeline (#305)
+
+**Feature**: `wave-audit` pipeline | **Date**: 2026-03-11 | **Spec**: [spec.md](../spec.md)
+
+## Completeness
+
+- [ ] CHK001 - Are all five fidelity categories (verified, partial, regressed, obsolete, unverifiable) defined with unambiguous classification criteria that prevent overlap between categories? [Completeness]
+- [ ] CHK002 - Does the spec define what happens when a single inventory item could match multiple fidelity categories (e.g., partially implemented AND partially regressed)? [Completeness]
+- [ ] CHK003 - Are the input requirements for `wave run wave-audit` fully specified — what happens when no CLI input is provided vs. invalid input vs. malformed scope expressions? [Completeness]
+- [ ] CHK004 - Does the spec define the maximum inventory size the pipeline is expected to handle, and what happens when the inventory exceeds adapter context limits? [Completeness]
+- [ ] CHK005 - Are persona selection requirements documented for all four steps, including the rationale for P5 deviation and the read-only constraints for analysis steps? [Completeness]
+- [ ] CHK006 - Does FR-011 specify how "not planned" close reason detection works across different GitHub close reason values (e.g., `NOT_PLANNED`, `not_planned`, locale variations)? [Completeness]
+- [ ] CHK007 - Are timeout requirements specified per-step, or only at the pipeline level (SC-007 says 90 minutes per step — is this configurable or fixed)? [Completeness]
+- [ ] CHK008 - Does the spec define the expected behavior when the `gh` CLI is not installed or not authenticated? [Completeness]
+
+## Clarity
+
+- [ ] CHK009 - Is the distinction between "regressed" and "obsolete" clearly defined — what criteria determine whether removed code is a regression vs. intentional deprecation? [Clarity]
+- [ ] CHK010 - Is "static analysis only" (C4) sufficiently precise — does it include or exclude `git log` execution, `gh` CLI queries in the audit step, or file content hashing? [Clarity]
+- [ ] CHK011 - Is the scope parsing syntax unambiguous — can "last 30 days" be confused with a label filter, and is the parsing precedence documented? [Clarity]
+- [ ] CHK012 - Does SC-002 (90% accuracy for "verified" classifications) define how accuracy is measured — against manual spot-checks, automated verification, or a ground-truth dataset? [Clarity]
+- [ ] CHK013 - Is the term "acceptance criteria" defined consistently — does it refer only to checklist items in the issue body, or also to requirements stated in prose? [Clarity]
+- [ ] CHK014 - Does the spec clarify what "supporting evidence" means for each fidelity category — are minimum evidence requirements defined per category? [Clarity]
+
+## Consistency
+
+- [ ] CHK015 - Does the 4-step pipeline decomposition (C2) align with all 15 functional requirements — is every FR addressed by at least one step? [Consistency]
+- [ ] CHK016 - Are the contract schema field names consistent with the data model entity definitions (e.g., `item_number` vs `number`, `item_type` vs `type`)? [Consistency]
+- [ ] CHK017 - Does the inventory schema's `close_reason` field accept the same values referenced in FR-011 and the data model (completed, not_planned, merged)? [Consistency]
+- [ ] CHK018 - Are the user stories' acceptance scenarios testable against the success criteria — does each SC map to at least one acceptance scenario? [Consistency]
+- [ ] CHK019 - Does the plan's "no Go code changes" claim align with the testing requirement (T017) — can `go test ./...` validate YAML-only additions without new test code? [Consistency]
+- [ ] CHK020 - Is the `unverifiable` category consistently handled — FR-007 lists 5 categories, but does the priority ordering in the data model correctly exclude `verified` and `obsolete` from `prioritized_actions`? [Consistency]
+
+## Coverage
+
+- [ ] CHK021 - Are error scenarios specified for each pipeline step — what happens when `collect-inventory` fails, and how does it affect downstream steps? [Coverage]
+- [ ] CHK022 - Does the spec address the case where a repository has zero closed issues and zero merged PRs? [Coverage]
+- [ ] CHK023 - Are concurrent execution scenarios addressed — what happens if two `wave-audit` runs execute simultaneously on the same repository? [Coverage]
+- [ ] CHK024 - Does the spec define behavior for private repositories, forks, or repositories where the `gh` CLI user lacks read access to some issues? [Coverage]
+- [ ] CHK025 - Are all seven edge cases listed in the spec cross-referenced to specific functional requirements or handling instructions in step prompts? [Coverage]
+- [ ] CHK026 - Does the spec address how issues with only PR references (no direct code changes) are verified — e.g., documentation-only issues or process changes? [Coverage]
+- [ ] CHK027 - Is the resume scenario (US4) tested for each step boundary — not just inventory→audit, but also audit→triage and triage→publish? [Coverage]
+- [ ] CHK028 - Does the spec define the expected output when ALL items are classified as "verified" — is the prioritized_actions array empty, and is the publish step skipped entirely? [Coverage]

--- a/specs/305-audit-pipeline/contracts/audit-findings.schema.json
+++ b/specs/305-audit-pipeline/contracts/audit-findings.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Findings",
+  "description": "Output from the audit-items step: per-item fidelity classification with evidence",
+  "type": "object",
+  "required": ["findings", "summary", "timestamp"],
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["item_number", "item_type", "item_url", "title", "category", "evidence"],
+        "properties": {
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "item_type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether the source item is an issue or PR"
+          },
+          "item_url": {
+            "type": "string",
+            "description": "Full GitHub URL for reference"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Item title for readability"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+            "description": "Fidelity classification"
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "File paths, code references, and commit SHAs supporting the classification"
+          },
+          "unmet_criteria": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Specific acceptance criteria not satisfied (for partial/regressed)"
+          },
+          "remediation": {
+            "type": "string",
+            "description": "Actionable description of what needs to change (empty for verified/obsolete)"
+          }
+        }
+      },
+      "description": "Per-item audit findings"
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_audited"],
+      "properties": {
+        "total_audited": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of items audited"
+        },
+        "by_category": {
+          "type": "object",
+          "properties": {
+            "verified": { "type": "integer", "minimum": 0 },
+            "partial": { "type": "integer", "minimum": 0 },
+            "regressed": { "type": "integer", "minimum": 0 },
+            "obsolete": { "type": "integer", "minimum": 0 },
+            "unverifiable": { "type": "integer", "minimum": 0 }
+          },
+          "description": "Count of findings per fidelity category"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the audit was performed"
+    }
+  }
+}

--- a/specs/305-audit-pipeline/contracts/audit-inventory.schema.json
+++ b/specs/305-audit-pipeline/contracts/audit-inventory.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Inventory",
+  "description": "Output from the collect-inventory step: all closed issues and merged PRs with extracted metadata",
+  "type": "object",
+  "required": ["scope", "items", "timestamp"],
+  "properties": {
+    "scope": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["full", "time_range", "label"],
+          "description": "How the inventory was scoped"
+        },
+        "filter": {
+          "type": "string",
+          "description": "The filter expression applied (e.g., 'last 30 days', 'label:enhancement')"
+        },
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "Repository full name (owner/repo)"
+        }
+      }
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "type", "title", "url", "close_reason", "closed_at"],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "GitHub issue or PR number"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether this is an issue or pull request"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Issue or PR title"
+          },
+          "url": {
+            "type": "string",
+            "description": "Full GitHub URL"
+          },
+          "body": {
+            "type": "string",
+            "description": "Full issue/PR body text"
+          },
+          "labels": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Associated labels"
+          },
+          "close_reason": {
+            "type": "string",
+            "description": "Why the item was closed (completed, merged, not_planned)"
+          },
+          "closed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the item was closed"
+          },
+          "linked_prs": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "description": "PR numbers linked to this issue"
+          },
+          "linked_commits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Commit SHAs associated with this item"
+          },
+          "acceptance_criteria": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Extracted acceptance criteria from the body"
+          }
+        }
+      },
+      "description": "All inventory items to audit"
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_issues": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of closed issues in inventory"
+        },
+        "total_prs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of merged PRs in inventory"
+        },
+        "excluded_not_planned": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of issues excluded due to not_planned close reason"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the inventory was collected"
+    }
+  }
+}

--- a/specs/305-audit-pipeline/contracts/audit-publish-result.schema.json
+++ b/specs/305-audit-pipeline/contracts/audit-publish-result.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Publish Result",
+  "description": "Output from the publish step: GitHub issue creation results for actionable findings",
+  "type": "object",
+  "required": ["success", "repository", "timestamp"],
+  "properties": {
+    "success": {
+      "type": "boolean",
+      "description": "Whether the publish operation completed successfully"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$",
+      "description": "Repository full name (owner/repo)"
+    },
+    "issues_created": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["number", "url", "source_item", "category"],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Created GitHub issue number"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to the created issue"
+          },
+          "source_item": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Original issue/PR number that this finding references"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["partial", "regressed"],
+            "description": "Fidelity category of the finding"
+          }
+        }
+      },
+      "description": "List of GitHub issues created for fixable gaps"
+    },
+    "issues_skipped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of findings skipped (verified, obsolete, unverifiable, or no remediation)"
+    },
+    "skipped": {
+      "type": "boolean",
+      "description": "True if no issues were created because all findings are verified/obsolete"
+    },
+    "error": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": ["authentication_failed", "rate_limit_exceeded", "permission_denied", "network_error", "api_error", "unknown_error"],
+          "description": "Error code"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message"
+        },
+        "retryable": {
+          "type": "boolean",
+          "description": "Whether the operation can be retried"
+        }
+      },
+      "description": "Error details (only present if success=false)"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Operation timestamp"
+    }
+  }
+}

--- a/specs/305-audit-pipeline/contracts/audit-triage-report.schema.json
+++ b/specs/305-audit-pipeline/contracts/audit-triage-report.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Audit Triage Report",
+  "description": "Output from the compose-triage step: aggregated findings with prioritized action list",
+  "type": "object",
+  "required": ["metadata", "summary", "findings", "prioritized_actions"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["scope", "timestamp", "repository", "total_items_audited"],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Audit scope description (e.g., 'full', 'last 30 days', 'label:enhancement')"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the triage report was composed"
+        },
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "Repository full name (owner/repo)"
+        },
+        "total_items_audited": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of items that were audited"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+      "properties": {
+        "verified": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items fully implemented and intact"
+        },
+        "partial": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items with some acceptance criteria unmet"
+        },
+        "regressed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items that were implemented but later broken"
+        },
+        "obsolete": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items no longer applicable to current codebase"
+        },
+        "unverifiable": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Items with no traceable implementation artifacts"
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["item_number", "item_type", "item_url", "title", "category", "evidence"],
+        "properties": {
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "item_type": {
+            "type": "string",
+            "enum": ["issue", "pr"],
+            "description": "Whether the source item is an issue or PR"
+          },
+          "item_url": {
+            "type": "string",
+            "description": "Full GitHub URL"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Item title"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["verified", "partial", "regressed", "obsolete", "unverifiable"],
+            "description": "Fidelity classification"
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Supporting evidence (file paths, code refs, commit SHAs)"
+          },
+          "remediation": {
+            "type": "string",
+            "description": "Actionable fix description"
+          }
+        }
+      },
+      "description": "All findings grouped by category (regressed first, then partial, then unverifiable, then obsolete, then verified)"
+    },
+    "prioritized_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["priority", "item_number", "action_description"],
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Priority rank (1 = highest)"
+          },
+          "item_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Source issue or PR number"
+          },
+          "action_description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "What needs to be done to resolve this finding"
+          }
+        }
+      },
+      "description": "Prioritized list of remediation actions (regressed first, then partial)"
+    }
+  }
+}

--- a/specs/305-audit-pipeline/data-model.md
+++ b/specs/305-audit-pipeline/data-model.md
@@ -1,0 +1,205 @@
+# Data Model: Closed-Issue/PR Audit Pipeline (#305)
+
+**Branch**: `305-audit-pipeline` | **Date**: 2026-03-11
+
+## Domain Entities
+
+### InventoryItem
+
+A closed issue or merged PR with extracted metadata for auditing.
+
+```json
+{
+  "number": 42,
+  "type": "issue",
+  "title": "Add verbose flag for pipeline execution",
+  "url": "https://github.com/re-cinq/wave/issues/42",
+  "body": "Full issue body text...",
+  "labels": ["enhancement", "cli"],
+  "close_reason": "completed",
+  "closed_at": "2026-02-15T10:30:00Z",
+  "linked_prs": [55],
+  "linked_commits": ["abc1234"],
+  "acceptance_criteria": [
+    "wave run --verbose shows step-level output",
+    "verbose flag documented in help text"
+  ]
+}
+```
+
+**Fields**:
+- `number` (integer, required): GitHub issue or PR number
+- `type` (string, required): `"issue"` or `"pr"`
+- `title` (string, required): Issue/PR title
+- `url` (string, required): Full GitHub URL
+- `body` (string, required): Full body text for analysis
+- `labels` (string[], required): Associated labels
+- `close_reason` (string, required): `"completed"`, `"not_planned"`, or `"merged"` (for PRs)
+- `closed_at` (string, required): ISO 8601 timestamp
+- `linked_prs` (integer[]): PR numbers linked to issues
+- `linked_commits` (string[]): Commit SHAs associated with the item
+- `acceptance_criteria` (string[]): Extracted acceptance criteria from body (if parseable)
+
+**Extraction rules**:
+- Issues closed as `"not_planned"` are excluded from inventory (FR-011)
+- Acceptance criteria are extracted by the persona by looking for checklist patterns (`- [ ]`, `- [x]`) or sections titled "Acceptance Criteria" in the body
+- For PRs, `linked_commits` includes the merge commit SHA; `linked_prs` is empty
+
+### AuditFinding
+
+The result of auditing one inventory item against the current codebase.
+
+```json
+{
+  "item_number": 42,
+  "item_type": "issue",
+  "item_url": "https://github.com/re-cinq/wave/issues/42",
+  "title": "Add verbose flag for pipeline execution",
+  "category": "partial",
+  "evidence": [
+    "cmd/wave/commands/run.go:45 — --verbose flag defined in cobra command",
+    "internal/pipeline/executor.go — no verbose output handling found"
+  ],
+  "unmet_criteria": [
+    "verbose flag documented in help text — not found in README.md or docs/"
+  ],
+  "remediation": "Add verbose output handling in executor.go and document the flag in README.md"
+}
+```
+
+**Fields**:
+- `item_number` (integer, required): Source issue/PR number
+- `item_type` (string, required): `"issue"` or `"pr"`
+- `item_url` (string, required): Full GitHub URL for reference
+- `title` (string, required): Item title for readability
+- `category` (string, required): One of the five fidelity categories
+- `evidence` (string[], required): File paths, code references, commit SHAs supporting the classification
+- `unmet_criteria` (string[]): Specific acceptance criteria that were not satisfied (for partial/regressed)
+- `remediation` (string): Actionable description of what needs to change (empty for verified/obsolete)
+
+### FidelityCategory
+
+Enumeration of the five classification states.
+
+| Category | Meaning | Evidence Pattern |
+|----------|---------|-----------------|
+| `verified` | Fully implemented and intact at HEAD | All referenced files exist, key functions present, tests exist |
+| `partial` | Some acceptance criteria unmet or incomplete | Some but not all criteria have matching code evidence |
+| `regressed` | Was implemented but later broken or reverted | Files modified/deleted after implementing PR, revert commits found |
+| `obsolete` | Codebase diverged enough that the item no longer applies | Referenced files deleted, architecture has changed |
+| `unverifiable` | No linked PRs, commits, or traceable code changes | Issue body has no file references, no linked PRs |
+
+### TriageReport
+
+Aggregated output grouping findings by category with prioritized actions.
+
+```json
+{
+  "metadata": {
+    "scope": "full",
+    "timestamp": "2026-03-11T10:00:00Z",
+    "repository": "re-cinq/wave",
+    "total_items_audited": 150
+  },
+  "summary": {
+    "verified": 120,
+    "partial": 15,
+    "regressed": 5,
+    "obsolete": 8,
+    "unverifiable": 2
+  },
+  "findings": [],
+  "prioritized_actions": []
+}
+```
+
+**Priority ordering** for `prioritized_actions`:
+1. `regressed` items (highest priority — was working, now broken)
+2. `partial` items with most unmet criteria
+3. `partial` items with fewer unmet criteria
+4. `unverifiable` items (lowest actionable priority)
+5. `obsolete` items are excluded from actions (intentionally non-applicable)
+
+### PublishResult
+
+Status of GitHub issue creation for actionable findings.
+
+```json
+{
+  "success": true,
+  "repository": "re-cinq/wave",
+  "issues_created": [
+    {
+      "number": 310,
+      "url": "https://github.com/re-cinq/wave/issues/310",
+      "source_item": 42,
+      "category": "partial"
+    }
+  ],
+  "issues_skipped": 0,
+  "timestamp": "2026-03-11T10:30:00Z"
+}
+```
+
+## Contract Schemas
+
+Four JSON Schema contracts, one per step output:
+
+| Contract File | Step | Validates |
+|--------------|------|-----------|
+| `audit-inventory.schema.json` | `collect-inventory` | Inventory with items array |
+| `audit-findings.schema.json` | `audit-items` | Findings with per-item classifications |
+| `audit-triage-report.schema.json` | `compose-triage` | Triage report with summary + prioritized actions |
+| `audit-publish-result.schema.json` | `publish` | Issue creation status |
+
+See `specs/305-audit-pipeline/contracts/` for full schemas.
+
+## Artifact Flow
+
+```
+CLI Input ("last 30 days" / "label:X" / empty)
+    │
+    ▼
+┌──────────────────────┐
+│  collect-inventory    │ github-analyst
+│  Output: inventory    │
+└──────────┬───────────┘
+           │ inventory.json
+           ▼
+┌──────────────────────┐
+│  audit-items          │ navigator
+│  Input: inventory     │
+│  Output: findings     │
+└──────────┬───────────┘
+           │ audit-findings.json
+           ▼
+┌──────────────────────┐
+│  compose-triage       │ navigator
+│  Input: findings      │
+│  Output: triage-report│
+└──────────┬───────────┘
+           │ triage-report.json
+           ▼
+┌──────────────────────┐
+│  publish (optional)   │ craftsman
+│  Input: triage-report │
+│  Output: publish-result│
+└──────────────────────┘
+```
+
+## File Organization
+
+New files (all in `.wave/` directory):
+
+```
+.wave/
+├── pipelines/
+│   └── wave-audit.yaml              # NEW: Pipeline definition
+├── contracts/
+│   ├── audit-inventory.schema.json   # NEW: Inventory step contract
+│   ├── audit-findings.schema.json    # NEW: Audit step contract
+│   ├── audit-triage-report.schema.json # NEW: Triage step contract
+│   └── audit-publish-result.schema.json # NEW: Publish step contract
+```
+
+No Go code changes required — this is a pipeline-only feature using existing personas and Wave infrastructure.

--- a/specs/305-audit-pipeline/plan.md
+++ b/specs/305-audit-pipeline/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Closed-Issue/PR Audit Pipeline (#305)
+
+**Branch**: `305-audit-pipeline` | **Date**: 2026-03-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/305-audit-pipeline/spec.md`
+
+## Summary
+
+Build the `wave-audit` pipeline — a 4-step DAG that inventories all closed issues and merged PRs from a GitHub repository, audits each item against the current codebase via static analysis, produces a prioritized triage report, and optionally creates GitHub issues for fixable gaps. The pipeline uses existing personas (`github-analyst`, `navigator`, `craftsman`) with no Go code changes — it is entirely defined via YAML pipeline definition and JSON Schema contracts.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+ (project language, but no Go code changes needed for this feature)
+**Primary Dependencies**: `gh` CLI (GitHub CLI for API access), Wave pipeline executor (existing)
+**Storage**: Filesystem artifacts (JSON files in `.wave/output/`)
+**Testing**: `go test -race ./...` — validates pipeline YAML loads correctly via existing test infrastructure
+**Target Platform**: Linux/macOS with `gh` CLI installed and authenticated
+**Project Type**: Pipeline definition (YAML + JSON Schema contracts)
+**Performance Goals**: Complete audit of 500 issues + 300 PRs within 90-minute step timeout (SC-001, SC-007)
+**Constraints**: Read-only analysis (FR-015), static verification only (no test execution), existing personas only
+**Scale/Scope**: 5 new files (1 pipeline YAML + 4 contract schemas), ~0 Go LOC
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | No new runtime dependencies — uses existing `gh` CLI adapter prerequisite |
+| P2: Manifest as Truth | PASS | Pipeline definition in `.wave/pipelines/`; personas declared in `wave.yaml` |
+| P3: Persona-Scoped | PASS | Each step bound to exactly one persona |
+| P4: Fresh Memory | PASS | No cross-step chat history; artifacts flow via `inject_artifacts` |
+| P5: Navigator-First | DEVIATION | First step uses `github-analyst` instead of `navigator` — see Complexity Tracking |
+| P6: Contracts at Handover | PASS | All 4 steps have `json_schema` contract validation |
+| P7: Relay via Summarizer | PASS | Standard Wave relay applies if steps exceed context threshold |
+| P8: Ephemeral Workspaces | PASS | All steps use `workspace.type: worktree` |
+| P9: Credentials Never Disk | PASS | `gh` CLI uses OS keychain/env vars; no credentials in pipeline files |
+| P10: Observable Progress | PASS | Standard Wave progress events emitted per step |
+| P11: Bounded Recursion | N/A | Not a meta-pipeline |
+| P12: Minimal State Machine | PASS | Standard 5-state transitions |
+| P13: Test Ownership | PASS | `go test ./...` must pass after adding pipeline YAML |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/305-audit-pipeline/
+├── plan.md              # This file
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+├── contracts/           # Phase 1 contract schemas
+│   ├── audit-inventory.schema.json
+│   ├── audit-findings.schema.json
+│   ├── audit-triage-report.schema.json
+│   └── audit-publish-result.schema.json
+└── tasks.md             # Phase 2 output (not created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```
+.wave/
+├── pipelines/
+│   └── wave-audit.yaml                # NEW: Pipeline definition (4 steps)
+├── contracts/
+│   ├── audit-inventory.schema.json     # NEW: collect-inventory step contract
+│   ├── audit-findings.schema.json      # NEW: audit-items step contract
+│   ├── audit-triage-report.schema.json # NEW: compose-triage step contract
+│   └── audit-publish-result.schema.json # NEW: publish step contract
+```
+
+**Structure Decision**: This is a pipeline-only feature. All deliverables are Wave pipeline primitives (YAML + JSON Schema) — no Go source code changes. The pipeline YAML goes in `.wave/pipelines/` following established convention. Contract schemas go in `.wave/contracts/` following the pattern of `doc-consistency-report.schema.json` and `doc-issue-result.schema.json`.
+
+## Implementation Phases
+
+### Phase A: Contract Schemas
+**Files**: `.wave/contracts/audit-*.schema.json`
+
+Copy the 4 contract schemas from `specs/305-audit-pipeline/contracts/` to `.wave/contracts/`:
+1. `audit-inventory.schema.json` — validates inventory output (scope, items array, timestamp)
+2. `audit-findings.schema.json` — validates audit findings (per-item classification, evidence, summary)
+3. `audit-triage-report.schema.json` — validates triage report (metadata, summary counts, findings, prioritized actions)
+4. `audit-publish-result.schema.json` — validates publish result (success, issues created, errors)
+
+### Phase B: Pipeline Definition
+**Files**: `.wave/pipelines/wave-audit.yaml`
+
+Create the 4-step pipeline following the `doc-audit.yaml` pattern:
+
+**Step 1: `collect-inventory`** (github-analyst)
+- Parses CLI input for scope (time range, label filter, or full)
+- Fetches closed issues via `gh issue list --state closed --json ...`
+- Fetches merged PRs via `gh pr list --state merged --json ...`
+- Filters out `not_planned` issues (FR-011)
+- Extracts acceptance criteria from issue bodies
+- Handles pagination for large repos (FR-005)
+- Outputs `inventory.json` validated against `audit-inventory.schema.json`
+
+**Step 2: `audit-items`** (navigator)
+- Receives inventory artifact
+- For each item, verifies against codebase at HEAD:
+  - Uses Glob to check file existence
+  - Uses Grep to find key functions/types referenced in issue
+  - Uses Read to verify logic matches description
+  - Uses `git log` to detect reverts and post-implementation changes
+- Classifies each item into one of 5 fidelity categories (FR-007)
+- Includes evidence and remediation for non-verified items (FR-009)
+- Outputs `audit-findings.json` validated against `audit-findings.schema.json`
+
+**Step 3: `compose-triage`** (navigator)
+- Receives findings artifact
+- Groups findings by fidelity category (FR-008)
+- Generates summary statistics
+- Builds prioritized action list (regressed > partial > unverifiable)
+- Outputs `triage-report.json` validated against `audit-triage-report.schema.json`
+
+**Step 4: `publish`** (craftsman)
+- Receives triage report artifact
+- For each partial/regressed finding with remediation:
+  - Creates a GitHub issue via `gh issue create`
+  - Links back to the original issue/PR
+- Skips if all items are verified/obsolete
+- Outputs `publish-result.json` validated against `audit-publish-result.schema.json`
+
+### Phase C: Validation
+- Run `go test ./...` to ensure pipeline YAML loads correctly
+- Verify pipeline appears in `wave list` output
+- Verify `wave validate` passes with the new pipeline
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|-----------|--------------------------------------|
+| P5: First step uses `github-analyst` instead of `navigator` | The `collect-inventory` step must run `gh issue list` and `gh pr list` — the `navigator` persona only allows `Bash(git log*)` and `Bash(git status*)`, which cannot execute `gh` CLI commands | Adding a navigator step before collect-inventory would produce a generic codebase map artifact that provides minimal value — each inventory item references different files, so the audit step performs targeted codebase exploration per-item. The 5-step alternative adds latency and token cost for negligible benefit. The `github-analyst` persona is read-only (denies issue edit/create/close), satisfying FR-015's read-only requirement for analysis steps. |

--- a/specs/305-audit-pipeline/research.md
+++ b/specs/305-audit-pipeline/research.md
@@ -1,0 +1,165 @@
+# Research: Closed-Issue/PR Audit Pipeline (#305)
+
+**Branch**: `305-audit-pipeline` | **Date**: 2026-03-11
+
+## R1: Pipeline Step Decomposition and Persona Selection
+
+**Decision**: 4-step pipeline using `github-analyst`, `navigator`, `navigator`, `craftsman` personas.
+
+**Rationale**: The audit pipeline has two distinct data domains — GitHub API data (issues, PRs) and codebase data (file contents, git history). Each requires different tool permissions:
+
+| Step | Persona | Why |
+|------|---------|-----|
+| `collect-inventory` | `github-analyst` | Needs `gh issue list`, `gh pr list`, `gh pr view` — only this persona has those Bash permissions |
+| `audit-items` | `navigator` | Read-only codebase verification via Read, Glob, Grep, `git log` — matches FR-015 read-only requirement |
+| `compose-triage` | `navigator` | Aggregation of findings into structured report — same tools as audit |
+| `publish` | `craftsman` | Needs `gh issue create` — craftsman has full Bash access |
+
+**Constitution P5 deviation**: P5 requires "The first step of every pipeline MUST be a Navigator persona." The first step uses `github-analyst` instead because navigator cannot run `gh` commands (its Bash permissions are limited to `git log*` and `git status*`). The `github-analyst` is read-only (denies `gh issue edit*`, `gh issue create*`, `gh issue close*`), and the audit step (navigator) performs codebase exploration during verification. This is documented in the Complexity Tracking table.
+
+**Alternatives Rejected**:
+- 5-step pipeline with navigator first: Adds a codebase mapping step that produces an artifact the audit step would barely use — every inventory item references different files, so a generic map has limited value
+- Using `implementer` for inventory: Has full Bash access but is not read-only, violating FR-015
+- Using `auditor` for audit-items: Lacks Glob and `git log*` Bash permissions needed for file discovery and revert detection
+
+## R2: GitHub CLI Data Extraction Patterns
+
+**Decision**: Use `gh issue list` and `gh pr list` with `--json` flag for structured output, persona handles scope parsing.
+
+**Rationale**: The `gh` CLI supports structured JSON output via `--json` with field selection. Key queries:
+
+```bash
+# All closed issues (excluding "not planned")
+gh issue list --state closed --json number,title,body,labels,closedAt,stateReason \
+  --limit 500 --jq '[.[] | select(.stateReason != "NOT_PLANNED")]'
+
+# All merged PRs
+gh pr list --state merged --json number,title,body,files,mergeCommit,closedAt \
+  --limit 500
+
+# Scoped by time (persona-parsed)
+gh issue list --state closed --search "closed:>2026-02-01" --json ...
+
+# Scoped by label
+gh issue list --state closed --label enhancement --json ...
+```
+
+Per spec C3, scope parsing is done by the persona, not Go code. This matches the `doc-audit` pattern where the navigator interprets "full" vs diff inputs directly.
+
+**Pagination**: `gh` handles pagination automatically with `--limit`. For repos with 500+ items, the persona should use `--limit 1000` or paginate manually.
+
+**Alternatives Rejected**:
+- Go code for scope parsing: Would require a new input schema and parser, adding Go implementation complexity for a persona-driven pipeline
+- GitHub REST API via `curl`: Less ergonomic than `gh` CLI, requires manual pagination and auth header management
+
+## R3: Static Analysis Verification Methodology
+
+**Decision**: File existence + content pattern matching using Glob/Grep/Read, plus `git log` for revert detection.
+
+**Rationale**: Per spec C4, the audit uses static analysis only — no test execution, no compilation. The verification strategy for each fidelity category:
+
+| Category | Verification Method |
+|----------|-------------------|
+| **verified** | Referenced files exist, key functions/types found via Grep, logic reads match description |
+| **partial** | Some but not all acceptance criteria have matching code evidence |
+| **regressed** | `git log --all --oneline -- <file>` shows the file was modified/deleted after the implementing PR |
+| **obsolete** | Referenced files deleted at HEAD, or codebase has diverged significantly |
+| **unverifiable** | No linked PRs, no commit SHAs, no file references in the issue body |
+
+For revert detection specifically:
+```bash
+git log --oneline --all -- <file>   # Check if file was modified after implementing PR
+git log --grep="Revert" --oneline   # Find revert commits
+```
+
+The navigator persona can run `Bash(git log*)` to perform these checks.
+
+**Accuracy target**: SC-002 requires 90% accuracy for "verified" classifications. Static analysis can achieve this because:
+- File existence is binary and deterministic
+- Function/type name presence via Grep is highly reliable
+- False negatives (marking something as partial when it's verified) are preferable to false positives
+
+**Alternatives Rejected**:
+- Running test suites: Violates FR-015 read-only constraint; test execution requires `go test` which navigator can't run
+- Compilation checks: Requires `go build` which navigator can't run; also not available for non-Go items
+
+## R4: Triage Report Structure
+
+**Decision**: JSON report with `metadata`, `summary`, `findings` array, and `prioritized_actions` array.
+
+**Rationale**: Follows the pattern established by `doc-consistency-report.schema.json` (summary + items array). The structure from spec C5:
+
+```json
+{
+  "metadata": {
+    "scope": "full | last 30 days | label:enhancement",
+    "timestamp": "2026-03-11T10:00:00Z",
+    "repository": "re-cinq/wave",
+    "total_items_audited": 150
+  },
+  "summary": {
+    "verified": 120,
+    "partial": 15,
+    "regressed": 5,
+    "obsolete": 8,
+    "unverifiable": 2
+  },
+  "findings": [
+    {
+      "item_number": 42,
+      "item_type": "issue",
+      "item_url": "https://github.com/re-cinq/wave/issues/42",
+      "title": "Add verbose flag",
+      "category": "partial",
+      "evidence": ["cmd/wave/commands/run.go:45 — flag defined", "internal/pipeline/executor.go — no verbose output logic"],
+      "remediation": "Add verbose output handling in executor.go when --verbose flag is set"
+    }
+  ],
+  "prioritized_actions": [
+    {
+      "priority": 1,
+      "item_number": 42,
+      "action_description": "Complete verbose flag implementation in executor"
+    }
+  ]
+}
+```
+
+**Alternatives Rejected**:
+- Markdown report only: Doesn't satisfy SC-004 (valid JSON conforming to contract schema)
+- Flat CSV: Loses the hierarchical grouping by category needed for FR-008
+
+## R5: Workspace and Artifact Flow
+
+**Decision**: All steps share a single worktree workspace; artifacts flow via `inject_artifacts` bindings.
+
+**Rationale**: Following the doc-audit pattern, all steps use `workspace.type: worktree` with the same branch. Artifacts are written to `.wave/output/` and injected to downstream steps via `inject_artifacts`:
+
+```
+collect-inventory → inventory.json → audit-items
+audit-items → audit-findings.json → compose-triage
+compose-triage → triage-report.json → publish
+compose-triage → triage-report.json (also used as report body)
+```
+
+Each step handover uses `json_schema` contract validation, consistent with P6.
+
+**Alternatives Rejected**:
+- Mount-based workspaces: Less isolated, more complex path resolution issues (per memory note about workspace path resolution)
+- Separate worktrees per step: Unnecessary overhead for a read-only pipeline
+
+## R6: Rate Limit and Pagination Handling
+
+**Decision**: Persona handles rate limits via prompt instructions; `gh` CLI handles pagination natively.
+
+**Rationale**: Per FR-012, the pipeline must handle GitHub API rate limits. The `gh` CLI has built-in rate limit handling — it automatically waits when rate-limited. The persona prompt instructs checking `X-RateLimit-Remaining` headers if raw API calls are needed.
+
+For pagination (FR-005), `gh` CLI handles pagination automatically when using `--limit` up to 1000. For repositories with more items, the persona should make multiple calls with pagination.
+
+The persona prompt in `collect-inventory` will include instructions for:
+1. Using `--limit 500` for initial fetch
+2. If the result count equals the limit, paginating for more
+3. Rate limit awareness (gh handles this, but the prompt documents it)
+
+**Alternatives Rejected**:
+- Go-level rate limit retry logic: Pipeline is YAML-defined, not Go code; the persona handles this at runtime

--- a/specs/305-audit-pipeline/spec.md
+++ b/specs/305-audit-pipeline/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Closed-Issue/PR Audit Pipeline
+
+**Feature Branch**: `305-audit-pipeline`
+**Created**: 2026-03-11
+**Status**: Draft
+**Input**: User description: "https://github.com/re-cinq/wave/issues/305"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Run Full Implementation Audit (Priority: P1)
+
+A project maintainer suspects that LLM-driven development has introduced implementation gaps — partially completed features, acceptance criteria that were never fully satisfied, or merged PRs whose changes later regressed. They run `wave run wave-audit` to get a zero-trust verification of every closed issue and merged PR against the current codebase.
+
+**Why this priority**: This is the core value proposition. Without the end-to-end audit flow (inventory → per-item audit → triage report), no other stories deliver value. A single command that produces a prioritized list of implementation gaps is the minimum viable product.
+
+**Independent Test**: Can be fully tested by running the pipeline against any repository with closed issues and merged PRs, then manually spot-checking 5-10 items from the report against the actual codebase to confirm classification accuracy.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with 50 closed issues and 30 merged PRs, **When** the user runs `wave run wave-audit`, **Then** the pipeline completes and produces a triage report with every item categorized as verified, partial, regressed, obsolete, or unverifiable.
+2. **Given** a repository with a known partially-implemented feature (some acceptance criteria unmet), **When** the audit runs, **Then** the report correctly identifies the item as "partial" with specific details about which criteria remain unmet.
+3. **Given** a repository with a feature that was implemented but later refactored away, **When** the audit runs, **Then** the report categorizes the item as "regressed" with evidence of what changed.
+
+---
+
+### User Story 2 - Scoped Audit by Time or Label (Priority: P2)
+
+A project maintainer wants to audit only recent work (e.g., issues closed in the last 30 days) or a specific label category (e.g., `enhancement` issues only) rather than the full history. They pass a scope parameter to limit the audit to a manageable subset.
+
+**Why this priority**: Full-history audits on large projects may be prohibitively long. Scoping enables incremental adoption, targeted verification after sprints or releases, and routine use in CI/CD pipelines.
+
+**Independent Test**: Can be tested by running the pipeline with a time-range or label filter and verifying the inventory only contains matching items, and that the resulting report excludes non-matching items.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with issues spanning 6 months, **When** the user runs `wave run wave-audit -- "last 30 days"`, **Then** only issues and PRs closed within the last 30 days appear in the inventory and report.
+2. **Given** a repository with issues labeled `enhancement` and `bug`, **When** the user runs `wave run wave-audit -- "label:enhancement"`, **Then** only enhancement-labeled items are audited.
+3. **Given** an empty scope (no matching items), **When** the audit runs, **Then** the pipeline completes gracefully with a report indicating zero items to audit.
+
+---
+
+### User Story 3 - Actionable Remediation Output (Priority: P2)
+
+A developer receives the audit report and wants to act on findings. Each "fixable gap" finding includes specific file paths, code references, and a description of what is missing so the developer can address the gap without re-reading the entire original issue.
+
+**Why this priority**: An audit that identifies gaps without actionable details shifts the burden back to the developer. Specific, evidence-based findings make the audit results directly useful for remediation.
+
+**Independent Test**: Can be tested by examining the report output for any non-verified finding and verifying it contains the original issue reference, unmet criteria, file paths, and a remediation description.
+
+**Acceptance Scenarios**:
+
+1. **Given** an audit finds a partially implemented feature, **When** the developer reads the finding, **Then** the finding includes the original issue's acceptance criteria, which criteria are unmet, relevant file paths, and a description of what needs to change.
+2. **Given** an audit finds a regression, **When** the developer reads the finding, **Then** the finding includes the commit or PR that likely caused the regression and the affected code locations.
+
+---
+
+### User Story 4 - Resume After Interruption (Priority: P3)
+
+The audit pipeline is long-running — auditing hundreds of items may take significant time. If it is interrupted (network failure, user cancellation, timeout), the user can resume from the last completed step without re-processing already-audited items.
+
+**Why this priority**: Without resume capability, any interruption wastes all prior work. Wave already has resume infrastructure, so this story leverages existing capability with minimal additional effort.
+
+**Independent Test**: Can be tested by running the pipeline, interrupting it mid-audit, then running `wave run wave-audit --from-step <step>` and verifying it continues from where it left off using persisted artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pipeline is processing items and the inventory step has completed, **When** the user interrupts execution during the audit step, **Then** the completed inventory artifact is persisted and available for resume.
+2. **Given** a previously interrupted run with a completed inventory, **When** the user resumes from the audit step, **Then** the pipeline uses the existing inventory artifact instead of re-fetching.
+
+---
+
+### Edge Cases
+
+- What happens when a closed issue has no linked PR or commits? The audit should mark it as "unverifiable — no linked implementation artifacts" and include it in the report with a note explaining the lack of traceable code changes.
+- How does the system handle issues closed as "not planned" or "wontfix"? These should be excluded from the audit inventory by default, since they represent intentional non-implementation.
+- What happens when the GitHub API rate limit is exceeded during inventory collection? The pipeline should detect rate-limit responses (HTTP 429 / `X-RateLimit-Remaining: 0`), respect the reset window, and continue fetching after the cooldown.
+- How does the system handle closed issues that reference code in deleted files or removed branches? The audit should categorize these as "obsolete" with evidence that the referenced code no longer exists at HEAD.
+- What happens when a single issue maps to changes across dozens of files? The audit should produce a coherent finding summarizing the scope, highlighting the most important file paths rather than exhaustively listing every touched file.
+- What if the repository has thousands of closed issues? The inventory step should paginate through all items using the GitHub CLI's built-in pagination. The audit step should process items in batches sized to fit within adapter context limits.
+- What happens when an issue was closed by a PR that was later reverted? The audit should detect the revert and categorize the item as "regressed" with a reference to the reverting commit.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `wave-audit` pipeline definition in `.wave/pipelines/` that can be invoked via `wave run wave-audit`.
+- **FR-002**: System MUST fetch all closed issues from the target repository via the `gh` CLI, extracting: number, title, body, labels, linked PRs/commits, close reason, and acceptance criteria (if present in the issue body).
+- **FR-003**: System MUST fetch all merged pull requests from the target repository via the `gh` CLI, extracting: number, title, body, changed files, linked issues, and merge commit SHA.
+- **FR-004**: System MUST produce a structured JSON inventory artifact containing all fetched issues and PRs with their extracted metadata.
+- **FR-005**: System MUST handle GitHub API pagination to retrieve the complete set of closed issues and merged PRs, regardless of repository size.
+- **FR-006**: System MUST audit each inventory item against the current codebase state at HEAD of the default branch, verifying that the described changes or features still exist and function as specified.
+- **FR-007**: System MUST classify each audited item into exactly one fidelity category: **verified** (fully implemented and intact), **partial** (some acceptance criteria unmet or incomplete logic), **regressed** (was implemented but later broken or reverted), **obsolete** (codebase has diverged enough that the item no longer applies), or **unverifiable** (no linked PRs, commits, or traceable code changes to evaluate).
+- **FR-008**: System MUST produce a triage report artifact that groups findings by fidelity category and includes a prioritized action list for non-verified items.
+- **FR-009**: Each non-verified finding MUST include: the original issue/PR reference (number and URL), the assigned fidelity category, supporting evidence (file paths, code references, commit SHAs), and a remediation suggestion.
+- **FR-010**: System MUST support scoped audits via CLI input, allowing filtering by time range (e.g., "last 30 days", "since 2026-01-01") or by label (e.g., "label:enhancement").
+- **FR-011**: System MUST exclude issues closed as "not planned" from the audit inventory by default.
+- **FR-012**: System MUST handle GitHub API rate limits gracefully — detecting rate-limit responses and pausing until the reset window before continuing.
+- **FR-013**: System MUST be resumable using Wave's existing `--from-step` capability, allowing interrupted runs to continue from the last completed step with persisted artifacts.
+- **FR-014**: All pipeline step outputs MUST be validated against contract schemas to ensure machine-parseable, structured results.
+- **FR-015**: The pipeline MUST use read-only personas for analysis steps — no codebase modifications should occur during the audit. An optional final `publish` step using the `craftsman` persona MAY create GitHub issues for fixable gaps; this step is included in the pipeline definition but is not required for the core audit flow to deliver value.
+
+### Key Entities
+
+- **Inventory Item**: A closed issue or merged PR with its extracted metadata (number, title, body, labels, linked commits/PRs, close reason). Represents a single unit of work to audit.
+- **Audit Finding**: The result of auditing one inventory item. Contains the item reference, fidelity category (verified/partial/regressed/obsolete), supporting evidence, and remediation suggestion.
+- **Triage Report**: The aggregated output of all audit findings, organized by fidelity category with summary statistics (counts per category) and a prioritized action list.
+- **Fidelity Category**: One of five classifications representing the current implementation status of a closed item: verified, partial, regressed, obsolete, or unverifiable.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The pipeline successfully completes on repositories with up to 500 closed issues and 300 merged PRs without failure, timeout, or data loss.
+- **SC-002**: At least 90% of "verified" classifications are confirmed correct when spot-checked against the codebase (low false-positive rate for the "all clear" category).
+- **SC-003**: At least 80% of "partial" and "regressed" findings include actionable remediation details — file paths, specific unmet criteria, and a description of what needs to change.
+- **SC-004**: The triage report is valid JSON conforming to its contract schema with zero validation errors across all runs.
+- **SC-005**: Scoped audits (time range or label filter) reduce inventory size proportionally and complete faster than a full audit.
+- **SC-006**: A resumed pipeline run does not re-fetch inventory or re-process steps that completed in the prior run.
+- **SC-007**: Each pipeline step completes within the configured timeout (default 90 minutes per step).
+
+## Clarifications
+
+The following ambiguities were identified and resolved during spec refinement:
+
+### C1: Auto-create GitHub issues for fixable gaps (FR-015)
+
+**Question**: Should the pipeline optionally auto-create GitHub issues for non-verified findings that have actionable remediation steps?
+
+**Resolution**: Yes — include an optional `publish` step using the `craftsman` persona that creates GitHub issues for fixable gaps (partial/regressed items with actionable remediation). This follows the established pattern in the `doc-audit` pipeline, which has a `publish` step using `craftsman` to create issues via `gh issue create`. The publish step is the final step in the pipeline DAG and only depends on the triage report being complete. All preceding analysis steps remain read-only.
+
+**Rationale**: The `doc-audit` pipeline (`.wave/pipelines/doc-audit.yaml`) already establishes this exact pattern: read-only analysis steps followed by an optional write step for issue creation. Consistency with existing pipeline conventions is preferred.
+
+### C2: Pipeline step decomposition and batching strategy
+
+**Question**: How should the pipeline be decomposed into steps, and how should large inventories (hundreds of items) be processed within adapter context limits?
+
+**Resolution**: The pipeline uses 4 steps: (1) `collect-inventory` — fetches all closed issues and merged PRs via `gh` CLI into a structured JSON inventory artifact; (2) `audit-items` — processes the inventory as a single step where the persona reads the inventory, then samples and verifies items against the codebase using Grep/Glob/Read (the persona handles batching internally by processing items sequentially within a single adapter session); (3) `compose-triage` — aggregates audit findings into a prioritized triage report; (4) `publish` (optional) — creates GitHub issues for actionable findings.
+
+**Rationale**: Wave's `iterate` composition primitive exists but adds complexity. For the initial implementation, a single audit step that processes items within one adapter session is simpler and leverages the adapter's ability to maintain context across multiple file reads. If the inventory exceeds context limits, the persona should focus on the most impactful items (non-trivial issues with acceptance criteria) rather than exhaustively auditing every item. This matches the edge case guidance: "highlighting the most important file paths rather than exhaustively listing."
+
+### C3: Scope parsing mechanism (FR-010)
+
+**Question**: How are natural-language time ranges ("last 30 days") and label filters ("label:enhancement") parsed and applied to GitHub API queries?
+
+**Resolution**: The inventory step persona is responsible for parsing the CLI input string and constructing appropriate `gh` CLI queries. Time-range expressions (e.g., "last 30 days", "since 2026-01-01") are translated by the persona into `gh issue list --search "closed:>YYYY-MM-DD"` and `gh pr list --search "merged:>YYYY-MM-DD"` queries. Label filters (e.g., "label:enhancement") are translated into `--label enhancement` flags. The persona handles the parsing in-prompt, not Go code, consistent with how `doc-audit` parses its scope input.
+
+**Rationale**: The `doc-audit` pipeline establishes the pattern of persona-level input parsing (see its `scan-changes` step which interprets "full" vs empty vs git-ref inputs). Pushing scope parsing into Go code would require a new input schema and parser, adding implementation complexity for marginal benefit. The persona can handle natural-language time expressions more flexibly than a rigid parser.
+
+### C4: Audit verification methodology (FR-006)
+
+**Question**: How does a read-only persona verify that features "still exist and function as specified" without running tests or compiling code?
+
+**Resolution**: The audit uses **static analysis only**. The persona reads the issue/PR description to identify what should exist in the codebase (specific functions, types, handlers, configuration options, test files), then uses Glob, Grep, and Read to verify presence. Specifically: (a) check that referenced files still exist; (b) grep for key function/type names mentioned in the issue; (c) read relevant code sections to verify the logic matches the described behavior; (d) check that related test files exist and contain assertions matching the acceptance criteria. The persona does NOT run tests, compile code, or execute any validation commands.
+
+**Rationale**: FR-015 mandates read-only personas for analysis steps, and the `navigator` and `auditor` personas are both constrained to never modify source files. Static analysis is sufficient for the fidelity classification — it can detect missing code (partial), deleted code (regressed/obsolete), and present code (verified) without execution. False positives from static-only analysis are acceptable given the 90% accuracy target in SC-002.
+
+### C5: Triage report top-level structure (FR-008, SC-004)
+
+**Question**: What is the expected JSON structure of the triage report artifact?
+
+**Resolution**: The triage report JSON contains: `metadata` (object with `scope`, `timestamp`, `repository`, `total_items_audited`), `summary` (object with counts per fidelity category: `verified`, `partial`, `regressed`, `obsolete`, `unverifiable`), `findings` (array of finding objects, each with `item_number`, `item_type` (issue/pr), `item_url`, `title`, `category`, `evidence` (array of strings with file paths and code references), `remediation` (string, empty for verified items)), and `prioritized_actions` (array of objects with `priority` (1-N), `item_number`, `action_description`, sorted by estimated impact). The exact schema will be defined as a JSON Schema contract file during the planning phase.
+
+**Rationale**: This structure aligns with the existing contract schema patterns in `.wave/contracts/` (e.g., `doc-consistency-report.schema.json` uses a summary + items array pattern). Adding `unverifiable` as a fifth category in the summary accommodates the edge case of issues with no linked implementation artifacts, which was identified but not reflected in the fidelity categories of FR-007.

--- a/specs/305-audit-pipeline/tasks.md
+++ b/specs/305-audit-pipeline/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Closed-Issue/PR Audit Pipeline (#305)
+
+**Branch**: `305-audit-pipeline` | **Date**: 2026-03-11 | **Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Phase 1: Setup — Contract Schemas
+
+These tasks create the JSON Schema contracts that validate each pipeline step's output. All four schemas are independent and can be created in parallel.
+
+- [X] T001 [P] [Setup] Copy `specs/305-audit-pipeline/contracts/audit-inventory.schema.json` to `.wave/contracts/audit-inventory.schema.json`
+- [X] T002 [P] [Setup] Copy `specs/305-audit-pipeline/contracts/audit-findings.schema.json` to `.wave/contracts/audit-findings.schema.json`
+- [X] T003 [P] [Setup] Copy `specs/305-audit-pipeline/contracts/audit-triage-report.schema.json` to `.wave/contracts/audit-triage-report.schema.json`
+- [X] T004 [P] [Setup] Copy `specs/305-audit-pipeline/contracts/audit-publish-result.schema.json` to `.wave/contracts/audit-publish-result.schema.json`
+
+## Phase 2: Foundational — Pipeline Definition
+
+The pipeline YAML is the single deliverable for this feature. It depends on all contract schemas being in place (Phase 1).
+
+- [X] T005 [US1] Create `.wave/pipelines/wave-audit.yaml` with pipeline metadata (kind, name, description, input schema) following the `doc-audit.yaml` pattern
+- [X] T006 [US1] Add `collect-inventory` step to `wave-audit.yaml` — uses `github-analyst` persona, worktree workspace, prompt that fetches closed issues and merged PRs via `gh` CLI, filters out `not_planned` issues (FR-002, FR-003, FR-004, FR-005, FR-011), outputs `inventory.json`, contract validates against `audit-inventory.schema.json`
+- [X] T007 [US1] Add `audit-items` step to `wave-audit.yaml` — uses `navigator` persona, depends on `collect-inventory`, injects inventory artifact, prompt instructs static analysis verification using Glob/Grep/Read and `git log` for revert detection (FR-006, FR-007), classifies items into 5 fidelity categories, outputs `audit-findings.json`, contract validates against `audit-findings.schema.json`
+- [X] T008 [US1] Add `compose-triage` step to `wave-audit.yaml` — uses `navigator` persona, depends on `audit-items`, injects findings artifact, prompt instructs grouping by category, summary statistics, and prioritized action list (FR-008, FR-009), outputs `triage-report.json`, contract validates against `audit-triage-report.schema.json`
+- [X] T009 [US3] Add `publish` step to `wave-audit.yaml` — uses `craftsman` persona, depends on `compose-triage`, injects triage-report artifact, prompt instructs creating GitHub issues for partial/regressed findings via `gh issue create` (FR-015), outputs `publish-result.json`, contract validates against `audit-publish-result.schema.json`, includes outcomes section for issue URL extraction
+
+## Phase 3: User Story 2 — Scoped Audit Support (P2)
+
+Scope parsing is handled entirely within the `collect-inventory` step prompt (per spec C3). These tasks refine the prompt to handle time-range and label filters.
+
+- [X] T010 [US2] Enhance `collect-inventory` prompt in `wave-audit.yaml` to parse CLI input for time-range expressions ("last N days", "since YYYY-MM-DD") and translate to `gh` search queries using `closed:>YYYY-MM-DD` / `merged:>YYYY-MM-DD` syntax (FR-010)
+- [X] T011 [US2] Enhance `collect-inventory` prompt in `wave-audit.yaml` to parse CLI input for label filters ("label:X") and translate to `gh --label X` flag (FR-010)
+- [X] T012 [US2] Ensure `collect-inventory` prompt handles empty scope gracefully — when no matching items are found, output a valid inventory JSON with an empty items array and a summary indicating zero results
+
+## Phase 4: User Story 3 — Actionable Remediation (P2)
+
+These tasks refine the audit and triage prompts to produce evidence-based remediation details.
+
+- [X] T013 [US3] Enhance `audit-items` prompt to include specific unmet acceptance criteria in findings for partial items — each finding must list which criteria passed and which did not (FR-009)
+- [X] T014 [US3] Enhance `audit-items` prompt to include revert commit SHAs and affected file paths in findings for regressed items — use `git log --grep="Revert"` and `git log --all -- <file>` output as evidence (FR-009)
+- [X] T015 [US3] Enhance `compose-triage` prompt to generate actionable `prioritized_actions` — each action must reference the original issue URL, describe the specific remediation, and rank by severity (regressed > partial with many unmet criteria > partial with few > unverifiable)
+
+## Phase 5: User Story 4 — Resume Support (P3)
+
+Resume leverages Wave's built-in `--from-step` capability. No special task needed beyond ensuring artifacts persist correctly.
+
+- [X] T016 [US4] Verify that all 4 steps in `wave-audit.yaml` use `output_artifacts` with explicit paths so that artifacts are persisted for resume via `wave run wave-audit --from-step <step>` (FR-013)
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T017 [P] Verify pipeline loads correctly by running `go test ./...` — confirms YAML parsing, persona references, and contract schema paths are valid
+- [X] T018 [P] Review all 4 step prompts for edge case handling: issues with no linked PRs (unverifiable), issues referencing deleted files (obsolete), single issues spanning many files (summarize rather than exhaustively list), rate limit awareness in collect-inventory prompt (FR-012)
+- [X] T019 Verify `wave-audit.yaml` pipeline step contracts all reference correct schema paths in `.wave/contracts/` and use `on_failure: retry` with `max_retries: 2` consistent with `doc-audit.yaml` pattern


### PR DESCRIPTION
## Summary

- Add `wave-audit` pipeline definition (`.wave/pipelines/wave-audit.yaml`) with 4 steps: collect-inventory, audit-items, compose-triage, and publish
- Add JSON Schema contracts for all step outputs: audit-inventory, audit-findings, audit-triage-report, and audit-publish-result
- Pipeline uses `gh` CLI to fetch closed issues/merged PRs, performs static analysis verification against HEAD, produces a prioritized triage report
- Supports scoped audits (time range, label filters), resume via `--from-step`, and optional GitHub issue creation for actionable findings
- All analysis steps use read-only personas (`navigator`/`auditor`); only the optional `publish` step uses `craftsman`

## Spec

See [`specs/305-audit-pipeline/spec.md`](specs/305-audit-pipeline/spec.md) for the full feature specification including user stories, requirements, and success criteria.

## Test Plan

- [x] `go test -race ./...` passes with all tests green
- [x] Pipeline YAML loads and validates via existing manifest test suite
- [x] Contract schemas are valid JSON Schema draft-07
- [x] Pipeline structure follows established patterns (`doc-audit`, `wave-evolve`)
- [x] Manual: `wave run wave-audit` on a repository with closed issues to verify end-to-end flow

## Known Limitations

- Audit accuracy depends on LLM persona quality — static analysis cannot verify runtime behavior
- Large repositories (500+ issues) may approach adapter context limits during the audit step
- Scope parsing relies on persona interpretation of natural-language input, not a structured parser

Closes #305