### PR TITLE
feat: expand reviewer persona deny patterns to block destructive actions

### DIFF
--- a/internal/defaults/personas/reviewer.yaml
+++ b/internal/defaults/personas/reviewer.yaml
@@ -8,7 +8,11 @@ permissions:
     - Grep
     - Bash
   deny:
+    - "Write(*.go)"
+    - "Write(*.ts)"
+    - "Write(*.py)"
+    - "Write(*.rs)"
     - "Edit(*)"
-    - "Bash(rm -rf /*)"
+    - "Bash(rm *)"
     - "Bash(git push*)"
     - "Bash(git commit*)"

--- a/internal/manifest/permissions_test.go
+++ b/internal/manifest/permissions_test.go
@@ -134,15 +134,33 @@ func TestPersonaPermission_ReviewerCannotWriteSourceFiles(t *testing.T) {
 		t.Error("reviewer should NOT be able to write .ts files")
 	}
 
-	// Test 3: Verify deny patterns include source file restrictions
+	// Test 3: Reviewer should NOT be able to write .py files
+	err = checker.CheckPermission("Write", "scripts/tool.py")
+	if err == nil {
+		t.Error("reviewer should NOT be able to write .py files")
+	}
+
+	// Test 4: Reviewer should NOT be able to write .rs files
+	err = checker.CheckPermission("Write", "src/lib.rs")
+	if err == nil {
+		t.Error("reviewer should NOT be able to write .rs files")
+	}
+
+	// Test 5: Verify deny patterns include source file restrictions
 	hasDenyGo := false
 	hasDenyTs := false
+	hasDenyPy := false
+	hasDenyRs := false
 	for _, deny := range reviewer.Permissions.Deny {
-		if deny == "Write(*.go)" {
+		switch deny {
+		case "Write(*.go)":
 			hasDenyGo = true
-		}
-		if deny == "Write(*.ts)" {
+		case "Write(*.ts)":
 			hasDenyTs = true
+		case "Write(*.py)":
+			hasDenyPy = true
+		case "Write(*.rs)":
+			hasDenyRs = true
 		}
 	}
 	if !hasDenyGo {
@@ -150,6 +168,70 @@ func TestPersonaPermission_ReviewerCannotWriteSourceFiles(t *testing.T) {
 	}
 	if !hasDenyTs {
 		t.Errorf("reviewer should have Write(*.ts) in deny patterns, got: %v", reviewer.Permissions.Deny)
+	}
+	if !hasDenyPy {
+		t.Errorf("reviewer should have Write(*.py) in deny patterns, got: %v", reviewer.Permissions.Deny)
+	}
+	if !hasDenyRs {
+		t.Errorf("reviewer should have Write(*.rs) in deny patterns, got: %v", reviewer.Permissions.Deny)
+	}
+}
+
+// TestPersonaPermission_ReviewerCannotRunDestructiveCommands verifies that the
+// reviewer persona cannot run destructive bash commands (rm, git push, git commit).
+func TestPersonaPermission_ReviewerCannotRunDestructiveCommands(t *testing.T) {
+	m := createTestManifestWithPersonas(t)
+
+	reviewer := m.GetPersona("reviewer")
+	if reviewer == nil {
+		t.Fatal("reviewer persona not found in manifest")
+	}
+
+	checker := adapter.NewPermissionChecker(
+		"reviewer",
+		reviewer.Permissions.AllowedTools,
+		reviewer.Permissions.Deny,
+	)
+
+	// Destructive commands that should be denied
+	deniedCommands := []struct {
+		command string
+		reason  string
+	}{
+		{"rm foo.txt", "reviewer should not be able to delete files"},
+		{"rm -rf /tmp", "reviewer should not be able to recursively delete"},
+		{"rm -f important.go", "reviewer should not be able to force-delete files"},
+		{"git push origin main", "reviewer should not be able to push to remote"},
+		{"git push --force", "reviewer should not be able to force push"},
+		{"git commit -m \"msg\"", "reviewer should not be able to commit"},
+		{"git commit --amend", "reviewer should not be able to amend commits"},
+	}
+
+	for _, dc := range deniedCommands {
+		t.Run(dc.command, func(t *testing.T) {
+			err := checker.CheckPermission("Bash", dc.command)
+			if err == nil {
+				t.Errorf("%s, but command was allowed: %s", dc.reason, dc.command)
+			}
+		})
+	}
+
+	// Safe commands that should still be allowed
+	allowedCommands := []struct {
+		command string
+		reason  string
+	}{
+		{"go test ./...", "reviewer should be able to run tests"},
+		{"npm test", "reviewer should be able to run npm tests"},
+	}
+
+	for _, ac := range allowedCommands {
+		t.Run(ac.command, func(t *testing.T) {
+			err := checker.CheckPermission("Bash", ac.command)
+			if err != nil {
+				t.Errorf("%s, got error: %v", ac.reason, err)
+			}
+		})
 	}
 }
 
@@ -319,6 +401,42 @@ func TestPersonaPermission_DenyPatternTakesPrecedence(t *testing.T) {
 			expectDeny:   true,
 			reason:       "deny(sudo *) should block sudo commands",
 		},
+		{
+			name:         "deny rm commands",
+			allowedTools: []string{"Bash"},
+			denyTools:    []string{"Bash(rm *)"},
+			tool:         "Bash",
+			argument:     "rm important-file.txt",
+			expectDeny:   true,
+			reason:       "deny(rm *) should block rm commands",
+		},
+		{
+			name:         "deny git push commands",
+			allowedTools: []string{"Bash"},
+			denyTools:    []string{"Bash(git push*)"},
+			tool:         "Bash",
+			argument:     "git push origin main",
+			expectDeny:   true,
+			reason:       "deny(git push*) should block git push commands",
+		},
+		{
+			name:         "deny git commit commands",
+			allowedTools: []string{"Bash"},
+			denyTools:    []string{"Bash(git commit*)"},
+			tool:         "Bash",
+			argument:     "git commit -m \"test\"",
+			expectDeny:   true,
+			reason:       "deny(git commit*) should block git commit commands",
+		},
+		{
+			name:         "deny rm does not block other commands",
+			allowedTools: []string{"Bash"},
+			denyTools:    []string{"Bash(rm *)"},
+			tool:         "Bash",
+			argument:     "ls -la",
+			expectDeny:   false,
+			reason:       "deny(rm *) should not block ls command",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -362,6 +480,8 @@ func TestPersonaPermission_ArtifactCreationScenarios(t *testing.T) {
 		{"reviewer", ".wave/artifacts/review.json", true, "reviewer can create files in .wave/artifacts/"},
 		{"reviewer", "src/main.go", false, "reviewer cannot create .go source files"},
 		{"reviewer", "src/app.ts", false, "reviewer cannot create .ts source files"},
+		{"reviewer", "scripts/tool.py", false, "reviewer cannot create .py source files"},
+		{"reviewer", "src/lib.rs", false, "reviewer cannot create .rs source files"},
 
 		// Navigator scenarios (read-only)
 		{"navigator", ".wave/artifact.json", false, "navigator cannot create artifact.json"},
@@ -599,16 +719,25 @@ func TestLoadWaveYAML_PersonaPermissions(t *testing.T) {
 			t.Error("reviewer in wave.yaml should have Write(.wave/artifact.json) or Write(.wave/artifacts/*) permission")
 		}
 
-		// Verify reviewer denies source file writes
-		hasDenyGo := false
-		for _, deny := range reviewer.Permissions.Deny {
-			if deny == "Write(*.go)" {
-				hasDenyGo = true
-				break
-			}
+		// Verify reviewer denies source file writes and destructive commands
+		expectedDenyPatterns := []string{
+			"Write(*.go)",
+			"Write(*.ts)",
+			"Write(*.py)",
+			"Write(*.rs)",
+			"Edit(*)",
+			"Bash(rm *)",
+			"Bash(git push*)",
+			"Bash(git commit*)",
 		}
-		if !hasDenyGo {
-			t.Error("reviewer in wave.yaml should deny Write(*.go)")
+		denySet := make(map[string]bool)
+		for _, deny := range reviewer.Permissions.Deny {
+			denySet[deny] = true
+		}
+		for _, expected := range expectedDenyPatterns {
+			if !denySet[expected] {
+				t.Errorf("reviewer in wave.yaml should deny %s, got deny list: %v", expected, reviewer.Permissions.Deny)
+			}
 		}
 	}
 
@@ -672,7 +801,7 @@ func createTestManifestWithPersonas(t *testing.T) *Manifest {
 						"Bash(go test*)",
 						"Bash(npm test*)",
 					},
-					Deny: []string{"Write(*.go)", "Write(*.ts)", "Edit(*)"},
+					Deny: []string{"Write(*.go)", "Write(*.ts)", "Write(*.py)", "Write(*.rs)", "Edit(*)", "Bash(rm *)", "Bash(git push*)", "Bash(git commit*)"},
 				},
 			},
 			"navigator": {

--- a/specs/033-reviewer-deny-patterns/plan.md
+++ b/specs/033-reviewer-deny-patterns/plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan: Expand Reviewer Deny Patterns
+
+## 1. Objective
+
+Add `Write(*.py)`, `Write(*.rs)`, `Bash(rm *)`, `Bash(git push*)`, and `Bash(git commit*)` to the reviewer persona's deny patterns in both `wave.yaml` and the embedded default, then add test coverage for each new pattern.
+
+## 2. Approach
+
+This is a configuration-only change with test additions. The deny pattern matching infrastructure (`internal/adapter/permissions.go`) already supports all the glob patterns needed — `Write(*.py)` uses `filepath.Match`, and `Bash(rm *)` / `Bash(git push*)` / `Bash(git commit*)` use `matchStringGlob` with space-aware prefix matching.
+
+The change touches three layers:
+1. **Project manifest** (`wave.yaml`) — the reviewer persona's live deny list
+2. **Embedded defaults** (`internal/defaults/personas/reviewer.yaml`) — the built-in default deny list
+3. **Tests** — expand `internal/manifest/permissions_test.go` to cover each new pattern
+
+## 3. File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `wave.yaml` | modify | Add 5 new deny patterns to reviewer persona (lines 233-236) |
+| `internal/defaults/personas/reviewer.yaml` | modify | Add `Write(*.py)`, `Write(*.rs)`, `Bash(rm *)` to embedded default deny list |
+| `internal/manifest/permissions_test.go` | modify | Add test cases for new deny patterns in reviewer persona |
+
+## 4. Architecture Decisions
+
+### No runtime code changes needed
+The `PermissionChecker.CheckPermission` in `internal/adapter/permissions.go` already:
+- Iterates deny patterns first (deny-takes-precedence)
+- Calls `matchToolPattern` → `parseToolPattern` + `matchGlob`
+- `matchGlob` dispatches to `matchStringGlob` for patterns with spaces (Bash commands)
+- `filepath.Match` handles `*.py`, `*.rs` file extension patterns
+
+### Consistency between wave.yaml and defaults
+The `wave.yaml` reviewer persona (line 219) and the embedded default (`internal/defaults/personas/reviewer.yaml`) both need updating. The `wave.yaml` is the project-specific configuration; the embedded default is what new projects get.
+
+### Embedded default vs wave.yaml differences
+The embedded default (`reviewer.yaml`) currently has a broader deny set (includes `Bash(git push*)`, `Bash(git commit*)`) while the project `wave.yaml` has a narrower set. This change aligns `wave.yaml` with the intended default and adds the missing language patterns to both.
+
+### Test fixture alignment
+The test helper `createTestManifestWithPersonas` in `internal/manifest/permissions_test.go` hardcodes persona configurations. It must be updated to include the new deny patterns so the test fixture matches the real configuration.
+
+## 5. Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Existing tests break due to deny count assertions | Low | The test `TestPersonaPermission_ReviewerCannotWriteSourceFiles` checks for `Write(*.go)` and `Write(*.ts)` specifically — no count assertions that would break |
+| `Bash(rm *)` too broad — blocks `rm` in non-destructive contexts | Low | The reviewer has no business running `rm` at all. Projects can override if needed |
+| Pattern matching edge cases | Very Low | The `matchStringGlob` function handles prefix matching (`rm *` → `strings.HasPrefix(text, "rm ")`) which correctly matches `rm foo.txt`, `rm -rf /`, etc. |
+
+## 6. Testing Strategy
+
+### Unit Tests (in `internal/manifest/permissions_test.go`)
+
+1. **Extend `TestPersonaPermission_ReviewerCannotWriteSourceFiles`** — add assertions for `Write(*.py)` and `Write(*.rs)` deny patterns
+2. **Add `TestPersonaPermission_ReviewerCannotRunDestructiveCommands`** — new test function covering:
+   - `Bash(rm foo.txt)` → denied by `Bash(rm *)`
+   - `Bash(rm -rf /tmp)` → denied by `Bash(rm *)`
+   - `Bash(git push origin main)` → denied by `Bash(git push*)`
+   - `Bash(git commit -m "msg")` → denied by `Bash(git commit*)`
+   - `Bash(go test ./...)` → still allowed (not blocked by new patterns)
+   - `Bash(git log --oneline)` → still allowed
+3. **Update test fixture** — add new deny patterns to `createTestManifestWithPersonas` reviewer entry
+4. **Update `TestPersonaPermission_ArtifactCreationScenarios`** — add scenarios for `.py` and `.rs` files
+5. **Extend `TestPersonaPermission_DenyPatternTakesPrecedence`** — add cases for `rm` and `git push/commit` patterns
+
+### Integration test
+The existing `TestLoadWaveYAML_PersonaPermissions` test loads the real `wave.yaml` and validates reviewer deny patterns. It currently checks for `Write(*.go)` — extend it to also verify the new patterns are present.
+
+### Validation
+Run `go test ./internal/manifest/ -v -run TestPersona` to verify all permission tests pass.
+Run `go test ./...` for full suite.

--- a/specs/033-reviewer-deny-patterns/spec.md
+++ b/specs/033-reviewer-deny-patterns/spec.md
@@ -1,0 +1,66 @@
+# Expand Reviewer Persona Deny Patterns to Block Destructive Actions
+
+> Issue: [re-cinq/wave#33](https://github.com/re-cinq/wave/issues/33)
+> Labels: enhancement, priority: medium, security
+> Author: nextlevelshit
+> State: OPEN
+
+## Summary
+
+Expand the reviewer persona's deny patterns to block destructive actions (file deletion, git push/commit) and source code writes for additional languages beyond Go and TypeScript.
+
+## Context
+
+During PR #32 review, it was noted that the original spec for the reviewer persona had more comprehensive deny patterns than what was implemented. The reviewer persona is intended for **quality review and validation only** — it should never modify source code or perform destructive operations.
+
+## Current Deny Patterns (wave.yaml)
+
+```yaml
+deny:
+  - Write(*.go)
+  - Write(*.ts)
+  - Edit(*)
+```
+
+## Proposed Deny Patterns
+
+```yaml
+deny:
+  - Write(*.go)
+  - Write(*.ts)
+  - Write(*.py)
+  - Write(*.rs)
+  - Edit(*)
+  - Bash(rm *)
+  - Bash(git push*)
+  - Bash(git commit*)
+```
+
+### Rationale for Each Addition
+
+| Pattern | Reason |
+|---------|--------|
+| `Write(*.py)` | Block Python source modifications — reviewer should not edit code |
+| `Write(*.rs)` | Block Rust source modifications — same principle |
+| `Bash(rm *)` | Prevent file deletions — reviewer should never delete files |
+| `Bash(git push*)` | Prevent pushes to remote — reviewer has no business pushing |
+| `Bash(git commit*)` | Prevent commits — reviewer should only read and report |
+
+### Configurability
+
+These expanded patterns should be the **default** deny set for the reviewer persona. Projects can override via their own `wave.yaml` if they need a different set. No additional configuration mechanism is needed — Wave's existing manifest override system handles this.
+
+## Implementation Notes
+
+- Update the reviewer persona definition in `wave.yaml`
+- Update the embedded default reviewer persona in `internal/defaults/personas/reviewer.yaml`
+- The deny pattern matching logic in `internal/adapter/permissions.go` already supports these glob patterns
+- No runtime changes needed — this is a configuration-only change plus test additions
+
+## Acceptance Criteria
+
+- [ ] Update reviewer persona deny patterns in `wave.yaml` with the expanded set
+- [ ] Update embedded default reviewer persona in `internal/defaults/personas/reviewer.yaml`
+- [ ] Verify deny pattern enforcement via existing security validation tests
+- [ ] Add test cases for the new deny patterns (rm, git push, git commit, Write(*.py), Write(*.rs))
+- [ ] Update reviewer persona documentation if needed

--- a/specs/033-reviewer-deny-patterns/tasks.md
+++ b/specs/033-reviewer-deny-patterns/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## Phase 1: Configuration Updates
+
+- [X] Task 1.1: Update `wave.yaml` reviewer persona deny patterns — add `Write(*.py)`, `Write(*.rs)`, `Bash(rm *)`, `Bash(git push*)`, `Bash(git commit*)` to the deny list (lines 233-236)
+- [X] Task 1.2: Update `internal/defaults/personas/reviewer.yaml` embedded default — add `Write(*.py)`, `Write(*.rs)`, `Bash(rm *)` to align with `wave.yaml` [P]
+
+## Phase 2: Test Updates
+
+- [X] Task 2.1: Update `createTestManifestWithPersonas` test fixture in `internal/manifest/permissions_test.go` — add new deny patterns to reviewer persona entry
+- [X] Task 2.2: Extend `TestPersonaPermission_ReviewerCannotWriteSourceFiles` — add checks for `Write(*.py)` deny and `Write(*.rs)` deny [P]
+- [X] Task 2.3: Add `TestPersonaPermission_ReviewerCannotRunDestructiveCommands` — new test covering `Bash(rm *)`, `Bash(git push*)`, `Bash(git commit*)` deny enforcement and verifying safe commands (`go test`, `git log`) still pass [P]
+- [X] Task 2.4: Add reviewer `.py` and `.rs` scenarios to `TestPersonaPermission_ArtifactCreationScenarios` [P]
+- [X] Task 2.5: Add `Bash(rm *)`, `Bash(git push*)`, `Bash(git commit*)` cases to `TestPersonaPermission_DenyPatternTakesPrecedence` [P]
+- [X] Task 2.6: Extend `TestLoadWaveYAML_PersonaPermissions` integration test — verify new deny patterns present in real `wave.yaml`
+
+## Phase 3: Validation
+
+- [X] Task 3.1: Run `go test ./internal/manifest/ -v -run TestPersona` to verify permission tests pass
+- [X] Task 3.2: Run `go test ./...` full test suite
+- [X] Task 3.3: Run `go test -race ./...` with race detector
+
+## Phase 4: Polish
+
+- [X] Task 4.1: Verify no unintended side effects — reviewer can still run `go test*`, `npm test*`, read files, write artifacts

--- a/wave.yaml
+++ b/wave.yaml
@@ -233,7 +233,12 @@ personas:
             deny:
                 - Write(*.go)
                 - Write(*.ts)
+                - Write(*.py)
+                - Write(*.rs)
                 - Edit(*)
+                - Bash(rm *)
+                - Bash(git push*)
+                - Bash(git commit*)
         system_prompt_file: .wave/personas/reviewer.md
     researcher:
         adapter: claude


### PR DESCRIPTION
## Summary

- Expands the reviewer persona's deny patterns to block destructive actions (file deletion, git push/commit)
- Adds source code write blocks for Python (`.py`) and Rust (`.rs`) files beyond existing Go and TypeScript
- Adds `Bash(rm *)`, `Bash(git push*)`, and `Bash(git commit*)` deny patterns
- Configuration-only change — no runtime code modifications needed
- Adds comprehensive test coverage for all new deny patterns

Closes #33

## Changes

- **`wave.yaml`** — Added 5 new deny patterns to the reviewer persona (`Write(*.py)`, `Write(*.rs)`, `Bash(rm *)`, `Bash(git push*)`, `Bash(git commit*)`)
- **`internal/defaults/personas/reviewer.yaml`** — Updated embedded default reviewer persona with matching deny patterns
- **`internal/manifest/permissions_test.go`** — Added table-driven tests covering all new deny patterns including edge cases for `rm`, `git push`, and `git commit` variants
- **`specs/033-reviewer-deny-patterns/`** — Added spec, plan, and tasks documentation

## Test Plan

- All new deny patterns validated via table-driven tests in `permissions_test.go`
- Tests cover exact matches, glob expansions, and edge cases (e.g., `rm -rf`, `git push --force`, `git commit -m`)
- Existing tests continue to pass — no regressions