### PR TITLE
feat: add --preserve-workspace flag for debugging

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -27,17 +27,18 @@ import (
 )
 
 type RunOptions struct {
-	Pipeline string
-	Input    string
-	DryRun   bool
-	FromStep string
-	Force    bool
-	Timeout  int
-	Manifest string
-	Mock     bool
-	RunID    string
-	Output   OutputConfig
-	Model    string
+	Pipeline          string
+	Input             string
+	DryRun            bool
+	FromStep          string
+	Force             bool
+	Timeout           int
+	Manifest          string
+	Mock              bool
+	RunID             string
+	Output            OutputConfig
+	Model             string
+	PreserveWorkspace bool
 }
 
 func NewRunCmd() *cobra.Command {
@@ -60,7 +61,8 @@ Arguments can be provided as positional args or flags:
   wave run --pipeline speckit-flow --input "add user auth"
   wave run hotfix --dry-run
   wave run migrate --from-step validate
-  wave run my-pipeline --model haiku`,
+  wave run my-pipeline --model haiku
+  wave run my-pipeline --preserve-workspace`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle positional arguments
@@ -110,6 +112,7 @@ Arguments can be provided as positional args or flags:
 	cmd.Flags().BoolVar(&opts.Mock, "mock", false, "Use mock adapter (for testing)")
 	cmd.Flags().StringVar(&opts.RunID, "run", "", "Resume from a specific run (uses that run's input)")
 	cmd.Flags().StringVar(&opts.Model, "model", "", "Override adapter model for this run (e.g. haiku, opus)")
+	cmd.Flags().BoolVar(&opts.PreserveWorkspace, "preserve-workspace", false, "Preserve workspace from previous run (for debugging)")
 
 	return cmd
 }
@@ -295,6 +298,9 @@ func runRun(opts RunOptions, debug bool) error {
 	}
 	if opts.Model != "" {
 		execOpts = append(execOpts, pipeline.WithModelOverride(opts.Model))
+	}
+	if opts.PreserveWorkspace {
+		execOpts = append(execOpts, pipeline.WithPreserveWorkspace(true))
 	}
 
 	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -74,6 +74,8 @@ type DefaultPipelineExecutor struct {
 	crossPipelineArtifacts map[string]map[string][]byte // pipelineName -> artifactName -> data
 	// ETA calculator for remaining pipeline time estimates
 	etaCalculator *ETACalculator
+	// Preserve workspace from previous run (skip cleanup for debugging)
+	preserveWorkspace bool
 }
 
 type ExecutorOption func(*DefaultPipelineExecutor)
@@ -119,6 +121,12 @@ func WithModelOverride(model string) ExecutorOption {
 // for cross-pipeline artifact references.
 func WithCrossPipelineArtifacts(artifacts map[string]map[string][]byte) ExecutorOption {
 	return func(ex *DefaultPipelineExecutor) { ex.crossPipelineArtifacts = artifacts }
+}
+
+// WithPreserveWorkspace skips workspace cleanup at pipeline start,
+// preserving the workspace from a previous run for debugging purposes.
+func WithPreserveWorkspace(preserve bool) ExecutorOption {
+	return func(ex *DefaultPipelineExecutor) { ex.preserveWorkspace = preserve }
 }
 
 // createRunID generates a run ID, preferring the state store's CreateRun()
@@ -196,6 +204,7 @@ func (e *DefaultPipelineExecutor) NewChildExecutor() *DefaultPipelineExecutor {
 		securityLogger:         e.securityLogger,
 		deliverableTracker:     deliverable.NewTracker(""),
 		crossPipelineArtifacts: e.crossPipelineArtifacts,
+		preserveWorkspace:      e.preserveWorkspace,
 	}
 }
 
@@ -314,14 +323,23 @@ func (e *DefaultPipelineExecutor) Execute(ctx context.Context, p *Pipeline, m *m
 		wsRoot = ".wave/workspaces"
 	}
 	pipelineWsPath := filepath.Join(wsRoot, pipelineID)
-	// Clean previous run artifacts to ensure fresh state
-	if err := os.RemoveAll(pipelineWsPath); err != nil {
+	// Clean previous run artifacts to ensure fresh state (unless --preserve-workspace is set)
+	if e.preserveWorkspace {
 		e.emit(event.Event{
 			Timestamp:  time.Now(),
 			PipelineID: pipelineID,
 			State:      "warning",
-			Message:    fmt.Sprintf("failed to clean workspace: %v", err),
+			Message:    "--preserve-workspace active: stale workspace state may cause non-reproducible results",
 		})
+	} else {
+		if err := os.RemoveAll(pipelineWsPath); err != nil {
+			e.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: pipelineID,
+				State:      "warning",
+				Message:    fmt.Sprintf("failed to clean workspace: %v", err),
+			})
+		}
 	}
 	if err := os.MkdirAll(pipelineWsPath, 0755); err != nil {
 		return fmt.Errorf("failed to create workspace: %w", err)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -4204,3 +4204,96 @@ func TestOptionalStep_PipelineStatusCompleted(t *testing.T) {
 	}
 	assert.True(t, foundCompleted, "should have emitted a completed event for the pipeline")
 }
+
+func TestPreserveWorkspaceKeepsExistingContent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Pre-create workspace directory with test content that should survive
+	runID := "preserve-test-run"
+	pipelineWsPath := filepath.Join(tmpDir, runID)
+	require.NoError(t, os.MkdirAll(pipelineWsPath, 0755))
+	markerFile := filepath.Join(pipelineWsPath, "debug-marker.txt")
+	require.NoError(t, os.WriteFile(markerFile, []byte("preserved"), 0644))
+
+	collector := newTestEventCollector()
+	mockAdapter := adapter.NewMockAdapter(
+		adapter.WithStdoutJSON(`{"status": "success"}`),
+	)
+
+	executor := NewDefaultPipelineExecutor(mockAdapter,
+		WithEmitter(collector),
+		WithRunID(runID),
+		WithPreserveWorkspace(true),
+	)
+
+	m := createTestManifest(tmpDir)
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "preserve-ws-test"},
+		Steps: []Step{
+			{ID: "step1", Persona: "navigator", Exec: ExecConfig{Source: "test"}},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.NoError(t, err)
+
+	// Verify pre-existing content was preserved
+	content, err := os.ReadFile(markerFile)
+	require.NoError(t, err)
+	assert.Equal(t, "preserved", string(content), "marker file should be preserved")
+
+	// Verify warning event was emitted
+	events := collector.GetEvents()
+	foundWarning := false
+	for _, evt := range events {
+		if evt.State == "warning" && strings.Contains(evt.Message, "--preserve-workspace active") {
+			foundWarning = true
+			break
+		}
+	}
+	assert.True(t, foundWarning, "should have emitted a preserve-workspace warning event")
+}
+
+func TestDefaultBehaviorCleansWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Pre-create workspace directory with test content that should be cleaned
+	runID := "cleanup-test-run"
+	pipelineWsPath := filepath.Join(tmpDir, runID)
+	require.NoError(t, os.MkdirAll(pipelineWsPath, 0755))
+	markerFile := filepath.Join(pipelineWsPath, "stale-marker.txt")
+	require.NoError(t, os.WriteFile(markerFile, []byte("should-be-removed"), 0644))
+
+	collector := newTestEventCollector()
+	mockAdapter := adapter.NewMockAdapter(
+		adapter.WithStdoutJSON(`{"status": "success"}`),
+	)
+
+	executor := NewDefaultPipelineExecutor(mockAdapter,
+		WithEmitter(collector),
+		WithRunID(runID),
+	)
+
+	m := createTestManifest(tmpDir)
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "cleanup-ws-test"},
+		Steps: []Step{
+			{ID: "step1", Persona: "navigator", Exec: ExecConfig{Source: "test"}},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.NoError(t, err)
+
+	// Verify pre-existing content was cleaned
+	_, err = os.Stat(markerFile)
+	assert.True(t, os.IsNotExist(err), "marker file should have been removed by workspace cleanup")
+}

--- a/specs/027-preserve-workspace/plan.md
+++ b/specs/027-preserve-workspace/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan: --preserve-workspace flag
+
+## Objective
+
+Add a `--preserve-workspace` boolean flag to the `wave run` command that skips the `os.RemoveAll` workspace cleanup at pipeline start, allowing developers to debug failed pipeline steps by inspecting preserved intermediate artifacts.
+
+## Approach
+
+Thread a `PreserveWorkspace` boolean through three layers:
+
+1. **CLI flag** → `RunOptions` struct in `cmd/wave/commands/run.go`
+2. **Executor option** → `DefaultPipelineExecutor` in `internal/pipeline/executor.go`
+3. **Conditional cleanup** → gate the `os.RemoveAll` call on the new flag
+
+The flag is purely additive — it only suppresses cleanup. No changes to workspace creation, artifact injection, or contract validation are needed. When active, a warning is emitted to stderr so users are aware that stale state may cause non-reproducible results.
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `cmd/wave/commands/run.go` | modify | Add `PreserveWorkspace` field to `RunOptions`, register `--preserve-workspace` flag, pass to executor via `WithPreserveWorkspace` option |
+| `internal/pipeline/executor.go` | modify | Add `preserveWorkspace` field to `DefaultPipelineExecutor`, add `WithPreserveWorkspace` option func, gate `os.RemoveAll` call on field value, emit warning event |
+| `internal/pipeline/executor_test.go` | modify | Add test verifying workspace preservation when flag is set |
+
+## Architecture Decisions
+
+1. **Executor option pattern**: Follow the existing `ExecutorOption` functional option pattern (`WithDebug`, `WithModelOverride`, etc.) for consistency. No new interfaces or types needed.
+
+2. **Warning via event emitter**: Use the existing `e.emit()` mechanism to emit a `"warning"` state event when preserve-workspace is active, consistent with how other warnings (e.g., failed cleanup) are already emitted.
+
+3. **No workspace manager changes**: The `os.RemoveAll` call is directly in `executor.Execute()` (line ~318), not in the `WorkspaceManager` interface. The gate applies at the same level — no changes to the workspace package.
+
+4. **Complementary with `--from-step`**: The flags operate independently — `--from-step` controls *which steps* run, `--preserve-workspace` controls *whether cleanup happens*. No special interaction logic is needed.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Stale workspace state causes confusing failures | Medium | Warning message clearly communicates the risk to users |
+| Flag forgotten in CI/automated contexts | Low | Flag defaults to `false`; only active when explicitly passed |
+| Workspace path collision with new run ID | Low | The `os.MkdirAll` call after the gated `RemoveAll` still ensures the directory exists; existing contents are simply preserved |
+
+## Testing Strategy
+
+1. **Unit test in `executor_test.go`**: Create a workspace directory with test content, run executor with `WithPreserveWorkspace(true)`, verify the content is still present after execution starts. Verify that without the flag, the content is removed.
+
+2. **Integration with existing tests**: Ensure `go test ./...` passes — no existing behavior changes when flag is not set (default `false`).
+
+3. **Manual verification**: `wave run --preserve-workspace <pipeline>` should show the warning and preserve prior workspace contents.

--- a/specs/027-preserve-workspace/spec.md
+++ b/specs/027-preserve-workspace/spec.md
@@ -1,0 +1,39 @@
+# feat: Add --preserve-workspace flag for debugging
+
+**Issue**: [#27](https://github.com/re-cinq/wave/issues/27)
+**Labels**: enhancement, good first issue, priority: low
+**Author**: nextlevelshit
+
+## Context
+
+From Copilot review on PR #26: workspace cleaning at pipeline start could break debugging workflows. When debugging a failed pipeline step, the workspace is destroyed before the developer can inspect intermediate artifacts, logs, or agent outputs.
+
+## Current Behavior
+
+Pipeline workspace is cleaned (`os.RemoveAll`) at the start of each run to ensure fresh state. This happens in the workspace setup phase before step execution begins.
+
+## Proposed Change
+
+Add `--preserve-workspace` flag to `wave run` command to skip workspace cleaning for debugging purposes.
+
+```bash
+wave run --preserve-workspace my-pipeline
+```
+
+When set, the workspace directory from the previous run is kept intact. The pipeline still runs but reuses the existing workspace rather than starting from a clean state.
+
+## Implementation Notes
+
+- **Flag registration**: Add `--preserve-workspace` bool flag in `cmd/wave/commands/run.go` via Cobra
+- **Workspace cleanup skip**: The `RemoveAll` call in `internal/pipeline/executor.go` (line ~318) should be gated on this flag
+- **Interaction with `--from-step`**: These flags are complementary — `--from-step` resumes from a specific step, `--preserve-workspace` keeps the filesystem state. Both can be used together for debugging a specific step with its prior outputs intact
+- **Warning output**: When `--preserve-workspace` is active, emit a warning that stale workspace state may cause non-reproducible results
+
+## Acceptance Criteria
+
+- [ ] Add `--preserve-workspace` bool flag to `wave run` command
+- [ ] Skip `RemoveAll` when flag is set
+- [ ] Emit warning when flag is active about potential stale state
+- [ ] Document flag in `--help` text with usage example
+- [ ] Works correctly in combination with `--from-step`
+- [ ] Unit test for flag parsing and workspace preservation logic

--- a/specs/027-preserve-workspace/tasks.md
+++ b/specs/027-preserve-workspace/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## Phase 1: Core Flag Plumbing
+
+- [X] Task 1.1: Add `PreserveWorkspace bool` field to `RunOptions` struct in `cmd/wave/commands/run.go`
+- [X] Task 1.2: Register `--preserve-workspace` flag via Cobra with help text: `"Preserve workspace from previous run (for debugging)"`
+- [X] Task 1.3: Add `preserveWorkspace bool` field to `DefaultPipelineExecutor` struct in `internal/pipeline/executor.go`
+- [X] Task 1.4: Add `WithPreserveWorkspace(bool) ExecutorOption` function following existing option pattern
+- [X] Task 1.5: Wire flag from `runRun()` into executor options: `pipeline.WithPreserveWorkspace(opts.PreserveWorkspace)`
+
+## Phase 2: Core Implementation
+
+- [X] Task 2.1: Gate the `os.RemoveAll(pipelineWsPath)` call at executor.go:~318 on `!e.preserveWorkspace`
+- [X] Task 2.2: Emit warning event when `preserveWorkspace` is true: `"--preserve-workspace active: stale workspace state may cause non-reproducible results"`
+- [X] Task 2.3: Copy `preserveWorkspace` field in `NewChildExecutor()` for matrix strategy consistency
+
+## Phase 3: Testing
+
+- [X] Task 3.1: Add unit test verifying workspace content is preserved when `WithPreserveWorkspace(true)` is set
+- [X] Task 3.2: Add unit test verifying workspace content is cleaned when `WithPreserveWorkspace(false)` (default behavior unchanged)
+- [X] Task 3.3: Run `go test ./...` to confirm no regressions
+
+## Phase 4: Polish
+
+- [X] Task 4.1: Add `--preserve-workspace` to the `Example` section in the run command's help text
+- [X] Task 4.2: Run `go vet ./...` for static analysis


### PR DESCRIPTION
## Summary

- Adds `--preserve-workspace` CLI flag to `wave run` that skips workspace cleanup, preserving state from previous runs for debugging
- Gates the `os.RemoveAll` call in the executor on the new flag, emitting a warning when workspace preservation is active
- Propagates the option through `ExecutorOption` pattern and child executors
- Complements existing `--from-step` flag for targeted debugging workflows

Closes #27

## Changes

- `cmd/wave/commands/run.go` — Register `--preserve-workspace` bool flag via Cobra, pass to executor options
- `internal/pipeline/executor.go` — Add `preserveWorkspace` field, `WithPreserveWorkspace` option, gate `RemoveAll` on flag, emit warning event when active, propagate to child executors
- `internal/pipeline/executor_test.go` — Two tests: verify workspace content is preserved when flag is set, verify default behavior still cleans workspace
- `specs/027-preserve-workspace/` — Feature specification, implementation plan, and task list

## Test Plan

- `TestPreserveWorkspaceKeepsExistingContent` — creates a marker file in the workspace dir, runs with `WithPreserveWorkspace(true)`, asserts the file survives and a warning event is emitted
- `TestDefaultBehaviorCleansWorkspace` — creates a marker file, runs without the flag, asserts the file is removed (regression guard)
- All existing tests continue to pass (`go test ./...`)