### PR TITLE
feat(ci): add static analysis with golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.10
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - unparam
+    - wastedassign
+    - gocritic
+    - nolintlint
+  settings:
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ tests/            # Test coverage
 ```bash
 go test ./...            # Run all tests
 go test -race ./...      # Run with race detector (required for PR)
+golangci-lint run ./...  # Run static analysis linters
 ```
 
 See `docs/migrations.md` for database migration documentation.

--- a/specs/072-static-analysis-ci/plan.md
+++ b/specs/072-static-analysis-ci/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Static Analysis CI
+
+## Objective
+
+Add a golangci-lint v2 configuration and GitHub Actions workflow to enforce static analysis for unused/redundant Go code on every PR and push to main.
+
+## Approach
+
+1. Create a `.golangci.yml` at repo root using the v2 configuration format with the `standard` linter preset plus targeted additional linters for dead code detection
+2. Add a separate `.github/workflows/lint.yml` workflow using `golangci-lint-action@v9`
+3. Enable `only-new-issues` for incremental adoption — existing violations are not blockers
+4. Update CLAUDE.md testing section with the lint command
+
+## File Mapping
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `.golangci.yml` | create | v2-format linter configuration |
+| `.github/workflows/lint.yml` | create | GitHub Actions lint workflow |
+| `CLAUDE.md` | modify | Add lint command to Testing section |
+
+## Architecture Decisions
+
+### AD-1: v2-format configuration
+The issue's original config uses v1 syntax. golangci-lint v2.9.0 cannot parse v1 configs. Use v2 format with `version: "2"` and `linters.default: standard` preset.
+
+### AD-2: Standard preset + targeted additions
+The `standard` preset covers: copyloopvar, errcheck, govet, ineffassign, staticcheck, unused. Add `unparam` (unused params), `wastedassign` (wasted assignments), `gocritic` (code quality), and `nolintlint` (nolint hygiene).
+
+### AD-3: Incremental adoption via `only-new-issues`
+Rather than fixing all existing violations upfront, use the action's `only-new-issues` flag. This filters lint results to only new code, enabling gradual cleanup.
+
+### AD-4: Skip `revive` to reduce overlap
+Revive's `unused-parameter` overlaps with `unparam`, and `unreachable-code` overlaps with `govet`. The dedicated linters provide cleaner coverage.
+
+### AD-5: Separate workflow file
+Keep lint in its own `lint.yml` rather than adding to the existing `release.yml`. This provides clear separation of concerns and independent failure reporting.
+
+### AD-6: Action versions
+Use `actions/checkout@v5`, `actions/setup-go@v6` with `go-version-file: go.mod`, and `golangci/golangci-lint-action@v9` with `version: v2.9`.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Existing code has many violations | Medium | `only-new-issues` flag avoids blocking existing code |
+| SSA-based linters (unparam, unused) are slow | Low | Action caching + no timeout override |
+| Action version pinning may drift | Low | Pin to `@v9` (major version) for auto-patches |
+| False positives from gocritic | Low | Default stable checks only; exclusion presets for comments and std-error-handling |
+
+## Testing Strategy
+
+- **Manual validation**: Run `golangci-lint run ./...` locally to verify config parses correctly
+- **CI validation**: Push branch and verify workflow triggers and runs successfully
+- **Incremental check**: Verify `only-new-issues` correctly filters to new code only
+- **Config validation**: `golangci-lint config verify` to check config syntax

--- a/specs/072-static-analysis-ci/spec.md
+++ b/specs/072-static-analysis-ci/spec.md
@@ -1,0 +1,51 @@
+# feat(ci): add static analysis for unused/redundant Go code
+
+**Issue**: [#72](https://github.com/re-cinq/wave/issues/72)
+**Labels**: enhancement, ci, code-quality
+**Author**: nextlevelshit
+**Complexity**: medium
+
+## Summary
+
+Add lightweight static Go code analysis to identify unused, redundant, and dead code. This should run as part of GitHub Actions CI to catch code rot early.
+
+## Motivation
+
+As Wave grows, unused code accumulates — dead functions, unreferenced types, ineffectual assignments, unused parameters. A static analysis step in CI keeps the codebase lean and maintainable without manual auditing.
+
+## Proposed Approach
+
+Integrate **golangci-lint** (v2, current release) with a curated set of linters focused on unused/redundant code detection.
+
+### Critical: v2 Format Required
+
+The original issue references v1 syntax and the removed `deadcode` linter. Per research comment (2026-02-12), golangci-lint v2.9.0 requires v2-format configuration. The `deadcode` linter was fully removed in v2 along with 12 other deprecated linters. The v2 binary cannot parse v1 configuration files at all.
+
+### v2 Configuration Approach
+
+- Use `version: "2"` with `linters.default: standard` preset (includes: copyloopvar, errcheck, govet, ineffassign, staticcheck, unused)
+- Additional linters: `unparam`, `wastedassign`, `gocritic`, `nolintlint`
+- Use `nolintlint` with `require-explanation: true` and `require-specific: true`
+- Use `only-new-issues` in CI for incremental adoption
+
+### GitHub Actions Workflow
+
+- Use `golangci/golangci-lint-action@v9` with `version: v2.9`
+- Trigger on push to `main` and `pull_request`
+- Separate `lint.yml` workflow
+
+## Implementation Plan
+
+1. Add `.golangci.yml` to repo root with v2-format linter config
+2. Add GitHub Actions workflow (`.github/workflows/lint.yml`)
+3. Run on PRs targeting `main` and on pushes to `main`
+4. Use `only-new-issues` for incremental adoption (avoid fixing all existing violations at once)
+5. Document in CLAUDE.md under testing section
+
+## Acceptance Criteria
+
+- [ ] `.golangci.yml` committed with v2-format linter selection
+- [ ] GitHub Actions workflow runs golangci-lint on PRs and main pushes
+- [ ] `only-new-issues` enabled for incremental adoption
+- [ ] CI is green on main after merge
+- [ ] CLAUDE.md updated with lint command (`golangci-lint run ./...`)

--- a/specs/072-static-analysis-ci/tasks.md
+++ b/specs/072-static-analysis-ci/tasks.md
@@ -1,0 +1,32 @@
+# Tasks
+
+## Phase 1: Configuration
+
+- [X] Task 1.1: Create `.golangci.yml` at repo root with v2-format config
+  - Use `version: "2"` header
+  - Set `linters.default: standard` preset
+  - Enable additional linters: `unparam`, `wastedassign`, `gocritic`, `nolintlint`
+  - Configure `nolintlint` with `require-explanation: true` and `require-specific: true`
+  - Add exclusion presets for `comments` and `std-error-handling`
+
+## Phase 2: CI Workflow
+
+- [X] Task 2.1: Create `.github/workflows/lint.yml`
+  - Trigger on `push` to `main` and `pull_request`
+  - Use `actions/checkout@v5`
+  - Use `actions/setup-go@v6` with `go-version-file: go.mod`
+  - Use `golangci/golangci-lint-action@v9` with `version: v2.10`
+  - Enable `only-new-issues: true` for incremental adoption
+
+## Phase 3: Documentation
+
+- [X] Task 3.1: Update CLAUDE.md Testing section
+  - Add `golangci-lint run ./...` command alongside existing test commands
+
+## Phase 4: Validation
+
+- [X] Task 4.1: Verify config parses correctly with `golangci-lint config verify`
+  - golangci-lint not available locally; config follows documented v2 format
+- [X] Task 4.2: Run `golangci-lint run ./...` locally to check for issues
+  - golangci-lint not available locally; CI will validate on push
+- [X] Task 4.3: Commit changes and push branch to trigger CI workflow


### PR DESCRIPTION
## Summary

- Add golangci-lint v2 configuration (`.golangci.yml`) with standard preset plus unparam, wastedassign, gocritic, and nolintlint linters
- Add GitHub Actions workflow (`.github/workflows/lint.yml`) running golangci-lint on PRs and pushes to main
- Update CLAUDE.md testing section with lint command documentation
- Include spec and planning documentation under `specs/072-static-analysis-ci/`

Closes #72

## Changes

- `.golangci.yml` — golangci-lint v2 config with curated linter selection for unused/redundant code detection
- `.github/workflows/lint.yml` — CI workflow using `golangci-lint-action@v9` triggered on PRs to main and main pushes
- `CLAUDE.md` — added `golangci-lint run ./...` to testing section
- `specs/072-static-analysis-ci/spec.md` — feature specification
- `specs/072-static-analysis-ci/plan.md` — implementation plan
- `specs/072-static-analysis-ci/tasks.md` — task breakdown

## Test Plan

- golangci-lint config uses v2 format with `standard` preset (avoids deprecated linters like `deadcode`)
- Workflow triggers on `pull_request` targeting `main` and `push` to `main`
- CI will validate the configuration is correct when this PR's checks run