### PR TITLE
feat: restore wave meta dynamic pipeline generation

### DIFF
--- a/cmd/wave/commands/meta.go
+++ b/cmd/wave/commands/meta.go
@@ -67,6 +67,11 @@ Examples:
 }
 
 func runMeta(input string, opts MetaOptions) error {
+	// Gate on onboarding completion
+	if err := checkOnboarding(); err != nil {
+		return err
+	}
+
 	manifestData, err := os.ReadFile(opts.Manifest)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/wave/commands/meta_test.go
+++ b/cmd/wave/commands/meta_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/recinq/wave/internal/onboarding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,6 +116,9 @@ func TestNewMetaCmd(t *testing.T) {
 func TestMetaCommand_MissingManifestError(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	// Satisfy onboarding check without creating wave.yaml
+	require.NoError(t, onboarding.MarkOnboarded(filepath.Join(tmpDir, ".wave")))
+
 	// Change to test directory (no manifest)
 	oldWd, err := os.Getwd()
 	require.NoError(t, err)
@@ -207,6 +211,27 @@ func TestMetaCommand_HelpText(t *testing.T) {
 	assert.Contains(t, cmd.Long, "wave meta \"implement user authentication\"")
 	assert.Contains(t, cmd.Long, "--dry-run")
 	assert.Contains(t, cmd.Long, "--save")
+}
+
+// TestMetaCommand_MockDryRun exercises the full meta command flow with Mock + DryRun,
+// verifying that the philosopher output is parsed and the pipeline plan is displayed.
+func TestMetaCommand_MockDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupTestManifestWithPhilosopher(t, tmpDir)
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(oldWd)
+	require.NoError(t, os.Chdir(tmpDir))
+
+	opts := MetaOptions{
+		Manifest: "wave.yaml",
+		Mock:     true,
+		DryRun:   true,
+	}
+
+	err = runMeta("implement user authentication", opts)
+	require.NoError(t, err)
 }
 
 // TestSaveMetaPipelinePath verifies save path logic

--- a/internal/adapter/mock.go
+++ b/internal/adapter/mock.go
@@ -138,6 +138,11 @@ func generateRealisticOutput(cfg AdapterRunConfig) string {
 		}
 	}
 
+	// Check for meta-philosopher workspace
+	if strings.Contains(cfg.WorkspacePath, "meta-philosopher") {
+		return generateMetaPhilosopherOutput(cfg)
+	}
+
 	// Extract step name from workspace path (e.g., ".wave/workspaces/prototype/docs" → "docs")
 	phase := filepath.Base(cfg.WorkspacePath)
 	switch phase {
@@ -570,6 +575,132 @@ func generateEpicReportOutput(cfg AdapterRunConfig) string {
 	}
 	out, _ := json.MarshalIndent(data, "", "  ")
 	return string(out)
+}
+
+// generateMetaPhilosopherOutput returns output in the --- PIPELINE --- / --- SCHEMAS ---
+// delimited format expected by extractPipelineAndSchemas in meta.go.
+func generateMetaPhilosopherOutput(cfg AdapterRunConfig) string {
+	return `--- PIPELINE ---
+kind: WavePipeline
+metadata:
+  name: generated-pipeline
+  description: Pipeline generated for the task
+input:
+  source: meta
+steps:
+  - id: navigate
+    persona: navigator
+    memory:
+      strategy: fresh
+    workspace:
+      root: "./"
+    exec:
+      type: prompt
+      source: "Analyze the codebase for: {{ input }}. Identify key files, patterns, dependencies, and impact areas relevant to the task."
+    output_artifacts:
+      - name: analysis
+        path: .wave/artifact.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        schema_path: ".wave/contracts/navigation-analysis.schema.json"
+
+  - id: implement
+    persona: craftsman
+    dependencies: [navigate]
+    memory:
+      strategy: fresh
+      inject_artifacts:
+        - step: navigate
+          artifact: analysis
+          as: analysis
+    workspace:
+      root: "./"
+    exec:
+      type: prompt
+      source: "Read .wave/artifacts/analysis.json to understand the codebase. Implement the feature: {{ input }}"
+    output_artifacts:
+      - name: result
+        path: .wave/artifact.json
+        type: json
+    handover:
+      contract:
+        type: json_schema
+        schema_path: ".wave/contracts/implementation-result.schema.json"
+
+--- SCHEMAS ---
+SCHEMA: .wave/contracts/navigation-analysis.schema.json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Navigation analysis results",
+  "required": ["files", "patterns", "dependencies", "impact_areas"],
+  "properties": {
+    "files": {
+      "type": "array",
+      "description": "List of relevant files",
+      "items": {
+        "type": "object",
+        "required": ["path", "purpose"],
+        "properties": {
+          "path": {"type": "string", "description": "File path"},
+          "purpose": {"type": "string", "description": "Purpose of this file"}
+        }
+      }
+    },
+    "patterns": {
+      "type": "array",
+      "description": "Identified patterns",
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": {"type": "string", "description": "Pattern name"},
+          "description": {"type": "string", "description": "Description"}
+        }
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "description": "Dependency relationships",
+      "properties": {
+        "internal": {"type": "array", "items": {"type": "string"}},
+        "external": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "impact_areas": {
+      "type": "array",
+      "description": "Areas impacted by changes",
+      "items": {"type": "string"}
+    }
+  }
+}
+
+SCHEMA: .wave/contracts/implementation-result.schema.json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Implementation result",
+  "required": ["status", "files_modified"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "failed"],
+      "description": "Implementation status"
+    },
+    "files_modified": {
+      "type": "array",
+      "description": "List of modified files",
+      "items": {"type": "string"}
+    },
+    "summary": {
+      "type": "string",
+      "description": "Summary of changes"
+    }
+  }
+}
+`
 }
 
 func extractArtifactNames(stdout string) []string {

--- a/internal/pipeline/meta.go
+++ b/internal/pipeline/meta.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -280,9 +281,11 @@ func (e *MetaPipelineExecutor) invokePhilosopherWithSchemas(ctx context.Context,
 	}
 
 	// Read stdout from the adapter result
-	buf := make([]byte, 1024*1024) // 1MB buffer
-	n, _ := result.Stdout.Read(buf)
-	output := string(buf[:n])
+	outputBytes, err := io.ReadAll(result.Stdout)
+	if err != nil {
+		return nil, result.TokensUsed, fmt.Errorf("failed to read philosopher output: %w", err)
+	}
+	output := string(outputBytes)
 
 	// Extract pipeline and schemas from the output
 	genResult, err := extractPipelineAndSchemas(output)

--- a/internal/pipeline/meta_test.go
+++ b/internal/pipeline/meta_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1608,5 +1609,92 @@ func TestBuildPhilosopherPrompt_ExampleSchemaIsComplete(t *testing.T) {
 	// Should not have incomplete/vague schemas
 	if strings.Contains(schemaSection, `"type": "object"}`) && !strings.Contains(schemaSection, `"properties"`) {
 		t.Error("example schema should not be vague - must define properties")
+	}
+}
+
+// TestExtractPipelineAndSchemas_MockOutput verifies that extractPipelineAndSchemas
+// correctly parses the delimited format produced by the mock adapter's
+// generateMetaPhilosopherOutput function.
+func TestExtractPipelineAndSchemas_MockOutput(t *testing.T) {
+	// Use the mock adapter to generate output in the expected format
+	mockAdapter := adapter.NewMockAdapter()
+	cfg := adapter.AdapterRunConfig{
+		WorkspacePath: ".wave/workspaces/meta-philosopher",
+		Persona:       "philosopher",
+	}
+	result, err := mockAdapter.Run(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("mock adapter run failed: %v", err)
+	}
+
+	outputBytes, err := io.ReadAll(result.Stdout)
+	if err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	output := string(outputBytes)
+
+	// Parse with extractPipelineAndSchemas
+	genResult, err := extractPipelineAndSchemas(output)
+	if err != nil {
+		t.Fatalf("extractPipelineAndSchemas failed: %v", err)
+	}
+
+	// Verify pipeline YAML was extracted
+	if genResult.PipelineYAML == "" {
+		t.Fatal("pipeline YAML should not be empty")
+	}
+
+	// Verify YAML is parseable as a WavePipeline
+	loader := &YAMLPipelineLoader{}
+	pipeline, err := loader.Unmarshal([]byte(genResult.PipelineYAML))
+	if err != nil {
+		t.Fatalf("failed to parse extracted pipeline YAML: %v", err)
+	}
+
+	// Verify pipeline structure
+	if pipeline.Kind != "WavePipeline" {
+		t.Errorf("expected kind WavePipeline, got %q", pipeline.Kind)
+	}
+	if len(pipeline.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(pipeline.Steps))
+	}
+	if pipeline.Steps[0].ID != "navigate" {
+		t.Errorf("expected first step ID 'navigate', got %q", pipeline.Steps[0].ID)
+	}
+	if pipeline.Steps[0].Persona != "navigator" {
+		t.Errorf("expected first step persona 'navigator', got %q", pipeline.Steps[0].Persona)
+	}
+	if pipeline.Steps[1].ID != "implement" {
+		t.Errorf("expected second step ID 'implement', got %q", pipeline.Steps[1].ID)
+	}
+
+	// Verify schemas were extracted
+	if len(genResult.Schemas) != 2 {
+		t.Fatalf("expected 2 schemas, got %d", len(genResult.Schemas))
+	}
+
+	navSchema, ok := genResult.Schemas[".wave/contracts/navigation-analysis.schema.json"]
+	if !ok {
+		t.Fatal("missing navigation-analysis schema")
+	}
+	// Verify schema is valid JSON
+	var navJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(navSchema), &navJSON); err != nil {
+		t.Fatalf("navigation schema is not valid JSON: %v", err)
+	}
+	if navJSON["type"] != "object" {
+		t.Errorf("navigation schema should have type 'object', got %v", navJSON["type"])
+	}
+
+	implSchema, ok := genResult.Schemas[".wave/contracts/implementation-result.schema.json"]
+	if !ok {
+		t.Fatal("missing implementation-result schema")
+	}
+	var implJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(implSchema), &implJSON); err != nil {
+		t.Fatalf("implementation schema is not valid JSON: %v", err)
+	}
+	if implJSON["type"] != "object" {
+		t.Errorf("implementation schema should have type 'object', got %v", implJSON["type"])
 	}
 }

--- a/specs/095-restore-wave-meta/plan.md
+++ b/specs/095-restore-wave-meta/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: Restore `wave meta`
+
+## Objective
+
+Fix the `wave meta` command so it works end-to-end in both live and mock modes: philosopher generates valid pipeline YAML, the executor parses and runs it, and `--dry-run`/`--save`/`--mock` flags all function correctly.
+
+## Approach
+
+The investigation revealed four specific issues (see spec.md § Diagnosed Issues). The fixes are targeted and localized — no architectural redesign needed.
+
+1. **Fix mock adapter** to produce `--- PIPELINE ---` / `--- SCHEMAS ---` formatted output when invoked for the meta-philosopher workspace
+2. **Fix unsafe io.Reader** consumption to use `io.ReadAll()` instead of manual buffer read
+3. **Add onboarding check** to the meta command
+4. **Add integration test** for `wave meta --mock --dry-run` to verify the full flow
+
+## File Mapping
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `internal/adapter/mock.go` | modify | Add `generateMetaPhilosopherOutput()` for meta-pipeline workspace path |
+| `internal/pipeline/meta.go` | modify | Replace manual `Read(buf)` with `io.ReadAll()` in `invokePhilosopherWithSchemas` |
+| `cmd/wave/commands/meta.go` | modify | Add `checkOnboarding()` call |
+| `cmd/wave/commands/meta_test.go` | modify | Add integration test for `--mock --dry-run` flow |
+| `internal/pipeline/meta_test.go` | modify | Add test for mock adapter philosopher output parsing |
+
+## Architecture Decisions
+
+### Mock output format
+The mock adapter's `generateRealisticOutput` routes based on workspace path, then persona. The meta executor creates workspace at `.wave/workspaces/meta-philosopher`. We add a workspace-path check for `meta-philosopher` that returns properly delimited output with a valid 2-step pipeline (navigate + implement) and matching schema files.
+
+### io.ReadAll vs buffered Read
+`io.ReadAll()` is the idiomatic Go approach for consuming an entire reader. The existing 1MB manual buffer is both fragile and unnecessarily complex. The mock adapter returns `bytes.NewReader()` which supports full reads, and the real adapter collects all stdout before returning, so `io.ReadAll()` is safe in both cases.
+
+### Onboarding check
+Mirrors the pattern in `do.go` and `run.go`. Placed at the top of `runMeta()` before manifest loading.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Mock output doesn't match real philosopher output format | Mock tests pass but real mode fails | The format (`--- PIPELINE ---` / `--- SCHEMAS ---`) is enforced by `extractPipelineAndSchemas` — both mock and real must produce it |
+| `io.ReadAll` on very large output | Memory spike | Philosopher output is bounded by token limits (max 500K tokens ≈ 2MB text). Acceptable. |
+| Philosopher persona system prompt conflicts with meta instructions | LLM confusion in real mode | The `buildPhilosopherPrompt` overrides the system prompt with pipeline-specific instructions. Not addressing persona file changes in this PR — that's a design improvement for a follow-up. |
+
+## Testing Strategy
+
+1. **Unit test** (`internal/pipeline/meta_test.go`): Verify `extractPipelineAndSchemas` correctly parses the mock adapter's philosopher output
+2. **Unit test** (`internal/adapter/mock.go`): Verify `generateMetaPhilosopherOutput` produces valid delimited format with parseable YAML and JSON schemas
+3. **Command test** (`cmd/wave/commands/meta_test.go`): Add `TestMetaCommand_MockDryRun` that exercises `runMeta` with `--mock --dry-run` end-to-end
+4. **Existing tests**: All existing meta tests continue to pass (verified: 19 pass currently)
+5. **Race detection**: `go test -race ./...` must pass

--- a/specs/095-restore-wave-meta/spec.md
+++ b/specs/095-restore-wave-meta/spec.md
@@ -1,0 +1,72 @@
+# feat: restore and stabilize `wave meta` dynamic pipeline generation
+
+**Issue**: [#95](https://github.com/re-cinq/wave/issues/95)
+**Labels**: enhancement, needs-design, priority: medium
+**Author**: nextlevelshit
+
+## Summary
+
+The `wave meta` command — which dynamically generates and executes multi-step pipelines via the philosopher persona — needs to be restored to working condition. The command exists in the codebase (`cmd/wave/commands/meta.go`) with full implementation including dry-run, save, and execution modes, but is currently non-functional or degraded.
+
+## Background
+
+`wave meta` was introduced in commit `164a20f` (\"implement meta-pipeline for self-designing pipelines\") and received subsequent improvements (progress events, schema generation, contract validation, prompt cleanup). It allows users to describe a task in natural language and have the philosopher persona design an appropriate pipeline with steps, personas, and contracts, then execute it.
+
+### Current Implementation
+
+- **Command**: `wave meta [task description]`
+- **Flags**: `--dry-run`, `--save <path>`, `--manifest <path>`, `--mock`
+- **Flow**: User input → philosopher persona generates pipeline YAML → pipeline executor runs generated steps
+- **Key files**: `cmd/wave/commands/meta.go`, `internal/pipeline/meta.go`
+
+## Problem
+
+The `wave meta` command is not functioning correctly. This issue tracks diagnosing the failure mode and restoring full functionality.
+
+## Acceptance Criteria
+
+- [ ] `wave meta "<task>" --dry-run` generates a valid pipeline and displays the step plan
+- [ ] `wave meta "<task>"` executes the generated pipeline end-to-end
+- [ ] `wave meta "<task>" --save <name>` persists the generated pipeline YAML for reuse
+- [ ] `wave meta` with `--mock` adapter works for testing without live LLM calls
+- [ ] All existing tests in `cmd/wave/commands/meta_test.go` pass
+- [ ] Philosopher persona is properly configured in the default manifest
+- [ ] Error messages are clear when prerequisites are missing (e.g., no philosopher persona)
+
+## Investigation Checklist
+
+- [ ] Verify the philosopher persona exists and is correctly defined in the default manifest
+- [ ] Check that `MetaPipelineExecutor` in `internal/pipeline/` is properly wired
+- [ ] Test with `--mock` adapter to isolate adapter vs. pipeline issues
+- [ ] Review recent refactors that may have broken the meta command integration
+- [ ] Confirm contract validation works for dynamically generated pipelines
+
+## Related History
+
+- `164a20f` — feat: implement meta-pipeline for self-designing pipelines
+- `c6e0870` — feat(do): add --meta flag for dynamic pipeline generation
+- `5b9ab1d` — fix(meta): remove redundant schema instructions from generated prompts
+- `5e7b2af` — feat: add standalone wave meta command
+- `6d24cc9` — refactor(pipeline): default memory.strategy to fresh
+
+## Diagnosed Issues
+
+### 1. Mock Adapter Does Not Produce Meta-Pipeline Format (Critical)
+
+The mock adapter (`internal/adapter/mock.go`) handles the philosopher persona by falling back to `generateDocsPhaseOutput()`, which returns JSON. However, `invokePhilosopherWithSchemas()` in `meta.go` expects output in the `--- PIPELINE ---` / `--- SCHEMAS ---` delimited format parsed by `extractPipelineAndSchemas()`. This means `wave meta --mock` always fails with "missing --- PIPELINE --- marker".
+
+**Root cause**: No `meta-philosopher` workspace path or philosopher-meta output generator in the mock adapter.
+
+### 2. Unsafe io.Reader Consumption (Bug)
+
+In `invokePhilosopherWithSchemas()` (`internal/pipeline/meta.go:283-285`), stdout is read with a single `result.Stdout.Read(buf)` call using a 1MB buffer. The `io.Reader` contract does NOT guarantee a single `Read()` returns all available data — it may return fewer bytes. For large generated pipeline YAML + schemas, this silently truncates output.
+
+**Root cause**: Should use `io.ReadAll()` instead of a manual `Read()` call.
+
+### 3. Missing Onboarding Check (Minor)
+
+The `meta` command does not call `checkOnboarding()` like other commands (`do`, `run`). This means `wave meta` can run in an uninitialized project without the expected guardrail error.
+
+### 4. Philosopher Persona System Prompt Mismatch (Design)
+
+The philosopher persona (`philosopher.md`) is configured as a spec/architecture writer, not a meta-pipeline architect. The `buildPhilosopherPrompt()` function injects pipeline-generation instructions, but the persona's system prompt may conflict or confuse the LLM when both are active.

--- a/specs/095-restore-wave-meta/tasks.md
+++ b/specs/095-restore-wave-meta/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Phase 1: Fix Core Bugs
+
+- [X] Task 1.1: Replace unsafe `Read(buf)` with `io.ReadAll()` in `invokePhilosopherWithSchemas` (`internal/pipeline/meta.go:283-285`)
+- [X] Task 1.2: Add `checkOnboarding()` call at the top of `runMeta()` in `cmd/wave/commands/meta.go`
+
+## Phase 2: Mock Adapter Support
+
+- [X] Task 2.1: Add `generateMetaPhilosopherOutput()` function to `internal/adapter/mock.go` that produces `--- PIPELINE ---` / `--- SCHEMAS ---` delimited output with a valid 2-step pipeline (navigate → implement) and matching JSON schema files
+- [X] Task 2.2: Add workspace-path routing in `generateRealisticOutput()` to detect `meta-philosopher` workspace path and call `generateMetaPhilosopherOutput()` [P]
+
+## Phase 3: Testing
+
+- [X] Task 3.1: Add test in `internal/pipeline/meta_test.go` to verify `extractPipelineAndSchemas` correctly parses the new mock output format
+- [X] Task 3.2: Add `TestMetaCommand_MockDryRun` in `cmd/wave/commands/meta_test.go` that exercises `runMeta` with `Mock: true, DryRun: true` end-to-end [P]
+- [X] Task 3.3: Run `go test -race ./...` to verify no regressions
+
+## Phase 4: Validation
+
+- [X] Task 4.1: Verify all 19 existing meta tests still pass
+- [X] Task 4.2: Verify `go build ./...` succeeds
+- [X] Task 4.3: Manual verification that the generated mock pipeline YAML is valid and can be loaded by `YAMLPipelineLoader`


### PR DESCRIPTION
## Summary

- Fix `wave meta` philosopher output reading — replace fixed 1MB buffer with `io.ReadAll` to prevent truncation of large pipeline YAML
- Add onboarding gate to `runMeta` so it fails early with a clear error if Wave hasn't been initialized
- Add mock adapter support for meta-philosopher workspace — generates realistic pipeline YAML with schemas in the expected delimited format
- Add comprehensive tests: `TestMetaCommand_MockDryRun` (end-to-end mock+dry-run), `TestExtractPipelineAndSchemas_MockOutput` (parser round-trip)
- Fix `TestMetaCommand_MissingManifestError` to satisfy the new onboarding prerequisite

Closes #95

## Changes

- `cmd/wave/commands/meta.go` — add `checkOnboarding()` gate at start of `runMeta`
- `cmd/wave/commands/meta_test.go` — add `TestMetaCommand_MockDryRun`, fix `MissingManifestError` test with onboarding setup
- `internal/adapter/mock.go` — add `generateMetaPhilosopherOutput()` with `--- PIPELINE ---` / `--- SCHEMAS ---` delimited output
- `internal/pipeline/meta.go` — replace fixed-size buffer read with `io.ReadAll` for philosopher stdout
- `internal/pipeline/meta_test.go` — add `TestExtractPipelineAndSchemas_MockOutput` verifying parser handles mock output

## Test Plan

- All existing tests in `cmd/wave/commands/meta_test.go` pass
- New `TestMetaCommand_MockDryRun` validates the full mock+dry-run flow
- New `TestExtractPipelineAndSchemas_MockOutput` validates pipeline YAML and schema extraction round-trip
- `go test ./...` passes