### PR TITLE
docs: ADR-003 layered architecture separation

### DIFF
--- a/docs/adr/003-layered-architecture.md
+++ b/docs/adr/003-layered-architecture.md
@@ -1,0 +1,275 @@
+# ADR-003: Layered Architecture Separation
+
+## Status
+Proposed
+
+## Date
+2026-03-13
+
+## Context
+
+Wave's `internal/` directory contains 25 packages that have grown organically during rapid prototyping (v0.15.0 → v0.84.1). While the separation between presentation and backend is already reasonably clean — `display/` imports only `event/`, `pathfmt/`, and `deliverable/`; `pipeline/` does not import `display/` or `tui/` — some areas have accumulated cross-layer coupling that warrants formal documentation and enforcement.
+
+### Current State
+
+An audit of the codebase reveals the following import relationships among internal packages:
+
+| Package | Internal Imports |
+|---------|-----------------|
+| `adapter` | `github` |
+| `audit` | (none) |
+| `contract` | `pathfmt` |
+| `defaults` | `manifest`, `pipeline` |
+| `deliverable` | `pathfmt` |
+| `display` | `deliverable`, `event`, `pathfmt` |
+| `doctor` | `forge`, `github`, `manifest`, `onboarding`, `pipeline` |
+| `event` | (none) |
+| `forge` | (none) |
+| `github` | (none) |
+| `manifest` | (none) |
+| `onboarding` | `manifest`, `tui` |
+| `pathfmt` | (none) |
+| `pipeline` | `adapter`, `audit`, `contract`, `deliverable`, `event`, `manifest`, `preflight`, `relay`, `security`, `skill`, `state`, `workspace`, `worktree` |
+| `preflight` | `skill` |
+| `recovery` | `contract`, `pathfmt`, `preflight`, `security` |
+| `relay` | (none) |
+| `security` | (none) |
+| `skill` | (none) |
+| `state` | (none) |
+| `suggest` | `doctor`, `forge` |
+| `tui` | `display`, `event`, `forge`, `github`, `manifest`, `pathfmt`, `pipeline`, `state` |
+| `webui` | `adapter`, `audit`, `display`, `event`, `manifest`, `pipeline`, `state`, `workspace` (behind `//go:build webui` tag) |
+| `workspace` | (none) |
+| `worktree` | (none) |
+
+The presentation/backend separation is mostly intact — the event system properly decouples display consumers from pipeline producers — but several violations exist:
+
+- **`webui` → `adapter`, `workspace`**: Presentation layer directly importing domain and infrastructure packages
+- **`doctor` → `onboarding`**: Domain package importing a presentation package
+- **`defaults` → `pipeline`**: Cross-cutting package importing domain, creating a circular-risk dependency
+
+The `pipeline/executor.go` god-object (2,493+ lines, 11+ responsibilities) is the primary structural concern, but that is addressed separately by [ADR-002](002-extract-step-executor.md). This ADR focuses on the inter-package layer boundaries, not intra-package decomposition.
+
+This work builds on the architecture audit from [#298](https://github.com/re-cinq/wave/issues/298).
+
+## Decision
+
+Adopt a four-layer architectural model for Wave's internal packages and enforce dependency rules between layers using CI-integrated linting.
+
+### Layer Definitions
+
+**1. Presentation** — User-facing interfaces (terminal, web, onboarding flows).
+
+| Package | Responsibility |
+|---------|---------------|
+| `display` | Terminal progress display and formatting |
+| `tui` | Bubble Tea terminal UI |
+| `webui` | Web operations dashboard |
+| `onboarding` | Interactive `wave init` flow |
+
+**2. Domain / Orchestration** — Core business logic for pipeline execution, validation, and coordination.
+
+| Package | Responsibility |
+|---------|---------------|
+| `pipeline` | Pipeline execution, DAG traversal, step management |
+| `adapter` | Subprocess execution and adapter management |
+| `contract` | Output validation (JSON schema, TypeScript, test suites) |
+| `relay` | Context compaction and summarization |
+| `deliverable` | Pipeline deliverable tracking and output |
+| `preflight` | Pipeline dependency validation and auto-install |
+| `recovery` | Pipeline recovery hints and error guidance |
+| `skill` | Skill discovery, provisioning, and command management |
+| `defaults` | Embedded default personas, pipelines, and contracts |
+| `suggest` | Pipeline suggestion engine |
+| `doctor` | Project health checking and optimization |
+
+**3. Infrastructure** — External system integrations and persistence.
+
+| Package | Responsibility |
+|---------|---------------|
+| `state` | SQLite persistence and state management |
+| `workspace` | Ephemeral workspace management |
+| `worktree` | Git worktree lifecycle for isolated workspaces |
+| `forge` | Git forge/hosting platform detection |
+| `github` | GitHub API integration |
+
+**4. Cross-cutting** — Shared utilities and concerns used across all layers.
+
+| Package | Responsibility |
+|---------|---------------|
+| `manifest` | Configuration loading and validation |
+| `security` | Security validation and sanitization |
+| `audit` | Audit logging and credential scrubbing |
+| `event` | Progress event emission and monitoring |
+| `pathfmt` | Path formatting and normalization utilities |
+
+### Dependency Rules
+
+```
+Presentation → Domain → Infrastructure
+     ↓             ↓           ↓
+     └─────── Cross-cutting ───┘
+```
+
+1. **Presentation** may import from **Domain**, **Infrastructure**, and **Cross-cutting**
+2. **Domain** may import from **Infrastructure** and **Cross-cutting**
+3. **Infrastructure** may import from **Cross-cutting** only
+4. **Cross-cutting** must not import from any other layer
+5. **No layer may import from Presentation** except Presentation itself
+6. **No reverse dependencies** — Domain must not import Presentation; Infrastructure must not import Domain or Presentation
+
+### Current Violations
+
+| Violation | Packages | Severity | Remediation |
+|-----------|----------|----------|-------------|
+| Presentation → Domain (direct adapter/workspace use) | `webui` → `adapter`, `workspace` | Medium | Refactor `webui` to use domain interfaces rather than concrete infrastructure types |
+| Domain → Presentation | `doctor` → `onboarding` | Medium | Extract the shared logic into a domain-level interface or move `onboarding` interaction behind an interface |
+| Cross-cutting → Domain | `defaults` → `pipeline` | Low | `defaults` embeds pipeline definitions — consider moving the pipeline type definitions it needs into `manifest` |
+
+## Options Considered
+
+### Option 1: Convention-Only Documentation
+
+Document the layer model and dependency rules in this ADR and in `CLAUDE.md`. Rely on code review to enforce boundaries. No tooling changes.
+
+**Pros:**
+- Zero implementation effort beyond writing the ADR
+- No CI pipeline changes or new dependencies
+- Flexible — allows pragmatic violations during rapid prototyping
+- Immediately actionable — contributors can reference the rules today
+
+**Cons:**
+- Enforcement depends entirely on reviewer diligence
+- Violations accumulate silently over time
+- AI personas generating code have no automated guardrails against cross-layer imports
+- Historical evidence shows documentation-only rules are frequently ignored under deadline pressure
+
+### Option 2: Go Build Constraints / `internal/` Sub-packages
+
+Restructure `internal/` into sub-directories per layer (e.g., `internal/presentation/tui/`, `internal/domain/pipeline/`). Go's `internal/` visibility rules would enforce some boundaries at compile time.
+
+**Pros:**
+- Compile-time enforcement — violations are build errors
+- Package paths make layer membership self-documenting
+- Strongest possible enforcement mechanism
+
+**Cons:**
+- Requires renaming every package and updating every import path across the entire codebase
+- Massive, risky refactoring with high merge-conflict potential
+- Breaks all existing test setups, CI scripts, and documentation references
+- Overly disruptive for the current prototype phase
+- Go's `internal/` rules enforce visibility but not dependency direction — a sub-package can still import siblings
+
+### Option 3: CI Linting with depguard / go-cleanarch (Recommended)
+
+Add a CI linting step using [depguard](https://github.com/OpenPeeDeeP/depguard) (via golangci-lint) or [go-cleanarch](https://github.com/roblaszczak/go-clean-arch) to enforce layer dependency rules. Violations fail the CI build.
+
+**Pros:**
+- Automated enforcement without restructuring the package tree
+- Incremental adoption — start with error-level rules for the most critical boundaries, warn on known violations
+- Integrates into the existing `golangci-lint` CI step
+- Configuration is declarative and version-controlled
+- AI personas see lint failures just like human developers, providing a natural guardrail
+
+**Cons:**
+- Requires maintaining a linter configuration that maps packages to layers
+- New packages must be classified in the config when added
+- Known violations must be explicitly allowed until remediated
+- depguard configuration can become complex for nuanced rules
+
+### Option 4: Go Modules Per Layer
+
+Split `internal/` into separate Go modules (e.g., `go.recinq.io/wave/presentation`, `go.recinq.io/wave/domain`). Module boundaries enforce dependency direction at the `go.mod` level.
+
+**Pros:**
+- Strongest enforcement — module boundaries are absolute
+- Independent versioning and release cycles per layer
+- Clear ownership boundaries for teams
+
+**Cons:**
+- Extreme restructuring effort — the most disruptive option
+- Go multi-module repositories are complex to manage (replace directives, version coordination)
+- Overkill for a single-team project in prototype phase
+- Significantly increases build and CI complexity
+- No community precedent for this pattern at Wave's scale
+
+## Consequences
+
+### Positive
+- Layer boundaries are formally documented and enforceable via CI, preventing further coupling drift
+- AI personas operating within Wave pipelines benefit from bounded contexts — each layer has a clear responsibility boundary that aligns with step isolation (fresh memory per step, artifact-based communication)
+- New contributors can orient themselves by layer rather than memorizing 25 individual package relationships
+- Security audit surface is clearer — infrastructure and cross-cutting packages can be reviewed independently from presentation logic
+- Future decomposition (e.g., ADR-002's StepExecutor extraction) has a documented architectural context to reference
+
+### Negative
+- Linter configuration must be maintained as packages are added or reclassified
+- Known violations (the three documented above) must be explicitly allowed until remediated, creating a "tech debt ledger" that requires attention
+- Layer classification edge cases will generate discussion (e.g., is `defaults` truly domain or cross-cutting?)
+
+### Neutral
+- No code restructuring is required — the layer model describes the current package layout with minimal violations
+- The four-layer model is a documentation overlay on the existing structure, not a mandate to reorganize
+- Existing pipeline definitions, personas, contracts, and manifests are unaffected
+
+## Implementation Notes
+
+### Phase 1: Linter Configuration
+
+Add depguard rules to the existing `.golangci.yml` configuration:
+
+```yaml
+linters-settings:
+  depguard:
+    rules:
+      presentation-no-reverse:
+        deny:
+          - pkg: "github.com/recinq/wave/internal/display"
+            desc: "Domain/Infrastructure must not import presentation packages"
+          - pkg: "github.com/recinq/wave/internal/tui"
+            desc: "Domain/Infrastructure must not import presentation packages"
+          - pkg: "github.com/recinq/wave/internal/webui"
+            desc: "Domain/Infrastructure must not import presentation packages"
+          - pkg: "github.com/recinq/wave/internal/onboarding"
+            desc: "Domain/Infrastructure must not import presentation packages"
+        files:
+          - "internal/pipeline/**"
+          - "internal/adapter/**"
+          - "internal/contract/**"
+          - "internal/state/**"
+          - "internal/workspace/**"
+          - "internal/worktree/**"
+      infrastructure-no-domain:
+        deny:
+          - pkg: "github.com/recinq/wave/internal/pipeline"
+            desc: "Infrastructure must not import domain packages"
+          - pkg: "github.com/recinq/wave/internal/adapter"
+            desc: "Infrastructure must not import domain packages"
+        files:
+          - "internal/state/**"
+          - "internal/workspace/**"
+          - "internal/worktree/**"
+          - "internal/forge/**"
+          - "internal/github/**"
+```
+
+### Phase 2: Violation Remediation
+
+Address the three documented violations in priority order:
+
+1. **`doctor` → `onboarding`** — Extract the shared interaction pattern into a domain-level interface
+2. **`webui` → `adapter`, `workspace`** — Introduce domain-level interfaces that `webui` depends on instead of concrete types
+3. **`defaults` → `pipeline`** — Evaluate whether the pipeline type definitions can be moved to `manifest`
+
+### Phase 3: New Package Classification
+
+When adding a new `internal/` package, classify it into one of the four layers and add it to the depguard configuration. Update this ADR's layer table if needed.
+
+### Agent / LLM Impact
+
+Clean layer separation directly supports Wave's multi-agent pipeline execution model:
+
+- **Fresh memory per step**: Each persona starts with no chat history. When a persona operates within a single layer (e.g., a security auditor reviewing only cross-cutting and infrastructure packages), the bounded context reduces the codebase surface the persona must comprehend, improving accuracy within the token window.
+- **Artifact-based communication**: Layer boundaries align with natural artifact boundaries — a domain step produces validated output (contracts), and a presentation step consumes it (display formatting). The layer model formalizes these handover points.
+- **Persona scoping**: Personas can be constrained to operate within specific layers. A "UI specialist" persona needs presentation + cross-cutting access but not domain internals. Layer boundaries make these permission rules precise and auditable.
+- **Workspace isolation**: Each pipeline step runs in an ephemeral worktree. Layer boundaries help determine which packages a step needs access to, enabling more targeted workspace mounts and reducing the attack surface of each step.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,5 @@ The template is `000-template.md` and is not itself a decision record.
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [001](001-formalize-adr-process.md) | Formalize ADR Process | Proposed | 2026-03-07 |
+| [002](002-extract-step-executor.md) | Extract StepExecutor from Pipeline Executor | Proposed | 2026-03-12 |
+| [003](003-layered-architecture.md) | Layered Architecture Separation | Proposed | 2026-03-13 |

--- a/specs/364-adr-layered-architecture/plan.md
+++ b/specs/364-adr-layered-architecture/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: ADR-003 Layered Architecture
+
+## Objective
+
+Write ADR-003 (`docs/adr/003-layered-architecture.md`) documenting formal layer boundaries for Wave's 25 internal packages, establishing dependency rules between layers, and defining a migration strategy to enforce those boundaries. This complements ADR-002 (Extract StepExecutor) and delivers on #298's architecture audit.
+
+## Approach
+
+This is a documentation-only change. The deliverable is a single ADR file following the existing template (`docs/adr/000-template.md`), plus an update to the ADR README index. No code changes are required.
+
+The ADR will be grounded in the actual dependency graph observed in the codebase (not hypothetical), classifying each of the 25 `internal/` packages into one of four layers and documenting the actual import relationships between them.
+
+### Verified Dependency Graph (from codebase analysis)
+
+| Package | Imports |
+|---------|---------|
+| `display` | `event`, `pathfmt`, `deliverable` |
+| `tui` | `display`, `event`, `forge`, `github`, `manifest`, `pathfmt`, `pipeline`, `state` |
+| `webui` | `adapter`, `audit`, `display`, `event`, `manifest`, `pipeline`, `state`, `workspace` |
+| `pipeline` | `adapter`, `audit`, `contract`, `deliverable`, `event`, `manifest`, `preflight`, `relay`, `security`, `skill`, `state`, `workspace`, `worktree` |
+| `adapter` | `github` |
+| `contract` | `pathfmt` |
+| `state` | (none) |
+| `workspace` | (none) |
+| `worktree` | (none) |
+| `manifest` | (none) |
+| `security` | (none) |
+| `audit` | (none) |
+| `event` | (none) |
+| `defaults` | `manifest`, `pipeline` |
+| `relay` | (none) |
+| `deliverable` | `pathfmt` |
+| `pathfmt` | (none) |
+| `onboarding` | `manifest`, `tui` |
+| `preflight` | `skill` |
+| `recovery` | `contract`, `pathfmt`, `preflight`, `security` |
+| `skill` | (none) |
+| `doctor` | `forge`, `github`, `manifest`, `onboarding`, `pipeline` |
+| `forge` | (none) |
+| `suggest` | `doctor`, `forge` |
+| `github` | (none) |
+
+### Proposed Layer Classification
+
+1. **Presentation** — `display`, `tui`, `webui`, `onboarding`
+2. **Domain/Orchestration** — `pipeline`, `adapter`, `contract`, `relay`, `deliverable`, `preflight`, `recovery`, `skill`, `defaults`, `suggest`, `doctor`
+3. **Infrastructure** — `state`, `workspace`, `worktree`, `forge`, `github`
+4. **Cross-cutting** — `manifest`, `security`, `audit`, `event`, `pathfmt`
+
+### Key Violations to Document
+
+1. **`webui` → `adapter`, `workspace`**: Presentation layer importing infrastructure/domain directly
+2. **`onboarding` → `tui`**: Cross-layer coupling within presentation (minor — both are presentation)
+3. **`defaults` → `pipeline`**: Infrastructure-like package importing domain (circular risk)
+4. **`doctor` → `onboarding`**: Domain package importing presentation
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/adr/003-layered-architecture.md` | create | The ADR document |
+| `docs/adr/README.md` | modify | Add ADR-003 to the index table |
+
+## Architecture Decisions
+
+- **Four-layer model** (Presentation / Domain / Infrastructure / Cross-cutting) rather than three-layer (Presentation / Business / Data) because Wave's cross-cutting concerns (manifest, security, audit, event, pathfmt) are genuinely shared and don't fit neatly into any single layer.
+- **Options Considered** will include: (1) Convention-only with documentation, (2) Go build constraints / `internal/` sub-packages, (3) CI linting with depguard/go-cleanarch, (4) Go Modules per layer. The recommendation will be Option 3 (CI linting) as it provides automated enforcement without restructuring the package tree.
+- **ADR-002 relationship**: This ADR defines the inter-package rules; ADR-002 addresses intra-package decomposition within `pipeline/`. They are complementary.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Layer classification disagreement | Medium | Low | ADR is "Proposed" status — open for review |
+| Stale dependency data | Low | Low | Based on actual codebase analysis at time of writing |
+| Over-prescription of rules | Medium | Medium | Focus on documenting current state and recommended direction, not mandating immediate restructuring |
+
+## Testing Strategy
+
+No code changes, so no unit/integration tests needed. Validation:
+- ADR follows the template structure from `000-template.md`
+- All 25 packages are classified
+- Dependency rules are consistent with the observed import graph
+- ADR-002 and #298 are properly referenced
+- README index is updated

--- a/specs/364-adr-layered-architecture/spec.md
+++ b/specs/364-adr-layered-architecture/spec.md
@@ -1,0 +1,57 @@
+# refactor: write ADR for layered architecture separation
+
+**Issue**: [#364](https://github.com/re-cinq/wave/issues/364)
+**Author**: nextlevelshit
+**State**: OPEN
+**Labels**: none
+
+## Summary
+
+Write an Architecture Decision Record (ADR) documenting the plan to enforce layered architecture boundaries in Wave. This ADR should build on the architecture audit from #298 and complement the existing ADR-002 (Extract StepExecutor).
+
+## Background
+
+Wave's `internal/` directory contains 25 packages. While the presentation/backend separation is already **reasonably clean** (see analysis below), some areas have accumulated coupling during rapid prototyping (v0.15.0 → v0.84.1). The primary concern is within the pipeline executor, not between presentation and backend layers.
+
+### Current Layer Separation (Audit)
+
+**Presentation layer** (`display/`, `tui/`, `webui/`):
+- `display/` imports only `event/`, `pathfmt/`, `deliverable/` — no backend imports
+- `tui/` reads from `state/` and `pipeline/` as data sources (read-only) — correct Observer pattern
+- `pipeline/` does NOT import `display/` or `tui/` — no reverse dependency
+
+**Backend layer** (`pipeline/`, `adapter/`, `contract/`, `state/`, `workspace/`, `worktree/`):
+- `adapter/claude.go` (855 lines) — clean subprocess execution, no display imports
+- `pipeline/executor.go` (2,848 lines, 37 methods) — **primary god-object concern**, owns 11+ responsibilities including DAG traversal, workspace creation, artifact injection, adapter invocation, contract validation, state persistence, relay monitoring, error recovery, and resume logic
+- Event system (`event/`) properly decouples presentation from backend
+
+**Cross-cutting** (`manifest/`, `security/`, `audit/`, `defaults/`):
+- These are appropriately shared across layers
+
+### What ADR-002 Already Covers
+
+ADR-002 (`docs/adr/002-extract-step-executor.md`, status: Proposed) addresses the `executor.go` god-object by extracting a `StepExecutor` component. This ADR should complement — not duplicate — that work.
+
+## Proposed ADR Scope
+
+The new ADR (likely ADR-003) should cover:
+
+1. **Define formal layer boundaries** — which packages belong to presentation, domain/orchestration, infrastructure, and cross-cutting layers
+2. **Establish dependency rules** — e.g., presentation may depend on domain but not vice versa; infrastructure implements domain interfaces
+3. **Document current violations** — any packages that cross layer boundaries inappropriately
+4. **Migration strategy** — concrete steps to enforce boundaries (Go build constraints, linting rules, or CI checks)
+5. **Agent/LLM impact** — how clean layer separation helps personas operate within bounded contexts (fresh memory per step, artifact-based communication)
+
+## Relationship to Other Issues
+
+- **#298** — parent issue for architecture audit and layered architecture transition. This issue delivers one of #298's remaining tasks
+- **ADR-002** — complements this by addressing the god-object within the pipeline package
+
+## Acceptance Criteria
+
+- [ ] ADR written in `docs/adr/003-layered-architecture.md` following the template in `docs/adr/000-template.md`
+- [ ] ADR documents current package-to-layer mapping
+- [ ] ADR defines dependency rules between layers
+- [ ] ADR includes Options Considered with pros/cons
+- [ ] ADR addresses how layer separation benefits multi-agent pipeline execution
+- [ ] References ADR-002 and issue #298 for continuity

--- a/specs/364-adr-layered-architecture/tasks.md
+++ b/specs/364-adr-layered-architecture/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Phase 1: Research & Preparation
+- [X] Task 1.1: Read ADR template (`docs/adr/000-template.md`) and existing ADRs (001, 002) for style/tone consistency
+- [X] Task 1.2: Verify the full dependency graph of all 25 internal packages (confirm no new imports since analysis)
+
+## Phase 2: Write ADR-003
+- [X] Task 2.1: Write the **Status** and **Date** sections (Status: Proposed)
+- [X] Task 2.2: Write the **Context** section — document the 25 packages, current layer separation audit, relationship to #298, and why formal boundaries are needed now
+- [X] Task 2.3: Write the **Decision** section — define the four-layer model (Presentation, Domain/Orchestration, Infrastructure, Cross-cutting) with explicit package-to-layer mapping and dependency rules
+- [X] Task 2.4: Write the **Options Considered** section with 4 options: (1) Convention-only documentation, (2) Go build constraints / sub-packages, (3) CI linting with depguard/go-cleanarch, (4) Go Modules per layer — each with pros/cons
+- [X] Task 2.5: Write the **Consequences** section — positive (automated enforcement, agent bounded contexts), negative (linter maintenance, classification disputes), neutral (no code restructuring required)
+- [X] Task 2.6: Write the **Implementation Notes** section — concrete steps for CI linting setup, depguard configuration, and migration path
+- [X] Task 2.7: Add the **Agent/LLM impact** subsection — how clean layers help personas operate with fresh memory and artifact-based communication
+
+## Phase 3: Update Index
+- [X] Task 3.1: Add ADR-003 entry to `docs/adr/README.md` index table
+
+## Phase 4: Validation
+- [X] Task 4.1: Verify ADR follows template structure from `000-template.md`
+- [X] Task 4.2: Verify all 6 acceptance criteria from issue #364 are met
+- [X] Task 4.3: Verify ADR-002 and #298 are properly referenced
+- [X] Task 4.4: Verify all 25 packages appear in the layer mapping


### PR DESCRIPTION
## Summary

- Adds ADR-003 documenting the plan to enforce layered architecture boundaries in Wave
- Defines four formal layers: Presentation, Domain/Orchestration, Infrastructure, and Cross-Cutting
- Establishes dependency rules between layers (presentation → domain, not vice versa)
- Documents current violations and a phased migration strategy
- Explains how clean layer separation benefits multi-agent pipeline execution

Closes #364

## Changes

- `docs/adr/003-layered-architecture.md` — new ADR following the 000-template format, covering package-to-layer mapping, dependency rules, options considered, and migration strategy
- `docs/adr/README.md` — updated ADR index with link to ADR-003
- `specs/364-adr-layered-architecture/` — planning artifacts (spec, plan, tasks) used during development

## Test Plan

- ADR follows the template structure defined in `docs/adr/000-template.md`
- All acceptance criteria from issue #364 are addressed:
  - ADR written at `docs/adr/003-layered-architecture.md`
  - Documents current package-to-layer mapping
  - Defines dependency rules between layers
  - Includes Options Considered with pros/cons
  - Addresses how layer separation benefits multi-agent pipeline execution
  - References ADR-002 and issue #298 for continuity
- No code changes — documentation only, no test suite impact