### PR TITLE
feat(onboarding): add interactive skill ecosystem selection to wave init

### DIFF
--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -31,6 +31,7 @@ type WizardResult struct {
 	Language     string
 	SourceGlob   string
 	Pipelines    []string // selected pipeline names
+	Skills       []string // installed skill names from onboarding
 	Dependencies []DependencyStatus
 }
 
@@ -129,6 +130,18 @@ func RunWizard(cfg WizardConfig) (*WizardResult, error) {
 	if modelResult != nil && modelResult.Data != nil {
 		if v, ok := modelResult.Data["model"].(string); ok {
 			result.Model = v
+		}
+	}
+
+	// Step 6: Skill selection
+	skillStep := &SkillSelectionStep{}
+	skillResult, err := skillStep.Run(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("skill selection failed: %w", err)
+	}
+	if skillResult != nil && skillResult.Data != nil {
+		if skills, ok := skillResult.Data["skills"].([]string); ok {
+			result.Skills = skills
 		}
 	}
 
@@ -249,6 +262,10 @@ func buildManifest(cfg WizardConfig, result *WizardResult) map[string]interface{
 			personas[name] = entry
 		}
 		m["personas"] = personas
+	}
+
+	if len(result.Skills) > 0 {
+		m["skills"] = result.Skills
 	}
 
 	return m

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -222,6 +222,39 @@ func TestBuildManifest_PersonaFallbackModel(t *testing.T) {
 	assert.Equal(t, "sonnet", nav["model"], "should fall back to persona config model")
 }
 
+func TestBuildManifest_WithSkills(t *testing.T) {
+	cfg := WizardConfig{
+		Workspace: ".wave/workspaces",
+	}
+	result := &WizardResult{
+		Adapter: "claude",
+		Skills:  []string{"golang", "spec-kit", "agentic-coding"},
+	}
+
+	m := buildManifest(cfg, result)
+
+	skills, ok := m["skills"]
+	require.True(t, ok, "manifest must contain skills key when skills are present")
+	skillsList, ok := skills.([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"golang", "spec-kit", "agentic-coding"}, skillsList)
+}
+
+func TestBuildManifest_NoSkills(t *testing.T) {
+	cfg := WizardConfig{
+		Workspace: ".wave/workspaces",
+	}
+	result := &WizardResult{
+		Adapter: "claude",
+		Skills:  []string{},
+	}
+
+	m := buildManifest(cfg, result)
+
+	_, ok := m["skills"]
+	assert.False(t, ok, "manifest should not have skills key when skills list is empty")
+}
+
 func TestBuildManifest_NoPersonas(t *testing.T) {
 	cfg := WizardConfig{
 		Workspace: ".wave/workspaces",

--- a/internal/onboarding/skill_step.go
+++ b/internal/onboarding/skill_step.go
@@ -1,0 +1,585 @@
+package onboarding
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/skill"
+	"github.com/recinq/wave/internal/tui"
+)
+
+// lookPathFunc is a function type for looking up executables on PATH.
+// Defaults to exec.LookPath but can be overridden for testing.
+type lookPathFunc func(string) (string, error)
+
+// commandRunner is a function type for running external commands and capturing stdout.
+// Defaults to running via exec.CommandContext but can be overridden for testing.
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// skillSearchResult represents a single tessl search result for display in the wizard.
+type skillSearchResult struct {
+	Name        string
+	Description string
+}
+
+// EcosystemDef defines a skill ecosystem that can be selected during onboarding.
+type EcosystemDef struct {
+	Name        string            // Display name shown in the selection form
+	Value       string            // Value used in form selection
+	Prefix      string            // SourceRouter prefix for installation
+	Dep         skill.CLIDependency // CLI dependency required by this ecosystem
+	InstallAll  bool              // true if the ecosystem installs all skills at once
+	Description string            // Human-readable description
+}
+
+// ecosystems defines the available skill ecosystems for the onboarding wizard.
+var ecosystems = []EcosystemDef{
+	{
+		Name:        "Tessl",
+		Value:       "tessl",
+		Prefix:      "tessl",
+		Dep:         skill.CLIDependency{Binary: "tessl", Instructions: "npm i -g @tessl/cli"},
+		InstallAll:  false,
+		Description: "Browse and select individual skills from the Tessl registry",
+	},
+	{
+		Name:        "BMAD",
+		Value:       "bmad",
+		Prefix:      "bmad",
+		Dep:         skill.CLIDependency{Binary: "npx", Instructions: "npm i -g npx (comes with npm)"},
+		InstallAll:  true,
+		Description: "Install all BMAD method skills for Claude Code",
+	},
+	{
+		Name:        "OpenSpec",
+		Value:       "openspec",
+		Prefix:      "openspec",
+		Dep:         skill.CLIDependency{Binary: "openspec", Instructions: "npm i -g @openspec/cli"},
+		InstallAll:  true,
+		Description: "Install all OpenSpec skills",
+	},
+	{
+		Name:        "Spec-Kit",
+		Value:       "speckit",
+		Prefix:      "speckit",
+		Dep:         skill.CLIDependency{Binary: "specify", Instructions: "npm i -g @speckit/cli"},
+		InstallAll:  true,
+		Description: "Install all Spec-Kit skills",
+	},
+}
+
+// SkillSelectionStep handles ecosystem selection and skill installation during onboarding.
+type SkillSelectionStep struct {
+	LookPath   lookPathFunc
+	RunCommand commandRunner
+}
+
+// Name returns the display name for this wizard step.
+func (s *SkillSelectionStep) Name() string { return "Skill Selection" }
+
+// Run executes the skill selection wizard step.
+func (s *SkillSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
+	// Non-interactive: skip skill selection entirely (FR-006)
+	if !cfg.Interactive {
+		return &StepResult{
+			Data: map[string]interface{}{
+				"skills": []string{},
+			},
+		}, nil
+	}
+
+	lookPath := s.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+
+	runCmd := s.RunCommand
+	if runCmd == nil {
+		runCmd = defaultCommandRunner
+	}
+
+	// Show reconfigure context if applicable (FR-009)
+	if cfg.Reconfigure && cfg.Existing != nil && len(cfg.Existing.Skills) > 0 {
+		fmt.Fprintf(os.Stderr, "\n  Currently installed skills: %s\n\n", strings.Join(cfg.Existing.Skills, ", "))
+	}
+
+	// Ecosystem selection form (FR-001)
+	selectedEcosystem, err := s.promptEcosystemSelection()
+	if err != nil {
+		return nil, err
+	}
+
+	// Skip selected — return empty skills (FR-001)
+	if selectedEcosystem == "skip" {
+		return &StepResult{
+			Data: map[string]interface{}{
+				"skills": []string{},
+			},
+		}, nil
+	}
+
+	// Find the selected ecosystem definition
+	eco := findEcosystem(selectedEcosystem)
+	if eco == nil {
+		return nil, fmt.Errorf("unknown ecosystem: %s", selectedEcosystem)
+	}
+
+	// Check CLI dependency (FR-007)
+	if _, lookErr := lookPath(eco.Dep.Binary); lookErr != nil {
+		shouldSkip, handleErr := s.handleMissingCLI(eco)
+		if handleErr != nil {
+			return nil, handleErr
+		}
+		if shouldSkip {
+			return &StepResult{
+				Data: map[string]interface{}{
+					"skills": []string{},
+				},
+			}, nil
+		}
+		// User saw instructions — check again
+		if _, retryErr := lookPath(eco.Dep.Binary); retryErr != nil {
+			fmt.Fprintf(os.Stderr, "  CLI still not found. Skipping skill installation.\n\n")
+			return &StepResult{
+				Data: map[string]interface{}{
+					"skills": []string{},
+				},
+			}, nil
+		}
+	}
+
+	// Ensure .wave/skills/ directory exists
+	skillsDir := ".wave/skills"
+	if cfg.WaveDir != "" {
+		skillsDir = cfg.WaveDir + "/skills"
+	}
+	if mkErr := os.MkdirAll(skillsDir, 0755); mkErr != nil {
+		return nil, fmt.Errorf("failed to create skills directory: %w", mkErr)
+	}
+
+	// Create store and router for installation
+	store := skill.NewDirectoryStore(skill.SkillSource{Root: skillsDir, Precedence: 1})
+	router := skill.NewDefaultRouter(".")
+	ctx := context.Background()
+
+	var installedSkills []string
+
+	if eco.InstallAll {
+		// Install-all ecosystems: confirm then install (FR-002)
+		installed, installErr := s.handleInstallAllEcosystem(ctx, eco, router, store)
+		if installErr != nil {
+			return nil, installErr
+		}
+		installedSkills = installed
+	} else {
+		// Tessl: search, browse, multi-select, then install (FR-002)
+		installed, installErr := s.handleTesslEcosystem(ctx, eco, router, store, runCmd)
+		if installErr != nil {
+			return nil, installErr
+		}
+		installedSkills = installed
+	}
+
+	// Merge with existing skills on reconfigure (deduplicated)
+	if cfg.Reconfigure && cfg.Existing != nil && len(cfg.Existing.Skills) > 0 {
+		installedSkills = mergeSkills(cfg.Existing.Skills, installedSkills)
+	}
+
+	return &StepResult{
+		Data: map[string]interface{}{
+			"skills": installedSkills,
+		},
+	}, nil
+}
+
+// promptEcosystemSelection shows the ecosystem selection form.
+func (s *SkillSelectionStep) promptEcosystemSelection() (string, error) {
+	var selected string
+
+	var options []huh.Option[string]
+	for _, eco := range ecosystems {
+		label := fmt.Sprintf("%-12s %s", eco.Name, eco.Description)
+		options = append(options, huh.NewOption(label, eco.Value))
+	}
+	options = append(options, huh.NewOption("Skip         Skip skill installation", "skip"))
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select a skill ecosystem").
+				Options(options...).
+				Value(&selected),
+		).Title("Step 6 of 6 — Skill Selection").
+			Description("Choose a skill ecosystem to install skills from, or skip."),
+	).WithTheme(tui.WaveTheme())
+
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return "", fmt.Errorf("wizard cancelled by user")
+		}
+		return "", err
+	}
+
+	return selected, nil
+}
+
+// handleMissingCLI presents options when a required CLI tool is not found.
+// Returns true if the user chooses to skip.
+func (s *SkillSelectionStep) handleMissingCLI(eco *EcosystemDef) (bool, error) {
+	var choice string
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("The %s CLI (%s) was not found on PATH", eco.Name, eco.Dep.Binary)).
+				Options(
+					huh.NewOption("Skip skill installation", "skip"),
+					huh.NewOption("Show install instructions", "instructions"),
+				).
+				Value(&choice),
+		),
+	).WithTheme(tui.WaveTheme())
+
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return false, fmt.Errorf("wizard cancelled by user")
+		}
+		return false, err
+	}
+
+	if choice == "skip" {
+		return true, nil
+	}
+
+	// Show install instructions
+	fmt.Fprintf(os.Stderr, "\n  Install %s with:\n    %s\n\n", eco.Dep.Binary, eco.Dep.Instructions)
+	fmt.Fprintf(os.Stderr, "  After installing, the wizard will check again.\n\n")
+
+	// Wait for user acknowledgment
+	var proceed bool
+	ackForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Continue after installing?").
+				Value(&proceed),
+		),
+	).WithTheme(tui.WaveTheme())
+
+	if err := ackForm.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return false, fmt.Errorf("wizard cancelled by user")
+		}
+		return false, err
+	}
+
+	if !proceed {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// handleTesslEcosystem handles the tessl ecosystem: search, browse, select, install.
+func (s *SkillSelectionStep) handleTesslEcosystem(
+	ctx context.Context,
+	eco *EcosystemDef,
+	router *skill.SourceRouter,
+	store skill.Store,
+	runCmd commandRunner,
+) ([]string, error) {
+	// Search for available skills
+	fmt.Fprintf(os.Stderr, "  Searching tessl registry...\n")
+	output, err := runCmd(ctx, "tessl", "search", "")
+	if err != nil {
+		// Network failure — offer skip or retry (edge case)
+		return s.handleSearchFailure(ctx, eco, router, store, runCmd, err)
+	}
+
+	results := parseTesslOutput(string(output))
+	if len(results) == 0 {
+		fmt.Fprintf(os.Stderr, "  No skills found in the tessl registry.\n\n")
+		return []string{}, nil
+	}
+
+	// Build multi-select options
+	var options []huh.Option[string]
+	for _, r := range results {
+		label := r.Name
+		if r.Description != "" {
+			label = fmt.Sprintf("%-30s %s", r.Name, r.Description)
+		}
+		options = append(options, huh.NewOption(label, r.Name))
+	}
+
+	var selectedSkills []string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select skills to install").
+				Options(options...).
+				Value(&selectedSkills).
+				Height(12),
+		).Description("Use space to toggle, enter to confirm. Type to filter."),
+	).WithTheme(tui.WaveTheme())
+
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil, fmt.Errorf("wizard cancelled by user")
+		}
+		return nil, err
+	}
+
+	if len(selectedSkills) == 0 {
+		return []string{}, nil
+	}
+
+	// Install each selected skill (FR-003, FR-004)
+	var installed []string
+	for _, name := range selectedSkills {
+		fmt.Fprintf(os.Stderr, "  Installing %s...\n", name)
+		source := eco.Prefix + ":" + name
+		result, installErr := router.Install(ctx, source, store)
+		if installErr != nil {
+			// FR-008: report failure but continue with remaining skills
+			fmt.Fprintf(os.Stderr, "  Failed to install %s: %v\n", name, installErr)
+			continue
+		}
+		for _, sk := range result.Skills {
+			installed = append(installed, sk.Name)
+			fmt.Fprintf(os.Stderr, "  Installed %s\n", sk.Name)
+		}
+		for _, warn := range result.Warnings {
+			fmt.Fprintf(os.Stderr, "  Warning: %s\n", warn)
+		}
+	}
+
+	return installed, nil
+}
+
+// handleSearchFailure presents skip/retry options when tessl search fails.
+func (s *SkillSelectionStep) handleSearchFailure(
+	ctx context.Context,
+	eco *EcosystemDef,
+	router *skill.SourceRouter,
+	store skill.Store,
+	runCmd commandRunner,
+	searchErr error,
+) ([]string, error) {
+	fmt.Fprintf(os.Stderr, "  Failed to search tessl registry: %v\n\n", searchErr)
+
+	var choice string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Registry search failed").
+				Options(
+					huh.NewOption("Skip skill installation", "skip"),
+					huh.NewOption("Retry search", "retry"),
+				).
+				Value(&choice),
+		),
+	).WithTheme(tui.WaveTheme())
+
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil, fmt.Errorf("wizard cancelled by user")
+		}
+		return nil, err
+	}
+
+	if choice == "skip" {
+		return []string{}, nil
+	}
+
+	// Retry the search
+	fmt.Fprintf(os.Stderr, "  Retrying tessl search...\n")
+	output, err := runCmd(ctx, "tessl", "search", "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Search failed again: %v. Skipping skill installation.\n\n", err)
+		return []string{}, nil
+	}
+
+	results := parseTesslOutput(string(output))
+	if len(results) == 0 {
+		fmt.Fprintf(os.Stderr, "  No skills found in the tessl registry.\n\n")
+		return []string{}, nil
+	}
+
+	// Show multi-select for retry results
+	var options []huh.Option[string]
+	for _, r := range results {
+		label := r.Name
+		if r.Description != "" {
+			label = fmt.Sprintf("%-30s %s", r.Name, r.Description)
+		}
+		options = append(options, huh.NewOption(label, r.Name))
+	}
+
+	var selectedSkills []string
+	selectForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select skills to install").
+				Options(options...).
+				Value(&selectedSkills).
+				Height(12),
+		).Description("Use space to toggle, enter to confirm. Type to filter."),
+	).WithTheme(tui.WaveTheme())
+
+	if err := selectForm.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil, fmt.Errorf("wizard cancelled by user")
+		}
+		return nil, err
+	}
+
+	if len(selectedSkills) == 0 {
+		return []string{}, nil
+	}
+
+	var installed []string
+	for _, name := range selectedSkills {
+		fmt.Fprintf(os.Stderr, "  Installing %s...\n", name)
+		source := eco.Prefix + ":" + name
+		result, installErr := router.Install(ctx, source, store)
+		if installErr != nil {
+			fmt.Fprintf(os.Stderr, "  Failed to install %s: %v\n", name, installErr)
+			continue
+		}
+		for _, sk := range result.Skills {
+			installed = append(installed, sk.Name)
+			fmt.Fprintf(os.Stderr, "  Installed %s\n", sk.Name)
+		}
+		for _, warn := range result.Warnings {
+			fmt.Fprintf(os.Stderr, "  Warning: %s\n", warn)
+		}
+	}
+
+	return installed, nil
+}
+
+// handleInstallAllEcosystem handles install-all ecosystems (BMAD, OpenSpec, Spec-Kit).
+func (s *SkillSelectionStep) handleInstallAllEcosystem(
+	ctx context.Context,
+	eco *EcosystemDef,
+	router *skill.SourceRouter,
+	store skill.Store,
+) ([]string, error) {
+	// Confirmation prompt (FR-002)
+	var confirmed bool
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Install all %s skills?", eco.Name)).
+				Description(eco.Description).
+				Value(&confirmed),
+		),
+	).WithTheme(tui.WaveTheme())
+
+	if err := form.Run(); err != nil {
+		if err == huh.ErrUserAborted {
+			return nil, fmt.Errorf("wizard cancelled by user")
+		}
+		return nil, err
+	}
+
+	if !confirmed {
+		return []string{}, nil
+	}
+
+	// Install all skills for this ecosystem (FR-003, FR-004)
+	fmt.Fprintf(os.Stderr, "  Installing %s skills...\n", eco.Name)
+	source := eco.Prefix + ":"
+	result, err := router.Install(ctx, source, store)
+	if err != nil {
+		// FR-008: report failure gracefully
+		fmt.Fprintf(os.Stderr, "  Failed to install %s skills: %v\n", eco.Name, err)
+		return []string{}, nil
+	}
+
+	var installed []string
+	for _, sk := range result.Skills {
+		installed = append(installed, sk.Name)
+		fmt.Fprintf(os.Stderr, "  Installed %s\n", sk.Name)
+	}
+	for _, warn := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "  Warning: %s\n", warn)
+	}
+
+	return installed, nil
+}
+
+// parseTesslOutput parses the output from `tessl search` into skill search results.
+// Adapted from cmd/wave/commands/skills.go:parseTesslSearchOutput for local types.
+func parseTesslOutput(output string) []skillSearchResult {
+	var results []skillSearchResult
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		// Parse tab-separated or space-separated output: name [rating] description
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		result := skillSearchResult{
+			Name: fields[0],
+		}
+		// If the second field looks like a rating (e.g. "4.5", "★★★"), skip it
+		if len(fields) >= 3 {
+			result.Description = strings.Join(fields[2:], " ")
+		} else {
+			result.Description = strings.Join(fields[1:], " ")
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+// findEcosystem looks up an ecosystem definition by its value identifier.
+func findEcosystem(value string) *EcosystemDef {
+	for i := range ecosystems {
+		if ecosystems[i].Value == value {
+			return &ecosystems[i]
+		}
+	}
+	return nil
+}
+
+// mergeSkills combines two skill name slices, deduplicating entries.
+func mergeSkills(existing, newSkills []string) []string {
+	seen := make(map[string]bool, len(existing)+len(newSkills))
+	var merged []string
+
+	for _, name := range existing {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	for _, name := range newSkills {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+
+	return merged
+}
+
+// defaultCommandRunner executes a command and returns its stdout output.
+func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%s failed: %w", name, err)
+	}
+	return output, nil
+}

--- a/internal/onboarding/skill_step_test.go
+++ b/internal/onboarding/skill_step_test.go
@@ -1,0 +1,285 @@
+package onboarding
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillSelectionStep_Name(t *testing.T) {
+	step := &SkillSelectionStep{}
+	assert.Equal(t, "Skill Selection", step.Name())
+}
+
+func TestSkillSelectionStep_NonInteractive(t *testing.T) {
+	step := &SkillSelectionStep{}
+	cfg := &WizardConfig{Interactive: false}
+
+	result, err := step.Run(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	skills, ok := result.Data["skills"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, skills)
+}
+
+func TestSkillSelectionStep_NonInteractiveWithExisting(t *testing.T) {
+	step := &SkillSelectionStep{}
+	cfg := &WizardConfig{
+		Interactive: false,
+		Reconfigure: true,
+		Existing: &manifest.Manifest{
+			Skills: []string{"golang", "spec-kit"},
+		},
+	}
+
+	result, err := step.Run(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Non-interactive always returns empty skills regardless of existing
+	skills, ok := result.Data["skills"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, skills)
+}
+
+func TestParseTesslOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []skillSearchResult
+	}{
+		{
+			name:     "empty output",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "blank lines only",
+			input:    "\n\n\n",
+			expected: nil,
+		},
+		{
+			name:  "single skill with rating",
+			input: "golang 4.5 A Go development skill",
+			expected: []skillSearchResult{
+				{Name: "golang", Description: "A Go development skill"},
+			},
+		},
+		{
+			name:  "single skill without rating (two fields)",
+			input: "golang description",
+			expected: []skillSearchResult{
+				{Name: "golang", Description: "description"},
+			},
+		},
+		{
+			name:  "three fields with rating",
+			input: "golang 4.5 A Go skill",
+			expected: []skillSearchResult{
+				{Name: "golang", Description: "A Go skill"},
+			},
+		},
+		{
+			name: "multiple skills",
+			input: `golang 4.5 A Go development skill
+spec-kit 4.2 Specification tools
+react 3.8 React component generation`,
+			expected: []skillSearchResult{
+				{Name: "golang", Description: "A Go development skill"},
+				{Name: "spec-kit", Description: "Specification tools"},
+				{Name: "react", Description: "React component generation"},
+			},
+		},
+		{
+			name:     "single field line (ignored)",
+			input:    "justname",
+			expected: nil,
+		},
+		{
+			name: "mixed valid and invalid lines",
+			input: `golang 4.5 A Go skill
+bad
+spec-kit 4.0 Specs`,
+			expected: []skillSearchResult{
+				{Name: "golang", Description: "A Go skill"},
+				{Name: "spec-kit", Description: "Specs"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := parseTesslOutput(tt.input)
+			assert.Equal(t, tt.expected, results)
+		})
+	}
+}
+
+func TestFindEcosystem(t *testing.T) {
+	tests := []struct {
+		value    string
+		found    bool
+		expected string
+	}{
+		{"tessl", true, "Tessl"},
+		{"bmad", true, "BMAD"},
+		{"openspec", true, "OpenSpec"},
+		{"speckit", true, "Spec-Kit"},
+		{"unknown", false, ""},
+		{"", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			eco := findEcosystem(tt.value)
+			if tt.found {
+				require.NotNil(t, eco)
+				assert.Equal(t, tt.expected, eco.Name)
+			} else {
+				assert.Nil(t, eco)
+			}
+		})
+	}
+}
+
+func TestMergeSkills(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		new      []string
+		expected []string
+	}{
+		{
+			name:     "both empty",
+			existing: nil,
+			new:      nil,
+			expected: nil,
+		},
+		{
+			name:     "existing only",
+			existing: []string{"golang", "spec-kit"},
+			new:      nil,
+			expected: []string{"golang", "spec-kit"},
+		},
+		{
+			name:     "new only",
+			existing: nil,
+			new:      []string{"react", "vue"},
+			expected: []string{"react", "vue"},
+		},
+		{
+			name:     "no overlap",
+			existing: []string{"golang"},
+			new:      []string{"react"},
+			expected: []string{"golang", "react"},
+		},
+		{
+			name:     "with duplicates",
+			existing: []string{"golang", "spec-kit"},
+			new:      []string{"spec-kit", "react"},
+			expected: []string{"golang", "spec-kit", "react"},
+		},
+		{
+			name:     "all duplicates",
+			existing: []string{"golang", "react"},
+			new:      []string{"golang", "react"},
+			expected: []string{"golang", "react"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeSkills(tt.existing, tt.new)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEcosystemDefinitions(t *testing.T) {
+	// Verify all ecosystems are properly defined
+	assert.Len(t, ecosystems, 4)
+
+	// Verify tessl
+	tessl := findEcosystem("tessl")
+	require.NotNil(t, tessl)
+	assert.Equal(t, "tessl", tessl.Dep.Binary)
+	assert.Equal(t, "npm i -g @tessl/cli", tessl.Dep.Instructions)
+	assert.False(t, tessl.InstallAll)
+
+	// Verify BMAD
+	bmad := findEcosystem("bmad")
+	require.NotNil(t, bmad)
+	assert.Equal(t, "npx", bmad.Dep.Binary)
+	assert.True(t, bmad.InstallAll)
+
+	// Verify OpenSpec
+	openspec := findEcosystem("openspec")
+	require.NotNil(t, openspec)
+	assert.Equal(t, "openspec", openspec.Dep.Binary)
+	assert.True(t, openspec.InstallAll)
+
+	// Verify Spec-Kit
+	speckit := findEcosystem("speckit")
+	require.NotNil(t, speckit)
+	assert.Equal(t, "specify", speckit.Dep.Binary)
+	assert.True(t, speckit.InstallAll)
+}
+
+func TestSkillSelectionStep_ReconfigureShowsExisting(t *testing.T) {
+	step := &SkillSelectionStep{}
+	cfg := &WizardConfig{
+		Interactive: false,
+		Reconfigure: true,
+		Existing: &manifest.Manifest{
+			Skills: []string{"golang", "spec-kit"},
+		},
+	}
+
+	// Non-interactive with reconfigure should not error
+	result, err := step.Run(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	skills, ok := result.Data["skills"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, skills, "non-interactive reconfigure returns empty skills")
+}
+
+func TestSkillSelectionStep_MissingCLI(t *testing.T) {
+	step := &SkillSelectionStep{
+		LookPath: func(binary string) (string, error) {
+			return "", fmt.Errorf("not found: %s", binary)
+		},
+	}
+	cfg := &WizardConfig{Interactive: false}
+
+	result, err := step.Run(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Non-interactive skips entirely regardless of CLI availability
+	skills, ok := result.Data["skills"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, skills)
+}
+
+func TestDefaultCommandRunner(t *testing.T) {
+	// Test with a command that should succeed
+	ctx := context.Background()
+	output, err := defaultCommandRunner(ctx, "echo", "hello")
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "hello")
+}
+
+func TestDefaultCommandRunner_Failure(t *testing.T) {
+	// Test with a command that doesn't exist
+	ctx := context.Background()
+	_, err := defaultCommandRunner(ctx, "nonexistent-binary-that-does-not-exist")
+	require.Error(t, err)
+}

--- a/internal/onboarding/steps.go
+++ b/internal/onboarding/steps.go
@@ -69,7 +69,7 @@ func (s *DependencyStep) Run(cfg *WizardConfig) (*StepResult, error) {
 
 	// Report dependency status
 	if cfg.Interactive {
-		fmt.Fprintf(os.Stderr, "\n  Step 1 of 5 — Dependency Verification\n\n")
+		fmt.Fprintf(os.Stderr, "\n  Step 1 of 6 — Dependency Verification\n\n")
 		for _, dep := range deps {
 			if dep.Found {
 				fmt.Fprintf(os.Stderr, "  ✓ %s\n", dep.Name)
@@ -138,7 +138,7 @@ func (s *TestConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Title("Build command").
 					Value(&buildCmd).
 					Placeholder("e.g. go build ./..."),
-			).Title("Step 2 of 5 — Test Commands").
+			).Title("Step 2 of 6 — Test Commands").
 				Description("Confirm or override the detected project commands."),
 		).WithTheme(tui.WaveTheme())
 
@@ -332,7 +332,7 @@ func (s *PipelineSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 				Options(options...).
 				Value(&selectedPipelines).
 				Height(12),
-		).Title("Step 3 of 5 — Pipeline Selection").
+		).Title("Step 3 of 6 — Pipeline Selection").
 			Description("Choose which pipelines to include in your project."),
 	).WithTheme(tui.WaveTheme())
 
@@ -389,7 +389,7 @@ func (s *AdapterConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Title("Select LLM adapter").
 					Options(options...).
 					Value(&selectedAdapter),
-			).Title("Step 4 of 5 — Adapter Configuration").
+			).Title("Step 4 of 6 — Adapter Configuration").
 				Description("Choose the LLM adapter for pipeline execution."),
 		).WithTheme(tui.WaveTheme())
 
@@ -483,7 +483,7 @@ func (s *ModelSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 						Title("Select default model").
 						Options(options...).
 						Value(&selectedModel),
-				).Title("Step 5 of 5 — Model Selection").
+				).Title("Step 5 of 6 — Model Selection").
 					Description("Choose the default model for pipeline execution."),
 			).WithTheme(tui.WaveTheme())
 
@@ -522,7 +522,7 @@ func (s *ModelSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 						Title("Enter model name (leave blank for adapter default)").
 						Value(&selectedModel).
 						Placeholder("e.g. gpt-4o"),
-				).Title("Step 5 of 5 — Model Selection").
+				).Title("Step 5 of 6 — Model Selection").
 					Description("Enter the model name for your adapter."),
 			).WithTheme(tui.WaveTheme())
 

--- a/specs/384-init-skill-selection/checklists/integration-boundaries.md
+++ b/specs/384-init-skill-selection/checklists/integration-boundaries.md
@@ -1,0 +1,28 @@
+# Integration & Boundary Checklist: Wave Init Interactive Skill Selection
+
+**Feature**: `384-init-skill-selection`
+**Date**: 2026-03-14
+**Focus**: Integration points, system boundaries, and cross-component requirements
+
+---
+
+## System Integration
+
+- [ ] CHK043 - Is the interaction between `SkillSelectionStep` and `SourceRouter` fully specified — does the step create its own router or receive one via dependency injection? [Completeness]
+- [ ] CHK044 - Is the `DirectoryStore` target path (`.wave/skills/`) consistent with how `wave skills install` creates its store, ensuring init-installed and CLI-installed skills coexist? [Consistency]
+- [ ] CHK045 - Does the data model specify whether `SkillSelectionStep` should validate that installed skills are loadable (have valid `SKILL.md`) before reporting success? [Completeness]
+- [ ] CHK046 - Is the relationship between `WizardResult.Skills` and `Manifest.Skills` type-compatible — both `[]string` with identical semantics? [Consistency]
+- [ ] CHK047 - Does the plan address whether `buildManifest()` should emit `skills: []` (empty list) or omit the key entirely when no skills are installed? [Clarity]
+
+## Boundary Conditions
+
+- [ ] CHK048 - Is the maximum length of a skill name bounded in the spec or delegated to adapter validation? [Completeness]
+- [ ] CHK049 - Are the valid characters for bare skill names defined (alphanumeric, hyphens, dots)? [Completeness]
+- [ ] CHK050 - Is the behavior defined when the ecosystem CLI exists but returns a non-zero exit code for reasons other than "not found"? [Coverage]
+- [ ] CHK051 - Does the spec address the case where `wave.yaml` already has a `skills:` key from manual editing — does `buildManifest()` merge or overwrite? [Coverage]
+
+## Cross-Feature Impact
+
+- [ ] CHK052 - Does adding Step 6 affect the existing `onboarding_test.go` assertions about step count or wizard flow completion? [Coverage]
+- [ ] CHK053 - Is the impact on `wave init --yes` documented for downstream automation scripts that rely on non-interactive init completing without new prompts? [Completeness]
+- [ ] CHK054 - Does the step renumbering (FR-012) account for any external documentation, help text, or error messages that reference "Step N of 5"? [Coverage]

--- a/specs/384-init-skill-selection/checklists/requirements.md
+++ b/specs/384-init-skill-selection/checklists/requirements.md
@@ -1,0 +1,74 @@
+# Quality Checklist: Wave Init Interactive Skill Selection
+
+## Specification Completeness
+
+- [x] Feature name and branch clearly defined
+- [x] Created date and status present
+- [x] Input source linked (GitHub issue #384)
+
+## User Stories
+
+- [x] Minimum 3 user stories with priorities assigned
+- [x] Each story has "Why this priority" explanation
+- [x] Each story has "Independent Test" description
+- [x] Each story has at least one acceptance scenario in Given/When/Then format
+- [x] Stories are ordered by priority (P1 first)
+- [x] P1 stories represent a viable MVP independently
+- [x] No story contains implementation details (HOW)
+- [x] All stories focus on WHAT and WHY
+
+## Acceptance Criteria Coverage
+
+- [x] All acceptance criteria from GitHub issue #384 are addressed:
+  - [x] `wave init` prompts for ecosystem selection after existing onboarding steps (US1, AC1)
+  - [x] Tessl ecosystem shows skills with search capability (US2, AC1, AC4)
+  - [x] BMAD/OpenSpec/Spec-Kit ecosystems show available skills (US2, AC2)
+  - [x] Multi-select UI for choosing multiple skills (US2, AC3)
+  - [x] Selected skills installed into `.wave/skills/` (US3, AC2)
+  - [x] Progress feedback during installation (US3, AC1)
+  - [x] "Skip" option bypasses entirely (US1, AC2)
+  - [x] Graceful handling when CLI not installed (US4)
+  - [x] Installed skills reflected in `wave.yaml` (US3, AC3)
+
+## Requirements Quality
+
+- [x] All requirements use RFC 2119 keywords (MUST/SHOULD/MAY)
+- [x] Each requirement is independently testable
+- [x] No implementation-specific technology mentioned in requirements
+- [x] Requirements are unambiguous — only one interpretation possible
+- [x] No duplicate requirements
+- [x] Maximum 3 `[NEEDS CLARIFICATION]` markers (actual: 0)
+
+## Key Entities
+
+- [x] Entities defined with clear descriptions
+- [x] Relationships between entities described
+- [x] No implementation details in entity definitions (no struct definitions, no code)
+
+## Edge Cases
+
+- [x] Minimum 3 edge cases identified
+- [x] Each edge case describes expected behavior
+- [x] Network failure scenarios covered
+- [x] User cancellation (Ctrl+C) scenario covered
+- [x] Conflict handling (duplicate skills) covered
+
+## Success Criteria
+
+- [x] All criteria are measurable
+- [x] All criteria are technology-agnostic
+- [x] Criteria cover happy path, error handling, and non-interactive mode
+- [x] Test coverage requirement specified (SC-009)
+
+## Dependencies & Scope
+
+- [x] Dependencies on other subsystems acknowledged (SourceAdapters, SkillStore)
+- [x] In-scope and out-of-scope clear from edge cases
+- [x] Integration points with existing system identified (WizardStep interface, huh forms, WaveTheme)
+
+## Overall
+
+- [x] Specification focuses on WHAT and WHY, not HOW
+- [x] No code snippets or implementation pseudocode in the spec
+- [x] Consistent formatting throughout
+- [x] All template placeholders replaced with real content

--- a/specs/384-init-skill-selection/checklists/review.md
+++ b/specs/384-init-skill-selection/checklists/review.md
@@ -1,0 +1,51 @@
+# Quality Review Checklist: Wave Init Interactive Skill Selection
+
+**Feature**: `384-init-skill-selection`
+**Date**: 2026-03-14
+**Artifact Scope**: spec.md, plan.md, tasks.md, data-model.md, research.md
+
+---
+
+## Completeness
+
+- [ ] CHK001 - Are error recovery paths defined for ALL user-facing operations (ecosystem select, skill list, install)? [Completeness]
+- [ ] CHK002 - Is the behavior specified when `tessl search ""` returns zero results (empty registry)? [Completeness]
+- [ ] CHK003 - Are timeout thresholds defined for subprocess calls (`tessl search`, adapter `Install()`)? [Completeness]
+- [ ] CHK004 - Is the ordering of installed skills in `wave.yaml` specified (alphabetical, insertion order, or unspecified)? [Completeness]
+- [ ] CHK005 - Is the maximum number of skills a user can select from tessl bounded or unbounded? Are display limits for very long skill lists addressed? [Completeness]
+- [ ] CHK006 - Does FR-009 (reconfigure) specify what happens when a previously installed skill is no longer available in the ecosystem registry? [Completeness]
+- [ ] CHK007 - Is the behavior defined when `wave init` is run in a project that already has a `.wave/skills/` directory with manually installed skills (not via init)? [Completeness]
+- [ ] CHK008 - Are accessibility requirements for the `huh` form interactions specified (keyboard navigation, screen reader compatibility)? [Completeness]
+- [ ] CHK009 - Is the expected `tessl search` output format documented or referenced so the parser contract is clear? [Completeness]
+- [ ] CHK010 - Does the spec address what happens when the user selects an ecosystem, installs skills, then re-runs `wave init` (not `--reconfigure`) — are existing skills overwritten or preserved? [Completeness]
+
+## Clarity
+
+- [ ] CHK011 - Does FR-002 clearly distinguish the two interaction modes (multi-select vs. confirm/skip) such that an implementer knows exactly when each applies? [Clarity]
+- [ ] CHK012 - Is the term "bare names" in FR-005 defined with examples covering edge cases (names with hyphens, dots, slashes)? [Clarity]
+- [ ] CHK013 - Does FR-006 define "non-interactive mode" exhaustively — is non-TTY detection separate from `--yes` or equivalent? [Clarity]
+- [ ] CHK014 - Is the "install instructions" display in US4/FR-007 specified — is it just text or does it offer to run the install command? [Clarity]
+- [ ] CHK015 - Does the spec clearly state whether "Skip" at ecosystem level means "no ecosystem chosen" vs. "ecosystem chosen but no skills selected"? [Clarity]
+- [ ] CHK016 - Is the phrase "shown as context" in FR-009/US5 defined — is it informational text, pre-selected options, or something else? [Clarity]
+- [ ] CHK017 - Are the success/failure status labels in FR-004 specified (exact wording: "success"/"failed"/"error"/etc.)? [Clarity]
+
+## Consistency
+
+- [ ] CHK018 - Does FR-012 (Step 6 insertion) align with the data-model's flow diagram showing Step 6 between model selection and writeManifest()? [Consistency]
+- [ ] CHK019 - Does the plan's "~300 lines new code" estimate align with the 28 tasks in tasks.md — is the scope consistent across artifacts? [Consistency]
+- [ ] CHK020 - Does the research decision on `parseTesslSearchOutput()` duplication (RQ-3) align with the task definition in T010 and the data model? [Consistency]
+- [ ] CHK021 - Are the ecosystem CLI dependencies in data-model.md consistent with those defined in `internal/skill/source_cli.go`? [Consistency]
+- [ ] CHK022 - Does the task dependency graph in tasks.md correctly reflect the sequential constraints implied by the spec (e.g., ecosystem select before skill browse before install)? [Consistency]
+- [ ] CHK023 - Does SC-003 ("no `skills:` key in wave.yaml") align with FR-005/FR-013 behavior when skills list is empty? [Consistency]
+- [ ] CHK024 - Are the acceptance scenario counts in the spec (US1:4, US2:5, US3:4, US4:3, US5:2) sufficient to cover all functional requirements (FR-001 through FR-013)? [Consistency]
+
+## Coverage
+
+- [ ] CHK025 - Are concurrent `wave init` runs addressed — what happens if two terminals run init simultaneously? [Coverage]
+- [ ] CHK026 - Is filesystem permission failure during `.wave/skills/` creation or skill file writing covered as an edge case? [Coverage]
+- [ ] CHK027 - Does the test plan (Phase 8 tasks) include integration-level tests for the full ecosystem→browse→install→manifest flow, or only unit tests? [Coverage]
+- [ ] CHK028 - Is the behavior when `SourceRouter.Install()` returns partial success (some skills installed, some failed) tested in the acceptance criteria? [Coverage]
+- [ ] CHK029 - Are all 5 edge cases in the spec traceable to at least one acceptance scenario or functional requirement? [Coverage]
+- [ ] CHK030 - Does the test coverage requirement (SC-009) specify minimum coverage thresholds or just "has tests"? [Coverage]
+- [ ] CHK031 - Is the `huh.ErrUserAborted` handling (T026) covered by acceptance criteria, or only by a polish task? [Coverage]
+- [ ] CHK032 - Are negative test cases defined for `parseTesslSearchOutput()` — malformed input, binary data, extremely long lines? [Coverage]

--- a/specs/384-init-skill-selection/checklists/ux-interactions.md
+++ b/specs/384-init-skill-selection/checklists/ux-interactions.md
@@ -1,0 +1,26 @@
+# UX & Interaction Flow Checklist: Wave Init Interactive Skill Selection
+
+**Feature**: `384-init-skill-selection`
+**Date**: 2026-03-14
+**Focus**: User experience flow completeness and interaction design requirements
+
+---
+
+## Flow Continuity
+
+- [ ] CHK033 - Is the transition from Step 5 (model selection) to Step 6 (skill selection) specified — does the user see a visual separator, header, or seamless continuation? [Completeness]
+- [ ] CHK034 - Is the post-installation summary display defined — does the user see a list of what was installed before the wizard completes? [Completeness]
+- [ ] CHK035 - Are the ecosystem selection option descriptions specified — does the user see just names ("tessl") or names with descriptions ("tessl — AI skill ecosystem")? [Completeness]
+- [ ] CHK036 - Is the install-all confirmation prompt wording specified — does the user know exactly what "all skills" means for BMAD/OpenSpec/Spec-Kit? [Clarity]
+- [ ] CHK037 - Is the order of ecosystem options in the selection form specified (alphabetical, popularity, fixed)? [Completeness]
+
+## Error UX
+
+- [ ] CHK038 - When a single skill fails in a batch, is the error message format for the failed skill defined separately from the success format? [Clarity]
+- [ ] CHK039 - After showing install instructions for a missing CLI, is the "retry" flow defined — can the user install the CLI in another terminal and retry within the wizard? [Completeness]
+- [ ] CHK040 - Is the network error message for `tessl search` failure distinguishable from a CLI-missing error? [Clarity]
+
+## Reconfiguration UX
+
+- [ ] CHK041 - During reconfigure, is it clear whether the user can remove previously installed skills, or only add new ones? [Clarity]
+- [ ] CHK042 - When reconfiguring with a different ecosystem than originally used, are the implications stated — do old skills remain alongside new ecosystem skills? [Completeness]

--- a/specs/384-init-skill-selection/data-model.md
+++ b/specs/384-init-skill-selection/data-model.md
@@ -1,0 +1,150 @@
+# Data Model: Wave Init Interactive Skill Selection
+
+**Feature Branch**: `384-init-skill-selection`
+**Date**: 2026-03-14
+
+## New Types
+
+### EcosystemDef (internal/onboarding/skill_step.go)
+
+Defines an ecosystem available for selection during onboarding.
+
+```go
+type EcosystemDef struct {
+    Name        string          // Display name (e.g., "tessl", "BMAD")
+    Value       string          // Select option value (e.g., "tessl", "bmad")
+    Prefix      string          // SourceAdapter prefix for installation routing
+    Dep         skill.CLIDependency // CLI binary required + install instructions
+    InstallAll  bool            // true = bulk install, false = individual selection
+    Description string          // Short description for the selection form
+}
+```
+
+**Usage**: Static slice `ecosystems` defined at package level. Used to populate the ecosystem `huh.Select` form and to drive the post-selection behavior (multi-select vs. confirm/skip).
+
+### SkillSelectionStep (internal/onboarding/skill_step.go)
+
+New `WizardStep` implementation for the ecosystem/skill selection flow.
+
+```go
+type SkillSelectionStep struct {
+    LookPath   lookPathFunc    // For testing: override exec.LookPath
+    RunCommand commandRunner   // For testing: override subprocess execution
+}
+```
+
+**Interface**: Implements `WizardStep` — `Name() string` returns `"Skill Selection"`, `Run(cfg *WizardConfig) (*StepResult, error)` orchestrates the full flow.
+
+**Behavior by mode**:
+- **Non-interactive** (`!cfg.Interactive`): Return immediately with empty skills (skip)
+- **Interactive, tessl**: Check CLI → `tessl search ""` → `huh.MultiSelect` → install each selected skill → return names
+- **Interactive, install-all**: Check CLI → `huh.Confirm` → run adapter `Install()` → return names
+- **Interactive, skip**: Return immediately with empty skills
+
+## Modified Types
+
+### WizardResult (internal/onboarding/onboarding.go)
+
+```go
+type WizardResult struct {
+    // ... existing fields ...
+    Skills []string // NEW: bare skill names installed during onboarding
+}
+```
+
+### WizardConfig (internal/onboarding/onboarding.go)
+
+No changes needed. The `Reconfigure` and `Existing` fields already support reconfiguration. `Existing.Skills` (from `Manifest.Skills`) provides previously installed skill names.
+
+## Data Flow
+
+```
+┌─────────────────────┐
+│ RunWizard()         │
+│                     │
+│ Steps 1-5 (exist)  │
+│         │           │
+│ Step 6: SkillSelectionStep.Run()
+│         │           │
+│         ▼           │
+│ ┌─ ecosystem select │
+│ │  tessl|bmad|...   │
+│ │  │                │
+│ │  ├─ tessl:        │
+│ │  │  tessl search  │──▶ parseTesslSearchOutput()
+│ │  │  MultiSelect   │
+│ │  │  for each:     │
+│ │  │    router.Install("tessl:<name>", store)
+│ │  │                │
+│ │  ├─ install-all:  │
+│ │  │  Confirm       │
+│ │  │  router.Install("<prefix>:", store)
+│ │  │                │
+│ │  └─ skip:         │
+│ │     return []     │
+│ │                   │
+│ └─▶ StepResult.Data["skills"] = []string{names...}
+│         │           │
+│         ▼           │
+│ result.Skills = ... │
+│         │           │
+│ writeManifest()     │
+│   buildManifest()   │
+│     m["skills"] = result.Skills  (when non-empty)
+│         │           │
+│ MarkOnboarded()     │
+└─────────────────────┘
+```
+
+## Store Interaction
+
+The `SkillSelectionStep` creates a `skill.DirectoryStore` targeting `.wave/skills/` (project-level, precedence 2) as the installation target. This matches the `newSkillStore()` pattern in `cmd/wave/commands/skills.go`.
+
+A `skill.SourceRouter` (via `skill.NewDefaultRouter(".")`) routes prefixed source strings to the correct adapter. For tessl, individual skills are installed as `"tessl:<name>"`. For install-all ecosystems, the adapter ignores the reference (e.g., `"bmad:"` routes to `BMADAdapter` which runs its bulk install command).
+
+## Manifest Output
+
+When `result.Skills` is non-empty, `buildManifest()` adds:
+
+```yaml
+skills:
+  - golang
+  - spec-kit
+  - agentic-coding
+```
+
+This matches the `Manifest.Skills []string` field format — bare names, no source prefixes.
+
+## Reconfiguration Context
+
+When `cfg.Reconfigure && cfg.Existing != nil`:
+- `cfg.Existing.Skills` contains previously installed skill names
+- The ecosystem selection form displays: "Currently installed: golang, spec-kit" as context
+- The user can choose a new ecosystem or skip
+- Previously installed skills are NOT removed — only new skills are added
+- The final `result.Skills` is the union of existing + newly installed
+
+## CLI Dependency Definitions
+
+| Ecosystem | CLI Binary | Install Instructions | Install-All? |
+|-----------|-----------|---------------------|-------------|
+| tessl     | `tessl`   | `npm i -g @tessl/cli` | No (individual select) |
+| BMAD      | `npx`     | `npm i -g npx (comes with npm)` | Yes |
+| OpenSpec  | `openspec`| `npm i -g @openspec/cli` | Yes |
+| Spec-Kit  | `specify` | `npm i -g @speckit/cli` | Yes |
+
+Source: `internal/skill/source_cli.go` — each adapter's `CLIDependency` field.
+
+## Testing Interfaces
+
+For testability, `SkillSelectionStep` accepts injectable functions:
+
+```go
+type lookPathFunc func(string) (string, error)
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+```
+
+These allow tests to:
+- Simulate CLI presence/absence without requiring actual binaries
+- Return canned `tessl search` output without network access
+- Verify install commands without running adapters

--- a/specs/384-init-skill-selection/plan.md
+++ b/specs/384-init-skill-selection/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Wave Init Interactive Skill Selection
+
+**Branch**: `384-init-skill-selection` | **Date**: 2026-03-14 | **Spec**: `specs/384-init-skill-selection/spec.md`
+**Input**: Feature specification from `/specs/384-init-skill-selection/spec.md`
+
+## Summary
+
+Add a new Step 6 to the `wave init` onboarding wizard that lets users select a skill ecosystem (tessl, BMAD, OpenSpec, Spec-Kit, or Skip), browse/select skills, and install them into `.wave/skills/` with progress feedback. Skills are recorded as bare names in `wave.yaml` under the `skills:` key. The implementation follows the existing `WizardStep` interface pattern using `huh` forms with `WaveTheme()`, reuses the `SourceRouter` and `SourceAdapter` infrastructure from `internal/skill/`, and supports non-interactive skip (`--yes`) and reconfiguration (`--reconfigure`).
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: `github.com/charmbracelet/huh v0.8.0`, `internal/skill` package (SourceAdapter, SourceRouter, DirectoryStore)
+**Storage**: Filesystem — `.wave/skills/` for skill files, `wave.yaml` for manifest
+**Testing**: `go test ./...` with `testify/assert`, `testify/require`; table-driven tests
+**Target Platform**: Linux/macOS CLI
+**Project Type**: Single Go binary
+**Performance Goals**: N/A — interactive wizard, not performance-sensitive
+**Constraints**: Must not add new dependencies; must work without ecosystem CLIs installed (graceful degradation)
+**Scale/Scope**: ~300 lines new code, ~50 lines modified code across 4 files
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | No new runtime dependencies. Ecosystem CLIs are external prerequisites checked at runtime |
+| P2: Manifest as SSOT | PASS | Skills recorded in `wave.yaml` under `skills:` key, matching `Manifest.Skills []string` |
+| P3: Persona-Scoped Execution | N/A | This feature does not modify persona execution |
+| P4: Fresh Memory | N/A | No pipeline step changes |
+| P5: Navigator-First | N/A | No pipeline changes |
+| P6: Contracts at Handover | N/A | No pipeline changes |
+| P7: Relay | N/A | No relay changes |
+| P8: Ephemeral Workspaces | N/A | No workspace changes |
+| P9: Credentials Never Touch Disk | PASS | No credentials involved |
+| P10: Observable Progress | PASS | Per-skill installation progress printed to stderr |
+| P11: Bounded Recursion | N/A | No meta-pipelines |
+| P12: Minimal State Machine | N/A | No state machine changes |
+| P13: Test Ownership | PASS | All new code will have unit tests; existing tests must continue to pass |
+
+**Post Phase-1 Re-check**: All principles remain PASS/N/A. No violations introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/384-init-skill-selection/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model output
+└── tasks.md             # Phase 2 task breakdown (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```
+internal/onboarding/
+├── onboarding.go        # MODIFY: Add Skills field to WizardResult, Step 6 call in RunWizard(), skills key in buildManifest()
+├── steps.go             # MODIFY: Renumber step labels from "N of 5" to "N of 6"
+├── skill_step.go        # NEW: SkillSelectionStep implementation with EcosystemDef, tessl search, install orchestration
+├── skill_step_test.go   # NEW: Unit tests for SkillSelectionStep
+├── onboarding_test.go   # MODIFY: Update test assertions for Skills field and step count
+└── steps_test.go        # (no changes needed — step tests don't assert on label text)
+```
+
+**Structure Decision**: All new code lives in `internal/onboarding/` package. The `skill_step.go` file is a new file in the existing package, following the pattern of `steps.go` containing all step implementations. Separating into its own file keeps `steps.go` focused on the original 5 steps and makes the new step self-contained.
+
+## Implementation Components
+
+### Component 1: SkillSelectionStep (internal/onboarding/skill_step.go)
+
+**New file** implementing the `WizardStep` interface.
+
+**Key elements**:
+- `EcosystemDef` struct and `ecosystems` package-level slice defining the 4 ecosystems
+- `SkillSelectionStep` struct with injectable `lookPath` and `runCommand` for testability
+- `Name()` returns `"Skill Selection"`
+- `Run()` orchestrates the full flow:
+  1. Non-interactive → skip immediately
+  2. Show reconfiguration context if `cfg.Reconfigure`
+  3. Ecosystem selection via `huh.Select[string]`
+  4. "Skip" → return empty
+  5. Check CLI dependency → offer skip or show install instructions
+  6. For tessl: `tessl search ""` → `parseTesslSearchOutput()` → `huh.MultiSelect[string]` → install each
+  7. For install-all: `huh.Confirm` → run adapter bulk install
+  8. Print per-skill progress to stderr
+  9. Return skill names via `StepResult.Data["skills"]`
+
+**Dependencies**: `internal/skill` (SourceRouter, DirectoryStore, DependencyError, CLIDependency), `charmbracelet/huh`, `internal/tui` (WaveTheme)
+
+**Functions to extract from skills.go for reuse**: `parseTesslSearchOutput()` — currently in `cmd/wave/commands/skills.go`. Since the onboarding package shouldn't import the commands package, the function should be either:
+- (a) Duplicated in `skill_step.go` (simple, ~25 lines), or
+- (b) Moved to `internal/skill/` as an exported function
+
+Recommendation: (a) Duplicate. The function is small, self-contained, and the onboarding context may diverge from CLI context (e.g., different field handling). Moving it to `internal/skill/` would create coupling for a simple parser.
+
+### Component 2: WizardResult Extension (internal/onboarding/onboarding.go)
+
+**Modifications**:
+- Add `Skills []string` field to `WizardResult`
+- Add Step 6 invocation in `RunWizard()` between model selection and `writeManifest()`
+- Extract skills from `StepResult.Data["skills"]` and set `result.Skills`
+- In `buildManifest()`: add `m["skills"] = result.Skills` when `len(result.Skills) > 0`
+
+### Component 3: Step Renumbering (internal/onboarding/steps.go)
+
+**Modifications**:
+- Change all `"Step N of 5"` labels to `"Step N of 6"` (6 occurrences in existing steps)
+
+### Component 4: Tests (internal/onboarding/skill_step_test.go, onboarding_test.go)
+
+**New file** `skill_step_test.go` with table-driven tests:
+
+| Test | Scenario |
+|------|----------|
+| `TestSkillSelectionStep_Name` | Returns "Skill Selection" |
+| `TestSkillSelectionStep_NonInteractive_Skips` | Non-interactive mode returns empty skills |
+| `TestSkillSelectionStep_Skip_Ecosystem` | User selects "Skip" → empty skills |
+| `TestSkillSelectionStep_MissingCLI` | CLI not found → returns empty skills (simulates skip path) |
+| `TestSkillSelectionStep_TesslSearchParse` | Parses tessl search output correctly |
+| `TestSkillSelectionStep_Reconfigure_ShowsExisting` | Reconfigure mode shows existing skills as context |
+
+**Modified** `onboarding_test.go`:
+- `TestBuildManifest_WithSkills` — verify `skills` key in manifest when skills present
+- `TestBuildManifest_NoSkills` — verify no `skills` key when empty
+- `TestRunWizard_NonInteractive` — verify `result.Skills` is empty (non-interactive skip)
+
+## Complexity Tracking
+
+_No constitution violations. No complexity justifications needed._
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|-----------|--------------------------------------|
+| (none) | — | — |

--- a/specs/384-init-skill-selection/research.md
+++ b/specs/384-init-skill-selection/research.md
@@ -1,0 +1,115 @@
+# Research: Wave Init Interactive Skill Selection
+
+**Feature Branch**: `384-init-skill-selection`
+**Date**: 2026-03-14
+
+## Research Questions
+
+### RQ-1: How does the existing wizard step architecture work?
+
+**Decision**: Implement `SkillSelectionStep` as a `WizardStep` interface conformant struct.
+
+**Rationale**: All existing wizard steps follow the same pattern:
+- Struct implementing `WizardStep` interface (`Name() string`, `Run(cfg *WizardConfig) (*StepResult, error)`)
+- Non-interactive path returns defaults immediately
+- Interactive path uses `huh` form library with `tui.WaveTheme()`
+- Results passed back via `StepResult.Data` map
+- Orchestrator in `RunWizard()` extracts typed values from `Data` map into `WizardResult` fields
+
+**Evidence**: `internal/onboarding/steps.go` — all 5 steps follow this pattern. Step labels hardcoded as `"Step N of 5"`.
+
+**Alternatives Rejected**:
+- Custom step outside the `WizardStep` interface — would break the consistent architecture
+- Post-wizard hook — would not participate in manifest generation
+
+### RQ-2: How do ecosystem source adapters work?
+
+**Decision**: Two interaction modes — multi-select for tessl, confirm/skip for install-all ecosystems.
+
+**Rationale**: The `SourceAdapter` interface exposes only `Install(ctx, ref, store)` — no `List()` method. Only tessl has an external registry search capability:
+- **tessl**: `tessl search ""` lists all skills, `tessl install <ref>` installs individual skills
+- **BMAD**: `npx bmad-method install --tools claude-code --yes` installs everything
+- **OpenSpec**: `openspec init` installs everything
+- **Spec-Kit**: `specify init` installs everything
+
+The tessl adapter installs to a temp dir, discovers `SKILL.md` files, then parses and writes to the store. Install-all adapters do the same but don't support individual skill references.
+
+**Evidence**: `internal/skill/source_cli.go` — `TesslAdapter.Install()` takes a `ref` param, while `BMADAdapter.Install()`, `OpenSpecAdapter.Install()`, and `SpecKitAdapter.Install()` ignore their `ref` parameter.
+
+**Alternatives Rejected**:
+- Adding `List()` to `SourceAdapter` — invasive change to an interface with 7 implementations, not all of which support listing
+- Treating all ecosystems as install-all — loses the tessl-specific individual selection capability
+
+### RQ-3: How should tessl search results populate the multi-select?
+
+**Decision**: Reuse the `parseTesslSearchOutput()` function from `cmd/wave/commands/skills.go` and the same `tessl search ""` subprocess pattern.
+
+**Rationale**: `parseTesslSearchOutput()` already parses tessl's tab/space-separated output into `SkillSearchResult{Name, Rating, Description}` structs. The same `exec.CommandContext(ctx, "tessl", "search", query)` pattern is used in `runSkillsSearch()`.
+
+For the onboarding step, we'll call `tessl search ""` to get all available skills, parse them into `SkillSearchResult` items, then build `huh.MultiSelect` options from them.
+
+**Evidence**: `cmd/wave/commands/skills.go:401` — `parseTesslSearchOutput` and `cmd/wave/commands/skills.go:389` — subprocess invocation.
+
+**Alternatives Rejected**:
+- Creating a new parser — duplication of working code
+- Calling through the `SourceRouter` — the router only does install, not search
+
+### RQ-4: How should `WizardResult` flow skills to `buildManifest()`?
+
+**Decision**: Add `Skills []string` field to `WizardResult`. `buildManifest()` adds `"skills"` key when non-empty.
+
+**Rationale**: The `Manifest.Skills` field is `[]string` (bare names, not source-prefixed). The existing `WizardResult` → `buildManifest()` pattern is straightforward: typed fields on `WizardResult` map directly to manifest keys. Adding `Skills []string` follows the same pattern as `Pipelines []string`.
+
+**Evidence**: `internal/manifest/types.go:23` — `Skills []string yaml:"skills,omitempty"`. `internal/onboarding/onboarding.go:162` — `buildManifest()` constructs a `map[string]interface{}`.
+
+**Alternatives Rejected**:
+- Storing source-prefixed names — doesn't match `Manifest.Skills` format
+- Writing skills to manifest separately after wizard — breaks the single `writeManifest()` call pattern
+
+### RQ-5: How to handle missing CLI dependencies gracefully?
+
+**Decision**: Use existing `checkDependency()` / `DependencyError` pattern. When detected, show a choice: "Skip" or "Show install instructions".
+
+**Rationale**: The `skill` package already has `checkDependency(dep CLIDependency, lookPath lookPathFunc)` which returns `*DependencyError` with `Binary` and `Instructions` fields. The CLI layer already classifies these via `classifySkillError()`. In the wizard context, we check before attempting install and present a user-friendly choice.
+
+**Evidence**: `internal/skill/source_cli.go:18-27` — `checkDependency`, `internal/skill/source.go:37-51` — `DependencyError`, `CLIDependency`.
+
+**Alternatives Rejected**:
+- Silently skipping — violates FR-007 requirement for user notification
+- Failing the wizard — too harsh for an optional feature
+
+### RQ-6: Step numbering strategy
+
+**Decision**: Renumber all existing step labels from "Step N of 5" to "Step N of 6". New skill selection step is "Step 6 of 6".
+
+**Rationale**: Step labels are hardcoded strings in each step's `Run()` method. Six occurrences to update (Steps 1-5 in their respective `Run()` methods). The new step inserts between model selection (Step 5) and `writeManifest()`.
+
+**Evidence**: `internal/onboarding/steps.go` — grep for `"Step N of 5"`: lines 72, 141, 335, 394, 487, 525.
+
+**Alternatives Rejected**:
+- Dynamic step numbering — over-engineering for 6 steps; adds complexity without clear benefit
+- Not renumbering — confusing UX ("Step 5 of 5" followed by "Step 6")
+
+### RQ-7: huh v0.8.0 MultiSelect API
+
+**Decision**: Use `huh.NewMultiSelect[string]()` with `.Options()`, `.Value()`, and `.Height()`.
+
+**Rationale**: The codebase already uses `huh.NewMultiSelect[string]()` in `PipelineSelectionStep` (steps.go:330). The same pattern works for skill selection. `huh.MultiSelect` supports built-in keyboard filtering in v0.8.0.
+
+**Evidence**: `internal/onboarding/steps.go:330-334` — existing `huh.NewMultiSelect[string]()` usage. `go.mod:8` — `github.com/charmbracelet/huh v0.8.0`.
+
+**Alternatives Rejected**:
+- Custom list rendering — loses huh theme integration and filtering
+- huh.Select for single skill at a time — poor UX for multi-selection
+
+### RQ-8: Installation progress feedback
+
+**Decision**: Use `fmt.Fprintf(os.Stderr, ...)` with per-skill status updates during installation, consistent with existing wizard step output patterns.
+
+**Rationale**: The wizard already writes progress to stderr (see `DependencyStep.Run()` which uses `fmt.Fprintf(os.Stderr, ...)`). For skill installation, iterate over selected skills, print "Installing <name>...", then print success/failure. The `SourceAdapter.Install()` return value includes `InstallResult.Skills` and `InstallResult.Warnings` for status tracking.
+
+**Evidence**: `internal/onboarding/steps.go:72-81` — stderr output pattern in `DependencyStep`.
+
+**Alternatives Rejected**:
+- Spinner/progress bar — overkill for sequential installs; adds external dependency
+- Silent installation — violates FR-004 requirement for progress feedback

--- a/specs/384-init-skill-selection/spec.md
+++ b/specs/384-init-skill-selection/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: Wave Init Interactive Skill Selection
+
+**Feature Branch**: `384-init-skill-selection`
+**Created**: 2026-03-14
+**Status**: Draft
+**Input**: User description: "https://github.com/re-cinq/wave/issues/384"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Ecosystem Selection During Init (Priority: P1)
+
+A user runs `wave init` for the first time. After completing the existing onboarding steps (dependency verification, test configuration, pipeline selection, adapter configuration, model selection), they are presented with an ecosystem selection prompt. The user selects an ecosystem (tessl, BMAD, OpenSpec, Spec-Kit) or chooses to skip skill installation entirely. Choosing "Skip" completes the wizard without installing any skills.
+
+**Why this priority**: This is the entry point for all skill installation during onboarding. Without ecosystem selection, no subsequent skill browsing or installation can occur. It also provides the "Skip" escape hatch for users who don't want skills.
+
+**Independent Test**: Can be fully tested by running `wave init` interactively and verifying the ecosystem prompt appears after model selection. Selecting "Skip" should complete onboarding with no skills in `wave.yaml`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `wave init` in interactive mode, **When** they complete the model selection step, **Then** a new "Skill Ecosystem" step appears offering: tessl, BMAD, OpenSpec, Spec-Kit, and Skip options.
+2. **Given** the ecosystem selection step is shown, **When** the user selects "Skip", **Then** the wizard completes without installing any skills and `wave.yaml` contains no skill entries.
+3. **Given** the user runs `wave init --yes` (non-interactive mode), **When** onboarding executes, **Then** the skill selection step is skipped entirely (no skills installed).
+4. **Given** the user runs `wave init --reconfigure`, **When** the ecosystem step appears, **Then** any previously installed skills are shown as context but do not constrain the new selection.
+
+---
+
+### User Story 2 - Skill Browsing and Multi-Selection (Priority: P1)
+
+After selecting an ecosystem, the user interaction depends on the ecosystem type:
+
+- **tessl**: The system runs `tessl search ""` (or similar) to fetch available skills from the registry, then presents a `huh.MultiSelect` form with skill names and descriptions. The `huh` library's built-in filtering allows the user to narrow results by typing.
+- **BMAD, OpenSpec, Spec-Kit**: These ecosystems use "install-all" adapters — their CLI commands (`npx bmad-method install`, `openspec init`, `specify init`) install all available skills at once. The user is shown a confirmation prompt describing what will be installed, with the option to confirm or skip. Individual skill selection is not supported for these ecosystems because their adapters do not expose a listing API.
+
+**Why this priority**: This is the core interaction for choosing which skills to install. Without browsing and selection, the feature has no practical value beyond ecosystem awareness.
+
+**Independent Test**: Can be tested by selecting the "tessl" ecosystem and verifying a multi-select list of skills appears. The user selects 2-3 skills and proceeds. For BMAD/OpenSpec/Spec-Kit, a confirmation prompt is shown instead of individual multi-select.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user selects "tessl" as ecosystem, **When** the skill list loads, **Then** a multi-select form displays available skills with names and descriptions, populated via `tessl search`.
+2. **Given** the user selects "BMAD" as ecosystem, **When** the ecosystem is confirmed, **Then** a confirmation prompt describes the install-all behavior and asks the user to confirm or skip.
+3. **Given** the tessl skill list is shown, **When** the user toggles multiple skills and confirms, **Then** all toggled skills are marked for installation.
+4. **Given** the user is browsing tessl skills, **When** they type a search term, **Then** the `huh.MultiSelect` built-in filter narrows the displayed options.
+5. **Given** a skill list or confirmation is shown, **When** the user selects no skills (tessl) or declines the confirmation (BMAD/OpenSpec/Spec-Kit), **Then** the wizard proceeds without installing any skills (equivalent to skip).
+
+---
+
+### User Story 3 - Skill Installation with Progress Feedback (Priority: P2)
+
+After the user confirms their skill selection, the system installs each selected skill into `.wave/skills/`. Progress feedback is shown for each skill: the skill name being installed and whether it succeeded or failed. On completion, the installed skills are recorded in the generated `wave.yaml` under the `skills:` key.
+
+**Why this priority**: Installation is essential for the feature to have lasting effect, but it depends on the browsing/selection flow being in place first. Progress feedback ensures the user knows what's happening during potentially slow network operations.
+
+**Independent Test**: Can be tested by selecting 2-3 skills and observing that each shows installation progress (name + status), the files appear in `.wave/skills/`, and `wave.yaml` lists them under `skills:`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has selected 3 skills for installation, **When** installation begins, **Then** each skill displays its name and a progress indicator (installing/success/failure).
+2. **Given** installation completes successfully for all skills, **When** the wizard finishes, **Then** `.wave/skills/` contains a subdirectory with `SKILL.md` for each installed skill.
+3. **Given** installation completes, **When** `wave.yaml` is written, **Then** the `skills:` key contains a list of all successfully installed skill names.
+4. **Given** one skill fails to install, **When** the remaining skills succeed, **Then** the wizard reports the failure, continues with the successful installs, and only lists successful skills in `wave.yaml`.
+
+---
+
+### User Story 4 - Graceful Handling of Missing Ecosystem CLI (Priority: P2)
+
+When the user selects an ecosystem whose CLI tool is not installed (e.g., selecting "tessl" when `tessl` is not on PATH, or selecting "BMAD" when `npx` is not available), the system detects this and offers a choice: skip skill installation or display install instructions for the missing CLI.
+
+**Why this priority**: Users may not have ecosystem CLIs pre-installed. Without graceful handling, the onboarding would fail or show cryptic errors. This ensures a smooth experience regardless of the user's environment.
+
+**Independent Test**: Can be tested by selecting an ecosystem without its CLI installed and verifying a helpful message appears offering to skip or showing install instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user selects "tessl" ecosystem, **When** `tessl` CLI is not found on PATH, **Then** the system shows a message explaining the missing dependency and offers: "Skip skill installation" or "Show install instructions".
+2. **Given** the user chooses "Show install instructions", **When** instructions are displayed, **Then** the install command (e.g., `npm i -g @tessl/cli`) is shown and the user can retry or skip.
+3. **Given** the user chooses "Skip" after a missing CLI warning, **When** the wizard continues, **Then** no skills are installed and the wizard completes normally.
+
+---
+
+### User Story 5 - Reconfigure Preserves Skill Context (Priority: P3)
+
+When a user runs `wave init --reconfigure`, the ecosystem/skill selection step shows their current skill configuration as context. They can keep existing skills, add new ones, or start fresh with a different ecosystem.
+
+**Why this priority**: Reconfiguration is a secondary workflow. Users expect their existing settings to be preserved as defaults when reconfiguring, but this is not the primary onboarding path.
+
+**Independent Test**: Can be tested by running `wave init`, installing skills, then running `wave init --reconfigure` and verifying existing skills are displayed during the ecosystem step.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has previously installed skills via `wave init`, **When** they run `wave init --reconfigure`, **Then** the ecosystem step shows currently installed skill names as context.
+2. **Given** existing skills are shown during reconfigure, **When** the user selects a different ecosystem, **Then** the new ecosystem's skills are shown and previously installed skills are not removed until new installation completes.
+
+---
+
+### Edge Cases
+
+- What happens when the ecosystem registry is unreachable (network failure during skill listing)?
+  - The system displays an error message and offers to skip skill installation or retry.
+- What happens when the user aborts (Ctrl+C) during skill installation?
+  - Partially installed skills are cleaned up. `wave.yaml` only lists fully installed skills.
+- What happens when a skill name conflicts with an already-installed skill?
+  - The system warns about the conflict and asks the user whether to overwrite or skip.
+- What happens when `.wave/skills/` directory doesn't exist yet?
+  - The system creates it automatically before installation begins (this is normal for fresh `wave init`).
+- What happens when multiple ecosystems are desired?
+  - The current scope supports selecting one ecosystem per init run. Users can install additional skills later via `wave skills install`.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST add a new wizard step after model selection that presents ecosystem choices: tessl, BMAD, OpenSpec, Spec-Kit, and Skip.
+- **FR-002**: System MUST display a multi-select form for tessl (populated via `tessl search`) or a confirm/skip prompt for install-all ecosystems (BMAD, OpenSpec, Spec-Kit) after the user chooses an ecosystem.
+- **FR-003**: System MUST install selected skills into `.wave/skills/` using the corresponding `SourceAdapter` (tessl, BMAD, OpenSpec, Spec-Kit).
+- **FR-004**: System MUST show per-skill progress during installation (skill name plus success/failure status).
+- **FR-005**: System MUST record all successfully installed skill names as bare names (e.g., `["golang", "spec-kit"]`, not source-prefixed) in `wave.yaml` under the top-level `skills:` key, matching the `Manifest.Skills []string` field.
+- **FR-006**: System MUST skip the skill selection step entirely when running in non-interactive mode (`--yes` flag or non-TTY).
+- **FR-007**: System MUST detect when an ecosystem's CLI dependency is missing and offer skip or install instructions.
+- **FR-008**: System MUST handle installation failures gracefully — report the failure, continue with remaining skills, and only list successful installs in `wave.yaml`.
+- **FR-009**: System MUST support the `--reconfigure` flag by showing existing installed skills as context during the ecosystem step.
+- **FR-010**: System MUST use the existing `huh` form library with `WaveTheme()` for consistent styling with the other wizard steps.
+- **FR-011**: System MUST implement the `WizardStep` interface for the new ecosystem/skill selection step, maintaining consistency with existing steps.
+- **FR-012**: The new step MUST be inserted as Step 6 in `RunWizard()` between model selection (Step 5) and `writeManifest()`. All existing step labels ("Step N of 5") MUST be renumbered to "Step N of 6".
+- **FR-013**: `WizardResult` MUST be extended with a `Skills []string` field, and `buildManifest()` MUST be updated to include the `skills:` key when skills are present.
+
+### Key Entities
+
+- **SkillSelectionStep**: A new `WizardStep` implementation (`internal/onboarding/steps.go`) that handles ecosystem choice, skill browsing/confirmation, and installation orchestration. Implements the `WizardStep` interface (`Name() string`, `Run(cfg *WizardConfig) (*StepResult, error)`).
+- **EcosystemDef**: A struct defining each ecosystem with fields: display name, `SourceAdapter` prefix (`tessl`, `bmad`, `openspec`, `speckit`), `CLIDependency` (binary name + install instructions), and a flag indicating whether it supports individual skill listing or is install-all.
+- **SkillListItem**: A displayable skill entry containing name and description. For tessl, populated from `tessl search` output via `parseTesslSearchOutput()`. Not applicable for install-all ecosystems.
+- **InstallProgress**: Per-skill installation status tracking (pending, installing, success, failure) for progress feedback rendering. Leverages the existing `InstallResult.Skills` and `InstallResult.Warnings` from the `SourceAdapter.Install()` return value.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users can complete the full `wave init` flow including skill selection in a single interactive session without leaving the terminal.
+- **SC-002**: All four supported ecosystems function correctly: tessl lists available skills via `tessl search` for individual selection; BMAD, OpenSpec, and Spec-Kit present confirm/skip for their install-all behavior. All install into `.wave/skills/`.
+- **SC-003**: The "Skip" option bypasses skill installation completely — no skills added to `.wave/skills/`, no `skills:` key in `wave.yaml`. (The `.wave/skills/` directory may exist from other operations; Skip simply doesn't add to it.)
+- **SC-004**: When an ecosystem CLI is missing, 100% of cases show the missing dependency message rather than an unhandled error.
+- **SC-005**: Installation failures for individual skills do not prevent other selected skills from being installed.
+- **SC-006**: The `skills:` key in the generated `wave.yaml` accurately reflects all successfully installed skills.
+- **SC-007**: The `--reconfigure` flow preserves awareness of previously installed skills.
+- **SC-008**: Non-interactive mode (`--yes`) skips skill selection without error.
+- **SC-009**: All new functionality has test coverage including unit tests for the wizard step and integration tests for the installation flow.
+
+## Clarifications
+
+The following ambiguities were identified during spec analysis and resolved based on codebase context:
+
+### C1: Skill listing behavior differs by ecosystem
+
+**Ambiguity**: The original spec described "a multi-select form with available skills" for all ecosystems, but the `SourceAdapter` interface only exposes `Install(ctx, ref, store)` — it has no `List()` method. Only tessl has a registry search capability (`tessl search`). The BMAD, OpenSpec, and Spec-Kit adapters are install-all: `npx bmad-method install --tools claude-code --yes`, `openspec init`, and `specify init` each install all available skills at once with no individual listing.
+
+**Resolution**: Two interaction modes — multi-select for tessl (populated via `tessl search`), confirm/skip for install-all ecosystems. This aligns with the actual adapter architecture in `internal/skill/source_cli.go` without requiring new `List()` methods on adapters.
+
+### C2: Wizard step numbering and insertion point
+
+**Ambiguity**: The wizard currently has 5 hardcoded steps labeled "Step N of 5" in `internal/onboarding/steps.go`. The spec says the new step appears "after model selection" but didn't specify how the step count changes or where the manifest write occurs.
+
+**Resolution**: The skill selection step becomes Step 6 (after model selection at Step 5), inserted before `writeManifest()` in `RunWizard()`. All existing step labels are renumbered from "Step N of 5" to "Step N of 6". Added FR-012 and FR-013 to codify this.
+
+### C3: Skills key format in wave.yaml
+
+**Ambiguity**: The spec said "record in `wave.yaml` under the `skills:` key" but didn't specify whether skills are stored as bare names (`["golang"]`) or source-prefixed (`["tessl:golang"]`).
+
+**Resolution**: Bare names. The `Manifest.Skills` field is `[]string` of plain skill names (see `internal/manifest/types.go:23`). `internal/skill/resolve.go` and `DirectoryStore` both operate on bare names. Source prefixes are only used during installation routing via `SourceRouter.Parse()`.
+
+### C4: Search/filter mechanism for tessl
+
+**Ambiguity**: The spec mentioned "search/filter capability" for tessl but didn't specify the implementation mechanism within the `huh` form framework.
+
+**Resolution**: Use `huh.MultiSelect` which has built-in keyboard filtering. Pre-populate the option list by running `tessl search ""` (list all) via the same subprocess pattern used in `cmd/wave/commands/skills.go:runSkillsSearch`. The `parseTesslSearchOutput()` function already exists for parsing tessl search results.
+
+### C5: WizardResult extension for skill data flow
+
+**Ambiguity**: `WizardResult` in `internal/onboarding/onboarding.go` has no skills field. The spec didn't address how skill selections flow from the new step to `writeManifest()` / `buildManifest()`.
+
+**Resolution**: Add `Skills []string` to `WizardResult`. The new step returns installed skill names via `StepResult.Data["skills"]`. `RunWizard()` extracts and sets `result.Skills`. `buildManifest()` conditionally includes `"skills"` key when `result.Skills` is non-empty. Added FR-013 to codify this.

--- a/specs/384-init-skill-selection/tasks.md
+++ b/specs/384-init-skill-selection/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Wave Init Interactive Skill Selection
+
+**Feature Branch**: `384-init-skill-selection`
+**Generated**: 2026-03-14
+**Spec**: `specs/384-init-skill-selection/spec.md`
+**Plan**: `specs/384-init-skill-selection/plan.md`
+
+---
+
+## Phase 1: Setup & Scaffolding
+
+- [X] T001 [P1] Create `internal/onboarding/skill_step.go` with `EcosystemDef` struct, `ecosystems` package-level slice (tessl, BMAD, OpenSpec, Spec-Kit), `lookPathFunc`/`commandRunner` type aliases, and `SkillSelectionStep` struct with injectable dependencies
+- [X] T002 [P1] Implement `SkillSelectionStep.Name()` returning `"Skill Selection"` and stub `Run()` method returning empty `StepResult` in `internal/onboarding/skill_step.go`
+
+## Phase 2: Foundational — WizardResult Extension & Step Renumbering
+
+- [X] T003 [P1] Add `Skills []string` field to `WizardResult` in `internal/onboarding/onboarding.go`
+- [X] T004 [P1] Renumber all step labels from `"Step N of 5"` to `"Step N of 6"` in `internal/onboarding/steps.go` (6 occurrences: lines 72, 141, 335, 392, 486, 525)
+- [X] T005 [P1] Add Step 6 invocation block in `RunWizard()` in `internal/onboarding/onboarding.go` — create `SkillSelectionStep`, call `Run()`, extract `skills` from `StepResult.Data["skills"]` into `result.Skills`
+- [X] T006 [P1] Update `buildManifest()` in `internal/onboarding/onboarding.go` — add `m["skills"] = result.Skills` when `len(result.Skills) > 0`
+
+## Phase 3: User Story 1 — Ecosystem Selection During Init (P1)
+
+- [X] T007 [P1] [US1] Implement non-interactive skip path in `SkillSelectionStep.Run()` — when `!cfg.Interactive`, return immediately with empty skills in `internal/onboarding/skill_step.go`
+- [X] T008 [P1] [US1] Implement ecosystem selection form using `huh.NewSelect[string]()` with options for tessl, BMAD, OpenSpec, Spec-Kit, and Skip, themed with `tui.WaveTheme()`, labeled `"Step 6 of 6 — Skill Selection"` in `internal/onboarding/skill_step.go`
+- [X] T009 [P1] [US1] Implement "Skip" selection handling — when user selects skip, return immediately with empty `StepResult.Data["skills"]` in `internal/onboarding/skill_step.go`
+
+## Phase 4: User Story 2 — Skill Browsing and Multi-Selection (P1)
+
+- [X] T010 [P1] [US2] Implement `parseTesslSearchOutput()` function in `internal/onboarding/skill_step.go` — duplicate from `cmd/wave/commands/skills.go`, parses tab/space-separated tessl output into `skillSearchResult{Name, Description}` structs
+- [X] T011 [P1] [US2] Implement tessl skill listing — run `tessl search ""` via `commandRunner`, parse output with `parseTesslSearchOutput()`, build `huh.NewMultiSelect[string]()` options with skill names and descriptions in `internal/onboarding/skill_step.go`
+- [X] T012 [P1] [US2] Implement install-all ecosystem confirmation — for BMAD/OpenSpec/Spec-Kit, show `huh.NewConfirm()` describing bulk install behavior, return empty skills if declined in `internal/onboarding/skill_step.go`
+
+## Phase 5: User Story 3 — Skill Installation with Progress Feedback (P2)
+
+- [X] T013 [P2] [US3] Implement tessl per-skill installation loop — for each selected skill, print "Installing <name>..." to stderr, call `SourceRouter.Install(ctx, "tessl:<name>", store)`, print success/failure status in `internal/onboarding/skill_step.go`
+- [X] T014 [P2] [US3] Implement install-all ecosystem execution — call `SourceRouter.Install(ctx, "<prefix>:", store)`, print per-skill results from `InstallResult.Skills`, handle warnings in `internal/onboarding/skill_step.go`
+- [X] T015 [P2] [US3] Collect installed skill names from `InstallResult.Skills` and return as `StepResult.Data["skills"]` (bare names, not prefixed) in `internal/onboarding/skill_step.go`
+
+## Phase 6: User Story 4 — Graceful Handling of Missing CLI (P2)
+
+- [X] T016 [P2] [US4] Implement CLI dependency check before installation — use `lookPathFunc` to check `EcosystemDef.Dep.Binary`, show missing dependency message with `EcosystemDef.Dep.Instructions`, offer "Skip" or "Show install instructions" choice via `huh.NewSelect[string]()` in `internal/onboarding/skill_step.go`
+
+## Phase 7: User Story 5 — Reconfigure Preserves Skill Context (P3)
+
+- [X] T017 [P3] [US5] Implement reconfigure context display — when `cfg.Reconfigure && cfg.Existing != nil`, show currently installed skill names from `cfg.Existing.Skills` as context before ecosystem selection in `internal/onboarding/skill_step.go`
+- [X] T018 [P3] [US5] Merge existing skills with newly installed skills — when reconfiguring, final `result.Skills` is the union of `cfg.Existing.Skills` and newly installed skills (deduped) in `internal/onboarding/skill_step.go`
+
+## Phase 8: Tests
+
+- [X] T019 [P1] [P] Create `internal/onboarding/skill_step_test.go` with `TestSkillSelectionStep_Name` verifying `Name()` returns `"Skill Selection"`
+- [X] T020 [P1] [P] Add `TestSkillSelectionStep_NonInteractive_Skips` — non-interactive mode returns empty `skills` in `StepResult.Data` in `internal/onboarding/skill_step_test.go`
+- [X] T021 [P1] [P] Add `TestParseTesslSearchOutput` — table-driven tests verifying parsing of tessl search output (empty, single, multi-line, malformed) in `internal/onboarding/skill_step_test.go`
+- [X] T022 [P1] [P] Add `TestSkillSelectionStep_MissingCLI` — inject `lookPathFunc` that returns error, verify step handles gracefully (returns empty skills in non-interactive) in `internal/onboarding/skill_step_test.go`
+- [X] T023 [P2] [P] Add `TestBuildManifest_WithSkills` — verify `buildManifest()` includes `skills` key when `result.Skills` is non-empty in `internal/onboarding/onboarding_test.go`
+- [X] T024 [P2] [P] Add `TestBuildManifest_NoSkills` — verify `buildManifest()` omits `skills` key when `result.Skills` is empty in `internal/onboarding/onboarding_test.go`
+- [X] T025 [P3] [P] Add `TestSkillSelectionStep_ReconfigureShowsExisting` — verify reconfigure mode with existing skills doesn't error in non-interactive path in `internal/onboarding/skill_step_test.go`
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [X] T026 [P2] Handle `huh.ErrUserAborted` (Ctrl+C) at all form interaction points — return `fmt.Errorf("wizard cancelled by user")` consistently in `internal/onboarding/skill_step.go`
+- [X] T027 [P2] Handle network failure during `tessl search` — if command fails, show error and offer skip/retry choice in `internal/onboarding/skill_step.go`
+- [X] T028 [P3] Ensure `.wave/skills/` directory is created before installation if it doesn't exist — use `os.MkdirAll()` in `internal/onboarding/skill_step.go`
+
+---
+
+## Dependency Graph
+
+```
+T001 → T002 → T007, T008, T009
+T003 → T005 → T006
+T004 (independent)
+T008 → T010 → T011
+T008 → T012
+T011 → T013
+T012 → T014
+T013, T014 → T015
+T008 → T016
+T007 → T017 → T018
+T002 → T019, T020
+T010 → T021
+T016 → T022
+T006 → T023, T024
+T017 → T025
+T008 → T026
+T011 → T027
+T015 → T028
+```
+
+## Parallelization Opportunities
+
+Tasks marked [P] can run in parallel within their phase:
+- **Phase 2**: T003 and T004 are independent of each other
+- **Phase 3**: T007 and T008 can start in parallel after T002
+- **Phase 8**: T019, T020, T021, T022 can all run in parallel; T023 and T024 can run in parallel
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total tasks | 28 |
+| P1 (critical) | 14 |
+| P2 (important) | 9 |
+| P3 (nice-to-have) | 5 |
+| Files created | 2 (`skill_step.go`, `skill_step_test.go`) |
+| Files modified | 2 (`onboarding.go`, `steps.go`) |
+| Parallel opportunities | 8 tasks |


### PR DESCRIPTION
## Summary
- Adds **Step 6 — Skill Selection** to the `wave init` onboarding wizard
- Supports 4 skill ecosystems: Tessl (browse + multi-select), BMAD, OpenSpec, Spec-Kit (install-all)
- Checks CLI dependencies before installation with install instructions and retry flow
- Handles network failures gracefully with skip/retry options
- Supports reconfigure mode with skill deduplication against existing manifest
- Updates step numbering across all wizard steps (1-5 → 1-6)
- Writes installed skills to `wave.yaml` manifest under the `skills` key

## Spec
[specs/384-init-skill-selection/spec.md](https://github.com/re-cinq/wave/blob/384-init-skill-selection/specs/384-init-skill-selection/spec.md)

## Test Plan
- Unit tests for `parseTesslOutput`, `findEcosystem`, `mergeSkills` helpers (table-driven)
- Non-interactive mode returns empty skills (no TUI prompts)
- Manifest building: `skills` key present when skills installed, absent when empty
- `defaultCommandRunner` success/failure paths
- All ecosystem definitions verified (binary names, install instructions, flags)
- Full `go test -race ./...` passes

## Known Limitations
- Interactive TUI flows (ecosystem selection, multi-select) are not unit-tested due to `huh` form dependencies — manual testing recommended
- Tessl search output parsing assumes whitespace-separated fields; may need adjustment if registry format changes

Closes #384
