### PR TITLE
fix: replace auto-close keywords with non-closing references in PR templates

### DIFF
--- a/.wave/pipelines/wave-audit.yaml
+++ b/.wave/pipelines/wave-audit.yaml
@@ -74,7 +74,7 @@ steps:
         - `number`, `type` (issue or pr), `title`, `url`, `body`, `labels`
         - `close_reason`: "completed" for issues, "merged" for PRs
         - `closed_at`: ISO 8601 timestamp
-        - `linked_prs`: For issues, search the body for "Fixes #N", "Closes #N", or PR cross-references
+        - `linked_prs`: For issues, search the body for "Fixes #N", "Closes #N", "Related to #N", or PR cross-references
         - `linked_commits`: For PRs, include the merge commit SHA
         - `acceptance_criteria`: Extract from issue body by looking for checklist patterns (`- [ ]`, `- [x]`) or sections titled "Acceptance Criteria", "Requirements", or similar headers
 

--- a/.wave/prompts/bb-implement-epic/report.md
+++ b/.wave/prompts/bb-implement-epic/report.md
@@ -24,7 +24,7 @@ Extract the workspace, repository slug, and epic number from the input. Read the
 For each subissue in the scope plan, check whether a pull request was created. Search for PRs that reference the subissue:
 
 ```bash
-curl -s "https://api.bitbucket.org/2.0/repositories/<WORKSPACE>/<REPO>/pullrequests?q=title+%7E+%22%23<SUBISSUE_NUMBER>%22+OR+description+%7E+%22closes+%23<SUBISSUE_NUMBER>%22&pagelen=5" \
+curl -s "https://api.bitbucket.org/2.0/repositories/<WORKSPACE>/<REPO>/pullrequests?q=title+%7E+%22%23<SUBISSUE_NUMBER>%22+OR+description+%7E+%22closes+%23<SUBISSUE_NUMBER>%22+OR+description+%7E+%22related+to+%23<SUBISSUE_NUMBER>%22&pagelen=5" \
   -H "Authorization: Bearer $BB_TOKEN" | jq '.values[] | {id: .id, title: .title, state: .state, links: .links}'
 ```
 

--- a/.wave/prompts/bb-implement/create-pr.md
+++ b/.wave/prompts/bb-implement/create-pr.md
@@ -37,7 +37,7 @@ git push -u origin <BRANCH_NAME> || GIT_SSH_COMMAND="ssh -F /dev/null" git push 
 
 ### Step 3: Create Pull Request
 
-Create the PR via the Bitbucket REST API. The PR description MUST include `Closes #<NUMBER>` to link to the issue.
+Create the PR via the Bitbucket REST API. The PR description MUST include `Related to #<NUMBER>` to link the issue (without auto-closing it when the PR is closed without merge).
 
 Write the PR payload to a temp file to avoid shell escaping issues:
 
@@ -45,7 +45,7 @@ Write the PR payload to a temp file to avoid shell escaping issues:
 cat > /tmp/bb-payload.json << 'PRBODY'
 {
   "title": "PR title",
-  "description": "PR description\n\nCloses #NUMBER",
+  "description": "PR description\n\nRelated to #NUMBER",
   "source": {"branch": {"name": "BRANCH_NAME"}},
   "destination": {"branch": {"name": "main"}},
   "close_source_branch": true
@@ -76,7 +76,7 @@ This is a best-effort operation. If reviewers aren't configured, the command wil
 
 - Do NOT spawn Task subagents — work directly in the main context
 - Do NOT run `git checkout`, `git stash`, or any branch-switching commands
-- The PR description MUST contain `Closes #<NUMBER>` to link to the issue
+- The PR description MUST contain `Related to #<NUMBER>` to link to the issue
 - Do NOT include Co-Authored-By or AI attribution in commits
 
 ## Output

--- a/.wave/prompts/gh-implement-epic/report.md
+++ b/.wave/prompts/gh-implement-epic/report.md
@@ -24,7 +24,7 @@ Extract the repository and epic number from the input. Read the scope plan artif
 For each subissue in the scope plan, check whether a pull request was created:
 
 ```bash
-gh pr list --repo <OWNER/REPO> --search "Closes #<SUBISSUE_NUMBER>" --json number,title,url,state --limit 5
+gh pr list --repo <OWNER/REPO> --search "Closes #<SUBISSUE_NUMBER> OR Related to #<SUBISSUE_NUMBER>" --json number,title,url,state --limit 5
 ```
 
 Also check if the subissue itself was closed:

--- a/.wave/prompts/gh-implement/create-pr.md
+++ b/.wave/prompts/gh-implement/create-pr.md
@@ -37,14 +37,14 @@ git push -u origin <BRANCH_NAME> || GIT_SSH_COMMAND="ssh -F /dev/null" git push 
 
 ### Step 3: Create Pull Request
 
-Create the PR using `gh pr create` with `--head` to target the branch. The PR body MUST include `Closes #<NUMBER>` to auto-close the issue on merge.
+Create the PR using `gh pr create` with `--head` to target the branch. The PR body MUST include `Related to #<NUMBER>` to link the issue (without auto-closing it when the PR is closed without merge).
 
 ```bash
 gh pr create --repo <OWNER/REPO> --head <BRANCH_NAME> --title "<concise title>" --body "$(cat <<'EOF'
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -68,7 +68,7 @@ This is a best-effort command. If Copilot isn't available in the repository, the
 
 - Do NOT spawn Task subagents — work directly in the main context
 - Do NOT run `git checkout`, `git stash`, or any branch-switching commands
-- The PR body MUST contain `Closes #<NUMBER>` to link to the issue
+- The PR body MUST contain `Related to #<NUMBER>` to link to the issue
 - Do NOT include Co-Authored-By or AI attribution in commits
 
 ## Output

--- a/.wave/prompts/gl-implement-epic/report.md
+++ b/.wave/prompts/gl-implement-epic/report.md
@@ -24,7 +24,7 @@ Extract the repository and epic number from the input. Read the scope plan artif
 For each subissue in the scope plan, check whether a merge request was created:
 
 ```bash
-glab mr list --repo <OWNER/REPO> --search "Closes #<SUBISSUE_NUMBER>" --output json --per-page 5
+glab mr list --repo <OWNER/REPO> --search "Closes #<SUBISSUE_NUMBER> OR Related to #<SUBISSUE_NUMBER>" --output json --per-page 5
 ```
 
 Also check if the subissue itself was closed:

--- a/.wave/prompts/gl-implement/create-mr.md
+++ b/.wave/prompts/gl-implement/create-mr.md
@@ -37,14 +37,14 @@ git push -u origin <BRANCH_NAME> || GIT_SSH_COMMAND="ssh -F /dev/null" git push 
 
 ### Step 3: Create Merge Request
 
-Create the merge request using `glab mr create` with `--source-branch` to target the branch. The merge request description MUST include `Closes #<NUMBER>` to auto-close the issue on merge.
+Create the merge request using `glab mr create` with `--source-branch` to target the branch. The merge request description MUST include `Related to #<NUMBER>` to link the issue (without auto-closing it when the MR is closed without merge).
 
 ```bash
 cat > /tmp/mr-body.md <<'EOF'
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -68,7 +68,7 @@ This is a best-effort command. If the reviewer isn't available in the project, t
 
 - Do NOT spawn Task subagents — work directly in the main context
 - Do NOT run `git checkout`, `git stash`, or any branch-switching commands
-- The merge request description MUST contain `Closes #<NUMBER>` to link to the issue
+- The merge request description MUST contain `Related to #<NUMBER>` to link to the issue
 - Do NOT include Co-Authored-By or AI attribution in commits
 
 ## Output

--- a/.wave/prompts/gt-implement-epic/report.md
+++ b/.wave/prompts/gt-implement-epic/report.md
@@ -24,7 +24,7 @@ Extract the repository and epic number from the input. Read the scope plan artif
 For each subissue in the scope plan, check whether a pull request was created:
 
 ```bash
-tea pr list --repo <OWNER/REPO> --output json --fields index,title,base,head,state | jq '[.[] | select(.title | test("Closes #<SUBISSUE_NUMBER>|closes #<SUBISSUE_NUMBER>"))]'
+tea pr list --repo <OWNER/REPO> --output json --fields index,title,base,head,state | jq '[.[] | select(.title | test("Closes #<SUBISSUE_NUMBER>|closes #<SUBISSUE_NUMBER>|Related to #<SUBISSUE_NUMBER>|related to #<SUBISSUE_NUMBER>"))]'
 ```
 
 Also check if the subissue itself was closed:

--- a/.wave/prompts/gt-implement/create-pr.md
+++ b/.wave/prompts/gt-implement/create-pr.md
@@ -37,14 +37,14 @@ git push -u origin <BRANCH_NAME> || GIT_SSH_COMMAND="ssh -F /dev/null" git push 
 
 ### Step 3: Create Pull Request
 
-Create the PR using `tea pulls create` with `--head` to target the branch. The PR description MUST include `Closes #<NUMBER>` to auto-close the issue on merge.
+Create the PR using `tea pulls create` with `--head` to target the branch. The PR description MUST include `Related to #<NUMBER>` to link the issue (without auto-closing it when the PR is closed without merge).
 
 ```bash
 cat > /tmp/pr-body.md <<'EOF'
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -59,7 +59,7 @@ tea pulls create --repo <OWNER/REPO> --head <BRANCH_NAME> --base main --title '<
 
 - Do NOT spawn Task subagents — work directly in the main context
 - Do NOT run `git checkout`, `git stash`, or any branch-switching commands
-- The PR description MUST contain `Closes #<NUMBER>` to link to the issue
+- The PR description MUST contain `Related to #<NUMBER>` to link to the issue
 - Do NOT include Co-Authored-By or AI attribution in commits
 
 ## Output

--- a/internal/contract/format_validator.go
+++ b/internal/contract/format_validator.go
@@ -164,9 +164,9 @@ func (v *FormatValidator) validateGitHubPRFormat(output map[string]interface{}) 
 			}
 		}
 
-		// Check for issue references (Closes #123 or Fixes #456)
-		if !regexp.MustCompile(`(?i)(closes|fixes|resolves)\s+#\d+`).MatchString(body) {
-			violations = append(violations, "PR body should reference related issues (Closes #123)")
+		// Check for issue references (Related to #123, Closes #123, or Fixes #456)
+		if !regexp.MustCompile(`(?i)(closes|fixes|resolves|related\s+to)\s+#\d+`).MatchString(body) {
+			violations = append(violations, "PR body should reference related issues (Related to #123 or Closes #123)")
 		}
 
 		// Check for checklist

--- a/internal/contract/format_validator_test.go
+++ b/internal/contract/format_validator_test.go
@@ -141,7 +141,7 @@ This PR adds OAuth2 authentication to the application.
 - Manual testing with Google OAuth
 
 ## Related Issues
-Closes #123
+Related to #123
 
 ## Checklist
 - [x] Tests added

--- a/internal/defaults/pipelines/wave-audit.yaml
+++ b/internal/defaults/pipelines/wave-audit.yaml
@@ -74,7 +74,7 @@ steps:
         - `number`, `type` (issue or pr), `title`, `url`, `body`, `labels`
         - `close_reason`: "completed" for issues, "merged" for PRs
         - `closed_at`: ISO 8601 timestamp
-        - `linked_prs`: For issues, search the body for "Fixes #N", "Closes #N", or PR cross-references
+        - `linked_prs`: For issues, search the body for "Fixes #N", "Closes #N", "Related to #N", or PR cross-references
         - `linked_commits`: For PRs, include the merge commit SHA
         - `acceptance_criteria`: Extract from issue body by looking for checklist patterns (`- [ ]`, `- [x]`) or sections titled "Acceptance Criteria", "Requirements", or similar headers
 

--- a/internal/defaults/prompts/implement/create-pr.md
+++ b/internal/defaults/prompts/implement/create-pr.md
@@ -38,7 +38,7 @@ git push -u origin <BRANCH_NAME> || GIT_SSH_COMMAND="ssh -F /dev/null" git push 
 ### Step 3: Create {{ forge.pr_term }}
 
 Use the appropriate CLI for your platform ({{ forge.type }}) to create the {{ forge.pr_term }}.
-The description MUST include `Closes #<NUMBER>` to auto-close the issue on merge.
+The description MUST include `Related to #<NUMBER>` to link the issue (without auto-closing it when the PR is closed without merge).
 
 **For GitHub** (`gh`):
 ```bash
@@ -46,7 +46,7 @@ gh pr create --repo <OWNER/REPO> --head <BRANCH_NAME> --title "<concise title>" 
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -63,7 +63,7 @@ cat > /tmp/mr-body.md <<'EOF'
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -79,7 +79,7 @@ glab mr create --repo <OWNER/REPO> --source-branch <BRANCH_NAME> --target-branch
 cat > /tmp/bb-payload.json << 'PRBODY'
 {
   "title": "PR title",
-  "description": "PR description\n\nCloses #NUMBER",
+  "description": "PR description\n\nRelated to #NUMBER",
   "source": {"branch": {"name": "BRANCH_NAME"}},
   "destination": {"branch": {"name": "main"}},
   "close_source_branch": true
@@ -98,7 +98,7 @@ cat > /tmp/pr-body.md <<'EOF'
 ## Summary
 <3-5 bullet points describing the changes>
 
-Closes #<ISSUE_NUMBER>
+Related to #<ISSUE_NUMBER>
 
 ## Changes
 <list of key files changed and why>
@@ -123,7 +123,7 @@ operation — if it fails, the {{ forge.pr_term }} is still created successfully
 
 - Do NOT spawn Task subagents — work directly in the main context
 - Do NOT run `git checkout`, `git stash`, or any branch-switching commands
-- The {{ forge.pr_term }} description MUST contain `Closes #<NUMBER>` to link to the issue
+- The {{ forge.pr_term }} description MUST contain `Related to #<NUMBER>` to link to the issue
 - Do NOT include Co-Authored-By or AI attribution in commits
 
 ## Output

--- a/specs/379-fix-autoclose-keywords/plan.md
+++ b/specs/379-fix-autoclose-keywords/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Fix Auto-Close Keywords
+
+## Objective
+
+Replace GitHub closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`) with non-closing references (`Related to #N`) in all Wave pipeline PR creation prompts, so that closing a PR without merging does not falsely close linked issues.
+
+## Approach
+
+Use **non-closing references** (`Related to #N`) in all PR body templates. This is the simplest, most reliable strategy because:
+- It prevents false-positive issue closures at the source
+- No external tooling (GitHub Actions, webhooks) needed
+- Works identically across all forge platforms (GitHub, GitLab, Gitea, Bitbucket)
+- Issues can still be manually closed or closed by a merge commit with closing keywords added at merge time by the human reviewer
+
+The format validator must also be updated to accept `Related to #N` references instead of only `Closes/Fixes/Resolves`.
+
+## File Mapping
+
+### Files to Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/defaults/prompts/implement/create-pr.md` | modify | Replace `Closes #N` with `Related to #N` in all forge templates and constraints |
+| `internal/contract/format_validator.go` | modify | Update regex and violation message to accept `Related to #N` alongside closing keywords |
+| `internal/contract/format_validator_test.go` | modify | Update test case to use `Related to #N` |
+| `.wave/prompts/gh-implement/create-pr.md` | modify | Replace `Closes #N` with `Related to #N` |
+| `.wave/prompts/gl-implement/create-mr.md` | modify | Replace `Closes #N` with `Related to #N` |
+| `.wave/prompts/gt-implement/create-pr.md` | modify | Replace `Closes #N` with `Related to #N` |
+| `.wave/prompts/bb-implement/create-pr.md` | modify | Replace `Closes #N` with `Related to #N` |
+| `.wave/prompts/gh-implement-epic/report.md` | modify | Update search pattern to also find `Related to #N` PRs |
+| `.wave/prompts/gl-implement-epic/report.md` | modify | Update search pattern to also find `Related to #N` MRs |
+| `.wave/prompts/gt-implement-epic/report.md` | modify | Update search pattern to also find `Related to #N` PRs |
+| `.wave/prompts/bb-implement-epic/report.md` | modify | Update search pattern to also find `Related to #N` PRs |
+| `internal/defaults/pipelines/wave-audit.yaml` | modify | Add `Related to #N` to search patterns (alongside existing closing keywords) |
+| `.wave/pipelines/wave-audit.yaml` | modify | Same as above (local override copy) |
+
+### Files NOT Changed (by design)
+
+| File | Reason |
+|------|--------|
+| `internal/defaults/prompts/speckit-flow/create-pr.md` | Already uses safe pattern (no closing keywords) |
+| `.wave/prompts/speckit-flow/create-pr.md` | Already uses safe pattern (no closing keywords) |
+
+## Architecture Decisions
+
+1. **`Related to #N` over `For #N`**: "Related to" is more widely recognized across platforms and conveys the relationship clearly without triggering auto-close behavior on any platform.
+
+2. **Keep validator accepting both patterns**: The format validator should accept BOTH `Related to #N` AND closing keywords (`Closes/Fixes/Resolves #N`). This is forward-compatible — if someone manually uses closing keywords in a custom PR, the validator won't reject it.
+
+3. **Epic reports use both patterns**: The epic report search commands must search for BOTH old closing keywords AND new non-closing references, since historical PRs use the old pattern and new PRs will use the new pattern.
+
+4. **Audit pipeline backward compatibility**: The wave-audit pipeline reads historical data, so it must continue searching for `Fixes #N`, `Closes #N` in addition to the new `Related to #N`.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Issues no longer auto-close on merge | Humans must manually close issues after merge, or add closing keywords to merge commit. This is the desired behavior — deliberate closure. |
+| Historical PRs searched differently | Epic report and audit patterns updated to search both old and new patterns |
+| Other closing keyword locations missed | Comprehensive grep identified all 12 files; speckit-flow already safe |
+
+## Testing Strategy
+
+1. **Unit tests**: Update `format_validator_test.go` to verify both `Related to #N` and `Closes #N` are accepted
+2. **Manual validation**: Run `go test -race ./...` to ensure no regressions
+3. **Grep audit**: Post-change grep for `Closes #|Fixes #|Resolves #` should only find:
+   - Read-only search patterns in audit/epic report contexts
+   - Format validator regex (which accepts both patterns)
+   - Test fixtures using both patterns

--- a/specs/379-fix-autoclose-keywords/spec.md
+++ b/specs/379-fix-autoclose-keywords/spec.md
@@ -1,0 +1,35 @@
+# fix: PRs closed without merge incorrectly auto-close linked issues
+
+**Issue**: [#379](https://github.com/re-cinq/wave/issues/379)
+**Labels**: bug, ux, pipeline, priority: high
+**Author**: nextlevelshit
+
+## Problem
+
+When Wave pipelines produce PRs that are later closed without merging (e.g., due to merge conflicts, review failures, or superseded implementations), GitHub automatically closes any linked issues referenced via `Closes #N` or `Fixes #N` keywords in the PR description or commit messages. This creates false positives — issues appear resolved when they were never actually implemented.
+
+### Evidence
+
+Recent examples of closed-without-merge PRs that may have falsely closed issues:
+- PR #378 (closed, not merged) — duplicate of #375
+- PR #373 (closed, not merged) — conflicts with #375
+- PR #361, #360, #359, #357, #355, #354 — all closed without merge
+
+## Root Cause
+
+GitHub closes linked issues when a PR is closed (not just merged) if the PR body or commits contain closing keywords (`Closes`, `Fixes`, `Resolves`). Wave's `implement` and `speckit-flow` pipelines include these keywords in auto-generated PR descriptions.
+
+## Acceptance Criteria
+
+- [ ] Identify all sources of closing keywords in Wave pipeline PR templates/personas
+- [ ] Replace closing keywords (`Closes`, `Fixes`, `Resolves`) with non-closing references (`Related to #N` or `For #N`) in all PR creation prompts
+- [ ] Update the format validator (`internal/contract/format_validator.go`) to accept non-closing issue references instead of requiring closing keywords
+- [ ] Update the format validator test to use non-closing references
+- [ ] Update epic report search patterns to also find PRs using non-closing references
+- [ ] Audit pipeline search patterns (wave-audit) should continue to search for both old closing keywords AND new non-closing references (for backward compatibility with historical PRs)
+- [ ] Document the chosen strategy
+
+## Additional Context
+
+Comment from @nextlevelshit:
+> in general we should have some after impl pipelines like updating the docs, changelogs, readme or anything else useful after or right before merging, like replying to a code review and triage the issues found ...

--- a/specs/379-fix-autoclose-keywords/tasks.md
+++ b/specs/379-fix-autoclose-keywords/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Phase 1: Core Fix — Replace Closing Keywords in Unified Prompts
+
+- [X] Task 1.1: Update `internal/defaults/prompts/implement/create-pr.md` — replace all `Closes #<NUMBER>` / `Closes #<ISSUE_NUMBER>` with `Related to #<NUMBER>` / `Related to #<ISSUE_NUMBER>` in all four forge template examples (GitHub, GitLab, Bitbucket, Gitea) and in the CONSTRAINTS section
+- [X] Task 1.2: Update `internal/contract/format_validator.go` — change the issue reference regex at line 168 to also accept `Related to #N` pattern: `(?i)(closes|fixes|resolves|related\s+to)\s+#\d+`; update violation message at line 169 to say `"PR body should reference related issues (Related to #123 or Closes #123)"`
+- [X] Task 1.3: Update `internal/contract/format_validator_test.go` — change the test case at line 144 from `Closes #123` to `Related to #123` to verify the new default pattern works
+
+## Phase 2: Deprecated Forge-Specific Prompts [P]
+
+- [X] Task 2.1: Update `.wave/prompts/gh-implement/create-pr.md` — replace `Closes #<NUMBER>` with `Related to #<NUMBER>` in PR body template and CONSTRAINTS section [P]
+- [X] Task 2.2: Update `.wave/prompts/gl-implement/create-mr.md` — replace `Closes #<NUMBER>` / `Closes #<ISSUE_NUMBER>` with `Related to` equivalents in MR body template and CONSTRAINTS section [P]
+- [X] Task 2.3: Update `.wave/prompts/gt-implement/create-pr.md` — replace `Closes #<NUMBER>` / `Closes #<ISSUE_NUMBER>` with `Related to` equivalents in PR body template and CONSTRAINTS section [P]
+- [X] Task 2.4: Update `.wave/prompts/bb-implement/create-pr.md` — replace `Closes #NUMBER` / `Closes #<NUMBER>` with `Related to` equivalents in PR body template and CONSTRAINTS section [P]
+
+## Phase 3: Epic Report Search Patterns [P]
+
+- [X] Task 3.1: Update `.wave/prompts/gh-implement-epic/report.md` — change `gh pr list --search "Closes #<SUBISSUE_NUMBER>"` to search for both old and new patterns: `"Closes #<N> OR Related to #<N>"` [P]
+- [X] Task 3.2: Update `.wave/prompts/gl-implement-epic/report.md` — change `glab mr list --search "Closes #<SUBISSUE_NUMBER>"` to search for both patterns [P]
+- [X] Task 3.3: Update `.wave/prompts/gt-implement-epic/report.md` — update `tea` search/jq filter to match both `Closes` and `Related to` patterns [P]
+- [X] Task 3.4: Update `.wave/prompts/bb-implement-epic/report.md` — update Bitbucket API search query to match both `closes` and `related+to` patterns [P]
+
+## Phase 4: Audit Pipeline Backward Compatibility [P]
+
+- [X] Task 4.1: Update `internal/defaults/pipelines/wave-audit.yaml` — add `"Related to #N"` alongside existing `"Fixes #N", "Closes #N"` in the linked_prs search pattern description [P]
+- [X] Task 4.2: Update `.wave/pipelines/wave-audit.yaml` — same change as above for the local override copy [P]
+
+## Phase 5: Testing and Validation
+
+- [X] Task 5.1: Run `go test -race ./...` to verify no test regressions
+- [X] Task 5.2: Run grep audit to confirm no remaining closing keywords in generation contexts (only in search/validator contexts)


### PR DESCRIPTION
## Summary

- Replace `Closes #N` / `Fixes #N` auto-close keywords with `Related to #N` in all PR/MR template prompts across GitHub, GitLab, Bitbucket, and Gitea forge variants
- Update the unified `create-pr.md` prompt in `internal/defaults/prompts/implement/` with the same change
- Update epic report prompts to also search for `Related to #N` references when checking subissue status
- Extend the format validator regex to accept `Related to #N` as a valid issue reference pattern
- Update `wave-audit.yaml` pipeline to recognize the new reference format when searching for linked PRs

This prevents GitHub (and other forges) from falsely closing linked issues when a PR is closed without being merged.

Related to #379

## Changes

- `internal/defaults/prompts/implement/create-pr.md` — replaced `Closes #N` with `Related to #N` in PR body template and instructions
- `.wave/prompts/gh-implement/create-pr.md` — same change for GitHub-specific (deprecated) prompt
- `.wave/prompts/gl-implement/create-mr.md` — same change for GitLab-specific (deprecated) prompt
- `.wave/prompts/bb-implement/create-pr.md` — same change for Bitbucket-specific (deprecated) prompt
- `.wave/prompts/gt-implement/create-pr.md` — same change for Gitea-specific (deprecated) prompt
- `.wave/prompts/{gh,gl,bb,gt}-implement-epic/report.md` — updated PR search queries to include `Related to #N`
- `internal/contract/format_validator.go` — extended regex to accept `Related to #N` as valid issue reference
- `internal/contract/format_validator_test.go` — updated test expectation for new validation message
- `.wave/pipelines/wave-audit.yaml` and `internal/defaults/pipelines/wave-audit.yaml` — added `Related to #N` to linked PR search patterns

## Test Plan

- `go test ./internal/contract/...` validates the updated format validator accepts `Related to #N`
- All existing tests pass with `go test ./...`
- New PRs created by Wave pipelines will use `Related to #N` instead of `Closes #N`, preventing false issue closures when PRs are closed without merge
