### PR TITLE
feat(init): flavour auto-detection, cold-start, and format_command

### DIFF
--- a/cmd/wave/commands/init.go
+++ b/cmd/wave/commands/init.go
@@ -3,15 +3,17 @@ package commands
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/recinq/wave/internal/defaults"
+	"github.com/recinq/wave/internal/flavour"
+	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/onboarding"
 	"github.com/recinq/wave/internal/pipeline"
@@ -167,6 +169,41 @@ func getFilteredAssets(cmd *cobra.Command, opts InitOptions) (*initAssets, error
 
 	contracts, prompts, personaConfigs := filterTransitiveDeps(cmd, pipelines, allContracts, allPrompts, allPersonaConfigs)
 
+	// Apply forge-based filtering (FR-008)
+	forgeInfo, _ := forge.DetectFromGitRemotes()
+	if forgeInfo.Type != forge.ForgeUnknown {
+		pipelineNames := make([]string, 0, len(pipelines))
+		for name := range pipelines {
+			pipelineNames = append(pipelineNames, strings.TrimSuffix(name, ".yaml"))
+		}
+		filtered := forge.FilterPipelinesByForge(forgeInfo.Type, pipelineNames)
+		filteredSet := make(map[string]bool, len(filtered))
+		for _, name := range filtered {
+			filteredSet[name] = true
+		}
+		for name := range pipelines {
+			baseName := strings.TrimSuffix(name, ".yaml")
+			if !filteredSet[baseName] {
+				delete(pipelines, name)
+			}
+		}
+	}
+
+	// Required pipelines safeguard (FR-010)
+	requiredPipelines := []string{"impl-issue"}
+	for _, req := range requiredPipelines {
+		yamlName := req + ".yaml"
+		if _, ok := pipelines[yamlName]; !ok {
+			// Re-fetch from all pipelines
+			allPipelines, err := defaults.GetPipelines()
+			if err == nil {
+				if content, ok := allPipelines[yamlName]; ok {
+					pipelines[yamlName] = content
+				}
+			}
+		}
+	}
+
 	return &initAssets{
 		personas:       personas,
 		personaConfigs: personaConfigs,
@@ -264,10 +301,37 @@ func filterTransitiveDeps(cmd *cobra.Command, pipelines, allContracts, allPrompt
 	return contracts, prompts, personaConfigs
 }
 
+// ensureGitRepo checks for .git directory existence and initializes a git
+// repository if absent. Returns needsInitialCommit=true when the repository
+// has no prior commits.
+func ensureGitRepo() (needsInitialCommit bool, err error) {
+	if _, err := os.Stat(".git"); os.IsNotExist(err) {
+		cmd := exec.Command("git", "init")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return false, fmt.Errorf("git init failed: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+		return true, nil
+	}
+
+	// Check for commits
+	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	if err := cmd.Run(); err != nil {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func runInit(cmd *cobra.Command, opts InitOptions) error {
 	// Handle --reconfigure: clear onboarding state and re-run wizard
 	if opts.Reconfigure {
 		return runReconfigure(cmd, opts)
+	}
+
+	// Cold-start: ensure git repository exists (FR-001)
+	needsInitialCommit, err := ensureGitRepo()
+	if err != nil {
+		return err
 	}
 
 	// Determine if we should run the interactive wizard
@@ -324,6 +388,12 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 	}
 
 	project := detectProject()
+	// Extract project metadata only when a project was detected (FR-009)
+	var metadata flavour.MetadataResult
+	if project != nil {
+		metadata = flavour.DetectMetadata(".")
+	}
+
 	// Get filtered assets based on --all flag (needed for persona configs in manifest)
 	assets, err := getFilteredAssets(cmd, opts)
 	if err != nil {
@@ -331,6 +401,14 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 	}
 
 	manifest := createDefaultManifest(opts.Adapter, opts.Workspace, project, assets.personaConfigs)
+	if metadata.Name != "" {
+		if md, ok := manifest["metadata"].(map[string]interface{}); ok {
+			md["name"] = metadata.Name
+			if metadata.Description != "" {
+				md["description"] = metadata.Description
+			}
+		}
+	}
 	manifestData, err := yaml.Marshal(manifest)
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
@@ -366,6 +444,13 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 	}
 
 	printInitSuccess(cmd, opts.OutputPath, assets)
+
+	// Cold-start: create initial commit if needed (FR-002)
+	if needsInitialCommit {
+		exec.Command("git", "add", "wave.yaml", ".wave/").Run()
+		exec.Command("git", "commit", "-m", "chore: initialize wave project").Run()
+	}
+
 	return nil
 }
 
@@ -787,6 +872,25 @@ func applyChanges(summary *ChangeSummary, outputPath string) error {
 	return nil
 }
 
+// suggestFirstPipeline checks for non-Wave source files and suggests
+// an appropriate first pipeline to run.
+func suggestFirstPipeline(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "ops-bootstrap"
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "wave.yaml" || name == ".wave" || name == ".git" || name == ".claude" {
+			continue
+		}
+		if !strings.HasPrefix(name, ".") {
+			return "audit-dx"
+		}
+	}
+	return "ops-bootstrap"
+}
+
 func printInitSuccess(cmd *cobra.Command, outputPath string, assets *initAssets) {
 	out := cmd.OutOrStdout()
 
@@ -816,10 +920,10 @@ func printInitSuccess(cmd *cobra.Command, outputPath string, assets *initAssets)
 	fmt.Fprintf(out, "\n")
 	fmt.Fprintf(out, "  Pipelines: %s\n", strings.Join(pipelineNames, ", "))
 	fmt.Fprintf(out, "\n")
+	suggested := suggestFirstPipeline(".")
 	fmt.Fprintf(out, "  Next steps:\n")
 	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
-	fmt.Fprintf(out, "    2. Run 'wave run ops-hello-world \"test\"' to verify setup\n")
-	fmt.Fprintf(out, "    3. Run 'wave run plan-task \"your feature\"' to plan a task\n")
+	fmt.Fprintf(out, "    2. Run 'wave run %s' to get started\n", suggested)
 	fmt.Fprintf(out, "\n")
 }
 
@@ -848,123 +952,31 @@ func printMergeSuccess(cmd *cobra.Command, outputPath string) {
 // a map suitable for inclusion as the "project" key in the manifest YAML.
 // Returns nil if no known project type is detected.
 func detectProject() map[string]interface{} {
-	fileExists := func(name string) bool {
-		_, err := os.Stat(name)
-		return err == nil
+	result := flavour.Detect(".")
+	if result.Flavour == "" {
+		return nil
 	}
 
-	// Check markers in priority order — first match wins
-	switch {
-	case fileExists("go.mod"):
-		return map[string]interface{}{
-			"language":      "go",
-			"test_command":  "go test ./...",
-			"lint_command":  "go vet ./...",
-			"build_command": "go build ./...",
-			"source_glob":   "*.go",
-		}
-
-	case fileExists("deno.json") || fileExists("deno.jsonc"):
-		return map[string]interface{}{
-			"language":      "typescript",
-			"test_command":  "deno test",
-			"lint_command":  "deno lint",
-			"build_command": "deno compile",
-			"source_glob":   "*.{ts,tsx}",
-		}
-
-	case fileExists("package.json"):
-		return detectNodeProject()
-
-	case fileExists("Cargo.toml"):
-		return map[string]interface{}{
-			"language":      "rust",
-			"test_command":  "cargo test",
-			"lint_command":  "cargo clippy",
-			"build_command": "cargo build",
-			"source_glob":   "*.rs",
-		}
-
-	case fileExists("pyproject.toml") || fileExists("setup.py"):
-		return map[string]interface{}{
-			"language":     "python",
-			"test_command": "pytest",
-			"lint_command": "ruff check .",
-			"source_glob":  "*.py",
-		}
+	project := map[string]interface{}{
+		"flavour":  result.Flavour,
+		"language": result.Language,
 	}
-
-	return nil
-}
-
-// detectNodeProject reads package.json to determine the package manager and
-// extract actual script commands for test, lint, and build.
-func detectNodeProject() map[string]interface{} {
-	fileExists := func(name string) bool {
-		_, err := os.Stat(name)
-		return err == nil
+	if result.TestCommand != "" {
+		project["test_command"] = result.TestCommand
 	}
-
-	// Determine package manager from lockfiles
-	runner := "npm"
-	switch {
-	case fileExists("bun.lockb") || fileExists("bun.lock"):
-		runner = "bun"
-	case fileExists("pnpm-lock.yaml"):
-		runner = "pnpm"
-	case fileExists("yarn.lock"):
-		runner = "yarn"
+	if result.LintCommand != "" {
+		project["lint_command"] = result.LintCommand
 	}
-
-	// Determine language from tsconfig presence
-	language := "javascript"
-	sourceGlob := "*.{js,jsx}"
-	if fileExists("tsconfig.json") {
-		language = "typescript"
-		sourceGlob = "*.{ts,tsx}"
+	if result.BuildCommand != "" {
+		project["build_command"] = result.BuildCommand
 	}
-
-	result := map[string]interface{}{
-		"language":    language,
-		"source_glob": sourceGlob,
+	if result.FormatCommand != "" {
+		project["format_command"] = result.FormatCommand
 	}
-
-	// Read package.json scripts to derive actual commands
-	data, err := os.ReadFile("package.json")
-	if err != nil {
-		return result
+	if result.SourceGlob != "" {
+		project["source_glob"] = result.SourceGlob
 	}
-
-	var pkg struct {
-		Scripts map[string]string `json:"scripts"`
-	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return result
-	}
-
-	runCmd := func(script string) string {
-		if runner == "npm" {
-			return "npm run " + script
-		}
-		return runner + " run " + script
-	}
-
-	// Map well-known script names to project commands
-	if _, ok := pkg.Scripts["test"]; ok {
-		if runner == "npm" {
-			result["test_command"] = "npm test"
-		} else {
-			result["test_command"] = runner + " test"
-		}
-	}
-	if _, ok := pkg.Scripts["lint"]; ok {
-		result["lint_command"] = runCmd("lint")
-	}
-	if _, ok := pkg.Scripts["build"]; ok {
-		result["build_command"] = runCmd("build")
-	}
-
-	return result
+	return project
 }
 
 // buildPersonaManifest converts parsed persona configs into the map[string]interface{}
@@ -1166,6 +1178,12 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 	// Print Wave logo
 	fmt.Fprintln(cmd.OutOrStdout(), tui.WaveLogo())
 
+	// Cold-start: ensure git repository exists (FR-001)
+	needsInitialCommit, err := ensureGitRepo()
+	if err != nil {
+		return err
+	}
+
 	// Check if wave.yaml already exists
 	var existing *manifest.Manifest
 	if data, err := os.ReadFile(opts.OutputPath); err == nil {
@@ -1246,6 +1264,13 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 	}
 
 	printWizardSuccess(cmd, opts.OutputPath, result)
+
+	// Cold-start: create initial commit if needed (FR-002)
+	if needsInitialCommit {
+		exec.Command("git", "add", "wave.yaml", ".wave/").Run()
+		exec.Command("git", "commit", "-m", "chore: initialize wave project").Run()
+	}
+
 	return nil
 }
 
@@ -1347,8 +1372,9 @@ func printWizardSuccess(cmd *cobra.Command, outputPath string, result *onboardin
 		fmt.Fprintf(out, "    %-20s %d selected\n", "Pipelines:", len(result.Pipelines))
 	}
 	fmt.Fprintf(out, "\n")
+	suggested := suggestFirstPipeline(".")
 	fmt.Fprintf(out, "  Next steps:\n")
 	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
-	fmt.Fprintf(out, "    2. Run 'wave run' to select and execute a pipeline\n")
+	fmt.Fprintf(out, "    2. Run 'wave run %s' to get started\n", suggested)
 	fmt.Fprintf(out, "\n")
 }

--- a/cmd/wave/commands/init_test.go
+++ b/cmd/wave/commands/init_test.go
@@ -307,7 +307,8 @@ func TestInitCreatesPipelineFiles(t *testing.T) {
 		assert.Equal(t, "WavePipeline", pipelineData["kind"], "%s should have kind WavePipeline", pipeline)
 	}
 
-	// Verify non-release pipelines are NOT created
+	// Verify non-release pipelines are NOT created (except required ones)
+	requiredPipelines := map[string]bool{"impl-issue.yaml": true}
 	allPipelines := defaults.PipelineNames()
 	for _, pipeline := range allPipelines {
 		isRelease := false
@@ -317,7 +318,7 @@ func TestInitCreatesPipelineFiles(t *testing.T) {
 				break
 			}
 		}
-		if !isRelease {
+		if !isRelease && !requiredPipelines[pipeline] {
 			path := filepath.Join(".wave", "pipelines", pipeline)
 			assert.False(t, fileExists(path), "non-release pipeline file %s should NOT be created", pipeline)
 		}
@@ -742,7 +743,8 @@ func TestInitAllFlagExtractsAllPipelines(t *testing.T) {
 	assert.Equal(t, len(allPipelines), len(entries), "--all should create all pipeline files")
 }
 
-// TestInitDefaultOnlyReleasePipelines tests that default wave init writes only release pipelines.
+// TestInitDefaultOnlyReleasePipelines tests that default wave init writes only release pipelines
+// plus any required pipelines (e.g., impl-issue) that are always included via the safeguard.
 func TestInitDefaultOnlyReleasePipelines(t *testing.T) {
 	env := newTestEnv(t)
 	defer env.cleanup()
@@ -753,13 +755,27 @@ func TestInitDefaultOnlyReleasePipelines(t *testing.T) {
 	releasePipelines, err := defaults.GetReleasePipelines()
 	require.NoError(t, err)
 
+	// Required pipelines are always included even if not marked release
+	requiredPipelines := []string{"impl-issue.yaml"}
+	expectedCount := len(releasePipelines)
+	for _, req := range requiredPipelines {
+		if _, ok := releasePipelines[req]; !ok {
+			expectedCount++
+		}
+	}
+
 	entries, err := os.ReadDir(".wave/pipelines")
 	require.NoError(t, err)
-	assert.Equal(t, len(releasePipelines), len(entries), "default init should create only release pipeline files")
+	assert.Equal(t, expectedCount, len(entries), "default init should create release + required pipeline files")
 
+	requiredSet := make(map[string]bool)
+	for _, req := range requiredPipelines {
+		requiredSet[req] = true
+	}
 	for _, entry := range entries {
 		_, isRelease := releasePipelines[entry.Name()]
-		assert.True(t, isRelease, "pipeline %s should be a release pipeline", entry.Name())
+		isRequired := requiredSet[entry.Name()]
+		assert.True(t, isRelease || isRequired, "pipeline %s should be a release or required pipeline", entry.Name())
 	}
 }
 
@@ -891,8 +907,16 @@ func TestInitDisplayShowsFilteredCounts(t *testing.T) {
 	releasePipelines, err := defaults.GetReleasePipelines()
 	require.NoError(t, err)
 
-	// The output should show the filtered pipeline count
-	expectedCount := fmt.Sprintf("%d pipelines", len(releasePipelines))
+	// The output should show the pipeline count (release + required)
+	// Required pipelines (e.g., impl-issue) may add to the count
+	requiredExtra := 0
+	requiredPipelines := []string{"impl-issue.yaml"}
+	for _, req := range requiredPipelines {
+		if _, ok := releasePipelines[req]; !ok {
+			requiredExtra++
+		}
+	}
+	expectedCount := fmt.Sprintf("%d pipelines", len(releasePipelines)+requiredExtra)
 	assert.Contains(t, stdout, expectedCount,
 		"init output should show filtered pipeline count")
 }
@@ -1808,5 +1832,87 @@ func TestInitMergeEdgeCases(t *testing.T) {
 		require.Error(t, err, "merge without --yes in non-interactive terminal should fail")
 		assert.Contains(t, err.Error(), "non-interactive",
 			"error should mention non-interactive terminal, got: %v", err)
+	})
+}
+
+// TestEnsureGitRepo tests the cold-start git repository initialization scenarios.
+func TestEnsureGitRepo(t *testing.T) {
+	t.Run("initializes git in empty dir", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.cleanup()
+
+		needsCommit, err := ensureGitRepo()
+		require.NoError(t, err)
+		assert.True(t, needsCommit)
+		assert.DirExists(t, ".git")
+	})
+
+	t.Run("detects no commits", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.cleanup()
+
+		cmd := exec.Command("git", "init")
+		require.NoError(t, cmd.Run())
+
+		needsCommit, err := ensureGitRepo()
+		require.NoError(t, err)
+		assert.True(t, needsCommit)
+	})
+
+	t.Run("detects existing commits", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.cleanup()
+
+		require.NoError(t, exec.Command("git", "init").Run())
+		require.NoError(t, exec.Command("git", "config", "user.email", "test@test.com").Run())
+		require.NoError(t, exec.Command("git", "config", "user.name", "Test").Run())
+		require.NoError(t, os.WriteFile("dummy.txt", []byte("hello"), 0644))
+		require.NoError(t, exec.Command("git", "add", ".").Run())
+		require.NoError(t, exec.Command("git", "commit", "-m", "initial").Run())
+
+		needsCommit, err := ensureGitRepo()
+		require.NoError(t, err)
+		assert.False(t, needsCommit)
+	})
+}
+
+// TestDetectProjectInInit tests that detectProject() uses the flavour package.
+func TestDetectProjectInInit(t *testing.T) {
+	t.Run("detects go project with flavour", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.cleanup()
+
+		require.NoError(t, os.WriteFile("go.mod", []byte("module example.com/test\n\ngo 1.21\n"), 0644))
+
+		result := detectProject()
+		require.NotNil(t, result)
+		assert.Equal(t, "go", result["flavour"])
+		assert.Equal(t, "go", result["language"])
+		assert.Equal(t, "go test ./...", result["test_command"])
+		assert.Equal(t, "gofmt -l .", result["format_command"])
+	})
+
+	t.Run("returns nil for unknown project", func(t *testing.T) {
+		env := newTestEnv(t)
+		defer env.cleanup()
+
+		result := detectProject()
+		assert.Nil(t, result)
+	})
+}
+
+// TestSuggestFirstPipeline tests the pipeline suggestion logic.
+func TestSuggestFirstPipeline(t *testing.T) {
+	t.Run("suggests audit-dx for existing code", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0644))
+		assert.Equal(t, "audit-dx", suggestFirstPipeline(dir))
+	})
+
+	t.Run("suggests ops-bootstrap for empty project", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".wave"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "wave.yaml"), []byte("apiVersion: v1"), 0644))
+		assert.Equal(t, "ops-bootstrap", suggestFirstPipeline(dir))
 	})
 }

--- a/internal/flavour/detect.go
+++ b/internal/flavour/detect.go
@@ -1,0 +1,303 @@
+package flavour
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// DetectionResult holds the result of flavour detection for a project directory.
+type DetectionResult struct {
+	Flavour       string
+	Language      string
+	TestCommand   string
+	LintCommand   string
+	BuildCommand  string
+	FormatCommand string
+	SourceGlob    string
+}
+
+// DetectionRule maps marker files to a flavour detection result.
+type DetectionRule struct {
+	Markers []string
+	Result  DetectionResult
+}
+
+// rules is the priority-ordered list of detection rules.
+// More specific markers (e.g., bun.lock) come before generic ones (e.g., package.json).
+var rules = []DetectionRule{
+	// Go
+	{Markers: []string{"go.mod"}, Result: DetectionResult{
+		Flavour: "go", Language: "go",
+		TestCommand: "go test ./...", LintCommand: "go vet ./...",
+		BuildCommand: "go build ./...", FormatCommand: "gofmt -l .",
+		SourceGlob: "*.go",
+	}},
+	// Rust
+	{Markers: []string{"Cargo.toml"}, Result: DetectionResult{
+		Flavour: "rust", Language: "rust",
+		TestCommand: "cargo test", LintCommand: "cargo clippy",
+		BuildCommand: "cargo build", FormatCommand: "cargo fmt -- --check",
+		SourceGlob: "*.rs",
+	}},
+	// Deno (before generic Node)
+	{Markers: []string{"deno.json", "deno.jsonc"}, Result: DetectionResult{
+		Flavour: "deno", Language: "typescript",
+		TestCommand: "deno test", LintCommand: "deno lint",
+		BuildCommand: "deno compile", FormatCommand: "deno fmt --check",
+		SourceGlob: "*.{ts,tsx}",
+	}},
+	// Bun (before generic Node)
+	{Markers: []string{"bun.lockb", "bun.lock"}, Result: DetectionResult{
+		Flavour: "bun", Language: "typescript",
+		TestCommand: "bun test", LintCommand: "bun run lint",
+		BuildCommand: "bun run build", FormatCommand: "",
+		SourceGlob: "*.{ts,tsx}",
+	}},
+	// pnpm
+	{Markers: []string{"pnpm-lock.yaml"}, Result: DetectionResult{
+		Flavour: "pnpm", Language: "javascript",
+		TestCommand: "pnpm test", LintCommand: "pnpm run lint",
+		BuildCommand: "pnpm run build", FormatCommand: "",
+		SourceGlob: "*.{js,jsx}",
+	}},
+	// Yarn
+	{Markers: []string{"yarn.lock"}, Result: DetectionResult{
+		Flavour: "yarn", Language: "javascript",
+		TestCommand: "yarn test", LintCommand: "yarn run lint",
+		BuildCommand: "yarn run build", FormatCommand: "",
+		SourceGlob: "*.{js,jsx}",
+	}},
+	// npm (generic Node, lowest Node priority)
+	{Markers: []string{"package.json"}, Result: DetectionResult{
+		Flavour: "node", Language: "javascript",
+		TestCommand: "npm test", LintCommand: "npm run lint",
+		BuildCommand: "npm run build", FormatCommand: "",
+		SourceGlob: "*.{js,jsx}",
+	}},
+	// Python (modern)
+	{Markers: []string{"pyproject.toml"}, Result: DetectionResult{
+		Flavour: "python", Language: "python",
+		TestCommand: "pytest", LintCommand: "ruff check .",
+		BuildCommand: "", FormatCommand: "ruff format --check .",
+		SourceGlob: "*.py",
+	}},
+	// Python (legacy)
+	{Markers: []string{"setup.py"}, Result: DetectionResult{
+		Flavour: "python", Language: "python",
+		TestCommand: "pytest", LintCommand: "ruff check .",
+		BuildCommand: "python setup.py build", FormatCommand: "ruff format --check .",
+		SourceGlob: "*.py",
+	}},
+	// C#
+	{Markers: []string{"*.csproj", "*.sln"}, Result: DetectionResult{
+		Flavour: "dotnet", Language: "csharp",
+		TestCommand: "dotnet test", LintCommand: "dotnet format --verify-no-changes",
+		BuildCommand: "dotnet build", FormatCommand: "dotnet format --verify-no-changes",
+		SourceGlob: "*.cs",
+	}},
+	// Java (Maven)
+	{Markers: []string{"pom.xml"}, Result: DetectionResult{
+		Flavour: "maven", Language: "java",
+		TestCommand: "mvn test", LintCommand: "mvn checkstyle:check",
+		BuildCommand: "mvn package", FormatCommand: "",
+		SourceGlob: "*.java",
+	}},
+	// Java (Gradle) — NOTE: build.gradle.kts also matches Kotlin below, but Gradle (Java) comes first.
+	// If a project has ONLY build.gradle.kts without .kt source files, they'll get gradle/java.
+	{Markers: []string{"build.gradle", "build.gradle.kts"}, Result: DetectionResult{
+		Flavour: "gradle", Language: "java",
+		TestCommand: "./gradlew test", LintCommand: "./gradlew check",
+		BuildCommand: "./gradlew build", FormatCommand: "",
+		SourceGlob: "*.java",
+	}},
+	// Elixir
+	{Markers: []string{"mix.exs"}, Result: DetectionResult{
+		Flavour: "elixir", Language: "elixir",
+		TestCommand: "mix test", LintCommand: "mix credo",
+		BuildCommand: "mix compile", FormatCommand: "mix format --check-formatted",
+		SourceGlob: "*.{ex,exs}",
+	}},
+	// Dart/Flutter
+	{Markers: []string{"pubspec.yaml"}, Result: DetectionResult{
+		Flavour: "dart", Language: "dart",
+		TestCommand: "dart test", LintCommand: "dart analyze",
+		BuildCommand: "dart compile exe", FormatCommand: "dart format --set-exit-if-changed .",
+		SourceGlob: "*.dart",
+	}},
+	// C++ (CMake)
+	{Markers: []string{"CMakeLists.txt"}, Result: DetectionResult{
+		Flavour: "cmake", Language: "cpp",
+		TestCommand: "ctest", LintCommand: "",
+		BuildCommand: "cmake --build build", FormatCommand: "",
+		SourceGlob: "*.{cpp,hpp,cc,h}",
+	}},
+	// Make
+	{Markers: []string{"Makefile"}, Result: DetectionResult{
+		Flavour: "make", Language: "",
+		TestCommand: "make test", LintCommand: "make lint",
+		BuildCommand: "make build", FormatCommand: "",
+		SourceGlob: "",
+	}},
+	// PHP
+	{Markers: []string{"composer.json"}, Result: DetectionResult{
+		Flavour: "php", Language: "php",
+		TestCommand: "vendor/bin/phpunit", LintCommand: "vendor/bin/phpstan analyse",
+		BuildCommand: "", FormatCommand: "vendor/bin/php-cs-fixer fix --dry-run",
+		SourceGlob: "*.php",
+	}},
+	// Ruby
+	{Markers: []string{"Gemfile"}, Result: DetectionResult{
+		Flavour: "ruby", Language: "ruby",
+		TestCommand: "bundle exec rspec", LintCommand: "bundle exec rubocop",
+		BuildCommand: "", FormatCommand: "bundle exec rubocop -A --fail-level error",
+		SourceGlob: "*.rb",
+	}},
+	// Swift
+	{Markers: []string{"Package.swift"}, Result: DetectionResult{
+		Flavour: "swift", Language: "swift",
+		TestCommand: "swift test", LintCommand: "swift package diagnose-api-breaking-changes",
+		BuildCommand: "swift build", FormatCommand: "swift-format lint -r .",
+		SourceGlob: "*.swift",
+	}},
+	// Zig
+	{Markers: []string{"build.zig"}, Result: DetectionResult{
+		Flavour: "zig", Language: "zig",
+		TestCommand: "zig build test", LintCommand: "",
+		BuildCommand: "zig build", FormatCommand: "zig fmt --check .",
+		SourceGlob: "*.zig",
+	}},
+	// Scala (sbt)
+	{Markers: []string{"build.sbt"}, Result: DetectionResult{
+		Flavour: "scala", Language: "scala",
+		TestCommand: "sbt test", LintCommand: "sbt scalafmtCheck",
+		BuildCommand: "sbt compile", FormatCommand: "sbt scalafmt",
+		SourceGlob: "*.scala",
+	}},
+	// Haskell (Cabal)
+	{Markers: []string{"*.cabal"}, Result: DetectionResult{
+		Flavour: "cabal", Language: "haskell",
+		TestCommand: "cabal test", LintCommand: "hlint .",
+		BuildCommand: "cabal build", FormatCommand: "",
+		SourceGlob: "*.hs",
+	}},
+	// Haskell (Stack)
+	{Markers: []string{"stack.yaml"}, Result: DetectionResult{
+		Flavour: "stack", Language: "haskell",
+		TestCommand: "stack test", LintCommand: "hlint .",
+		BuildCommand: "stack build", FormatCommand: "",
+		SourceGlob: "*.hs",
+	}},
+	// TypeScript standalone (tsconfig but no package.json)
+	{Markers: []string{"tsconfig.json"}, Result: DetectionResult{
+		Flavour: "typescript", Language: "typescript",
+		TestCommand: "", LintCommand: "tsc --noEmit",
+		BuildCommand: "tsc", FormatCommand: "",
+		SourceGlob: "*.{ts,tsx}",
+	}},
+}
+
+// nodeFlavours is the set of flavours that are Node-based and support refinement.
+var nodeFlavours = map[string]bool{
+	"node": true,
+	"bun":  true,
+	"pnpm": true,
+	"yarn": true,
+}
+
+// Detect scans the given directory for marker files and returns the first
+// matching flavour detection result. Returns a zero-value DetectionResult
+// if no markers match.
+func Detect(dir string) DetectionResult {
+	for _, rule := range rules {
+		if matchesAny(dir, rule.Markers) {
+			result := rule.Result
+			// Apply Node refinement for Node-based flavours
+			if nodeFlavours[result.Flavour] {
+				refineNodeResult(dir, &result)
+			}
+			return result
+		}
+	}
+	return DetectionResult{}
+}
+
+// matchesAny checks if any of the marker patterns exist in the directory.
+// Supports both exact filenames and glob patterns (e.g., "*.csproj").
+func matchesAny(dir string, markers []string) bool {
+	for _, marker := range markers {
+		if isGlobPattern(marker) {
+			matches, err := filepath.Glob(filepath.Join(dir, marker))
+			if err == nil && len(matches) > 0 {
+				return true
+			}
+		} else {
+			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isGlobPattern returns true if the string contains glob metacharacters.
+func isGlobPattern(s string) bool {
+	for _, c := range s {
+		if c == '*' || c == '?' || c == '[' {
+			return true
+		}
+	}
+	return false
+}
+
+// refineNodeResult checks for tsconfig.json and reads package.json scripts
+// to refine the detection result for Node-based projects.
+func refineNodeResult(dir string, result *DetectionResult) {
+	// Check for TypeScript
+	if _, err := os.Stat(filepath.Join(dir, "tsconfig.json")); err == nil {
+		result.Language = "typescript"
+		result.SourceGlob = "*.{ts,tsx}"
+	}
+
+	// Read package.json scripts to derive actual commands
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return
+	}
+
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return
+	}
+
+	runner := result.Flavour
+	if runner == "node" {
+		runner = "npm"
+	}
+
+	runCmd := func(script string) string {
+		if runner == "npm" {
+			return "npm run " + script
+		}
+		return runner + " run " + script
+	}
+
+	if _, ok := pkg.Scripts["test"]; ok {
+		if runner == "npm" {
+			result.TestCommand = "npm test"
+		} else {
+			result.TestCommand = runner + " test"
+		}
+	}
+	if _, ok := pkg.Scripts["lint"]; ok {
+		result.LintCommand = runCmd("lint")
+	}
+	if _, ok := pkg.Scripts["build"]; ok {
+		result.BuildCommand = runCmd("build")
+	}
+	if _, ok := pkg.Scripts["format"]; ok {
+		result.FormatCommand = runCmd("format")
+	}
+}

--- a/internal/flavour/detect_test.go
+++ b/internal/flavour/detect_test.go
@@ -1,0 +1,510 @@
+package flavour
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetect_AllFlavours verifies that each supported language/toolchain is
+// correctly identified from its marker files.
+func TestDetect_AllFlavours(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string // filename -> content (empty string = touch)
+		expected DetectionResult
+	}{
+		// --- Go ---
+		{
+			name:  "go",
+			files: map[string]string{"go.mod": "module example.com/foo\n\ngo 1.21\n"},
+			expected: DetectionResult{
+				Flavour: "go", Language: "go",
+				TestCommand: "go test ./...", LintCommand: "go vet ./...",
+				BuildCommand: "go build ./...", FormatCommand: "gofmt -l .",
+				SourceGlob: "*.go",
+			},
+		},
+		// --- Rust ---
+		{
+			name:  "rust",
+			files: map[string]string{"Cargo.toml": "[package]\nname = \"myapp\"\n"},
+			expected: DetectionResult{
+				Flavour: "rust", Language: "rust",
+				TestCommand: "cargo test", LintCommand: "cargo clippy",
+				BuildCommand: "cargo build", FormatCommand: "cargo fmt -- --check",
+				SourceGlob: "*.rs",
+			},
+		},
+		// --- Deno (deno.json) ---
+		{
+			name:  "deno_json",
+			files: map[string]string{"deno.json": "{}"},
+			expected: DetectionResult{
+				Flavour: "deno", Language: "typescript",
+				TestCommand: "deno test", LintCommand: "deno lint",
+				BuildCommand: "deno compile", FormatCommand: "deno fmt --check",
+				SourceGlob: "*.{ts,tsx}",
+			},
+		},
+		// --- Deno (deno.jsonc) ---
+		{
+			name:  "deno_jsonc",
+			files: map[string]string{"deno.jsonc": "{}"},
+			expected: DetectionResult{
+				Flavour: "deno", Language: "typescript",
+				TestCommand: "deno test", LintCommand: "deno lint",
+				BuildCommand: "deno compile", FormatCommand: "deno fmt --check",
+				SourceGlob: "*.{ts,tsx}",
+			},
+		},
+		// --- Bun (bun.lockb) ---
+		{
+			name:  "bun_lockb",
+			files: map[string]string{"bun.lockb": "", "package.json": `{"name":"x"}`},
+			expected: DetectionResult{
+				Flavour: "bun", Language: "typescript",
+				TestCommand: "bun test", LintCommand: "bun run lint",
+				BuildCommand: "bun run build", FormatCommand: "",
+				SourceGlob: "*.{ts,tsx}",
+			},
+		},
+		// --- Bun (bun.lock) ---
+		{
+			name:  "bun_lock",
+			files: map[string]string{"bun.lock": "", "package.json": `{"name":"x"}`},
+			expected: DetectionResult{
+				Flavour: "bun", Language: "typescript",
+				TestCommand: "bun test", LintCommand: "bun run lint",
+				BuildCommand: "bun run build", FormatCommand: "",
+				SourceGlob: "*.{ts,tsx}",
+			},
+		},
+		// --- pnpm ---
+		{
+			name:  "pnpm",
+			files: map[string]string{"pnpm-lock.yaml": "", "package.json": `{"name":"x"}`},
+			expected: DetectionResult{
+				Flavour: "pnpm", Language: "javascript",
+				TestCommand: "pnpm test", LintCommand: "pnpm run lint",
+				BuildCommand: "pnpm run build", FormatCommand: "",
+				SourceGlob: "*.{js,jsx}",
+			},
+		},
+		// --- Yarn ---
+		{
+			name:  "yarn",
+			files: map[string]string{"yarn.lock": "", "package.json": `{"name":"x"}`},
+			expected: DetectionResult{
+				Flavour: "yarn", Language: "javascript",
+				TestCommand: "yarn test", LintCommand: "yarn run lint",
+				BuildCommand: "yarn run build", FormatCommand: "",
+				SourceGlob: "*.{js,jsx}",
+			},
+		},
+		// --- Node (generic npm — package.json only, no lockfile) ---
+		{
+			name:  "node",
+			files: map[string]string{"package.json": `{"name":"x"}`},
+			expected: DetectionResult{
+				Flavour: "node", Language: "javascript",
+				TestCommand: "npm test", LintCommand: "npm run lint",
+				BuildCommand: "npm run build", FormatCommand: "",
+				SourceGlob: "*.{js,jsx}",
+			},
+		},
+		// --- Python (modern — pyproject.toml) ---
+		{
+			name:  "python_modern",
+			files: map[string]string{"pyproject.toml": "[project]\nname = \"mylib\"\n"},
+			expected: DetectionResult{
+				Flavour: "python", Language: "python",
+				TestCommand: "pytest", LintCommand: "ruff check .",
+				BuildCommand: "", FormatCommand: "ruff format --check .",
+				SourceGlob: "*.py",
+			},
+		},
+		// --- Python (legacy — setup.py) ---
+		{
+			name:  "python_legacy",
+			files: map[string]string{"setup.py": "from setuptools import setup\nsetup()\n"},
+			expected: DetectionResult{
+				Flavour: "python", Language: "python",
+				TestCommand: "pytest", LintCommand: "ruff check .",
+				BuildCommand: "python setup.py build", FormatCommand: "ruff format --check .",
+				SourceGlob: "*.py",
+			},
+		},
+		// --- .NET (csproj) ---
+		{
+			name:  "dotnet",
+			files: map[string]string{"MyProject.csproj": "<Project></Project>"},
+			expected: DetectionResult{
+				Flavour: "dotnet", Language: "csharp",
+				TestCommand: "dotnet test", LintCommand: "dotnet format --verify-no-changes",
+				BuildCommand: "dotnet build", FormatCommand: "dotnet format --verify-no-changes",
+				SourceGlob: "*.cs",
+			},
+		},
+		// --- Maven ---
+		{
+			name:  "maven",
+			files: map[string]string{"pom.xml": "<project></project>"},
+			expected: DetectionResult{
+				Flavour: "maven", Language: "java",
+				TestCommand: "mvn test", LintCommand: "mvn checkstyle:check",
+				BuildCommand: "mvn package", FormatCommand: "",
+				SourceGlob: "*.java",
+			},
+		},
+		// --- Gradle ---
+		{
+			name:  "gradle",
+			files: map[string]string{"build.gradle": "plugins { id 'java' }"},
+			expected: DetectionResult{
+				Flavour: "gradle", Language: "java",
+				TestCommand: "./gradlew test", LintCommand: "./gradlew check",
+				BuildCommand: "./gradlew build", FormatCommand: "",
+				SourceGlob: "*.java",
+			},
+		},
+		// --- Elixir ---
+		{
+			name:  "elixir",
+			files: map[string]string{"mix.exs": "defmodule MyApp.MixProject do\nend\n"},
+			expected: DetectionResult{
+				Flavour: "elixir", Language: "elixir",
+				TestCommand: "mix test", LintCommand: "mix credo",
+				BuildCommand: "mix compile", FormatCommand: "mix format --check-formatted",
+				SourceGlob: "*.{ex,exs}",
+			},
+		},
+		// --- Dart ---
+		{
+			name:  "dart",
+			files: map[string]string{"pubspec.yaml": "name: myapp\n"},
+			expected: DetectionResult{
+				Flavour: "dart", Language: "dart",
+				TestCommand: "dart test", LintCommand: "dart analyze",
+				BuildCommand: "dart compile exe", FormatCommand: "dart format --set-exit-if-changed .",
+				SourceGlob: "*.dart",
+			},
+		},
+		// --- CMake ---
+		{
+			name:  "cmake",
+			files: map[string]string{"CMakeLists.txt": "cmake_minimum_required(VERSION 3.20)\n"},
+			expected: DetectionResult{
+				Flavour: "cmake", Language: "cpp",
+				TestCommand: "ctest", LintCommand: "",
+				BuildCommand: "cmake --build build", FormatCommand: "",
+				SourceGlob: "*.{cpp,hpp,cc,h}",
+			},
+		},
+		// --- Make ---
+		{
+			name:  "make",
+			files: map[string]string{"Makefile": "all:\n\techo hello\n"},
+			expected: DetectionResult{
+				Flavour: "make", Language: "",
+				TestCommand: "make test", LintCommand: "make lint",
+				BuildCommand: "make build", FormatCommand: "",
+				SourceGlob: "",
+			},
+		},
+		// --- PHP ---
+		{
+			name:  "php",
+			files: map[string]string{"composer.json": `{"name":"vendor/pkg"}`},
+			expected: DetectionResult{
+				Flavour: "php", Language: "php",
+				TestCommand: "vendor/bin/phpunit", LintCommand: "vendor/bin/phpstan analyse",
+				BuildCommand: "", FormatCommand: "vendor/bin/php-cs-fixer fix --dry-run",
+				SourceGlob: "*.php",
+			},
+		},
+		// --- Ruby ---
+		{
+			name:  "ruby",
+			files: map[string]string{"Gemfile": "source 'https://rubygems.org'\n"},
+			expected: DetectionResult{
+				Flavour: "ruby", Language: "ruby",
+				TestCommand: "bundle exec rspec", LintCommand: "bundle exec rubocop",
+				BuildCommand: "", FormatCommand: "bundle exec rubocop -A --fail-level error",
+				SourceGlob: "*.rb",
+			},
+		},
+		// --- Swift ---
+		{
+			name:  "swift",
+			files: map[string]string{"Package.swift": "// swift-tools-version:5.9\n"},
+			expected: DetectionResult{
+				Flavour: "swift", Language: "swift",
+				TestCommand: "swift test", LintCommand: "swift package diagnose-api-breaking-changes",
+				BuildCommand: "swift build", FormatCommand: "swift-format lint -r .",
+				SourceGlob: "*.swift",
+			},
+		},
+		// --- Zig ---
+		{
+			name:  "zig",
+			files: map[string]string{"build.zig": "const std = @import(\"std\");\n"},
+			expected: DetectionResult{
+				Flavour: "zig", Language: "zig",
+				TestCommand: "zig build test", LintCommand: "",
+				BuildCommand: "zig build", FormatCommand: "zig fmt --check .",
+				SourceGlob: "*.zig",
+			},
+		},
+		// --- Scala ---
+		{
+			name:  "scala",
+			files: map[string]string{"build.sbt": "name := \"myapp\"\n"},
+			expected: DetectionResult{
+				Flavour: "scala", Language: "scala",
+				TestCommand: "sbt test", LintCommand: "sbt scalafmtCheck",
+				BuildCommand: "sbt compile", FormatCommand: "sbt scalafmt",
+				SourceGlob: "*.scala",
+			},
+		},
+		// --- Haskell (Cabal — glob marker *.cabal) ---
+		{
+			name:  "cabal",
+			files: map[string]string{"myproject.cabal": "name: myproject\n"},
+			expected: DetectionResult{
+				Flavour: "cabal", Language: "haskell",
+				TestCommand: "cabal test", LintCommand: "hlint .",
+				BuildCommand: "cabal build", FormatCommand: "",
+				SourceGlob: "*.hs",
+			},
+		},
+		// --- Haskell (Stack) ---
+		{
+			name:  "stack",
+			files: map[string]string{"stack.yaml": "resolver: lts-21.0\n"},
+			expected: DetectionResult{
+				Flavour: "stack", Language: "haskell",
+				TestCommand: "stack test", LintCommand: "hlint .",
+				BuildCommand: "stack build", FormatCommand: "",
+				SourceGlob: "*.hs",
+			},
+		},
+		// --- TypeScript standalone (tsconfig.json only, no package.json) ---
+		{
+			name:  "typescript_standalone",
+			files: map[string]string{"tsconfig.json": `{"compilerOptions":{}}`},
+			expected: DetectionResult{
+				Flavour: "typescript", Language: "typescript",
+				TestCommand: "", LintCommand: "tsc --noEmit",
+				BuildCommand: "tsc", FormatCommand: "",
+				SourceGlob: "*.{ts,tsx}",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, tc.files)
+
+			result := Detect(dir)
+			assert.Equal(t, tc.expected.Flavour, result.Flavour, "Flavour mismatch")
+			assert.Equal(t, tc.expected.Language, result.Language, "Language mismatch")
+			assert.Equal(t, tc.expected.TestCommand, result.TestCommand, "TestCommand mismatch")
+			assert.Equal(t, tc.expected.LintCommand, result.LintCommand, "LintCommand mismatch")
+			assert.Equal(t, tc.expected.BuildCommand, result.BuildCommand, "BuildCommand mismatch")
+			assert.Equal(t, tc.expected.FormatCommand, result.FormatCommand, "FormatCommand mismatch")
+			assert.Equal(t, tc.expected.SourceGlob, result.SourceGlob, "SourceGlob mismatch")
+		})
+	}
+}
+
+// TestDetect_SpecificityOrdering verifies that more specific markers are
+// matched before generic ones when multiple marker files are present.
+func TestDetect_SpecificityOrdering(t *testing.T) {
+	tests := []struct {
+		name            string
+		files           map[string]string
+		expectedFlavour string
+	}{
+		{
+			name:            "bun.lock beats package.json",
+			files:           map[string]string{"bun.lock": "", "package.json": `{"name":"x"}`},
+			expectedFlavour: "bun",
+		},
+		{
+			name:            "pnpm-lock.yaml beats package.json",
+			files:           map[string]string{"pnpm-lock.yaml": "", "package.json": `{"name":"x"}`},
+			expectedFlavour: "pnpm",
+		},
+		{
+			name:            "yarn.lock beats package.json",
+			files:           map[string]string{"yarn.lock": "", "package.json": `{"name":"x"}`},
+			expectedFlavour: "yarn",
+		},
+		{
+			name:            "deno.json beats package.json",
+			files:           map[string]string{"deno.json": "{}", "package.json": `{"name":"x"}`},
+			expectedFlavour: "deno",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, tc.files)
+
+			result := Detect(dir)
+			assert.Equal(t, tc.expectedFlavour, result.Flavour,
+				"expected %s to take priority", tc.expectedFlavour)
+		})
+	}
+}
+
+// TestDetect_NoMatch verifies that an empty directory yields a zero-value
+// DetectionResult.
+func TestDetect_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+
+	result := Detect(dir)
+	assert.Equal(t, DetectionResult{}, result, "expected zero-value result for empty directory")
+}
+
+// TestDetect_NodeWithTSConfig verifies that a Node-based flavour with a
+// tsconfig.json file refines the language to "typescript" and the source glob
+// to "*.{ts,tsx}".
+func TestDetect_NodeWithTSConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":  `{"name":"x"}`,
+		"tsconfig.json": `{"compilerOptions":{}}`,
+	})
+
+	result := Detect(dir)
+	assert.Equal(t, "node", result.Flavour, "flavour should still be node")
+	assert.Equal(t, "typescript", result.Language, "language should be refined to typescript")
+	assert.Equal(t, "*.{ts,tsx}", result.SourceGlob, "source glob should be refined for typescript")
+}
+
+// TestDetect_NodeWithPackageJSONScripts verifies that when package.json
+// contains scripts, the detected commands are derived from those scripts.
+func TestDetect_NodeWithPackageJSONScripts(t *testing.T) {
+	dir := t.TempDir()
+
+	pkgJSON := map[string]interface{}{
+		"name": "my-app",
+		"scripts": map[string]interface{}{
+			"test":  "jest",
+			"lint":  "eslint .",
+			"build": "tsc",
+		},
+	}
+	data, err := json.Marshal(pkgJSON)
+	require.NoError(t, err)
+
+	writeFiles(t, dir, map[string]string{
+		"package.json": string(data),
+	})
+
+	result := Detect(dir)
+	assert.Equal(t, "node", result.Flavour)
+	// When scripts are present, commands should be derived from them.
+	assert.Equal(t, "npm test", result.TestCommand)
+	assert.Equal(t, "npm run lint", result.LintCommand)
+	assert.Equal(t, "npm run build", result.BuildCommand)
+}
+
+// TestDetectMetadata verifies metadata extraction from language-specific
+// manifest files.
+func TestDetectMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		dirName  string // if set, the temp dir will be created with this name pattern
+		expected MetadataResult
+	}{
+		{
+			name: "go.mod extracts name from module path",
+			files: map[string]string{
+				"go.mod": "module github.com/org/myrepo\n\ngo 1.21\n",
+			},
+			expected: MetadataResult{
+				Name: "myrepo",
+			},
+		},
+		{
+			name: "package.json extracts name and description",
+			files: map[string]string{
+				"package.json": `{"name":"my-app","description":"A cool application"}`,
+			},
+			expected: MetadataResult{
+				Name:        "my-app",
+				Description: "A cool application",
+			},
+		},
+		{
+			name: "Cargo.toml extracts name from package section",
+			files: map[string]string{
+				"Cargo.toml": "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\n",
+			},
+			expected: MetadataResult{
+				Name: "my-crate",
+			},
+		},
+		{
+			name: "pyproject.toml extracts name from project section",
+			files: map[string]string{
+				"pyproject.toml": "[project]\nname = \"my-lib\"\ndescription = \"A Python library\"\n",
+			},
+			expected: MetadataResult{
+				Name: "my-lib",
+			},
+		},
+		{
+			name:  "no manifest falls back to directory name",
+			files: map[string]string{},
+			expected: MetadataResult{
+				Name: "", // Will be checked separately since dir name is dynamic
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, tc.files)
+
+			result := DetectMetadata(dir)
+
+			if tc.name == "no manifest falls back to directory name" {
+				// The fallback uses the directory basename, which is the
+				// temp dir name. Just verify it is non-empty.
+				assert.NotEmpty(t, result.Name,
+					"expected directory name as fallback")
+				assert.Equal(t, filepath.Base(dir), result.Name,
+					"expected fallback to match directory basename")
+			} else {
+				assert.Equal(t, tc.expected.Name, result.Name, "Name mismatch")
+				if tc.expected.Description != "" {
+					assert.Equal(t, tc.expected.Description, result.Description,
+						"Description mismatch")
+				}
+			}
+		})
+	}
+}
+
+// writeFiles creates the given files in dir. Each key is a filename (no
+// subdirectories), each value is the file content.
+func writeFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		err := os.WriteFile(path, []byte(content), 0o644)
+		require.NoError(t, err, "failed to write %s", name)
+	}
+}

--- a/internal/flavour/metadata.go
+++ b/internal/flavour/metadata.go
@@ -1,0 +1,170 @@
+package flavour
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MetadataResult holds extracted project metadata.
+type MetadataResult struct {
+	Name        string
+	Description string
+}
+
+// DetectMetadata extracts project name and description from language-specific
+// manifest files in the given directory. Returns zero-value MetadataResult
+// if no metadata can be extracted; falls back to directory name for the project name.
+func DetectMetadata(dir string) MetadataResult {
+	// Try go.mod
+	if result, ok := detectGoMetadata(dir); ok {
+		return result
+	}
+
+	// Try package.json
+	if result, ok := detectPackageJSONMetadata(dir); ok {
+		return result
+	}
+
+	// Try Cargo.toml
+	if result, ok := detectCargoMetadata(dir); ok {
+		return result
+	}
+
+	// Try pyproject.toml
+	if result, ok := detectPyprojectMetadata(dir); ok {
+		return result
+	}
+
+	// Fallback: use directory name
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return MetadataResult{}
+	}
+	return MetadataResult{Name: filepath.Base(absDir)}
+}
+
+func detectGoMetadata(dir string) (MetadataResult, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return MetadataResult{}, false
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			modulePath := strings.TrimPrefix(line, "module ")
+			modulePath = strings.TrimSpace(modulePath)
+			// Extract repo name from last path segment
+			parts := strings.Split(modulePath, "/")
+			name := parts[len(parts)-1]
+			return MetadataResult{Name: name}, true
+		}
+	}
+	return MetadataResult{}, false
+}
+
+func detectPackageJSONMetadata(dir string) (MetadataResult, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return MetadataResult{}, false
+	}
+
+	var pkg struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return MetadataResult{}, false
+	}
+	if pkg.Name == "" {
+		return MetadataResult{}, false
+	}
+	return MetadataResult{Name: pkg.Name, Description: pkg.Description}, true
+}
+
+func detectCargoMetadata(dir string) (MetadataResult, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, "Cargo.toml"))
+	if err != nil {
+		return MetadataResult{}, false
+	}
+
+	result := MetadataResult{}
+	inPackage := false
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "[package]" {
+			inPackage = true
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			inPackage = false
+			continue
+		}
+		if !inPackage {
+			continue
+		}
+		if strings.HasPrefix(line, "name") {
+			result.Name = extractTOMLStringValue(line)
+		}
+		if strings.HasPrefix(line, "description") {
+			result.Description = extractTOMLStringValue(line)
+		}
+	}
+
+	if result.Name == "" {
+		return MetadataResult{}, false
+	}
+	return result, true
+}
+
+func detectPyprojectMetadata(dir string) (MetadataResult, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
+	if err != nil {
+		return MetadataResult{}, false
+	}
+
+	result := MetadataResult{}
+	inSection := false
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "[project]" || line == "[tool.poetry]" {
+			inSection = true
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			inSection = false
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if strings.HasPrefix(line, "name") {
+			result.Name = extractTOMLStringValue(line)
+		}
+		if strings.HasPrefix(line, "description") {
+			result.Description = extractTOMLStringValue(line)
+		}
+	}
+
+	if result.Name == "" {
+		return MetadataResult{}, false
+	}
+	return result, true
+}
+
+// extractTOMLStringValue extracts a string value from a TOML key = "value" line.
+func extractTOMLStringValue(line string) string {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	val := strings.TrimSpace(parts[1])
+	val = strings.Trim(val, "\"")
+	return val
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -6,11 +6,13 @@ import (
 )
 
 type Project struct {
-	Language     string `yaml:"language,omitempty"`
-	TestCommand  string `yaml:"test_command,omitempty"`
-	LintCommand  string `yaml:"lint_command,omitempty"`
-	BuildCommand string `yaml:"build_command,omitempty"`
-	SourceGlob   string `yaml:"source_glob,omitempty"`
+	Language      string `yaml:"language,omitempty"`
+	Flavour       string `yaml:"flavour,omitempty"`
+	TestCommand   string `yaml:"test_command,omitempty"`
+	LintCommand   string `yaml:"lint_command,omitempty"`
+	BuildCommand  string `yaml:"build_command,omitempty"`
+	FormatCommand string `yaml:"format_command,omitempty"`
+	SourceGlob    string `yaml:"source_glob,omitempty"`
 }
 
 type Manifest struct {
@@ -176,6 +178,9 @@ func (p *Project) ProjectVars() map[string]string {
 	if p.Language != "" {
 		vars["project.language"] = p.Language
 	}
+	if p.Flavour != "" {
+		vars["project.flavour"] = p.Flavour
+	}
 	if p.TestCommand != "" {
 		vars["project.test_command"] = p.TestCommand
 	}
@@ -184,6 +189,9 @@ func (p *Project) ProjectVars() map[string]string {
 	}
 	if p.BuildCommand != "" {
 		vars["project.build_command"] = p.BuildCommand
+	}
+	if p.FormatCommand != "" {
+		vars["project.format_command"] = p.FormatCommand
 	}
 	if p.SourceGlob != "" {
 		vars["project.source_glob"] = p.SourceGlob

--- a/internal/manifest/types_test.go
+++ b/internal/manifest/types_test.go
@@ -1,0 +1,103 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProjectVars(t *testing.T) {
+	t.Run("nil project returns empty map", func(t *testing.T) {
+		var p *Project
+		vars := p.ProjectVars()
+		assert.NotNil(t, vars)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("all fields set returns all keys", func(t *testing.T) {
+		p := &Project{
+			Language:      "go",
+			Flavour:       "go",
+			TestCommand:   "go test ./...",
+			LintCommand:   "go vet ./...",
+			BuildCommand:  "go build ./...",
+			FormatCommand: "gofmt -l .",
+			SourceGlob:    "**/*.go",
+		}
+		vars := p.ProjectVars()
+
+		assert.Equal(t, "go", vars["project.language"])
+		assert.Equal(t, "go", vars["project.flavour"])
+		assert.Equal(t, "go test ./...", vars["project.test_command"])
+		assert.Equal(t, "go vet ./...", vars["project.lint_command"])
+		assert.Equal(t, "go build ./...", vars["project.build_command"])
+		assert.Equal(t, "gofmt -l .", vars["project.format_command"])
+		assert.Equal(t, "**/*.go", vars["project.source_glob"])
+		assert.Len(t, vars, 7)
+	})
+
+	t.Run("only flavour set returns only flavour key", func(t *testing.T) {
+		p := &Project{
+			Flavour: "rust",
+		}
+		vars := p.ProjectVars()
+
+		assert.Equal(t, "rust", vars["project.flavour"])
+		assert.Len(t, vars, 1)
+	})
+
+	t.Run("empty flavour and format_command omitted from map", func(t *testing.T) {
+		p := &Project{
+			Language:     "python",
+			TestCommand:  "pytest",
+			LintCommand:  "ruff check .",
+			BuildCommand: "python setup.py build",
+			SourceGlob:   "**/*.py",
+			// Flavour and FormatCommand intentionally left empty
+		}
+		vars := p.ProjectVars()
+
+		assert.Equal(t, "python", vars["project.language"])
+		assert.Equal(t, "pytest", vars["project.test_command"])
+		assert.Equal(t, "ruff check .", vars["project.lint_command"])
+		assert.Equal(t, "python setup.py build", vars["project.build_command"])
+		assert.Equal(t, "**/*.py", vars["project.source_glob"])
+
+		_, hasFlavour := vars["project.flavour"]
+		assert.False(t, hasFlavour, "project.flavour should not be present when empty")
+
+		_, hasFormat := vars["project.format_command"]
+		assert.False(t, hasFormat, "project.format_command should not be present when empty")
+
+		assert.Len(t, vars, 5)
+	})
+
+	t.Run("YAML round-trip preserves flavour and format_command", func(t *testing.T) {
+		original := &Project{
+			Language:      "go",
+			Flavour:       "go",
+			TestCommand:   "go test ./...",
+			LintCommand:   "go vet ./...",
+			BuildCommand:  "go build ./...",
+			FormatCommand: "gofmt -l .",
+			SourceGlob:    "**/*.go",
+		}
+
+		data, err := yaml.Marshal(original)
+		require.NoError(t, err)
+
+		var roundTripped Project
+		err = yaml.Unmarshal(data, &roundTripped)
+		require.NoError(t, err)
+
+		assert.Equal(t, original.Language, roundTripped.Language)
+		assert.Equal(t, original.Flavour, roundTripped.Flavour)
+		assert.Equal(t, original.TestCommand, roundTripped.TestCommand)
+		assert.Equal(t, original.LintCommand, roundTripped.LintCommand)
+		assert.Equal(t, original.BuildCommand, roundTripped.BuildCommand)
+		assert.Equal(t, original.FormatCommand, roundTripped.FormatCommand)
+		assert.Equal(t, original.SourceGlob, roundTripped.SourceGlob)
+	})
+}

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -23,16 +23,18 @@ type WizardConfig struct {
 
 // WizardResult holds the collected results from all wizard steps.
 type WizardResult struct {
-	Adapter      string
-	Model        string
-	TestCommand  string
-	LintCommand  string
-	BuildCommand string
-	Language     string
-	SourceGlob   string
-	Pipelines    []string // selected pipeline names
-	Skills       []string // installed skill names from onboarding
-	Dependencies []DependencyStatus
+	Adapter       string
+	Model         string
+	Flavour       string
+	TestCommand   string
+	LintCommand   string
+	BuildCommand  string
+	FormatCommand string
+	Language      string
+	SourceGlob    string
+	Pipelines     []string // selected pipeline names
+	Skills        []string // installed skill names from onboarding
+	Dependencies  []DependencyStatus
 }
 
 // DependencyStatus reports the status of a required dependency.
@@ -93,6 +95,12 @@ func RunWizard(cfg WizardConfig) (*WizardResult, error) {
 		}
 		if v, ok := testResult.Data["source_glob"].(string); ok {
 			result.SourceGlob = v
+		}
+		if v, ok := testResult.Data["flavour"].(string); ok {
+			result.Flavour = v
+		}
+		if v, ok := testResult.Data["format_command"].(string); ok {
+			result.FormatCommand = v
 		}
 	}
 
@@ -232,6 +240,12 @@ func buildManifest(cfg WizardConfig, result *WizardResult) map[string]interface{
 	}
 	if result.BuildCommand != "" {
 		project["build_command"] = result.BuildCommand
+	}
+	if result.FormatCommand != "" {
+		project["format_command"] = result.FormatCommand
+	}
+	if result.Flavour != "" {
+		project["flavour"] = result.Flavour
 	}
 	if result.SourceGlob != "" {
 		project["source_glob"] = result.SourceGlob

--- a/internal/onboarding/steps.go
+++ b/internal/onboarding/steps.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/flavour"
 	"github.com/recinq/wave/internal/tui"
 )
 
@@ -103,6 +104,8 @@ func (s *TestConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 	buildCmd := getStringDefault(detected, "build_command", "")
 	language := getStringDefault(detected, "language", "")
 	sourceGlob := getStringDefault(detected, "source_glob", "")
+	flavourName := getStringDefault(detected, "flavour", "")
+	formatCmd := getStringDefault(detected, "format_command", "")
 
 	// Pre-fill from existing manifest if reconfiguring
 	if cfg.Reconfigure && cfg.Existing != nil && cfg.Existing.Project != nil {
@@ -120,6 +123,12 @@ func (s *TestConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 		}
 		if cfg.Existing.Project.SourceGlob != "" {
 			sourceGlob = cfg.Existing.Project.SourceGlob
+		}
+		if cfg.Existing.Project.FormatCommand != "" {
+			formatCmd = cfg.Existing.Project.FormatCommand
+		}
+		if cfg.Existing.Project.Flavour != "" {
+			flavourName = cfg.Existing.Project.Flavour
 		}
 	}
 
@@ -152,64 +161,42 @@ func (s *TestConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 
 	return &StepResult{
 		Data: map[string]interface{}{
-			"test_command":  testCmd,
-			"lint_command":  lintCmd,
-			"build_command": buildCmd,
-			"language":      language,
-			"source_glob":   sourceGlob,
+			"test_command":   testCmd,
+			"lint_command":   lintCmd,
+			"build_command":  buildCmd,
+			"language":       language,
+			"source_glob":    sourceGlob,
+			"flavour":        flavourName,
+			"format_command": formatCmd,
 		},
 	}, nil
 }
 
 // detectProjectType probes the current directory for project type markers.
 func detectProjectType() map[string]string {
-	fileExists := func(name string) bool {
-		_, err := os.Stat(name)
-		return err == nil
+	result := flavour.Detect(".")
+	if result.Flavour == "" {
+		return map[string]string{}
 	}
 
-	switch {
-	case fileExists("go.mod"):
-		return map[string]string{
-			"language":      "go",
-			"test_command":  "go test ./...",
-			"lint_command":  "go vet ./...",
-			"build_command": "go build ./...",
-			"source_glob":   "*.go",
-		}
-	case fileExists("deno.json") || fileExists("deno.jsonc"):
-		return map[string]string{
-			"language":      "typescript",
-			"test_command":  "deno test",
-			"lint_command":  "deno lint",
-			"build_command": "deno compile",
-			"source_glob":   "*.{ts,tsx}",
-		}
-	case fileExists("package.json"):
-		return map[string]string{
-			"language":     "javascript",
-			"test_command": "npm test",
-			"lint_command": "npm run lint",
-			"source_glob":  "*.{js,jsx}",
-		}
-	case fileExists("Cargo.toml"):
-		return map[string]string{
-			"language":      "rust",
-			"test_command":  "cargo test",
-			"lint_command":  "cargo clippy",
-			"build_command": "cargo build",
-			"source_glob":   "*.rs",
-		}
-	case fileExists("pyproject.toml") || fileExists("setup.py"):
-		return map[string]string{
-			"language":     "python",
-			"test_command": "pytest",
-			"lint_command": "ruff check .",
-			"source_glob":  "*.py",
-		}
+	m := map[string]string{
+		"flavour":     result.Flavour,
+		"language":    result.Language,
+		"source_glob": result.SourceGlob,
 	}
-
-	return map[string]string{}
+	if result.TestCommand != "" {
+		m["test_command"] = result.TestCommand
+	}
+	if result.LintCommand != "" {
+		m["lint_command"] = result.LintCommand
+	}
+	if result.BuildCommand != "" {
+		m["build_command"] = result.BuildCommand
+	}
+	if result.FormatCommand != "" {
+		m["format_command"] = result.FormatCommand
+	}
+	return m
 }
 
 func getStringDefault(m map[string]string, key, fallback string) string {

--- a/specs/403-init-cold-start-flavour/checklists/detection-matrix.md
+++ b/specs/403-init-cold-start-flavour/checklists/detection-matrix.md
@@ -1,0 +1,33 @@
+# Detection Matrix Quality Checklist
+
+**Feature**: Init Cold-Start Fix, Flavour Auto-Detection
+**Date**: 2026-03-16
+
+This checklist validates the quality of requirements for the 25+ language flavour detection matrix.
+
+## Completeness
+
+- [ ] CHK030 - Does every detection rule specify all six output fields (flavour, language, test, lint, build, format, source glob)? [Completeness]
+- [ ] CHK031 - Are empty command fields explicitly documented as intentional (e.g., bun has no format_command) vs accidentally omitted? [Completeness]
+- [ ] CHK032 - Is the behavior for marker files that exist but are empty or malformed defined? [Completeness]
+- [ ] CHK033 - Are all Node ecosystem variants covered (npm, yarn classic, yarn berry, pnpm, bun)? [Completeness]
+- [ ] CHK034 - Is the Python ecosystem coverage complete (pyproject.toml, setup.py, setup.cfg, requirements.txt)? [Completeness]
+
+## Clarity
+
+- [ ] CHK035 - Is it clear that markers use ANY-match semantics (one marker suffices) rather than ALL-match? [Clarity]
+- [ ] CHK036 - Is the glob pattern matching behavior defined (e.g., does `*.csproj` match in subdirectories or only the root)? [Clarity]
+- [ ] CHK037 - Is it clear which command fields accept empty string as "not applicable" vs which require a value? [Clarity]
+
+## Consistency
+
+- [ ] CHK038 - Are command styles consistent across similar ecosystems (e.g., all use `--check` for format verification where available)? [Consistency]
+- [ ] CHK039 - Is the Gradle/Kotlin overlap explicitly resolved in the priority ordering (Kotlin rule uses same marker as Gradle)? [Consistency]
+- [ ] CHK040 - Are the source glob patterns consistent in format (`*.go` vs `*.{ts,tsx}`) and is the brace syntax documented? [Consistency]
+
+## Coverage
+
+- [ ] CHK041 - Are version-specific tool differences addressed (e.g., yarn classic vs yarn berry have different lock file formats)? [Coverage]
+- [ ] CHK042 - Is the Flutter vs pure Dart distinction addressed (both use `pubspec.yaml`)? [Coverage]
+- [ ] CHK043 - Are polyglot projects (e.g., Go backend + TypeScript frontend) addressed in the detection strategy? [Coverage]
+- [ ] CHK044 - Is the `make` flavour ambiguity addressed — many projects have a Makefile alongside a language-specific build tool? [Coverage]

--- a/specs/403-init-cold-start-flavour/checklists/requirements.md
+++ b/specs/403-init-cold-start-flavour/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Requirements Quality Checklist: 403-init-cold-start-flavour
+
+## Spec Structure
+- [x] Feature branch name matches spec header
+- [x] Status is set to "Draft"
+- [x] Input references the source issue URL
+- [x] All mandatory sections present (User Scenarios, Requirements, Success Criteria)
+
+## User Stories
+- [x] Stories are prioritized (P1, P2, P3)
+- [x] Each story has a clear "Why this priority" explanation
+- [x] Each story has an independent test description
+- [x] Acceptance scenarios use Given/When/Then format
+- [x] Stories are independently testable and deliverable
+- [x] P1 stories form a viable MVP without P2/P3
+- [x] No implementation details leak into story descriptions
+
+## Requirements
+- [x] All requirements use MUST/SHOULD/MAY language (RFC 2119)
+- [x] Each requirement is independently testable
+- [x] Requirements are unambiguous — no subjective terms
+- [x] No duplicate requirements
+- [x] Requirements trace back to user stories
+- [x] Maximum 3 `[NEEDS CLARIFICATION]` markers (current: 0)
+
+## Edge Cases
+- [x] At least 5 edge cases identified
+- [x] Edge cases cover error conditions
+- [x] Edge cases cover boundary conditions
+- [x] Edge cases cover concurrent/conflicting state
+- [x] Each edge case has a clear expected behavior
+
+## Key Entities
+- [x] All domain entities identified
+- [x] Entity relationships described
+- [x] No implementation details in entity descriptions
+
+## Success Criteria
+- [x] All criteria are measurable
+- [x] All criteria are technology-agnostic
+- [x] Criteria cover both functional correctness and non-regression
+- [x] At least one criterion per P1 user story
+
+## Completeness
+- [x] Spec covers all acceptance criteria from the source issue
+- [x] Cold-start fix (Phase 1) fully specified
+- [x] Flavour system (Phase 2) fully specified
+- [x] Smart init (Phase 4) fully specified
+- [x] Detection matrix coverage matches issue (25+ languages)
+- [x] Backward compatibility explicitly addressed

--- a/specs/403-init-cold-start-flavour/checklists/review.md
+++ b/specs/403-init-cold-start-flavour/checklists/review.md
@@ -1,0 +1,45 @@
+# Requirements Quality Review Checklist
+
+**Feature**: Init Cold-Start Fix, Flavour Auto-Detection
+**Date**: 2026-03-16
+
+## Completeness
+
+- [ ] CHK001 - Are all cold-start failure modes enumerated (no .git, no commits, no remote, no files)? [Completeness]
+- [ ] CHK002 - Does the spec define what happens when `git init` itself fails (permissions, disk full, nested .git)? [Completeness]
+- [ ] CHK003 - Are all 25+ flavour detection rules fully specified with marker files, commands, and source globs? [Completeness]
+- [ ] CHK004 - Is the Node refinement logic (tsconfig override, package.json script parsing) specified with enough detail for implementation? [Completeness]
+- [ ] CHK005 - Does the spec cover all existing `wave init` flags (`--merge`, `--force`, `--reconfigure`, `--all`, `--yes`) in combination with the new cold-start logic? [Completeness]
+- [ ] CHK006 - Are error messages and user-facing output defined for each failure scenario? [Completeness]
+- [ ] CHK007 - Is the behavior for `wave init` in a directory that already has `wave.yaml` AND no `.git` specified? [Completeness]
+- [ ] CHK008 - Does the metadata extraction spec define fallback behavior for all supported manifest file formats (not just the happy path)? [Completeness]
+- [ ] CHK009 - Is the initial commit scope clearly defined (which files are staged, which are excluded)? [Completeness]
+
+## Clarity
+
+- [ ] CHK010 - Is the priority ordering of detection rules unambiguous (e.g., Kotlin uses `build.gradle.kts` which also matches Gradle — is precedence clear)? [Clarity]
+- [ ] CHK011 - Is the distinction between "flavour" and "language" clearly defined with examples of when they differ (e.g., bun flavour vs typescript language)? [Clarity]
+- [ ] CHK012 - Are the forge-filtering semantics clear on what "matching" means for pipeline names (prefix matching vs metadata)? [Clarity]
+- [ ] CHK013 - Is the `requiredPipelines` safeguard scope defined — just `impl-issue` or extensible to other pipelines? [Clarity]
+- [ ] CHK014 - Is the interaction between `--reconfigure` and flavour re-detection clearly specified (overwrite vs merge existing values)? [Clarity]
+- [ ] CHK015 - Are the conditions for the first-run suggestion heuristic ("source files exist" vs "empty project") precisely defined? [Clarity]
+
+## Consistency
+
+- [ ] CHK016 - Are the new `project.flavour` and `project.format_command` fields consistent with existing `project.*` field naming conventions in the manifest? [Consistency]
+- [ ] CHK017 - Does the detection matrix in data-model.md match the flavour list in FR-013 exactly (no missing or extra entries)? [Consistency]
+- [ ] CHK018 - Are the acceptance scenarios in all 7 user stories consistent with the functional requirements (FR-001 through FR-013)? [Consistency]
+- [ ] CHK019 - Is the `ensureGitRepo()` placement consistent across both entry points (`runInit` and `runWizardInit`)? [Consistency]
+- [ ] CHK020 - Does the plan's Phase ordering match the task dependency graph (no circular or missing dependencies)? [Consistency]
+- [ ] CHK021 - Are the Kotlin and Gradle detection rules consistent — both use `build.gradle.kts` but yield different flavours. Is the conflict addressed? [Consistency]
+
+## Coverage
+
+- [ ] CHK022 - Are edge cases for glob-based markers (`*.csproj`, `*.cabal`) covered — what if multiple files match? [Coverage]
+- [ ] CHK023 - Is the monorepo case addressed (multiple languages in subdirectories but detection runs at root)? [Coverage]
+- [ ] CHK024 - Is the Windows path handling covered for all file detection and git operations? [Coverage]
+- [ ] CHK025 - Are concurrent `wave init` invocations in the same directory addressed (race conditions on git init)? [Coverage]
+- [ ] CHK026 - Is the non-interactive (`--yes`) mode covered for every new feature (cold-start, flavour, metadata, suggestion)? [Coverage]
+- [ ] CHK027 - Are backward compatibility tests specified for loading existing manifests without the new `flavour`/`format_command` fields? [Coverage]
+- [ ] CHK028 - Is the enterprise GitHub domain case covered in the forge detection edge cases? [Coverage]
+- [ ] CHK029 - Are test requirements specified for the detection priority ordering (verifying bun beats node, deno beats node, etc.)? [Coverage]

--- a/specs/403-init-cold-start-flavour/data-model.md
+++ b/specs/403-init-cold-start-flavour/data-model.md
@@ -1,0 +1,306 @@
+# Data Model: Init Cold-Start Fix, Flavour Auto-Detection
+
+**Date**: 2026-03-16
+**Branch**: `403-init-cold-start-flavour`
+
+## New Package: `internal/flavour`
+
+### Core Types
+
+```go
+// DetectionResult holds the result of flavour detection for a project directory.
+type DetectionResult struct {
+    Flavour       string // e.g., "go", "rust", "bun", "python"
+    Language      string // e.g., "go", "rust", "typescript", "python"
+    TestCommand   string // e.g., "go test ./..."
+    LintCommand   string // e.g., "go vet ./..."
+    BuildCommand  string // e.g., "go build ./..."
+    FormatCommand string // e.g., "gofmt -l ."
+    SourceGlob    string // e.g., "*.go"
+}
+
+// MetadataResult holds extracted project metadata.
+type MetadataResult struct {
+    Name        string // Project name from manifest file
+    Description string // Project description from manifest file
+}
+
+// DetectionRule maps marker files to a flavour detection result.
+type DetectionRule struct {
+    Markers []string         // Files to check for (ANY match triggers)
+    Result  DetectionResult  // The detection result when matched
+}
+```
+
+### Detection Matrix (Priority-Ordered)
+
+```go
+var rules = []DetectionRule{
+    // --- Go ---
+    {Markers: []string{"go.mod"}, Result: DetectionResult{
+        Flavour: "go", Language: "go",
+        TestCommand: "go test ./...", LintCommand: "go vet ./...",
+        BuildCommand: "go build ./...", FormatCommand: "gofmt -l .",
+        SourceGlob: "*.go",
+    }},
+    // --- Rust ---
+    {Markers: []string{"Cargo.toml"}, Result: DetectionResult{
+        Flavour: "rust", Language: "rust",
+        TestCommand: "cargo test", LintCommand: "cargo clippy",
+        BuildCommand: "cargo build", FormatCommand: "cargo fmt -- --check",
+        SourceGlob: "*.rs",
+    }},
+    // --- Deno (before generic Node) ---
+    {Markers: []string{"deno.json", "deno.jsonc"}, Result: DetectionResult{
+        Flavour: "deno", Language: "typescript",
+        TestCommand: "deno test", LintCommand: "deno lint",
+        BuildCommand: "deno compile", FormatCommand: "deno fmt --check",
+        SourceGlob: "*.{ts,tsx}",
+    }},
+    // --- Bun (before generic Node) ---
+    {Markers: []string{"bun.lockb", "bun.lock"}, Result: DetectionResult{
+        Flavour: "bun", Language: "typescript",
+        TestCommand: "bun test", LintCommand: "bun run lint",
+        BuildCommand: "bun run build", FormatCommand: "",
+        SourceGlob: "*.{ts,tsx}",
+    }},
+    // --- pnpm ---
+    {Markers: []string{"pnpm-lock.yaml"}, Result: DetectionResult{
+        Flavour: "pnpm", Language: "javascript",
+        TestCommand: "pnpm test", LintCommand: "pnpm run lint",
+        BuildCommand: "pnpm run build", FormatCommand: "",
+        SourceGlob: "*.{js,jsx}",
+    }},
+    // --- Yarn ---
+    {Markers: []string{"yarn.lock"}, Result: DetectionResult{
+        Flavour: "yarn", Language: "javascript",
+        TestCommand: "yarn test", LintCommand: "yarn run lint",
+        BuildCommand: "yarn run build", FormatCommand: "",
+        SourceGlob: "*.{js,jsx}",
+    }},
+    // --- npm (generic Node, lowest Node priority) ---
+    {Markers: []string{"package.json"}, Result: DetectionResult{
+        Flavour: "node", Language: "javascript",
+        TestCommand: "npm test", LintCommand: "npm run lint",
+        BuildCommand: "npm run build", FormatCommand: "",
+        SourceGlob: "*.{js,jsx}",
+    }},
+    // --- Python (modern) ---
+    {Markers: []string{"pyproject.toml"}, Result: DetectionResult{
+        Flavour: "python", Language: "python",
+        TestCommand: "pytest", LintCommand: "ruff check .",
+        BuildCommand: "", FormatCommand: "ruff format --check .",
+        SourceGlob: "*.py",
+    }},
+    // --- Python (legacy) ---
+    {Markers: []string{"setup.py"}, Result: DetectionResult{
+        Flavour: "python", Language: "python",
+        TestCommand: "pytest", LintCommand: "ruff check .",
+        BuildCommand: "python setup.py build", FormatCommand: "ruff format --check .",
+        SourceGlob: "*.py",
+    }},
+    // --- C# ---
+    {Markers: []string{"*.csproj", "*.sln"}, Result: DetectionResult{
+        Flavour: "dotnet", Language: "csharp",
+        TestCommand: "dotnet test", LintCommand: "dotnet format --verify-no-changes",
+        BuildCommand: "dotnet build", FormatCommand: "dotnet format --verify-no-changes",
+        SourceGlob: "*.cs",
+    }},
+    // --- Java (Maven) ---
+    {Markers: []string{"pom.xml"}, Result: DetectionResult{
+        Flavour: "maven", Language: "java",
+        TestCommand: "mvn test", LintCommand: "mvn checkstyle:check",
+        BuildCommand: "mvn package", FormatCommand: "",
+        SourceGlob: "*.java",
+    }},
+    // --- Java (Gradle) ---
+    {Markers: []string{"build.gradle", "build.gradle.kts"}, Result: DetectionResult{
+        Flavour: "gradle", Language: "java",
+        TestCommand: "./gradlew test", LintCommand: "./gradlew check",
+        BuildCommand: "./gradlew build", FormatCommand: "",
+        SourceGlob: "*.java",
+    }},
+    // --- Kotlin ---
+    {Markers: []string{"build.gradle.kts"}, Result: DetectionResult{
+        Flavour: "kotlin", Language: "kotlin",
+        TestCommand: "./gradlew test", LintCommand: "./gradlew ktlintCheck",
+        BuildCommand: "./gradlew build", FormatCommand: "./gradlew ktlintFormat",
+        SourceGlob: "*.kt",
+    }},
+    // --- Elixir ---
+    {Markers: []string{"mix.exs"}, Result: DetectionResult{
+        Flavour: "elixir", Language: "elixir",
+        TestCommand: "mix test", LintCommand: "mix credo",
+        BuildCommand: "mix compile", FormatCommand: "mix format --check-formatted",
+        SourceGlob: "*.{ex,exs}",
+    }},
+    // --- Dart/Flutter ---
+    {Markers: []string{"pubspec.yaml"}, Result: DetectionResult{
+        Flavour: "dart", Language: "dart",
+        TestCommand: "dart test", LintCommand: "dart analyze",
+        BuildCommand: "dart compile exe", FormatCommand: "dart format --set-exit-if-changed .",
+        SourceGlob: "*.dart",
+    }},
+    // --- C++ (CMake) ---
+    {Markers: []string{"CMakeLists.txt"}, Result: DetectionResult{
+        Flavour: "cmake", Language: "cpp",
+        TestCommand: "ctest", LintCommand: "",
+        BuildCommand: "cmake --build build", FormatCommand: "",
+        SourceGlob: "*.{cpp,hpp,cc,h}",
+    }},
+    // --- Make ---
+    {Markers: []string{"Makefile"}, Result: DetectionResult{
+        Flavour: "make", Language: "",
+        TestCommand: "make test", LintCommand: "make lint",
+        BuildCommand: "make build", FormatCommand: "",
+        SourceGlob: "",
+    }},
+    // --- PHP ---
+    {Markers: []string{"composer.json"}, Result: DetectionResult{
+        Flavour: "php", Language: "php",
+        TestCommand: "vendor/bin/phpunit", LintCommand: "vendor/bin/phpstan analyse",
+        BuildCommand: "", FormatCommand: "vendor/bin/php-cs-fixer fix --dry-run",
+        SourceGlob: "*.php",
+    }},
+    // --- Ruby ---
+    {Markers: []string{"Gemfile"}, Result: DetectionResult{
+        Flavour: "ruby", Language: "ruby",
+        TestCommand: "bundle exec rspec", LintCommand: "bundle exec rubocop",
+        BuildCommand: "", FormatCommand: "bundle exec rubocop -A --fail-level error",
+        SourceGlob: "*.rb",
+    }},
+    // --- Swift ---
+    {Markers: []string{"Package.swift"}, Result: DetectionResult{
+        Flavour: "swift", Language: "swift",
+        TestCommand: "swift test", LintCommand: "swift package diagnose-api-breaking-changes",
+        BuildCommand: "swift build", FormatCommand: "swift-format lint -r .",
+        SourceGlob: "*.swift",
+    }},
+    // --- Zig ---
+    {Markers: []string{"build.zig"}, Result: DetectionResult{
+        Flavour: "zig", Language: "zig",
+        TestCommand: "zig build test", LintCommand: "",
+        BuildCommand: "zig build", FormatCommand: "zig fmt --check .",
+        SourceGlob: "*.zig",
+    }},
+    // --- Scala (sbt) ---
+    {Markers: []string{"build.sbt"}, Result: DetectionResult{
+        Flavour: "scala", Language: "scala",
+        TestCommand: "sbt test", LintCommand: "sbt scalafmtCheck",
+        BuildCommand: "sbt compile", FormatCommand: "sbt scalafmt",
+        SourceGlob: "*.scala",
+    }},
+    // --- Haskell (Cabal) ---
+    {Markers: []string{"*.cabal"}, Result: DetectionResult{
+        Flavour: "cabal", Language: "haskell",
+        TestCommand: "cabal test", LintCommand: "hlint .",
+        BuildCommand: "cabal build", FormatCommand: "",
+        SourceGlob: "*.hs",
+    }},
+    // --- Haskell (Stack) ---
+    {Markers: []string{"stack.yaml"}, Result: DetectionResult{
+        Flavour: "stack", Language: "haskell",
+        TestCommand: "stack test", LintCommand: "hlint .",
+        BuildCommand: "stack build", FormatCommand: "",
+        SourceGlob: "*.hs",
+    }},
+    // --- TypeScript standalone (tsconfig but no package.json) ---
+    // NOTE: This is checked AFTER all Node variants. If package.json exists,
+    // a Node flavour will match first. This catches standalone tsc projects.
+    {Markers: []string{"tsconfig.json"}, Result: DetectionResult{
+        Flavour: "typescript", Language: "typescript",
+        TestCommand: "", LintCommand: "tsc --noEmit",
+        BuildCommand: "tsc", FormatCommand: "",
+        SourceGlob: "*.{ts,tsx}",
+    }},
+}
+```
+
+**Note on marker matching**: Most markers are exact filenames. Glob patterns like `*.csproj` and `*.cabal` require a directory scan check (any file matching the pattern).
+
+### Node Refinement
+
+For Node-based flavours (`node`, `bun`, `pnpm`, `yarn`), the `Detect` function should refine the result by:
+1. Checking `tsconfig.json` to override `Language` to `"typescript"` and `SourceGlob` to `"*.{ts,tsx}"`
+2. Reading `package.json` scripts to derive actual test/lint/build commands (reuse logic from existing `detectNodeProject`)
+
+## Modified Types
+
+### `manifest.Project` (internal/manifest/types.go)
+
+```go
+type Project struct {
+    Language      string `yaml:"language,omitempty"`
+    Flavour       string `yaml:"flavour,omitempty"`        // NEW
+    TestCommand   string `yaml:"test_command,omitempty"`
+    LintCommand   string `yaml:"lint_command,omitempty"`
+    BuildCommand  string `yaml:"build_command,omitempty"`
+    FormatCommand string `yaml:"format_command,omitempty"` // NEW
+    SourceGlob    string `yaml:"source_glob,omitempty"`
+}
+```
+
+### `onboarding.WizardResult` (internal/onboarding/onboarding.go)
+
+```go
+type WizardResult struct {
+    Adapter       string
+    Model         string
+    Flavour       string // NEW
+    TestCommand   string
+    LintCommand   string
+    BuildCommand  string
+    FormatCommand string // NEW
+    Language      string
+    SourceGlob    string
+    Pipelines     []string
+    Skills        []string
+    Dependencies  []DependencyStatus
+}
+```
+
+## Function Signatures
+
+### `internal/flavour` Package
+
+```go
+// Detect scans the given directory for marker files and returns the first
+// matching flavour detection result. Returns a zero-value DetectionResult
+// if no markers match.
+func Detect(dir string) DetectionResult
+
+// DetectMetadata extracts project name and description from language-specific
+// manifest files in the given directory. Returns zero-value MetadataResult
+// if no metadata can be extracted.
+func DetectMetadata(dir string) MetadataResult
+```
+
+### Modified Functions
+
+```go
+// ProjectVars — add two new entries
+func (p *Project) ProjectVars() map[string]string {
+    // ... existing ...
+    if p.Flavour != "" {
+        vars["project.flavour"] = p.Flavour
+    }
+    if p.FormatCommand != "" {
+        vars["project.format_command"] = p.FormatCommand
+    }
+    return vars
+}
+```
+
+## Integration Points
+
+| Caller | Current | After |
+|--------|---------|-------|
+| `init.go:detectProject()` | Inline 5-language switch | `flavour.Detect(".")` + convert to map |
+| `onboarding/steps.go:detectProjectType()` | Inline 5-language switch | `flavour.Detect(".")` + convert to map |
+| `init.go:createDefaultManifest()` | No flavour/format | Include `flavour` and `format_command` |
+| `onboarding.go:buildManifest()` | No flavour/format | Include `flavour` and `format_command` |
+| `init.go:runInit()` | No git check | Pre-wizard git bootstrap |
+| `init.go:runWizardInit()` | No git check | Pre-wizard git bootstrap |
+| `init.go:getFilteredAssets()` | No forge filter | Add `FilterPipelinesByForge` call |
+| `init.go:printInitSuccess()` | Static next-steps | Dynamic suggestion based on project state |
+| `init.go:printWizardSuccess()` | Static next-steps | Dynamic suggestion based on project state |

--- a/specs/403-init-cold-start-flavour/plan.md
+++ b/specs/403-init-cold-start-flavour/plan.md
@@ -1,0 +1,169 @@
+# Implementation Plan: Init Cold-Start Fix, Flavour Auto-Detection
+
+**Branch**: `403-init-cold-start-flavour` | **Date**: 2026-03-16 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/403-init-cold-start-flavour/spec.md`
+
+## Summary
+
+Fix `wave init` cold-start failures (no `.git`, no commits, no remote) and introduce automatic language/flavour detection for 25+ languages. Adds a new `internal/flavour` package for structured project detection, extends the manifest `Project` struct with `flavour` and `format_command` fields, integrates forge-filtered pipeline selection during init, extracts project metadata from manifest files, and provides first-run pipeline suggestions.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: `gopkg.in/yaml.v3`, `github.com/spf13/cobra`, `github.com/charmbracelet/huh`
+**Storage**: Filesystem (`wave.yaml`, `.wave/` directory tree)
+**Testing**: `go test ./...` with table-driven tests
+**Target Platform**: Linux, macOS, Windows (single static binary)
+**Project Type**: Single Go module
+**Constraints**: No runtime dependencies beyond adapter binaries
+**Scale/Scope**: ~8 files modified, 1 new package created
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | No new dependencies added. `internal/flavour` is pure Go. |
+| P2: Manifest as Source of Truth | PASS | New fields (`flavour`, `format_command`) are in `wave.yaml`. |
+| P3: Persona-Scoped Execution | N/A | Init flow does not involve persona execution. |
+| P4: Fresh Memory | N/A | No pipeline steps involved. |
+| P5: Navigator-First | N/A | Not a pipeline change. |
+| P6: Contracts at Handovers | N/A | Not a pipeline change. |
+| P7: Relay via Summarizer | N/A | Not relevant. |
+| P8: Ephemeral Workspaces | N/A | Not relevant. |
+| P9: Credentials Never Touch Disk | PASS | No credential handling in init. |
+| P10: Observable Progress | PASS | Init already prints structured output. |
+| P11: Bounded Recursion | N/A | Not relevant. |
+| P12: Step State Machine | N/A | Not a pipeline change. |
+| P13: Test Ownership | PASS | All new code has corresponding tests. Existing test suites must pass. |
+
+**Post-Phase 1 Re-check**: All principles still pass. No new violations introduced by the design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/403-init-cold-start-flavour/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research
+├── data-model.md        # Phase 1 data model
+└── tasks.md             # Phase 2 output (not yet created)
+```
+
+### Source Code (repository root)
+
+```
+internal/
+├── flavour/             # NEW: Flavour detection package
+│   ├── detect.go        # Detect() and detection rules matrix
+│   ├── metadata.go      # DetectMetadata() for name/description extraction
+│   └── detect_test.go   # Table-driven tests for all 25+ flavours
+├── manifest/
+│   └── types.go         # MODIFIED: Add Flavour, FormatCommand to Project
+├── onboarding/
+│   ├── onboarding.go    # MODIFIED: Add Flavour, FormatCommand to WizardResult + buildManifest
+│   └── steps.go         # MODIFIED: Replace detectProjectType() with flavour.Detect()
+└── forge/
+    └── detect.go        # EXISTING: FilterPipelinesByForge (no changes needed)
+
+cmd/wave/commands/
+└── init.go              # MODIFIED: Cold-start git bootstrap, forge filtering,
+                         #           metadata extraction, first-run suggestion,
+                         #           replace detectProject() with flavour.Detect()
+```
+
+**Structure Decision**: This is a modification to an existing Go module structure. The only new directory is `internal/flavour/`. All other changes are modifications to existing files.
+
+## Implementation Phases
+
+### Phase A: Foundation — `internal/flavour` Package (Stories 2, 3, 13)
+
+**Goal**: Create the flavour detection engine as a standalone testable package.
+
+**Files**:
+1. `internal/flavour/detect.go` — `DetectionResult` type, `DetectionRule` type, ordered rules slice, `Detect(dir string)` function
+2. `internal/flavour/metadata.go` — `MetadataResult` type, `DetectMetadata(dir string)` function
+3. `internal/flavour/detect_test.go` — Table-driven tests: one test case per flavour, specificity ordering tests, no-match test, metadata extraction tests
+
+**Key Design Decisions**:
+- Marker matching: `os.Stat` for exact filenames, `filepath.Glob` for patterns (`*.csproj`, `*.cabal`)
+- Node refinement: After base detection, check `tsconfig.json` for language override and `package.json` scripts for command override
+- Priority: Rules are checked in slice order. More specific markers (e.g., `bun.lock`) come before generic ones (`package.json`)
+
+### Phase B: Manifest Extension (Story 3)
+
+**Goal**: Add `Flavour` and `FormatCommand` to the type system and template variables.
+
+**Files**:
+1. `internal/manifest/types.go` — Add fields to `Project` struct, extend `ProjectVars()`
+2. `internal/onboarding/onboarding.go` — Add fields to `WizardResult`, extend `buildManifest()`
+
+**Backward Compatibility**: Both new fields are `yaml:"...,omitempty"`. Existing manifests without these fields load without error (FR-011).
+
+### Phase C: Cold-Start Git Bootstrap (Story 1)
+
+**Goal**: Ensure `wave init` works in directories without `.git`, without commits, and without remotes.
+
+**Files**:
+1. `cmd/wave/commands/init.go` — Add `ensureGitRepo()` helper called from both `runInit()` and `runWizardInit()` before any other logic
+
+**Logic**:
+```
+ensureGitRepo():
+  if .git not exists:
+    git init
+  if git rev-parse --verify HEAD fails (no commits):
+    defer: after wave files written, create initial commit
+  forge detection: already handles no-remote gracefully
+```
+
+**Initial Commit**: Stage only `wave.yaml` and `.wave/` contents. Message: `chore: initialize wave project`. Only created when the repo had no prior commits.
+
+### Phase D: Integration — Wire Flavour Detection into Init (Stories 2, 5, 6, 7)
+
+**Goal**: Replace duplicate detection logic with `flavour.Detect()`, add metadata extraction, forge filtering, required pipeline safeguard, and first-run suggestions.
+
+**Files**:
+1. `cmd/wave/commands/init.go`:
+   - Replace `detectProject()` body with `flavour.Detect(".")` conversion
+   - Replace `detectNodeProject()` — logic moves to flavour package
+   - Add `flavour.DetectMetadata(".")` call to populate `metadata.name`/`metadata.description`
+   - Add `forge.DetectFromGitRemotes()` + `forge.FilterPipelinesByForge()` in `getFilteredAssets()`
+   - Add `requiredPipelines` safeguard for `impl-issue`
+   - Update `printInitSuccess()` and `printWizardSuccess()` with dynamic first-run suggestion
+2. `internal/onboarding/steps.go`:
+   - Replace `detectProjectType()` body with `flavour.Detect(".")` conversion
+   - Add `format_command` to `TestConfigStep` result
+
+### Phase E: Tests (All Stories)
+
+**Goal**: Comprehensive test coverage.
+
+**Files**:
+1. `internal/flavour/detect_test.go` — Already created in Phase A
+2. `cmd/wave/commands/init_test.go` — Tests for:
+   - Cold-start in empty directory (no `.git`)
+   - Cold-start with `.git` but no commits
+   - Cold-start with `.git`, commits, no remote
+   - Flavour detection integration (go.mod → go flavour in manifest)
+   - Forge-filtered pipeline selection
+   - Required pipeline safeguard
+   - Metadata extraction
+   - Backward compatibility (existing manifest without new fields)
+3. `internal/manifest/types_test.go` — Tests for `ProjectVars()` with new fields
+
+## Complexity Tracking
+
+No constitution violations to justify.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Node detection order (bun vs npm) | Strict priority ordering in rules slice; tested individually |
+| Glob patterns for markers (`*.csproj`) | `filepath.Glob` is well-tested; fallback to no-match |
+| Git operations in init failing | `ensureGitRepo` wraps all git calls with clear error messages |
+| Existing tests breaking | `go test ./...` required before PR; new fields are `omitempty` |

--- a/specs/403-init-cold-start-flavour/research.md
+++ b/specs/403-init-cold-start-flavour/research.md
@@ -1,0 +1,100 @@
+# Research: Init Cold-Start Fix, Flavour Auto-Detection
+
+**Date**: 2026-03-16
+**Branch**: `403-init-cold-start-flavour`
+
+## Research Areas
+
+### R1: Cold-Start Git Bootstrap
+
+**Decision**: Pre-wizard git init in `runInit`/`runWizardInit`
+**Rationale**: The onboarding wizard and forge detection both depend on git state. Bootstrapping `.git` before the wizard matches the existing control flow where `runInit` orchestrates prerequisites and the wizard handles configuration.
+**Alternatives Rejected**:
+- Moving git init into the wizard: Violates separation of concerns. The wizard collects user preferences; git setup is infrastructure.
+- Lazy init on first `wave run`: Too late — `wave init` needs to write `.wave/` and commit.
+
+**Key Findings**:
+- `runInit` (init.go:267) and `runWizardInit` (init.go:1165) are the two entry points that need cold-start logic.
+- `forge.DetectFromGitRemotes()` already returns `ForgeUnknown` gracefully when git is unavailable or has no remotes (detect.go:64-88). No fix needed there.
+- The worktree manager is not invoked during init, so worktree crashes are not relevant to this issue.
+- `git rev-parse --verify HEAD` can check for commits; exit code 128 = no commits.
+
+### R2: Flavour Detection Architecture
+
+**Decision**: New `internal/flavour` package with `Detect(dir string) DetectionResult`
+**Rationale**: The detection matrix (25+ languages) is too large for inline functions. A dedicated package provides clean testing surface, reuse by `wave doctor` and `wave suggest`, and a structured return type instead of `map[string]string`.
+**Alternatives Rejected**:
+- Extending `detectProjectType()` in onboarding/steps.go: Returns untyped map, mixes with wizard flow, not reusable.
+- Extending `detectProject()` in init.go: Same issues plus it returns `map[string]interface{}`.
+
+**Key Findings**:
+- Two duplicate detection functions exist: `detectProjectType()` (onboarding/steps.go:165) and `detectProject()` (init.go:850). Both should be replaced.
+- `detectNodeProject()` (init.go:902) has sophisticated lockfile-based package manager detection — this logic should move into the flavour package.
+- The detection must be ordered by specificity: `bun.lock` before `package.json`, `deno.json` before `package.json`, etc.
+- Current coverage: go, deno, node, rust, python (5 languages). Target: 25+.
+
+### R3: Manifest Field Extension
+
+**Decision**: Add `Flavour` and `FormatCommand` to `manifest.Project` struct
+**Rationale**: These are project-level properties that parallel existing `Language`, `TestCommand`, etc. The `ProjectVars()` method already emits template variables for these fields.
+**Alternatives Rejected**:
+- Separate `flavour` top-level key: Breaks the `project.*` namespace convention.
+- Storing flavour only in detection, not manifest: Pipelines need template access at runtime.
+
+**Key Findings**:
+- `Project` struct (types.go:8-14) needs two new fields: `Flavour string` and `FormatCommand string`.
+- `ProjectVars()` (types.go:171-192) needs two new entries.
+- `buildManifest()` (onboarding.go:175) and `createDefaultManifest()` (init.go:994) need to propagate the new fields.
+- `WizardResult` (onboarding.go:25) needs `Flavour` and `FormatCommand` fields.
+
+### R4: Forge-Filtered Pipeline Selection During Init
+
+**Decision**: Call `forge.FilterPipelinesByForge()` in `getFilteredAssets()` after release filtering
+**Rationale**: The function already exists and handles the exact semantics needed. Pipelines without forge prefixes pass through unchanged.
+**Alternatives Rejected**:
+- New filter in wizard: Duplicates existing logic.
+- Metadata-based forge tags: Over-engineering for current needs.
+
+**Key Findings**:
+- `getFilteredAssets()` (init.go:116) is the natural integration point.
+- After release filtering, the pipeline name list can be passed to `FilterPipelinesByForge()`.
+- For `--all` mode, forge filtering should still apply (you want all release pipelines for your forge, not all forges).
+- `DetectFromGitRemotes()` needs to be called once and the result threaded through.
+
+### R5: Project Metadata Extraction
+
+**Decision**: `flavour.DetectMetadata(dir string) MetadataResult` in the new flavour package
+**Rationale**: Metadata extraction is tightly coupled to the same marker files used for flavour detection. Same package, separate function.
+**Alternatives Rejected**:
+- Metadata extraction in onboarding: Not reusable, and the parsing logic belongs with flavour detection.
+
+**Key Findings**:
+- `go.mod`: Parse module path, extract repo name from last path segment.
+- `package.json`: JSON unmarshal, read `name` and `description`.
+- `Cargo.toml`: TOML-like parsing (line scanning for `name = "..."` under `[package]`).
+- `pyproject.toml`: Similar line scanning under `[project]` or `[tool.poetry]`.
+- Fallback: use directory name as project name.
+
+### R6: First-Run Suggestion
+
+**Decision**: Check for source files in the project after init completes; suggest `audit-dx` if present, `ops-bootstrap` if empty.
+**Rationale**: Simple heuristic that covers the two main user flows.
+**Alternatives Rejected**:
+- Complex suggestion engine: Over-engineering for a hint message.
+
+**Key Findings**:
+- `internal/suggest/engine.go` exists but is for runtime pipeline suggestion, not init-time hints.
+- The check should look for any non-Wave source files (anything outside `.wave/`, `wave.yaml`).
+- Both `printInitSuccess` and `printWizardSuccess` need to include the suggestion.
+
+### R7: Required Pipeline Safeguard (Story 7)
+
+**Decision**: Add `requiredPipelines` list to `getFilteredAssets` as defense-in-depth
+**Rationale**: `impl-issue` has no forge prefix so it passes forge filtering. But `getFilteredAssets` also filters by `release: true`. A safeguard ensures essential pipelines survive all filters.
+**Alternatives Rejected**:
+- Trusting existing filters only: One metadata change could break it.
+
+**Key Findings**:
+- `getFilteredAssets()` calls `defaults.GetReleasePipelines()` which filters embedded pipelines by `release: true` metadata.
+- `impl-issue.yaml` currently has `release: true`, but this could change.
+- A `requiredPipelines` set (just `impl-issue` for now) that forces inclusion after all filtering is cheap insurance.

--- a/specs/403-init-cold-start-flavour/spec.md
+++ b/specs/403-init-cold-start-flavour/spec.md
@@ -1,0 +1,217 @@
+# Feature Specification: Init Cold-Start Fix, Flavour Auto-Detection, and Smart Init
+
+**Feature Branch**: `403-init-cold-start-flavour`
+**Created**: 2026-03-16
+**Status**: Clarified
+**Input**: User description: "https://github.com/re-cinq/wave/issues/403"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Cold-Start Init in Empty Directory (Priority: P1)
+
+A developer creates a brand-new project directory with no git history and runs `wave init`. Today this crashes because the worktree manager expects `.git`, a commit history, and a remote. The system should gracefully handle all three missing prerequisites and produce a working Wave setup.
+
+**Why this priority**: Without this fix, Wave is completely unusable for greenfield projects. This is a blocking bug that prevents adoption.
+
+**Independent Test**: Run `wave init` in an empty directory and verify it completes without errors, producing a valid `wave.yaml`, `.wave/` structure, and a git repository with at least one commit.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty directory with no `.git`, **When** `wave init` is run, **Then** the system initializes a git repository (`git init`), writes Wave configuration files, creates an initial commit, and completes successfully.
+2. **Given** a directory with `.git` but no commits, **When** `wave init` is run, **Then** the system creates an initial commit with the Wave files and completes successfully.
+3. **Given** a directory with `.git` and commits but no remote, **When** `wave init` is run, **Then** the system skips forge detection gracefully, logs a warning, and completes successfully without crashing.
+4. **Given** a directory with `.git`, commits, and a remote, **When** `wave init` is run, **Then** the system detects the forge from the remote and proceeds as it does today.
+
+---
+
+### User Story 2 - Automatic Language and Flavour Detection (Priority: P1)
+
+A developer runs `wave init` in a project that already has source code. The system automatically detects the project's programming language and toolchain from marker files (e.g., `go.mod`, `Cargo.toml`, `package.json`) and pre-fills the `project` section of `wave.yaml` with appropriate commands.
+
+**Why this priority**: This is the core value of the flavour system — it eliminates manual configuration for the vast majority of projects and makes Wave immediately useful out of the box.
+
+**Independent Test**: Place a `Cargo.toml` in a directory, run `wave init`, and verify `wave.yaml` contains `project.flavour: rust`, `project.test_command: cargo test`, etc.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory containing `go.mod`, **When** `wave init` is run, **Then** `wave.yaml` contains `project.flavour: go`, `project.language: go`, `project.test_command: go test ./...`, `project.lint_command: go vet ./...`, `project.build_command: go build ./...`, `project.format_command: gofmt -l .`, `project.source_glob: "*.go"`.
+2. **Given** a directory containing `Cargo.toml`, **When** `wave init` is run, **Then** `wave.yaml` contains `project.flavour: rust` with the Rust-specific commands from the detection matrix.
+3. **Given** a directory containing `package.json` and `bun.lock`, **When** `wave init` is run, **Then** the system detects the `bun` flavour (not generic `node`) because more specific markers are checked first.
+4. **Given** a directory containing no recognized marker files, **When** `wave init` is run, **Then** the system prompts the user for project commands (interactive) or leaves them empty (non-interactive) without erroring.
+5. **Given** a directory containing multiple marker files (e.g., `go.mod` and `package.json`), **When** `wave init` is run, **Then** the system uses the first match from the priority-ordered detection list.
+
+---
+
+### User Story 3 - New Manifest Fields for Flavour (Priority: P1)
+
+The `wave.yaml` manifest gains new fields under `project:` to capture the detected flavour and format command. These fields are available as template variables in persona prompts and pipeline definitions.
+
+**Why this priority**: The flavour and format_command fields are prerequisites for both auto-detection (Story 2) and smart init (Story 5). Without the data model change, no downstream feature works.
+
+**Independent Test**: Create a `wave.yaml` with `project.flavour: rust` and `project.format_command: cargo fmt -- --check`, load it, and verify `ProjectVars()` returns the new keys.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `wave.yaml` with `project.flavour: rust`, **When** the manifest is loaded, **Then** `project.Flavour` is populated and `ProjectVars()` includes `"project.flavour": "rust"`.
+2. **Given** a `wave.yaml` with `project.format_command: cargo fmt -- --check`, **When** the manifest is loaded, **Then** `project.FormatCommand` is populated and available as template variable `project.format_command`.
+3. **Given** a `wave.yaml` without `project.flavour`, **When** the manifest is loaded, **Then** the field defaults to empty string and no error is raised (backward compatible).
+
+---
+
+### User Story 4 - Forge-Filtered Persona and Pipeline Selection (Priority: P2)
+
+During `wave init`, the system detects the git forge (GitHub, GitLab, Bitbucket, Gitea) from the remote URL and only includes personas and pipelines relevant to that forge.
+
+**Why this priority**: Important for a clean setup, but the system works without it (users just see extra unused pipelines). Not blocking for MVP.
+
+**Independent Test**: Initialize Wave in a repo with a GitHub remote and verify only forge-agnostic pipelines and any forge-matching prefixed pipelines are included in the selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with a GitHub remote, **When** `wave init` is run, **Then** only forge-agnostic pipelines (no forge prefix) and `gh-*` prefixed pipelines (if any local overrides exist) are included in the pipeline selection. Note: after the pipeline unification (PR #375), most embedded pipelines are forge-agnostic and pass through unfiltered.
+2. **Given** a repository with a GitLab remote, **When** `wave init` is run, **Then** only forge-agnostic and `gl-*` prefixed pipelines are included.
+3. **Given** a repository with no remote, **When** `wave init` is run, **Then** all pipelines are included (no filtering applied).
+4. **Given** a repository with a recognized forge, **When** `wave init` is run in non-interactive mode (`--yes`), **Then** forge filtering is applied automatically without prompts.
+
+---
+
+### User Story 5 - Project Metadata Extraction (Priority: P2)
+
+The system extracts the project name and description from language-specific manifest files (`Cargo.toml`, `go.mod`, `package.json`, `pyproject.toml`, etc.) and populates `metadata.name` and `metadata.description` in `wave.yaml`.
+
+**Why this priority**: Nice UX polish that reduces manual entry, but not blocking for core functionality.
+
+**Independent Test**: Place a `package.json` with `"name": "my-app"` and `"description": "A cool app"`, run `wave init`, and verify `wave.yaml` metadata fields are populated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `package.json` with `name` and `description` fields, **When** `wave init` is run, **Then** `wave.yaml` metadata contains the extracted name and description.
+2. **Given** a `go.mod` with module path `github.com/org/repo`, **When** `wave init` is run, **Then** the project name is extracted as `repo` from the module path.
+3. **Given** a `Cargo.toml` with `[package]` section containing `name` and `description`, **When** `wave init` is run, **Then** metadata is populated from those fields.
+4. **Given** no recognized manifest file, **When** `wave init` is run, **Then** the directory name is used as the project name.
+
+---
+
+### User Story 6 - First-Run Suggestion (Priority: P3)
+
+After initialization completes, the system suggests an appropriate first pipeline to run based on project state: `ops-bootstrap` for empty projects, `audit-dx` for projects with existing code.
+
+**Why this priority**: Pure UX enhancement — helpful but not required for the init flow to function.
+
+**Independent Test**: Run `wave init` in a directory with existing source code and verify the completion message suggests `audit-dx`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty project (no source files beyond Wave config), **When** `wave init` completes, **Then** the success message suggests running `wave run ops-bootstrap`.
+2. **Given** a project with existing source files, **When** `wave init` completes, **Then** the success message suggests running `wave run audit-dx`.
+
+---
+
+### User Story 7 - Ensuring impl-issue Pipeline Inclusion (Priority: P2)
+
+The `impl-issue` pipeline is always included in the pipeline set regardless of any filtering logic, since it was previously missing from some init configurations.
+
+**Why this priority**: This is a bug fix — `impl-issue` is the most commonly used pipeline and must always be available.
+
+**Independent Test**: Run `wave init` with any combination of flags and verify `impl-issue` is present in the generated pipeline set.
+
+**Acceptance Scenarios**:
+
+1. **Given** any project configuration, **When** `wave init` is run, **Then** the `impl-issue` pipeline is included in `.wave/pipelines/`.
+2. **Given** a forge-filtered init (e.g., GitLab), **When** pipelines are filtered, **Then** `impl-issue` survives the filter because it has no forge prefix.
+
+---
+
+### Edge Cases
+
+- What happens when `git init` fails (e.g., permissions issue)? The system reports a clear error message and exits without writing partial configuration.
+- What happens when multiple package managers are detected (e.g., both `yarn.lock` and `pnpm-lock.yaml`)? The first match in priority order wins; the more specific marker takes precedence.
+- What happens when `wave init` is run in a directory that already has `wave.yaml`? Existing behavior is preserved — prompt for overwrite or use `--force`/`--merge`.
+- What happens when the detected flavour's tool (e.g., `cargo`) is not installed? The flavour is still set in the manifest; the dependency check step warns about missing tools but does not block initialization.
+- What happens when `wave init --yes` is used in an empty directory? Cold-start proceeds fully non-interactively: `git init`, detect language, write config, create commit.
+- What happens when the remote URL uses an enterprise GitHub domain (e.g., `github.mycompany.com`)? Forge detection correctly classifies it as GitHub via existing `classifyHost()` logic.
+- What happens when `wave init --reconfigure` is used and the flavour has changed (e.g., project migrated from npm to bun)? The system re-detects the flavour and updates the project section.
+
+## Clarifications
+
+### Q1: Where does the cold-start git init logic live?
+
+**Ambiguity**: The spec says `wave init` should run `git init` when `.git` is absent, but doesn't specify whether this logic belongs in `cmd/wave/commands/init.go` (the `runInit` function) or in the `internal/onboarding` package.
+
+**Resolution**: The cold-start logic (git init, initial commit) belongs in `cmd/wave/commands/init.go` in the `runInit` function, **before** the onboarding wizard is invoked. The onboarding wizard (`internal/onboarding`) is concerned with configuration collection, not git repository setup. The `runInit` function already orchestrates the high-level flow (check existing files, invoke wizard, write assets) and is the natural place for pre-wizard git bootstrapping.
+
+**Rationale**: Follows existing separation of concerns — `runInit` handles prerequisites and orchestration, the wizard handles interactive configuration. Cold-start is a prerequisite, not a configuration step.
+
+### Q2: Should flavour detection extend `detectProjectType` or create a new package?
+
+**Ambiguity**: The existing `detectProjectType()` in `internal/onboarding/steps.go` covers only 5 languages and returns `map[string]string` without a `flavour` key. The spec requires 25+ languages with a `flavour` field. Should this be an in-place extension or a new `internal/flavour` package?
+
+**Resolution**: Create a new `internal/flavour` package with a `Detect()` function that returns a structured `DetectionResult` type (not a raw map). The existing `detectProjectType()` in `internal/onboarding/steps.go` should be replaced with a call to `flavour.Detect()`. The new package provides:
+- A `DetectionResult` struct with fields: `Flavour`, `Language`, `TestCommand`, `LintCommand`, `BuildCommand`, `FormatCommand`, `SourceGlob`
+- A priority-ordered slice of `DetectionRule` structs (marker files → result)
+- A `DetectMetadata()` function for project name/description extraction (Story 5)
+
+**Rationale**: The flavour detection matrix is a standalone concern with its own test surface. A dedicated package keeps the onboarding package focused on wizard flow and makes the detection logic reusable by other components (e.g., `wave doctor`, `wave suggest`).
+
+### Q3: How does forge-filtered pipeline selection interact with the unified pipeline naming?
+
+**Ambiguity**: Story 4 references `gh-*` prefixed pipelines, but the pipeline unification (PR #375, #380) replaced forge-specific pipelines with forge-agnostic unified pipelines (e.g., `impl-issue` instead of `gh-implement`). The `FilterPipelinesByForge` function in `internal/forge/detect.go` already exists and handles prefix-based filtering. Are there still forge-prefixed pipelines to filter?
+
+**Resolution**: After the pipeline unification, most pipelines are forge-agnostic (no forge prefix). Forge-filtered selection during init should use the existing `forge.FilterPipelinesByForge()` function, which already correctly passes through pipelines without forge prefixes. The practical effect is: if a user has custom `gh-*` or `gl-*` local pipeline overrides, those get filtered; the default embedded pipelines are all forge-agnostic and pass through unfiltered. Story 4's acceptance scenarios should be read as applying to the **full pipeline catalog** (embedded + local overrides), not just embedded pipelines. Update acceptance scenario wording accordingly.
+
+**Rationale**: The existing `FilterPipelinesByForge` already implements the correct logic — include pipelines matching the forge prefix OR having no forge prefix. No new filtering logic is needed; the init flow just needs to call this function during pipeline selection.
+
+### Q4: Does `impl-issue` actually need special inclusion logic (Story 7)?
+
+**Ambiguity**: Story 7 says `impl-issue` must "always be included regardless of filtering logic," but `impl-issue` has no forge prefix. The existing `FilterPipelinesByForge` already includes all pipelines without a forge prefix. Is Story 7 already satisfied by the existing forge filter, or is there a separate filtering path that could exclude it?
+
+**Resolution**: Story 7 is already satisfied by the existing `forge.FilterPipelinesByForge()` behavior — pipelines without a forge prefix (like `impl-issue`) always pass through. However, there is a separate risk: the `getFilteredAssets()` function in `init.go` filters by `release: true` metadata. If `impl-issue` were ever not marked as `release: true`, it would be excluded. The implementation should add a `requiredPipelines` safeguard in the pipeline selection step that ensures `impl-issue` (and potentially other essential pipelines) are always included regardless of release filtering. This is a defense-in-depth measure.
+
+**Rationale**: Belt-and-suspenders approach. The forge filter already handles it, but the release filter is a separate code path that could exclude essential pipelines. A small `requiredPipelines` list is cheap insurance.
+
+### Q5: What is the initial commit message and what files does it include?
+
+**Ambiguity**: FR-002 says "create an initial git commit after writing Wave configuration files" but doesn't specify the commit message, which files to stage, or whether the commit should include only Wave files or all files in the directory.
+
+**Resolution**: The initial commit should:
+- Stage only Wave-generated files: `wave.yaml`, `.wave/` directory contents
+- Use the commit message: `chore: initialize wave project`
+- NOT stage any pre-existing user files (source code, etc.) — the user should control what goes into their repository
+- If the directory is truly empty (no prior files), the commit contains only Wave configuration
+
+**Rationale**: Staging only Wave files respects user intent — they haven't asked Wave to commit their source code. The conventional commit prefix `chore:` matches the project's commit style. This also avoids accidentally committing sensitive files.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST check for `.git` directory existence and run `git init` if absent during `wave init`.
+- **FR-002**: System MUST create an initial git commit after writing Wave configuration files when the repository has no prior commits.
+- **FR-003**: System MUST handle missing git remote gracefully during forge detection, falling back to `ForgeUnknown` without crashing.
+- **FR-004**: System MUST detect project language and toolchain from at least 25 marker file patterns as specified in the detection matrix.
+- **FR-005**: System MUST check more specific markers before generic ones (e.g., `bun.lock` before `package.json`) using priority-ordered detection.
+- **FR-006**: System MUST add `flavour` and `format_command` fields to the `Project` struct in the manifest type system.
+- **FR-007**: System MUST expose `project.flavour` and `project.format_command` as template variables via `ProjectVars()`.
+- **FR-008**: System MUST detect the git forge from remote URLs and filter pipelines to only those matching the detected forge during init.
+- **FR-009**: System MUST extract project name and description from language-specific manifest files when available.
+- **FR-010**: System MUST always include the `impl-issue` pipeline in the pipeline set regardless of forge filtering or other selection criteria.
+- **FR-011**: System MUST preserve backward compatibility — existing `wave.yaml` files without new fields MUST load without error.
+- **FR-012**: System MUST suggest an appropriate first pipeline based on project state after init completes.
+- **FR-013**: System MUST support the full detection matrix: go, rust, node (npm/yarn/pnpm/bun), deno, python (modern/legacy), C#, Java (Maven/Gradle), Kotlin, Elixir, Dart/Flutter, C++ (CMake), Make, PHP, Ruby, Swift, Zig, Scala, Haskell (Cabal/Stack), TypeScript standalone.
+
+### Key Entities
+
+- **Flavour**: A named project type (e.g., `go`, `rust`, `bun`, `python`) derived from marker file detection. Determines default commands for test, lint, build, format, and source glob. Stored in `project.flavour`.
+- **Detection Rule**: A mapping from one or more marker files to a flavour with associated default commands. Rules are ordered by specificity — more specific markers are checked before generic ones.
+- **Project Metadata**: Name and description extracted from language-specific manifest files (e.g., `package.json`, `Cargo.toml`), used to pre-populate `wave.yaml` metadata.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: `wave init` in an empty directory (no `.git`, no files) completes without error and produces a valid `wave.yaml` and `.wave/` directory with a git repository containing at least one commit.
+- **SC-002**: All 25+ language flavours from the detection matrix are correctly identified when their marker files are present.
+- **SC-003**: The generated `wave.yaml` contains correct `project.flavour`, `project.language`, and all command fields for every detected flavour.
+- **SC-004**: Forge-filtered pipeline selection excludes pipelines for non-matching forges while retaining forge-agnostic pipelines.
+- **SC-005**: All existing `wave init` functionality (interactive wizard, `--merge`, `--force`, `--reconfigure`, `--all`, `--yes`) continues to work without regression.
+- **SC-006**: `project.flavour` and `project.format_command` are available as template variables in persona prompts and pipeline definitions.

--- a/specs/403-init-cold-start-flavour/tasks.md
+++ b/specs/403-init-cold-start-flavour/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Init Cold-Start Fix, Flavour Auto-Detection
+
+**Branch**: `403-init-cold-start-flavour` | **Date**: 2026-03-16
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 [P1] Setup — Create `internal/flavour/` package directory and `detect.go` with package declaration, `DetectionResult` struct, `DetectionRule` struct, and the exported `Detect(dir string) DetectionResult` function signature (empty body returning zero value) — `internal/flavour/detect.go`
+- [X] T002 [P1] Setup — Create `internal/flavour/metadata.go` with `MetadataResult` struct and exported `DetectMetadata(dir string) MetadataResult` function signature (empty body returning zero value) — `internal/flavour/metadata.go`
+
+---
+
+## Phase 2: Foundation — Flavour Detection Engine (Story 2, FR-004/005/013)
+
+- [X] T003 [P1] [Story2] Implement priority-ordered detection rules slice with all 25+ language flavours as specified in data-model.md: go, rust, deno, bun, pnpm, yarn, node, python (modern/legacy), dotnet, maven, gradle, kotlin, elixir, dart, cmake, make, php, ruby, swift, zig, scala, cabal, stack, typescript-standalone. Each rule maps marker files to a `DetectionResult` with flavour, language, test/lint/build/format commands, and source glob — `internal/flavour/detect.go`
+- [X] T004 [P1] [Story2] Implement `Detect(dir string) DetectionResult` function body: iterate rules in priority order, check each marker (exact filename via `os.Stat`, glob patterns via `filepath.Glob`), return first match. Return zero value if no match — `internal/flavour/detect.go`
+- [X] T005 [P1] [Story2] Implement Node refinement logic in `Detect`: after matching any Node-based flavour (node, bun, pnpm, yarn), check for `tsconfig.json` to override Language to `"typescript"` and SourceGlob to `"*.{ts,tsx}"`. Read `package.json` scripts to derive actual test/lint/build commands (port logic from existing `detectNodeProject()` in init.go:902) — `internal/flavour/detect.go`
+- [X] T006 [P1] [Story2] [P] Write table-driven tests for `Detect()`: one test case per flavour (25+), specificity ordering tests (bun.lock before package.json, deno.json before package.json), no-match test, Node+tsconfig refinement test, glob marker tests (*.csproj, *.cabal) — `internal/flavour/detect_test.go`
+
+---
+
+## Phase 3: Manifest Extension (Story 3, FR-006/007/011)
+
+- [X] T007 [P1] [Story3] Add `Flavour string` and `FormatCommand string` fields (both `yaml:"...,omitempty"`) to the `Project` struct in `internal/manifest/types.go` — `internal/manifest/types.go:8-14`
+- [X] T008 [P1] [Story3] Extend `ProjectVars()` to include `project.flavour` and `project.format_command` entries when non-empty — `internal/manifest/types.go:171-192`
+- [X] T009 [P1] [Story3] [P] Add `Flavour` and `FormatCommand` fields to `WizardResult` struct in `internal/onboarding/onboarding.go` — `internal/onboarding/onboarding.go:25-36`
+- [X] T010 [P1] [Story3] Update `buildManifest()` to propagate `Flavour` and `FormatCommand` from `WizardResult` into the manifest project section — `internal/onboarding/onboarding.go:175`
+- [X] T011 [P1] [Story3] [P] Write tests for `ProjectVars()` with new fields: verify `project.flavour` and `project.format_command` are present when set, absent when empty — `internal/manifest/types_test.go`
+
+---
+
+## Phase 4: Cold-Start Git Bootstrap (Story 1, FR-001/002/003)
+
+- [X] T012 [P1] [Story1] Add `ensureGitRepo()` helper function in `cmd/wave/commands/init.go` that: (1) checks for `.git` existence and runs `git init` if absent, (2) checks for commits via `git rev-parse --verify HEAD` and returns a boolean `needsInitialCommit` flag — `cmd/wave/commands/init.go`
+- [X] T013 [P1] [Story1] Wire `ensureGitRepo()` into `runInit()` (line 267): call before any other logic. If `needsInitialCommit` is true, defer creating an initial commit after Wave files are written (stage only `wave.yaml` and `.wave/`, commit message `chore: initialize wave project`) — `cmd/wave/commands/init.go:267`
+- [X] T014 [P1] [Story1] Wire `ensureGitRepo()` into `runWizardInit()` (line 1165): same logic as T013 — `cmd/wave/commands/init.go:1165`
+
+---
+
+## Phase 5: Integration — Flavour into Init (Stories 2, 5, FR-009)
+
+- [X] T015 [P1] [Story2] Replace `detectProject()` function body (init.go:850) with a call to `flavour.Detect(".")` and convert `DetectionResult` to `map[string]interface{}` including the new `flavour` and `format_command` keys — `cmd/wave/commands/init.go:850`
+- [X] T016 [P1] [Story2] Replace `detectProjectType()` function body (onboarding/steps.go:165) with a call to `flavour.Detect(".")` and convert `DetectionResult` to `map[string]string`. Add `format_command` to the TestConfigStep result — `internal/onboarding/steps.go:165`
+- [X] T017 [P1] [Story2] Update `createDefaultManifest()` (init.go:994) to include `flavour` and `format_command` keys in the project section when present — `cmd/wave/commands/init.go:994`
+
+---
+
+## Phase 6: Metadata Extraction (Story 5, FR-009)
+
+- [X] T018 [P2] [Story5] Implement `DetectMetadata(dir string) MetadataResult` function body: parse `go.mod` (extract repo name from module path), `package.json` (JSON unmarshal name/description), `Cargo.toml` (line scan `name =` under `[package]`), `pyproject.toml` (line scan under `[project]`). Fallback: use directory name as project name — `internal/flavour/metadata.go`
+- [X] T019 [P2] [Story5] [P] Write table-driven tests for `DetectMetadata()`: go.mod, package.json, Cargo.toml, pyproject.toml, no-manifest-fallback-to-dirname — `internal/flavour/detect_test.go`
+- [X] T020 [P2] [Story5] Wire `flavour.DetectMetadata(".")` into `runInit()` and `runWizardInit()` to populate `metadata.name` and `metadata.description` in the manifest when not already set — `cmd/wave/commands/init.go`
+
+---
+
+## Phase 7: Forge Filtering & Required Pipelines (Stories 4, 7, FR-008/010)
+
+- [X] T021 [P2] [Story4] Add forge detection call (`forge.DetectFromGitRemotes()`) in `getFilteredAssets()` (init.go:116) and apply `forge.FilterPipelinesByForge()` to the pipeline name list after release filtering — `cmd/wave/commands/init.go:116`
+- [X] T022 [P2] [Story7] [P] Add `requiredPipelines` safeguard in `getFilteredAssets()`: after all filtering, ensure `impl-issue` is always present in the pipeline set — `cmd/wave/commands/init.go:116`
+
+---
+
+## Phase 8: First-Run Suggestion (Story 6, FR-012)
+
+- [X] T023 [P3] [Story6] Add `suggestFirstPipeline(dir string) string` helper that checks for non-Wave source files: returns `"audit-dx"` if source files exist, `"ops-bootstrap"` if empty — `cmd/wave/commands/init.go`
+- [X] T024 [P3] [Story6] Update `printInitSuccess()` (init.go:790) and `printWizardSuccess()` (init.go:1332) to call `suggestFirstPipeline()` and include the suggestion in the success message — `cmd/wave/commands/init.go:790`
+
+---
+
+## Phase 9: Integration Tests & Polish
+
+- [X] T025 [P1] [P] Write integration tests for cold-start scenarios: (1) empty dir no .git, (2) .git but no commits, (3) .git + commits + no remote, (4) .git + commits + remote — `cmd/wave/commands/init_test.go`
+- [X] T026 [P2] [P] Write integration tests for flavour detection in init: run `detectProject()` with go.mod present → verify flavour=go in result — `cmd/wave/commands/init_test.go`
+- [X] T027 [P2] [P] Write integration tests for forge-filtered pipeline selection and requiredPipelines safeguard — `cmd/wave/commands/init_test.go`
+- [X] T028 [P1] Run `go test ./...` and `go vet ./...` to verify all tests pass and no regressions — full codebase
+- [X] T029 [P1] Run `golangci-lint run ./...` and fix any lint issues — full codebase
+
+---
+
+## Dependency Graph
+
+```
+T001, T002 (setup, parallel)
+  ├── T003 → T004 → T005 (detection engine, sequential)
+  │   └── T006 (tests, after T005)
+  ├── T007 → T008 (manifest types, sequential)
+  │   ├── T009 (wizard result, parallel with T008)
+  │   ├── T010 (buildManifest, after T008+T009)
+  │   └── T011 (type tests, parallel with T010)
+  └── T012 → T013 → T014 (cold-start, sequential)
+T005 + T008 → T015 → T016 → T017 (integration, needs both flavour + manifest)
+T005 → T018 → T019, T020 (metadata, after detection engine)
+T015 → T021 → T022 (forge filtering, after integration)
+T015 → T023 → T024 (suggestion, after integration)
+T013 + T015 → T025, T026, T027 (integration tests, after cold-start + flavour wired)
+T025..T027 → T028 → T029 (final validation, sequential)
+```
+
+## Task Summary
+
+| Phase | Tasks | Parallelizable |
+|-------|-------|----------------|
+| 1: Setup | T001-T002 | 2 |
+| 2: Flavour Engine | T003-T006 | 1 (T006) |
+| 3: Manifest Extension | T007-T011 | 2 (T009, T011) |
+| 4: Cold-Start | T012-T014 | 0 |
+| 5: Flavour Integration | T015-T017 | 0 |
+| 6: Metadata | T018-T020 | 1 (T019) |
+| 7: Forge Filtering | T021-T022 | 1 (T022) |
+| 8: First-Run Suggestion | T023-T024 | 0 |
+| 9: Polish | T025-T029 | 3 (T025-T027) |
+| **Total** | **29** | **10** |


### PR DESCRIPTION
## Summary

- **New `internal/flavour` package**: Centralizes project detection with 25+ language/toolchain flavours (Go, Rust, Deno, Bun, pnpm, Yarn, npm, Python, C#, Java/Maven, Java/Gradle, Elixir, Dart, C++/CMake, Make, PHP, Ruby, Swift, Zig, Scala, Haskell/Cabal, Haskell/Stack, TypeScript standalone)
- **Cold-start support**: `wave init` now auto-initializes a git repository if none exists and creates an initial commit with wave configuration
- **`format_command` field**: New manifest field populated by flavour detection for projects that have a formatter
- **Forge-based pipeline filtering**: Filters pipelines by detected forge (GitHub/GitLab) with required-pipeline safeguard ensuring `impl-issue` is always available
- **Project metadata extraction**: Reads project name/description from `go.mod`, `package.json`, `Cargo.toml`, or `pyproject.toml` and populates manifest metadata
- **First-run pipeline suggestion**: `wave init` now suggests `audit-dx` for existing codebases or `ops-bootstrap` for empty projects

## Spec

[specs/403-init-cold-start-flavour/spec.md](specs/403-init-cold-start-flavour/spec.md)

## Test Plan

- All existing tests pass (`go test -race ./...` — 31 packages OK)
- New tests for `ensureGitRepo` (empty dir, no commits, existing commits)
- New tests for `detectProject` via flavour package integration
- New tests for `suggestFirstPipeline` logic
- New `internal/manifest/types_test.go` for `ProjectVars()` with new fields
- Comprehensive `internal/flavour/detect_test.go` covering all 25+ flavours, Node refinement, glob markers, and metadata extraction

## Known Limitations

- TOML metadata parsing uses line-by-line scanning (no full TOML parser) — sufficient for `name`/`description` extraction but won't handle complex TOML structures
- Forge filtering relies on `forge.FilterPipelinesByForge` which filters by naming convention — custom pipeline names won't be filtered

Closes #403
