### PR TITLE
fix(tui): prevent pipeline refresh from overwriting issues view

### DIFF
--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -968,8 +968,10 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 	case PipelineSelectedMsg:
 		var listCmd, detailCmd tea.Cmd
 		m.list, listCmd = m.list.Update(msg)
-		// When in Issues view, show pipeline detail in right pane.
-		if m.currentView == ViewIssues {
+		// When in Issues view, show pipeline detail in right pane — but only
+		// when the selection came from the issue list (user interaction), not
+		// from the pipeline list's periodic data refresh.
+		if m.currentView == ViewIssues && msg.FromIssueList {
 			m.issueShowPipeline = true
 		}
 		// Wire live output from SQLite events for running pipelines on hover

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -813,3 +813,44 @@ func TestContentModel_EnterOnRunningItem_EmitsLiveOutputActive(t *testing.T) {
 	assert.Equal(t, stateRunningLive, c.detail.paneState, "detail pane should be in live output state")
 	assert.Equal(t, "r1", c.detachedPollRunID, "should start detached polling for the run")
 }
+
+func TestContentModel_PipelineRefreshDoesNotOverwriteIssueView(t *testing.T) {
+	// Regression test: periodic pipeline data refresh was re-emitting
+	// PipelineSelectedMsg which flipped issueShowPipeline to true,
+	// overwriting the issue detail pane with pipeline output.
+	m := newTestContentModel(t)
+	m.currentView = ViewIssues
+	m.issueShowPipeline = false
+
+	// Simulate a PipelineSelectedMsg from the pipeline list's periodic
+	// data refresh (FromIssueList is false).
+	refreshMsg := PipelineSelectedMsg{
+		RunID: "run-refresh",
+		Name:  "some-pipeline",
+		Kind:  itemKindFinished,
+	}
+	m, _ = m.Update(refreshMsg)
+
+	assert.False(t, m.issueShowPipeline,
+		"pipeline list refresh must not flip issueShowPipeline to true")
+}
+
+func TestContentModel_IssueListPipelineSelectionShowsPipelineDetail(t *testing.T) {
+	// When the user selects a pipeline child in the issue list,
+	// issueShowPipeline should be set to true.
+	m := newTestContentModel(t)
+	m.currentView = ViewIssues
+	m.issueShowPipeline = false
+
+	// Simulate a PipelineSelectedMsg from the issue list (FromIssueList is true).
+	issueMsg := PipelineSelectedMsg{
+		RunID:         "run-issue",
+		Name:          "child-pipeline",
+		Kind:          itemKindRunning,
+		FromIssueList: true,
+	}
+	m, _ = m.Update(issueMsg)
+
+	assert.True(t, m.issueShowPipeline,
+		"issue list pipeline selection should show pipeline detail")
+}

--- a/internal/tui/header_messages.go
+++ b/internal/tui/header_messages.go
@@ -41,6 +41,7 @@ type PipelineSelectedMsg struct {
 	BranchDeleted bool      // True if the branch no longer exists
 	Kind          itemKind  // itemKindRunning, itemKindFinished, or itemKindAvailable
 	StartedAt     time.Time // When the run was started (zero for available pipelines)
+	FromIssueList bool      // True when emitted by issue list (not pipeline list refresh)
 }
 
 // FocusPane identifies which pane has keyboard focus.

--- a/internal/tui/issue_list.go
+++ b/internal/tui/issue_list.go
@@ -528,12 +528,13 @@ func (m IssueListModel) emitSelectionMsg() tea.Cmd {
 			r := m.running[item.dataIndex]
 			return func() tea.Msg {
 				return PipelineSelectedMsg{
-					RunID:      r.RunID,
-					Name:       r.Name,
-					Input:      r.Input,
-					BranchName: r.BranchName,
-					Kind:       itemKindRunning,
-					StartedAt:  r.StartedAt,
+					RunID:         r.RunID,
+					Name:          r.Name,
+					Input:         r.Input,
+					BranchName:    r.BranchName,
+					Kind:          itemKindRunning,
+					StartedAt:     r.StartedAt,
+					FromIssueList: true,
 				}
 			}
 		}
@@ -542,12 +543,13 @@ func (m IssueListModel) emitSelectionMsg() tea.Cmd {
 			f := m.finished[item.dataIndex]
 			return func() tea.Msg {
 				return PipelineSelectedMsg{
-					RunID:      f.RunID,
-					Name:       f.Name,
-					Input:      f.Input,
-					BranchName: f.BranchName,
-					Kind:       itemKindFinished,
-					StartedAt:  f.StartedAt,
+					RunID:         f.RunID,
+					Name:          f.Name,
+					Input:         f.Input,
+					BranchName:    f.BranchName,
+					Kind:          itemKindFinished,
+					StartedAt:     f.StartedAt,
+					FromIssueList: true,
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Add `FromIssueList` flag to `PipelineSelectedMsg` to distinguish user selections from periodic refresh events
- Only flip `issueShowPipeline` when the selection originates from the issue list, not from pipeline list data refresh
- Add two regression tests covering both scenarios

## Root Cause
The periodic pipeline data refresh re-emitted `PipelineSelectedMsg` without origin context. The `ContentModel.Update` handler treated all such messages identically, flipping `issueShowPipeline = true` even during refresh cycles, which replaced the issue detail pane with pipeline output.

## Test plan
- [x] `TestContentModel_PipelineRefreshDoesNotOverwriteIssueView` — verifies refresh doesn't flip the flag
- [x] `TestContentModel_IssueListPipelineSelectionShowsPipelineDetail` — verifies user selection still works
- [x] Full test suite passes with `-race`

Fixes #411