### PR TITLE
fix(webui): wire cursor pagination in HTML runs page

### DIFF
--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -115,7 +115,6 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 // handleRunsPage handles GET /runs - serves the HTML run list page.
 func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	cursor, _ := decodeCursor(r.URL.Query().Get("cursor"))
-	_ = cursor // TODO: pass to query
 
 	limit := parsePageSize(r)
 	status := r.URL.Query().Get("status")
@@ -123,6 +122,11 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	opts := state.ListRunsOptions{
 		Status: status,
 		Limit:  limit + 1,
+	}
+
+	if cursor != nil {
+		opts.BeforeUnix = cursor.Timestamp
+		opts.BeforeRunID = cursor.RunID
 	}
 
 	runs, err := s.store.ListRuns(opts)


### PR DESCRIPTION
## Summary
- The API endpoint `/api/runs` already supported cursor-based pagination correctly
- The HTML page handler `/runs` decoded the cursor but discarded it (TODO comment)
- Wire `BeforeUnix`/`BeforeRunID` into `ListRunsOptions` for the HTML handler

Closes #441