### PR TITLE
feat(bench): add --offset flag to skip tasks in dataset

### DIFF
--- a/cmd/wave/commands/bench.go
+++ b/cmd/wave/commands/bench.go
@@ -47,6 +47,7 @@ func newBenchRunCmd() *cobra.Command {
 		limit          int
 		timeout        int
 		concurrency    int
+		offset         int
 		outputPath     string
 		datasetsDir    string
 		keepWorkspaces bool
@@ -111,6 +112,7 @@ Use --mode to select execution mode:
 				WorkDir:        ".wave/bench/workspaces",
 				KeepWorkspaces: keepWorkspaces,
 				Concurrency:    concurrency,
+				Offset:         offset,
 			}
 			if timeout > 0 {
 				cfg.TaskTimeout = time.Duration(timeout) * time.Second
@@ -167,6 +169,7 @@ Use --mode to select execution mode:
 	cmd.Flags().StringVar(&datasetsDir, "datasets-dir", ".wave/bench/datasets", "Directory to search for dataset files")
 	cmd.Flags().BoolVar(&keepWorkspaces, "keep-workspaces", false, "Preserve task worktrees after completion")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of tasks to run in parallel")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Skip the first N tasks in the dataset")
 
 	return cmd
 }

--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -46,6 +46,8 @@ type RunConfig struct {
 	KeepWorkspaces bool
 	// Concurrency is the number of tasks to run in parallel. Defaults to 1.
 	Concurrency int
+	// Offset skips the first N tasks in the dataset.
+	Offset int
 }
 
 // PipelineRunner is the interface for executing a single pipeline against a task.
@@ -232,6 +234,9 @@ func RunBenchmark(ctx context.Context, tasks []BenchTask, cfg RunConfig, runner 
 		return nil, fmt.Errorf("pipeline name is required (unless mode is %q)", ModeClaude)
 	}
 
+	if cfg.Offset > 0 && cfg.Offset < len(tasks) {
+		tasks = tasks[cfg.Offset:]
+	}
 	limit := len(tasks)
 	if cfg.Limit > 0 && cfg.Limit < limit {
 		limit = cfg.Limit


### PR DESCRIPTION
## Summary
- Adds `--offset` flag to `wave bench run` to skip the first N tasks, enabling batch runs across the full dataset

## Test plan
- [x] Verified with `--offset 10 --limit 10` running tasks 11-20