### PR TITLE
fix: refactor status command to use StateStore interface

### DIFF
--- a/cmd/wave/commands/status.go
+++ b/cmd/wave/commands/status.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,9 +8,8 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/display"
+	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-
-	_ "modernc.org/sqlite"
 )
 
 // StatusOptions holds options for the status command.
@@ -100,29 +98,52 @@ func runStatus(opts StatusOptions) error {
 		return nil
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewStateStore(dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to open state database: %w", err)
 	}
-	defer db.Close()
-
-	// Configure SQLite for read-only access
-	db.SetMaxOpenConns(1)
+	defer store.Close()
 
 	if opts.RunID != "" {
-		return showRunDetails(db, opts)
+		return showRunDetails(store, opts)
 	}
 
 	if opts.All {
-		return showAllRuns(db, opts, 10)
+		return showAllRuns(store, opts, 10)
 	}
 
-	return showRunningRuns(db, opts)
+	return showRunningRuns(store, opts)
+}
+
+// runRecordToStatusInfo converts a state.RunRecord to a StatusRunInfo for display.
+func runRecordToStatusInfo(r *state.RunRecord) StatusRunInfo {
+	info := StatusRunInfo{
+		RunID:       r.RunID,
+		Pipeline:    r.PipelineName,
+		Status:      r.Status,
+		CurrentStep: r.CurrentStep,
+		Tokens:      r.TotalTokens,
+		TokensStr:   formatTokens(r.TotalTokens),
+		StartedAt:   r.StartedAt.Format("2006-01-02 15:04:05"),
+		Input:       r.Input,
+		Error:       r.ErrorMessage,
+	}
+
+	if r.CompletedAt != nil {
+		info.CompletedAt = r.CompletedAt.Format("2006-01-02 15:04:05")
+		info.Elapsed = formatElapsed(r.CompletedAt.Sub(r.StartedAt))
+		info.ElapsedMs = r.CompletedAt.Sub(r.StartedAt).Milliseconds()
+	} else {
+		info.Elapsed = formatElapsed(time.Since(r.StartedAt))
+		info.ElapsedMs = time.Since(r.StartedAt).Milliseconds()
+	}
+
+	return info
 }
 
 // showRunDetails shows detailed status for a specific run.
-func showRunDetails(db *sql.DB, opts StatusOptions) error {
-	run, err := queryRun(db, opts.RunID)
+func showRunDetails(store state.StateStore, opts StatusOptions) error {
+	record, err := store.GetRun(opts.RunID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			if opts.Format == "json" {
@@ -134,6 +155,8 @@ func showRunDetails(db *sql.DB, opts StatusOptions) error {
 		}
 		return err
 	}
+
+	run := runRecordToStatusInfo(record)
 
 	if opts.Format == "json" {
 		output := StatusOutput{Runs: []StatusRunInfo{run}}
@@ -174,13 +197,13 @@ func showRunDetails(db *sql.DB, opts StatusOptions) error {
 }
 
 // showRunningRuns shows currently running pipelines.
-func showRunningRuns(db *sql.DB, opts StatusOptions) error {
-	runs, err := queryRunningRuns(db)
+func showRunningRuns(store state.StateStore, opts StatusOptions) error {
+	records, err := store.GetRunningRuns()
 	if err != nil {
 		return err
 	}
 
-	if len(runs) == 0 {
+	if len(records) == 0 {
 		if opts.Format == "json" {
 			fmt.Println(`{"runs":[]}`)
 			return nil
@@ -189,23 +212,33 @@ func showRunningRuns(db *sql.DB, opts StatusOptions) error {
 		return nil
 	}
 
+	runs := make([]StatusRunInfo, len(records))
+	for i := range records {
+		runs[i] = runRecordToStatusInfo(&records[i])
+	}
+
 	return outputRuns(runs, opts)
 }
 
 // showAllRuns shows recent pipelines.
-func showAllRuns(db *sql.DB, opts StatusOptions, limit int) error {
-	runs, err := queryRecentRuns(db, limit)
+func showAllRuns(store state.StateStore, opts StatusOptions, limit int) error {
+	records, err := store.ListRuns(state.ListRunsOptions{Limit: limit})
 	if err != nil {
 		return err
 	}
 
-	if len(runs) == 0 {
+	if len(records) == 0 {
 		if opts.Format == "json" {
 			fmt.Println(`{"runs":[]}`)
 			return nil
 		}
 		fmt.Fprintln(os.Stderr, "No pipelines found")
 		return nil
+	}
+
+	runs := make([]StatusRunInfo, len(records))
+	for i := range records {
+		runs[i] = runRecordToStatusInfo(&records[i])
 	}
 
 	return outputRuns(runs, opts)
@@ -285,164 +318,6 @@ func outputRuns(runs []StatusRunInfo, opts StatusOptions) error {
 	}
 
 	return nil
-}
-
-// queryRun queries a specific run by ID.
-func queryRun(db *sql.DB, runID string) (StatusRunInfo, error) {
-	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, error_message
-	          FROM pipeline_run
-	          WHERE run_id = ?`
-
-	var run StatusRunInfo
-	var startedAt int64
-	var completedAt sql.NullInt64
-	var input, currentStep, errorMessage sql.NullString
-	var tokens int
-
-	err := db.QueryRow(query, runID).Scan(
-		&run.RunID,
-		&run.Pipeline,
-		&run.Status,
-		&input,
-		&currentStep,
-		&tokens,
-		&startedAt,
-		&completedAt,
-		&errorMessage,
-	)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return run, fmt.Errorf("run not found: %s", runID)
-		}
-		return run, fmt.Errorf("failed to query run: %w", err)
-	}
-
-	run.Tokens = tokens
-	run.TokensStr = formatTokens(tokens)
-	run.StartedAt = time.Unix(startedAt, 0).Format("2006-01-02 15:04:05")
-
-	if input.Valid {
-		run.Input = input.String
-	}
-	if currentStep.Valid {
-		run.CurrentStep = currentStep.String
-	}
-	if completedAt.Valid {
-		run.CompletedAt = time.Unix(completedAt.Int64, 0).Format("2006-01-02 15:04:05")
-		run.Elapsed = formatElapsed(time.Unix(completedAt.Int64, 0).Sub(time.Unix(startedAt, 0)))
-		run.ElapsedMs = completedAt.Int64*1000 - startedAt*1000
-	} else {
-		run.Elapsed = formatElapsed(time.Since(time.Unix(startedAt, 0)))
-		run.ElapsedMs = time.Since(time.Unix(startedAt, 0)).Milliseconds()
-	}
-	if errorMessage.Valid {
-		run.Error = errorMessage.String
-	}
-
-	return run, nil
-}
-
-// queryRunningRuns queries currently running pipelines.
-func queryRunningRuns(db *sql.DB) ([]StatusRunInfo, error) {
-	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, error_message
-	          FROM pipeline_run
-	          WHERE status = 'running'
-	          ORDER BY started_at DESC`
-
-	return queryRunsInternal(db, query)
-}
-
-// queryRecentRuns queries recent pipelines.
-func queryRecentRuns(db *sql.DB, limit int) ([]StatusRunInfo, error) {
-	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
-	                 started_at, completed_at, error_message
-	          FROM pipeline_run
-	          ORDER BY started_at DESC
-	          LIMIT ?`
-
-	return queryRunsInternalWithArgs(db, query, limit)
-}
-
-// queryRunsInternal executes a query and returns StatusRunInfo slice.
-func queryRunsInternal(db *sql.DB, query string) ([]StatusRunInfo, error) {
-	rows, err := db.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query runs: %w", err)
-	}
-	defer rows.Close()
-
-	return scanRuns(rows)
-}
-
-// queryRunsInternalWithArgs executes a query with arguments.
-func queryRunsInternalWithArgs(db *sql.DB, query string, args ...any) ([]StatusRunInfo, error) {
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query runs: %w", err)
-	}
-	defer rows.Close()
-
-	return scanRuns(rows)
-}
-
-// scanRuns scans rows into StatusRunInfo slice.
-func scanRuns(rows *sql.Rows) ([]StatusRunInfo, error) {
-	var runs []StatusRunInfo
-
-	for rows.Next() {
-		var run StatusRunInfo
-		var startedAt int64
-		var completedAt sql.NullInt64
-		var input, currentStep, errorMessage sql.NullString
-		var tokens int
-
-		err := rows.Scan(
-			&run.RunID,
-			&run.Pipeline,
-			&run.Status,
-			&input,
-			&currentStep,
-			&tokens,
-			&startedAt,
-			&completedAt,
-			&errorMessage,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to scan run: %w", err)
-		}
-
-		run.Tokens = tokens
-		run.TokensStr = formatTokens(tokens)
-		run.StartedAt = time.Unix(startedAt, 0).Format("2006-01-02 15:04:05")
-
-		if input.Valid {
-			run.Input = input.String
-		}
-		if currentStep.Valid {
-			run.CurrentStep = currentStep.String
-		}
-		if completedAt.Valid {
-			run.CompletedAt = time.Unix(completedAt.Int64, 0).Format("2006-01-02 15:04:05")
-			run.Elapsed = formatElapsed(time.Unix(completedAt.Int64, 0).Sub(time.Unix(startedAt, 0)))
-			run.ElapsedMs = completedAt.Int64*1000 - startedAt*1000
-		} else {
-			run.Elapsed = formatElapsed(time.Since(time.Unix(startedAt, 0)))
-			run.ElapsedMs = time.Since(time.Unix(startedAt, 0)).Milliseconds()
-		}
-		if errorMessage.Valid {
-			run.Error = errorMessage.String
-		}
-
-		runs = append(runs, run)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating runs: %w", err)
-	}
-
-	return runs, nil
 }
 
 // statusColor returns the ANSI color code for a status.

--- a/cmd/wave/commands/status_test.go
+++ b/cmd/wave/commands/status_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,7 +22,8 @@ type statusTestHelper struct {
 	t       *testing.T
 	tmpDir  string
 	origDir string
-	db      *sql.DB
+	store   state.StateStore
+	db      *sql.DB // direct connection for test data insertion with specific IDs
 }
 
 // newStatusTestHelper creates a new test helper with a temporary directory and database.
@@ -36,44 +38,20 @@ func newStatusTestHelper(t *testing.T) *statusTestHelper {
 	err = os.MkdirAll(waveDir, 0755)
 	require.NoError(t, err, "failed to create .wave directory")
 
-	// Create and initialize database
+	// Create state store (applies all migrations, ensuring full schema)
 	dbPath := filepath.Join(waveDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err, "failed to open database")
+	store, err := state.NewStateStore(dbPath)
+	require.NoError(t, err, "failed to create state store")
 
-	// Initialize schema
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
-			input TEXT,
-			current_step TEXT,
-			total_tokens INTEGER DEFAULT 0,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER,
-			cancelled_at INTEGER,
-			error_message TEXT
-		);
-		CREATE TABLE IF NOT EXISTS event_log (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			run_id TEXT NOT NULL,
-			timestamp INTEGER NOT NULL,
-			step_id TEXT,
-			state TEXT NOT NULL,
-			persona TEXT,
-			message TEXT,
-			tokens_used INTEGER,
-			duration_ms INTEGER,
-			FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
-		);
-	`)
-	require.NoError(t, err, "failed to initialize schema")
+	// Open a direct SQL connection for inserting test data with specific run IDs
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err, "failed to open direct db connection")
 
 	return &statusTestHelper{
 		t:       t,
 		tmpDir:  tmpDir,
 		origDir: origDir,
+		store:   store,
 		db:      db,
 	}
 }
@@ -85,12 +63,15 @@ func (h *statusTestHelper) chdir() {
 	require.NoError(h.t, err, "failed to change to temp directory")
 }
 
-// restore returns to the original directory and closes the database.
+// restore returns to the original directory and closes the store.
 func (h *statusTestHelper) restore() {
 	h.t.Helper()
 	_ = os.Chdir(h.origDir)
 	if h.db != nil {
 		h.db.Close()
+	}
+	if h.store != nil {
+		h.store.Close()
 	}
 }
 
@@ -104,10 +85,17 @@ func (h *statusTestHelper) createRun(runID, pipelineName, status, currentStep st
 		completedAtUnix = &unix
 	}
 
+	var step any
+	if currentStep == "" {
+		step = nil
+	} else {
+		step = currentStep
+	}
+
 	_, err := h.db.Exec(`
 		INSERT INTO pipeline_run (run_id, pipeline_name, status, current_step, total_tokens, started_at, completed_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, runID, pipelineName, status, currentStep, tokens, startedAt.Unix(), completedAtUnix)
+	`, runID, pipelineName, status, step, tokens, startedAt.Unix(), completedAtUnix)
 	require.NoError(h.t, err, "failed to create run")
 }
 
@@ -115,10 +103,17 @@ func (h *statusTestHelper) createRun(runID, pipelineName, status, currentStep st
 func (h *statusTestHelper) createRunWithInput(runID, pipelineName, status, input string, startedAt time.Time, errorMsg string) {
 	h.t.Helper()
 
+	var errVal any
+	if errorMsg == "" {
+		errVal = nil
+	} else {
+		errVal = errorMsg
+	}
+
 	_, err := h.db.Exec(`
 		INSERT INTO pipeline_run (run_id, pipeline_name, status, input, total_tokens, started_at, error_message)
 		VALUES (?, ?, ?, ?, 0, ?, ?)
-	`, runID, pipelineName, status, input, startedAt.Unix(), errorMsg)
+	`, runID, pipelineName, status, input, startedAt.Unix(), errVal)
 	require.NoError(h.t, err, "failed to create run")
 }
 

--- a/specs/488-status-statestore/plan.md
+++ b/specs/488-status-statestore/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan
+
+## Objective
+
+Refactor `cmd/wave/commands/status.go` to use the `StateStore` interface instead of direct SQLite access, aligning it with the pattern used by all other commands (artifacts, compose, postmortem, chat, cancel, etc.).
+
+## Approach
+
+Single-file refactor of `status.go`:
+
+1. Replace `sql.Open("sqlite", dbPath)` with `state.NewStateStore(dbPath)`
+2. Replace `queryRun(db, runID)` with `store.GetRun(runID)` + conversion to `StatusRunInfo`
+3. Replace `queryRunningRuns(db)` with `store.GetRunningRuns()` + conversion
+4. Replace `queryRecentRuns(db, limit)` with `store.ListRuns(state.ListRunsOptions{Limit: limit})` + conversion
+5. Delete all raw SQL helper functions (~160 lines)
+6. Add a `runRecordToStatusInfo` conversion function
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `cmd/wave/commands/status.go` | modify | Replace direct SQL with StateStore calls |
+
+## Architecture Decisions
+
+- **Conversion function**: `RunRecord` has `time.Time` fields while `StatusRunInfo` uses formatted strings. A `runRecordToStatusInfo()` helper converts between them, keeping display logic in the commands package.
+- **Error message compatibility**: `StateStore.GetRun()` already returns `"run not found: <id>"` errors, matching the existing `queryRun` behavior — no change in error handling needed.
+- **GetRunningRuns() behavior**: The StateStore's `GetRunningRuns()` includes both `status='running'` and recent `status='pending'` runs (within 5 minutes). The current raw SQL only checks `status='running'`. This is a minor behavior improvement — pending runs that just started will now also appear.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Field mapping mismatch between `RunRecord` and `StatusRunInfo` | Verify all fields map correctly; `RunRecord` has all needed fields |
+| Different SQL query semantics | `GetRunningRuns()` includes pending runs — acceptable improvement |
+
+## Testing Strategy
+
+- Existing tests (if any) should continue to pass
+- `go test ./cmd/wave/commands/...` to verify no compilation errors
+- `go vet ./...` for static analysis
+- Manual verification that `wave status` output format is unchanged

--- a/specs/488-status-statestore/spec.md
+++ b/specs/488-status-statestore/spec.md
@@ -1,0 +1,26 @@
+# audit: regressed — status command direct SQLite access (#2)
+
+**Issue**: [#488](https://github.com/re-cinq/wave/issues/488)
+**Labels**: audit
+**Author**: nextlevelshit
+**Source**: #2 — Refactor Status Command to Use StateStore Interface
+
+## Problem
+
+`cmd/wave/commands/status.go` bypasses the `StateStore` interface and accesses SQLite directly:
+
+- Imports `database/sql` and `modernc.org/sqlite`
+- Contains raw SQL helper functions: `queryRun`, `queryRunningRuns`, `queryRecentRuns`, `queryRunsInternal`, `queryRunsInternalWithArgs`, `scanRuns`
+- `runStatus()` opens `sql.Open("sqlite", dbPath)` directly instead of using `state.NewStateStore()`
+
+## Acceptance Criteria
+
+1. `status.go` uses `state.NewStateStore()` to obtain a `StateStore` instance
+2. `showRunDetails` calls `store.GetRun(runID)` instead of `queryRun(db, runID)`
+3. `showRunningRuns` calls `store.GetRunningRuns()` instead of `queryRunningRuns(db)`
+4. `showAllRuns` calls `store.ListRuns(opts)` instead of `queryRecentRuns(db, limit)`
+5. All raw SQL helper functions removed: `queryRun`, `queryRunningRuns`, `queryRecentRuns`, `queryRunsInternal`, `queryRunsInternalWithArgs`, `scanRuns`
+6. `database/sql` and `modernc.org/sqlite` imports removed from `status.go`
+7. `RunRecord` fields mapped to `StatusRunInfo` for display formatting
+8. `go test ./...` passes
+9. `go vet ./...` clean

--- a/specs/488-status-statestore/tasks.md
+++ b/specs/488-status-statestore/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## Phase 1: Core Refactor
+
+- [X] Task 1.1: Update imports — replace `database/sql` and `modernc.org/sqlite` with `github.com/recinq/wave/internal/state`
+- [X] Task 1.2: Add `runRecordToStatusInfo(r *state.RunRecord) StatusRunInfo` conversion function
+- [X] Task 1.3: Refactor `runStatus()` — replace `sql.Open()` with `state.NewStateStore()`, update function signatures to pass `state.StateStore` instead of `*sql.DB`
+- [X] Task 1.4: Refactor `showRunDetails()` — use `store.GetRun()` + conversion
+- [X] Task 1.5: Refactor `showRunningRuns()` — use `store.GetRunningRuns()` + conversion
+- [X] Task 1.6: Refactor `showAllRuns()` — use `store.ListRuns()` + conversion
+
+## Phase 2: Cleanup
+
+- [X] Task 2.1: Delete `queryRun`, `queryRunningRuns`, `queryRecentRuns`, `queryRunsInternal`, `queryRunsInternalWithArgs`, `scanRuns` functions (lines 291-446)
+
+## Phase 3: Validation
+
+- [X] Task 3.1: Run `go build ./cmd/wave/...` to verify compilation
+- [X] Task 3.2: Run `go vet ./...` for static analysis
+- [X] Task 3.3: Run `go test ./...` for full test suite


### PR DESCRIPTION
## Summary
- Refactors `cmd/wave/commands/status.go` to use the `StateStore` interface instead of direct `database/sql` queries
- Removes raw SQL and direct SQLite dependency from the status command

Fixes #488

## Test plan
- [x] `go test ./...` passes
- [x] Status command still works with StateStore methods