### PR TITLE
chore(pipeline): remove misleading backward-compatible comments

### DIFF
--- a/internal/pipeline/resume.go
+++ b/internal/pipeline/resume.go
@@ -564,7 +564,7 @@ func (r *ResumeManager) GetRecommendedResumePoint(p *Pipeline) (string, error) {
 		return "", fmt.Errorf("pipeline has no steps")
 	}
 
-	// Prototype-specific logic (backward compatible)
+	// Prototype-specific logic
 	if p.Metadata.Name == "prototype" || p.Metadata.Name == "impl-prototype" {
 		return r.getPrototypeResumePoint(p)
 	}

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -29,7 +29,7 @@ func (v *PhaseSkipValidator) ValidatePhaseSequence(p *Pipeline, fromStep string)
 		return nil // Starting from beginning, no validation needed
 	}
 
-	// Prototype-specific validation (backward compatible)
+	// Prototype-specific validation
 	if p.Metadata.Name == "impl-prototype" || p.Metadata.Name == "prototype" {
 		return v.validatePrototypePhaseSequence(p, fromStep)
 	}

--- a/specs/500-remove-compat-shims/plan.md
+++ b/specs/500-remove-compat-shims/plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan
+
+## Objective
+
+Remove residual "backward compatible" comments from pipeline validation and resume code, and review whether the Down migration infrastructure should be kept or removed.
+
+## Approach
+
+This is a minimal cleanup: two comment edits and one architectural decision about migration rollback infrastructure.
+
+### Comment Removal (validation.go, resume.go)
+
+The comments mark prototype-specific code paths as "backward compatible" — but these aren't shims, they're the actual implementation for prototype pipelines. The parenthetical is misleading. Remove the "(backward compatible)" text from both comments while keeping the descriptive part.
+
+### Down Migration Review (migrations.go)
+
+**Decision: Keep the Down migration infrastructure.**
+
+Rationale:
+- The `Migration` struct's `Down` field, `RollbackMigration()`, `MigrateDown()`, and `wave migrate down` CLI command form standard migration infrastructure
+- All 10 current migrations have `Down: ""` — this is expected since SQLite `ALTER TABLE` and `CREATE TABLE` operations are hard to reverse safely
+- The infrastructure isn't a "backward-compatibility shim" — it's forward-looking capability for future migrations that might need rollback
+- The `wave migrate down` CLI command is a documented user-facing feature
+- Removing it would require deleting the CLI command, test coverage, and struct field — high churn for no functional benefit
+
+No changes needed for migrations.go.
+
+## File Mapping
+
+| File | Action | Change |
+|------|--------|--------|
+| `internal/pipeline/validation.go` | modify | Remove "(backward compatible)" from line 32 comment |
+| `internal/pipeline/resume.go` | modify | Remove "(backward compatible)" from line 567 comment |
+
+## Architecture Decisions
+
+- **Keep deprecated.go**: Intentional UX shim for pipeline name resolution — not a backward-compat artifact to remove
+- **Keep Down migration infrastructure**: Standard migration pattern, not a backward-compat shim
+
+## Risks
+
+- **None significant** — this is a comment-only change with no behavioral impact
+
+## Testing Strategy
+
+- Run `go test ./...` to confirm no regressions
+- No new tests needed — comments don't affect behavior

--- a/specs/500-remove-compat-shims/spec.md
+++ b/specs/500-remove-compat-shims/spec.md
@@ -1,0 +1,24 @@
+# audit: partial — backward-compat shims remaining (#115)
+
+**Issue**: [#500](https://github.com/re-cinq/wave/issues/500)
+**Source**: [#115](https://github.com/re-cinq/wave/issues/115) — chore: remove backwards-compatibility shims and reduce accidental complexity
+**Category**: audit — partial remediation
+**Labels**: audit
+**Author**: nextlevelshit
+
+## Summary
+
+Wave-audit pipeline detected residual backward-compatibility comments and infrastructure from the prototype era. While most shims have been removed, several remain:
+
+1. `internal/pipeline/validation.go:32` — comment "Prototype-specific validation (backward compatible)" on code that handles `impl-prototype`/`prototype` pipeline names
+2. `internal/pipeline/resume.go:567` — comment "Prototype-specific logic (backward compatible)" on code that handles prototype resume points
+3. `internal/state/migrations.go` — Down migration infrastructure (`RollbackMigration`, `MigrateDown`, `Migration.Down` field) exists but all 10 migration definitions have `Down: ""`
+4. `internal/pipeline/deprecated.go` — `ResolveDeprecatedName` taxonomy mappings (intentional UX shim, leave as-is)
+
+## Acceptance Criteria
+
+- [ ] Remove "backward compatible" parenthetical from comment at `validation.go:32`
+- [ ] Remove "backward compatible" parenthetical from comment at `resume.go:567`
+- [ ] Review Down migration paths — decide whether to keep or remove the infrastructure
+- [ ] `deprecated.go` left unchanged (intentional UX shim)
+- [ ] All tests pass (`go test ./...`)

--- a/specs/500-remove-compat-shims/tasks.md
+++ b/specs/500-remove-compat-shims/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## Phase 1: Comment Cleanup
+- [X] Task 1.1: Remove "(backward compatible)" from `internal/pipeline/validation.go:32` comment [P]
+- [X] Task 1.2: Remove "(backward compatible)" from `internal/pipeline/resume.go:567` comment [P]
+
+## Phase 2: Validation
+- [X] Task 2.1: Run `go test ./...` to confirm no test regressions
+- [X] Task 2.2: Run `go vet ./...` to confirm no issues
+
+## Phase 3: Polish
+- [X] Task 3.1: Commit changes with conventional commit message


### PR DESCRIPTION
## Summary
- Removes stale "backward compatible" comments from `internal/pipeline/validation.go` and `internal/pipeline/resume.go`
- These comments referenced a transitional state that no longer exists

Fixes #500

## Test plan
- [x] `go test ./...` passes
- [x] Comments-only change, no behavioral impact