### PR TITLE
docs: add Logs vs Progress Output section to CLI reference

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -269,6 +269,61 @@ wave logs --format json          # Output as JSON for scripting
 
 ---
 
+## Logs vs Progress Output
+
+Wave has two distinct observability mechanisms that serve different purposes:
+
+- **`wave logs`** reads the event history from the state database *after* events have been recorded. It works on both running and completed pipelines and is the primary tool for post-hoc debugging.
+- **`--output` modes** (`text`, `json`, `quiet`) control how real-time progress is rendered to the terminal *during* execution. They determine what you see while a pipeline runs.
+
+### Comparison
+
+| | `wave logs` | `--output` modes |
+|---|---|---|
+| **Mechanism** | Reads recorded events from SQLite state DB | Renders progress events to terminal in real-time |
+| **Data source** | `.wave/state.db` (persisted) | Live event stream (ephemeral) |
+| **Timing** | During or after execution | Only during execution |
+| **Typical use** | Post-hoc debugging, audit trail, scripting | Watching progress, CI output formatting |
+
+### Use-Case Examples
+
+**1. Debugging a failed step**
+
+After a pipeline fails, use `wave logs` to inspect what happened:
+
+```bash
+wave logs impl-issue-20260320-abc123 --errors
+wave logs impl-issue-20260320-abc123 --step implement --format json
+```
+
+The logs are persisted in the state database, so you can inspect them long after the run finishes.
+
+**2. Watching a pipeline run live**
+
+To see real-time progress with tool activity while a pipeline executes:
+
+```bash
+wave run impl-issue -o text -v -- "https://github.com/org/repo/issues/42"
+```
+
+The `-o text` flag renders plain-text progress to stderr, and `-v` adds real-time tool activity lines. This output is ephemeral — once the terminal is closed, it is gone.
+
+**3. Scripting and CI integration**
+
+For machine-readable output, combine both mechanisms:
+
+```bash
+# Real-time: stream structured JSON events during execution
+wave run impl-issue -o json -- "https://github.com/org/repo/issues/42"
+
+# Post-hoc: query the state DB after completion
+wave logs impl-issue-20260320-abc123 --format json
+```
+
+Use `-o json` when you need to process events as they happen (e.g., updating a CI dashboard). Use `wave logs --format json` when you need to analyze a completed run (e.g., extracting step durations for metrics).
+
+---
+
 ## wave cancel
 
 Cancel a running pipeline.

--- a/specs/504-logs-vs-output-docs/plan.md
+++ b/specs/504-logs-vs-output-docs/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan
+
+## Objective
+
+Add a "Logs vs Progress Output" comparison section to `docs/reference/cli.md` explaining the difference between `wave logs` (post-hoc event history from the state DB) and `--output` modes (real-time progress rendering during execution), with 3 use-case examples.
+
+## Approach
+
+Insert a new section into the CLI reference document between the `wave logs` section (ends at line ~268) and the `wave cancel` section (starts at line ~272). This placement is logical because it directly follows the `wave logs` documentation and provides context before moving on to other commands.
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/reference/cli.md` | modify | Add "Logs vs Progress Output" section after line ~268 |
+
+## Architecture Decisions
+
+- **Placement**: After `wave logs` section, before `wave cancel`. This keeps the comparison close to the `wave logs` docs where users are most likely looking for it.
+- **Format**: Use a comparison table followed by 3 concrete use-case examples with command snippets. Consistent with the rest of the CLI reference style.
+- **No code changes**: Pure documentation — no Go files modified.
+
+## Risks
+
+- **Line numbers may drift**: The issue references specific line numbers which may have shifted. Mitigated by using section headers for anchoring instead.
+- **Minimal risk**: Single-file docs change with no code impact.
+
+## Testing Strategy
+
+- No automated tests needed (documentation-only change)
+- Manual validation: ensure the markdown renders correctly and the section flows logically within the document
+- Verify `go test ./...` still passes (no code changes, but confirms no regressions)

--- a/specs/504-logs-vs-output-docs/spec.md
+++ b/specs/504-logs-vs-output-docs/spec.md
@@ -1,0 +1,23 @@
+# audit: partial — logs vs output docs section (#22)
+
+**Issue**: [#504](https://github.com/re-cinq/wave/issues/504)
+**Labels**: audit
+**Author**: nextlevelshit
+**Source**: #22 — docs: Guidelines for logs vs progress output parameters
+
+## Summary
+
+The CLI reference documentation (`docs/reference/cli.md`) documents both `wave logs` and `--output` modes individually, but lacks an explicit comparison section explaining the difference between these two distinct observability mechanisms.
+
+## Current State
+
+- `docs/reference/cli.md:242-268`: `wave logs` command documented with `--step`, `--errors`, `--tail`, `--follow`, `--since`, `--level`, `--format` flags
+- `docs/reference/cli.md:955-958`: `--output` flag with auto/json/text/quiet modes documented in Global Options
+- `cmd/wave/commands/run.go:133`: output flags registered in code
+
+## Acceptance Criteria
+
+1. Add a "Logs vs Progress Output" section to `docs/reference/cli.md`
+2. Explain the difference between `wave logs` (event history from state DB) and `--output` modes (real-time progress rendering)
+3. Include 3 use-case examples demonstrating when to use each
+4. Section should be placed logically near the existing `wave logs` section or in a dedicated "Concepts" area within the CLI reference

--- a/specs/504-logs-vs-output-docs/tasks.md
+++ b/specs/504-logs-vs-output-docs/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## Phase 1: Implementation
+
+- [X] Task 1.1: Add "Logs vs Progress Output" section to `docs/reference/cli.md` after the `wave logs` section (~line 268), including:
+  - A brief intro explaining the two mechanisms
+  - A comparison table (mechanism, data source, timing, typical use)
+  - 3 use-case examples with command snippets:
+    1. Debugging a failed step (use `wave logs`)
+    2. Watching a pipeline run live (use `--output text -v`)
+    3. Scripting/CI integration (use `--output json` for real-time, `wave logs --format json` for post-hoc)
+
+## Phase 2: Validation
+
+- [X] Task 2.1: Run `go test ./...` to confirm no regressions
+- [X] Task 2.2: Review markdown rendering for consistency with existing CLI reference style


### PR DESCRIPTION
## Summary
- Adds a new section to docs/reference/cli.md explaining the difference between wave logs (event history) and --output modes (progress display)

Fixes #504

## Test plan
- [x] go test ./... passes
- [x] Documentation renders correctly