### PR TITLE
refactor: audit and remove dead code from dashboard.go

### DIFF
--- a/internal/display/dashboard.go
+++ b/internal/display/dashboard.go
@@ -27,16 +27,6 @@ func NewDashboard() *Dashboard {
 	}
 }
 
-// NewDashboardWithConfig creates a dashboard with specific configuration.
-func NewDashboardWithConfig(colorMode string, asciiOnly bool) *Dashboard {
-	return &Dashboard{
-		codec:     NewANSICodecWithConfig(colorMode, asciiOnly),
-		charSet:   GetUnicodeCharSet(),
-		termInfo:  NewTerminalInfo(),
-		lastLines: 0,
-	}
-}
-
 // Render displays the compact dashboard with no clearing.
 func (d *Dashboard) Render(ctx *PipelineContext) error {
 	// No clearing at all - just output content
@@ -65,18 +55,6 @@ func (d *Dashboard) Render(ctx *PipelineContext) error {
 // Clear removes the dashboard display (no-op since we don't clear).
 func (d *Dashboard) Clear() {
 	// No clearing needed
-}
-
-// clearPreviousRender clears the previously rendered dashboard.
-func (d *Dashboard) clearPreviousRender() {
-	if !d.termInfo.SupportsANSI() {
-		return
-	}
-
-	for i := 0; i < d.lastLines; i++ {
-		fmt.Print(d.codec.CursorUp(1))
-		fmt.Print(d.codec.ClearLine())
-	}
 }
 
 // renderHeader displays the Wave ASCII logo with project info on the right.
@@ -344,24 +322,5 @@ func (d *Dashboard) renderPulsatingStep(stepLabel string) string {
 	default:
 		return d.codec.Primary(stepLabel)
 	}
-}
-
-// formatDashboardDuration converts milliseconds to a human-readable duration string.
-func formatDashboardDuration(ms int64) string {
-	duration := time.Duration(ms) * time.Millisecond
-
-	if duration < time.Minute {
-		return fmt.Sprintf("%ds", int(duration.Seconds()))
-	}
-
-	if duration < time.Hour {
-		minutes := int(duration.Minutes())
-		seconds := int(duration.Seconds()) % 60
-		return fmt.Sprintf("%dm %ds", minutes, seconds)
-	}
-
-	hours := int(duration.Hours())
-	minutes := int(duration.Minutes()) % 60
-	return fmt.Sprintf("%dh %dm", hours, minutes)
 }
 

--- a/internal/display/dashboard_test.go
+++ b/internal/display/dashboard_test.go
@@ -97,30 +97,6 @@ func TestDashboard_StatusIcon(t *testing.T) {
 	}
 }
 
-func TestFormatDashboardDuration(t *testing.T) {
-	tests := []struct {
-		name     string
-		ms       int64
-		contains string
-	}{
-		{"seconds", 30000, "s"},
-		{"minutes", 120000, "m"},
-		{"hours", 7200000, "h"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatDashboardDuration(tt.ms)
-			if result == "" {
-				t.Error("Duration should not be empty")
-			}
-			if !strings.Contains(result, tt.contains) {
-				t.Errorf("Duration %q should contain %q", result, tt.contains)
-			}
-		})
-	}
-}
-
 func TestDashboard_RenderPanels(t *testing.T) {
 	dashboard := NewDashboard()
 

--- a/internal/display/types.go
+++ b/internal/display/types.go
@@ -96,18 +96,6 @@ type DisplayConfig struct {
 	AnimationEnabled bool   // Enable/disable animations
 }
 
-// ProgressRenderer defines the interface for rendering progress information.
-type ProgressRenderer interface {
-	// Render updates the display with current progress state
-	Render(progress *PipelineProgress) error
-
-	// Clear removes the current display
-	Clear() error
-
-	// Close cleans up resources
-	Close() error
-}
-
 // ColorScheme provides color mappings for different terminal types.
 var DefaultColorScheme = ColorPalette{
 	Primary:    "\033[36m", // Standard cyan

--- a/internal/display/types_test.go
+++ b/internal/display/types_test.go
@@ -280,25 +280,6 @@ func TestPipelineContext_Structure(t *testing.T) {
 	}
 }
 
-func TestProgressRenderer_Interface(t *testing.T) {
-	// This test verifies the interface can be implemented
-	var _ ProgressRenderer = (*mockProgressRenderer)(nil)
-}
-
-type mockProgressRenderer struct{}
-
-func (m *mockProgressRenderer) Render(progress *PipelineProgress) error {
-	return nil
-}
-
-func (m *mockProgressRenderer) Clear() error {
-	return nil
-}
-
-func (m *mockProgressRenderer) Close() error {
-	return nil
-}
-
 func TestPipelineContext_StepPersonas(t *testing.T) {
 	ctx := PipelineContext{
 		StepOrder: []string{"step-1", "step-2", "step-3"},

--- a/specs/508-dashboard-dead-code/plan.md
+++ b/specs/508-dashboard-dead-code/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: Dashboard Dead Code Removal
+
+## Objective
+
+Remove dead code from `internal/display/dashboard.go` and `internal/display/types.go` that was re-introduced after PR #353's cleanup, and update corresponding tests.
+
+## Approach
+
+Systematic codebase-wide grep analysis identified the following dead code:
+
+### Dead Code in `dashboard.go`
+
+1. **`clearPreviousRender()`** (lines 71-80) — Method on `*Dashboard` that clears previous render output. Never called from any production code. The `Render()` method explicitly comments "No clearing at all" and the `Clear()` method is a no-op. This method is vestigial from a previous rendering approach.
+
+2. **`formatDashboardDuration()`** (lines 350-366) — Unexported function that formats milliseconds to human-readable duration. Never called from any production code. The dashboard uses `fmt.Sprintf("%.1fs", ...)` directly in `formatElapsedInfo()` instead. Only exercised by `TestFormatDashboardDuration` in dashboard_test.go.
+
+3. **`NewDashboardWithConfig()`** (lines 31-38) — Exported constructor that accepts `colorMode` and `asciiOnly` parameters. Never called from any file outside `dashboard.go` — not even from tests. The only production caller is `progress.go:274` which uses `NewDashboard()` (the zero-config constructor).
+
+### Dead Code in `types.go`
+
+4. **`ProgressRenderer` interface** (lines 99-109) — Interface defining `Render`, `Clear`, `Close` methods accepting `*PipelineProgress`. Never implemented or used in production code. Only referenced in `types_test.go` for interface compliance testing with a mock. The actual rendering uses `Dashboard.Render(*PipelineContext)` which has a completely different signature.
+
+### Alive Code (Confirmed NOT Dead)
+
+- `Dashboard` struct, `NewDashboard()`, `Render()`, `Clear()` — used by `progress.go`
+- `DisplayConfig`, `DefaultDisplayConfig()`, `Validate()` — used by capability.go, progress tests, integration tests
+- `AnimationType` constants — used by animation.go, capability.go, progress.go
+- `ColorPalette`, all color scheme vars, `GetColorSchemeByName()` — used by capability.go, tests
+- `TerminalCapabilities` — used by terminal.go, capability.go
+- `StepProgress`, `PipelineProgress` — used across pipeline, event, state, TUI packages
+- `HandoverInfo`, `PipelineContext` — used by progress.go, bubbletea_progress.go, TUI
+
+## File Mapping
+
+| File | Action | Details |
+|------|--------|---------|
+| `internal/display/dashboard.go` | modify | Remove `clearPreviousRender`, `formatDashboardDuration`, `NewDashboardWithConfig` |
+| `internal/display/dashboard_test.go` | modify | Remove `TestFormatDashboardDuration` test |
+| `internal/display/types.go` | modify | Remove `ProgressRenderer` interface |
+| `internal/display/types_test.go` | modify | Remove `TestProgressRenderer_Interface` test and `mockProgressRenderer` |
+
+## Architecture Decisions
+
+- **No removal of `dashboard.go` itself**: The file contains actively-used code (`Dashboard` struct, `Render`, rendering methods). Only specific dead methods are removed.
+- **No removal of `DisplayConfig`**: All 6 occurrences in types.go are actively used (struct definition, DefaultDisplayConfig, Validate, field definitions).
+- **Test removal is limited**: Only tests that exclusively test dead code are removed. Tests that cover live functionality are preserved.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Removing code that's used via reflection or code generation | Grep verified no dynamic references; Go doesn't support method-name-based reflection calls |
+| Breaking external consumers | This is an internal package — no external API contract |
+| Missing a caller in a build tag-gated file | Searched all `*.go` files regardless of build tags |
+
+## Testing Strategy
+
+- Run `go build ./...` to verify compilation after removals
+- Run `go test ./internal/display/...` to verify display package tests pass
+- Run `go test ./...` to verify no downstream breakage
+- Run `go vet ./...` to verify no new warnings

--- a/specs/508-dashboard-dead-code/spec.md
+++ b/specs/508-dashboard-dead-code/spec.md
@@ -1,0 +1,30 @@
+# audit: partial — dashboard.go dead code re-added (#353)
+
+**Issue**: [#508](https://github.com/re-cinq/wave/issues/508)
+**Labels**: audit
+**Author**: nextlevelshit
+**Detected by**: wave-audit pipeline run 2026-03-20
+
+## Background
+
+PR #353 (`fix(display): remove unused DisplayConfig fields and dead dashboard methods`) removed dead methods from `dashboard.go`. However, commit `64ea502` (`feat: optional pipeline steps`) later re-added content to the file. The audit found that `internal/display/dashboard.go` still exists at HEAD and `internal/display/types.go` still has DisplayConfig occurrences.
+
+## Evidence
+
+- `internal/display/dashboard.go` — still exists, not removed
+- `git log` shows commit ae56cb9 removed dead methods from dashboard.go
+- Later commit 64ea502 re-added content to dashboard.go (feat: optional pipeline steps)
+- `internal/display/types.go` — still has 6 DisplayConfig occurrences
+- PR claimed dashboard.go would have 159 lines removed; file still present at HEAD
+
+## Remediation
+
+Audit `internal/display/dashboard.go` for any methods that are again unused since commit 64ea502 re-added content. Verify which DisplayConfig fields remain genuinely unused.
+
+## Acceptance Criteria
+
+- [ ] All dead code in `internal/display/dashboard.go` is identified and removed
+- [ ] All dead code in `internal/display/types.go` related to this audit is identified and removed
+- [ ] Tests referencing removed dead code are updated or removed
+- [ ] All remaining tests pass (`go test ./...`)
+- [ ] No new compilation warnings introduced

--- a/specs/508-dashboard-dead-code/tasks.md
+++ b/specs/508-dashboard-dead-code/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Phase 1: Remove Dead Code from dashboard.go
+- [X] Task 1.1: Remove `clearPreviousRender()` method (lines 70-80) [P]
+- [X] Task 1.2: Remove `formatDashboardDuration()` function (lines 349-366) [P]
+- [X] Task 1.3: Remove `NewDashboardWithConfig()` constructor (lines 30-38) [P]
+
+## Phase 2: Remove Dead Code from types.go
+- [X] Task 2.1: Remove `ProgressRenderer` interface (lines 99-109)
+
+## Phase 3: Update Tests
+- [X] Task 3.1: Remove `TestFormatDashboardDuration` from `internal/display/dashboard_test.go` [P]
+- [X] Task 3.2: Remove `TestProgressRenderer_Interface` and `mockProgressRenderer` from `internal/display/types_test.go` [P]
+
+## Phase 4: Validation
+- [X] Task 4.1: Run `go build ./...` to verify compilation
+- [X] Task 4.2: Run `go test ./internal/display/...` to verify display package tests
+- [X] Task 4.3: Run `go test ./...` to verify full test suite
+- [X] Task 4.4: Run `go vet ./...` to verify no warnings


### PR DESCRIPTION
## Summary
- Audits internal/display/dashboard.go for unused methods after commit 64ea502
- Removes dead code paths that are no longer referenced

Fixes #508

## Test plan
- [x] go test ./... passes
- [x] No production code references removed symbols