### PR TITLE
fix(cli): move embedded examples to cobra Example field

### DIFF
--- a/cmd/wave/commands/bench.go
+++ b/cmd/wave/commands/bench.go
@@ -28,6 +28,10 @@ Subcommands:
   report   Generate a summary from benchmark results
   list     List available benchmark datasets
   compare  Compare two benchmark result files`,
+		Example: `  wave bench run --dataset swe-bench-lite.jsonl --pipeline bench-solve
+  wave bench report --results results.json
+  wave bench compare --base baseline.json --compare wave-run.json
+  wave bench list`,
 	}
 
 	cmd.AddCommand(newBenchRunCmd())

--- a/cmd/wave/commands/cancel.go
+++ b/cmd/wave/commands/cancel.go
@@ -49,10 +49,8 @@ Graceful cancellation (default):
 Force cancellation (--force):
   - Immediately sends SIGTERM to the adapter process group
   - Waits 5 seconds, then sends SIGKILL if still running
-  - The current step may be incomplete
-
-Examples:
-  wave cancel                    # Cancel most recent running pipeline
+  - The current step may be incomplete`,
+		Example: `  wave cancel                    # Cancel most recent running pipeline
   wave cancel abc123             # Cancel specific run
   wave cancel --force            # Forcibly terminate immediately
   wave cancel --format json      # Output result as JSON`,

--- a/cmd/wave/commands/list.go
+++ b/cmd/wave/commands/list.go
@@ -132,6 +132,12 @@ For 'list runs', additional flags are available:
   --limit N           Maximum number of runs to show (default 10)
   --run-pipeline P    Filter to specific pipeline
   --run-status S      Filter by status (running, completed, failed, cancelled)`,
+		Example: `  wave list pipelines
+  wave list runs
+  wave list runs --limit 5 --run-status failed
+  wave list personas --format json
+  wave list contracts
+  wave list skills`,
 		ValidArgs: []string{"adapters", "runs", "pipelines", "personas", "contracts", "skills", "compositions"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			filter := ""

--- a/cmd/wave/commands/logs.go
+++ b/cmd/wave/commands/logs.go
@@ -58,18 +58,16 @@ func NewLogsCmd() *cobra.Command {
 		Long: `Show logs from pipeline runs.
 
 Without arguments, shows logs from the most recent run.
-With a run-id argument, shows logs for that specific run.
-
-Examples:
-  wave logs                      # Show logs from most recent run
+With a run-id argument, shows logs for that specific run.`,
+		Example: `  wave logs                        # Show logs from most recent run
   wave logs debug-20260202-143022  # Show logs for specific run
-  wave logs --step investigate   # Filter by step ID
-  wave logs --errors             # Show only errors
-  wave logs --tail 20            # Show last 20 log entries
-  wave logs --since 10m          # Show logs from last 10 minutes
-  wave logs --follow             # Stream logs in real-time
-  wave logs --format json        # Output as JSON for scripting
-  wave logs --trace              # Show debug trace events (requires --debug run)`,
+  wave logs --step investigate     # Filter by step ID
+  wave logs --errors               # Show only errors
+  wave logs --tail 20              # Show last 20 log entries
+  wave logs --since 10m            # Show logs from last 10 minutes
+  wave logs --follow               # Stream logs in real-time
+  wave logs --format json          # Output as JSON for scripting
+  wave logs --trace                # Show debug trace events (requires --debug run)`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -48,10 +48,8 @@ With --from-step, execution resumes from the specified step regardless
 of which step failed.
 
 The --force flag skips phase-sequence and stale-artifact validation,
-matching the behaviour of 'wave run --force'.
-
-Examples:
-  wave resume impl-speckit-20240315-abc123
+matching the behaviour of 'wave run --force'.`,
+		Example: `  wave resume impl-speckit-20240315-abc123
   wave resume impl-speckit-20240315-abc123 --from-step implement
   wave resume impl-speckit-20240315-abc123 --from-step plan --force
   wave resume impl-speckit-20240315-abc123 --model opus`,

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -64,12 +64,7 @@ Supports dry-run mode, step resumption, custom timeouts, model override,
 and detached execution (--detach) for background runs that survive shell exit.
 
 The --model flag overrides the adapter model for all steps in the run,
-including any per-persona model pinning in wave.yaml.
-
-Arguments can be provided as positional args or flags:
-  wave run ops-pr-review "Review auth module"
-  wave run --pipeline ops-pr-review --input "Review auth module"
-  wave run ops-pr-review --input "Review auth module"`,
+including any per-persona model pinning in wave.yaml.`,
 		Example: `  wave run ops-pr-review "Review the authentication changes"
   wave run --pipeline impl-speckit --input "add user auth"
   wave run impl-hotfix --dry-run

--- a/specs/525-cobra-example-field/plan.md
+++ b/specs/525-cobra-example-field/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: Cobra Example Field Migration
+
+## Objective
+
+Move embedded examples from cobra `Long` descriptions to the dedicated `Example` field across CLI commands, improving `--help` output formatting and consistency.
+
+## Approach
+
+Mechanical refactoring: for each affected command, extract example lines from `Long` and place them in the `Example` field. Where a command already has an `Example` field, merge content. Where `Long` has no actual examples (just documentation), add an `Example` field with representative usage patterns.
+
+## File Mapping
+
+| File | Action |
+|------|--------|
+| `cmd/wave/commands/run.go` | Modify — move argument pattern lines from `Long` to existing `Example` |
+| `cmd/wave/commands/resume.go` | Modify — extract examples from `Long`, add `Example` field |
+| `cmd/wave/commands/cancel.go` | Modify — extract examples from `Long`, add `Example` field |
+| `cmd/wave/commands/list.go` | Modify — add `Example` field with usage examples |
+| `cmd/wave/commands/logs.go` | Modify — extract examples from `Long`, add `Example` field |
+| `cmd/wave/commands/bench.go` | Modify — add `Example` to parent bench command |
+
+No action needed:
+- `doctor.go` — already has proper `Example` field
+- `pause` — command does not exist in the codebase
+
+## Architecture Decisions
+
+- Keep `Long` descriptions focused on explanation (what the command does, how flags interact)
+- `Example` field should show 2-line-indented examples (cobra convention)
+- Preserve all existing examples verbatim — just relocate them
+- For commands with no explicit examples in `Long` (list, bench parent), synthesize examples from the documented usage patterns
+
+## Risks
+
+- **Low risk**: Purely cosmetic change to help output formatting
+- **No behavioral change**: Only `Long` and `Example` string fields are modified
+- **Test impact**: Existing tests that assert on help output may need updating (unlikely — help text tests are uncommon)
+
+## Testing Strategy
+
+- Run `go build ./...` to verify compilation
+- Run `go test ./...` to verify no test regressions
+- Manual verification: `wave <cmd> -h` shows examples in the "Examples:" section

--- a/specs/525-cobra-example-field/spec.md
+++ b/specs/525-cobra-example-field/spec.md
@@ -1,0 +1,46 @@
+# fix(cli): move embedded examples to cobra Example field
+
+**Issue**: [#525](https://github.com/re-cinq/wave/issues/525)
+**Author**: nextlevelshit
+**Labels**: none
+**Complexity**: simple
+
+## Description
+
+8 commands currently have examples embedded in their Long description text instead of using cobra's dedicated Example field.
+
+The Example field provides better CLI documentation formatting and consistency. Migrate command examples from Long descriptions to the Example field in each command's cobra.Command struct.
+
+Commands that need Example field migration:
+- run
+- pause
+- resume
+- cancel
+- list
+- logs
+- doctor
+- bench
+
+This improves `wave <command> -h` output and makes examples more discoverable.
+
+## Acceptance Criteria
+
+- [ ] All commands listed above have examples in the `Example` field of their `cobra.Command` struct
+- [ ] The `Long` field no longer contains example-style `wave <cmd> ...` lines
+- [ ] `wave <command> -h` output shows examples in the dedicated "Examples:" section
+- [ ] All existing tests pass
+
+## Codebase Analysis
+
+After inspecting each command file:
+
+| Command | File | Current State | Action Needed |
+|---------|------|---------------|---------------|
+| run | `cmd/wave/commands/run.go` | Already has `Example` field. `Long` has 3 argument-pattern lines that look like examples | Move argument pattern lines from `Long` to `Example` (merge with existing) |
+| pause | N/A | **Does not exist** in the codebase | No action — skip |
+| resume | `cmd/wave/commands/resume.go` | Examples embedded in `Long` (lines 53-57). No `Example` field | Extract examples from `Long` into new `Example` field |
+| cancel | `cmd/wave/commands/cancel.go` | Examples embedded in `Long` (lines 54-58). No `Example` field | Extract examples from `Long` into new `Example` field |
+| list | `cmd/wave/commands/list.go` | `Long` contains argument/flag documentation, not examples. No `Example` field | Add `Example` field with usage examples |
+| logs | `cmd/wave/commands/logs.go` | Examples embedded in `Long` (lines 63-72). No `Example` field | Extract examples from `Long` into new `Example` field |
+| doctor | `cmd/wave/commands/doctor.go` | Already has `Example` field (lines 42-47). `Long` is clean | Already done — verify only |
+| bench | `cmd/wave/commands/bench.go` | Parent cmd has subcommand list in `Long`. Subcommands (`run`, `report`, `list`, `compare`) already have `Example` fields | Add `Example` to parent bench command; subcommands already correct |

--- a/specs/525-cobra-example-field/tasks.md
+++ b/specs/525-cobra-example-field/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Phase 1: Extract examples from Long to Example field
+
+- [X] Task 1.1: `run.go` — Remove argument pattern lines (lines 69-72) from `Long`, they duplicate what's already in `Example` [P]
+- [X] Task 1.2: `resume.go` — Extract 4 example lines from `Long`, create `Example` field [P]
+- [X] Task 1.3: `cancel.go` — Extract 4 example lines from `Long`, create `Example` field [P]
+- [X] Task 1.4: `logs.go` — Extract 9 example lines from `Long`, create `Example` field [P]
+
+## Phase 2: Add Example field where missing
+
+- [X] Task 2.1: `list.go` — Add `Example` field with representative usage patterns (list runs, list pipelines, etc.) [P]
+- [X] Task 2.2: `bench.go` — Add `Example` field to parent bench command showing subcommand usage [P]
+
+## Phase 3: Verification
+
+- [X] Task 3.1: Verify `doctor.go` already has correct `Example` field (no changes needed)
+- [X] Task 3.2: Confirm `pause` command does not exist (no changes needed)
+
+## Phase 4: Validation
+
+- [X] Task 4.1: Run `go build ./...` to verify compilation
+- [X] Task 4.2: Run `go test ./cmd/wave/commands/...` to verify no test regressions


### PR DESCRIPTION
## Summary
- Moved embedded examples from `Long` text to cobra `Example:` field across CLI commands
- Ensures consistent `Examples:` section rendering in `--help` output

Related to #525

## Test plan
- [ ] Run `wave status --help` and verify Examples section appears
- [ ] Run `wave logs --help` and verify Examples section appears
- [ ] Run `wave list --help` and verify Examples section appears