### PR TITLE
docs: update README command table to include all 22 registered commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,22 +117,29 @@ Usage:
   wave [command]
 
 Available Commands:
+  agent       Persona-to-agent compiler utilities
   artifacts   List and export pipeline artifacts
+  bench       Run and analyze SWE-bench benchmarks
   cancel      Cancel a running pipeline
-  chat        Interactive analysis of pipeline runs
+  chat        Open interactive analysis of a pipeline run
   clean       Clean up project artifacts
   completion  Generate the autocompletion script for the specified shell
+  compose     Validate and execute a pipeline sequence
   do          Execute an ad-hoc task
+  doctor      Check project health and environment setup
   help        Help about any command
   init        Initialize a new Wave project
-  list        List pipelines and personas
+  list        List Wave configuration and resources
   logs        Show pipeline logs
-  meta        Generate a custom pipeline
-  migrate     Database migration commands
-  run         Run a pipeline (use --from-step to resume)
-  serve       Start the web operations dashboard
+  meta        Generate and run a custom pipeline dynamically
+  migrate     Database migration management
+  postmortem  Analyse a failed pipeline run and suggest recovery steps
+  resume      Resume a failed pipeline run
+  run         Run a pipeline
+  serve       Start the web dashboard server
+  skills      Skill lifecycle management
   status      Show pipeline status
-  bench       Run and analyze SWE-bench benchmarks
+  suggest     Propose pipeline runs based on codebase state
   validate    Validate Wave configuration
 
 Flags:
@@ -157,8 +164,10 @@ Use "wave [command] --help" for more information about a command.
 |---------|-------------|
 | `wave init` | Initialize project with personas and pipelines |
 | `wave run <pipeline>` | Execute a pipeline |
+| `wave resume <run-id>` | Resume a failed pipeline run |
 | `wave do "<task>"` | Quick ad-hoc task (auto-generates 2-step pipeline) |
-| `wave meta "<task>"` | Generate custom multi-step pipeline with schemas |
+| `wave meta "<task>"` | Generate and run a custom pipeline dynamically |
+| `wave compose <file>` | Validate and execute a pipeline sequence |
 | `wave cancel [run-id]` | Cancel running pipeline (graceful or `--force`) |
 
 ### Monitoring & Inspection
@@ -168,7 +177,9 @@ Use "wave [command] --help" for more information about a command.
 | `wave status [run-id]` | Show pipeline status (running, recent, details) |
 | `wave logs [run-id]` | View event logs (`--follow`, `--tail`, `--errors`) |
 | `wave artifacts [run-id]` | List and export pipeline artifacts |
-| `wave list [resource]` | List pipelines, personas, adapters, or runs |
+| `wave list [resource]` | List Wave configuration and resources |
+| `wave chat [run-id]` | Open interactive analysis of a pipeline run |
+| `wave postmortem [run-id]` | Analyse a failed pipeline run and suggest recovery steps |
 
 ### Benchmarking
 
@@ -183,8 +194,14 @@ Use "wave [command] --help" for more information about a command.
 
 | Command | Description |
 |---------|-------------|
-| `wave validate` | Check manifest and pipeline configuration |
-| `wave clean` | Remove workspaces and state (`--older-than`, `--status`) |
+| `wave validate` | Validate Wave configuration |
+| `wave clean` | Clean up project artifacts (`--older-than`, `--status`) |
+| `wave doctor` | Check project health and environment setup |
+| `wave suggest` | Propose pipeline runs based on codebase state |
+| `wave serve` | Start the web dashboard server |
+| `wave migrate` | Database migration management |
+| `wave skills` | Skill lifecycle management |
+| `wave agent` | Persona-to-agent compiler utilities |
 
 ---
 

--- a/specs/522-readme-command-table/plan.md
+++ b/specs/522-readme-command-table/plan.md
@@ -1,0 +1,37 @@
+# Implementation Plan
+
+## Objective
+
+Update the README.md command tables and CLI Reference block to document all 22 registered CLI commands, ensuring comprehensive coverage.
+
+## Approach
+
+Single-file documentation update to `README.md`. Two sections need changes:
+
+1. **CLI Reference block** (lines ~107-148): Add the 7 missing commands (resume, compose, doctor, suggest, skills, postmortem, agent) to the text-art command listing
+2. **Commands tables** (lines ~152-188): Add the 10 missing commands to the appropriate table sections, creating new sections where needed
+
+## File Mapping
+
+| File | Action | Details |
+|------|--------|---------|
+| `README.md` | modify | Update CLI Reference block and Commands tables |
+
+## Architecture Decisions
+
+1. **Grouping**: New commands will be organized into existing or new table sections:
+   - **Pipeline Execution**: Add `resume`, `compose` (pipeline-related)
+   - **Monitoring & Inspection**: Add `chat`, `postmortem` (analysis tools)
+   - **Maintenance**: Add `doctor`, `suggest`, `serve`, `migrate`, `skills`, `agent`
+2. **Description source**: Use the `Short` field from each command's Go source as the canonical description
+3. **CLI Reference block**: Add commands in alphabetical order to match existing convention
+
+## Risks
+
+- **Stale descriptions**: If command descriptions change in Go source, README will drift. Mitigation: descriptions are pulled directly from source for this PR.
+- **No risk of code breakage**: Documentation-only change.
+
+## Testing Strategy
+
+- Visual review that all 22 commands appear in both sections
+- No automated tests needed (docs-only change)

--- a/specs/522-readme-command-table/spec.md
+++ b/specs/522-readme-command-table/spec.md
@@ -1,0 +1,62 @@
+# docs: update README command table to include all 22 registered commands
+
+**Issue**: [#522](https://github.com/re-cinq/wave/issues/522)
+**Author**: nextlevelshit
+**State**: OPEN
+
+## Description
+
+The README command table is incomplete. Currently missing 8 commands:
+
+- do
+- meta
+- validate
+- clean
+- status
+- logs
+- cancel
+- chat
+
+The README should document all 22 registered commands for comprehensive CLI reference.
+
+## Assessment Notes
+
+The issue body lists 8 commands as missing but several (do, meta, validate, clean, status, logs, cancel) are already present in the README. The body may be stale. The actual audit reveals the following gaps:
+
+### Registered Commands (22 total from `cmd/wave/main.go`)
+
+1. init, 2. validate, 3. run, 4. resume, 5. do, 6. meta, 7. clean, 8. list, 9. status, 10. logs, 11. cancel, 12. artifacts, 13. migrate, 14. serve, 15. chat, 16. compose, 17. doctor, 18. suggest, 19. skills, 20. postmortem, 21. agent, 22. bench
+
+### Currently in README "Commands" Tables (12)
+
+init, run, do, meta, cancel, status, logs, artifacts, list, bench, validate, clean
+
+### Missing from "Commands" Tables (10)
+
+| Command | Short Description |
+|---------|-------------------|
+| `resume` | Resume a failed pipeline run |
+| `chat` | Open interactive analysis of a pipeline run |
+| `compose` | Validate and execute a pipeline sequence |
+| `doctor` | Check project health and environment setup |
+| `suggest` | Propose pipeline runs based on codebase state |
+| `skills` | Skill lifecycle management |
+| `postmortem` | Analyse a failed pipeline run and suggest recovery steps |
+| `agent` | Persona-to-agent compiler utilities |
+| `serve` | Start the web dashboard server |
+| `migrate` | Database migration management |
+
+### Missing from CLI Reference Block (7)
+
+resume, compose, doctor, suggest, skills, postmortem, agent
+
+### Also Missing (built-in cobra commands, already in CLI block)
+
+completion, help — these are already shown in the CLI Reference block.
+
+## Acceptance Criteria
+
+- [ ] All 22 registered commands appear in the "Commands" tables section
+- [ ] The CLI Reference text block lists all registered commands
+- [ ] Commands are grouped logically in appropriate table sections
+- [ ] Descriptions match the `Short` field from the Go source code

--- a/specs/522-readme-command-table/tasks.md
+++ b/specs/522-readme-command-table/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## Phase 1: Update CLI Reference Block
+
+- [X] Task 1.1: Add missing commands to the CLI Reference text block (resume, compose, doctor, suggest, skills, postmortem, agent) in alphabetical order
+
+## Phase 2: Update Command Tables
+
+- [X] Task 2.1: Add `resume` and `compose` to the Pipeline Execution table
+- [X] Task 2.2: Add `chat` and `postmortem` to the Monitoring & Inspection table
+- [X] Task 2.3: Add `doctor`, `suggest`, `serve`, `migrate`, `skills`, and `agent` to the Maintenance table (or split into sub-sections if the table gets too large)
+
+## Phase 3: Validation
+
+- [X] Task 3.1: Verify all 22 registered commands appear in both the CLI Reference block and the Commands tables
+- [X] Task 3.2: Verify descriptions match Go source `Short` fields


### PR DESCRIPTION
## Summary
- Updated the README CLI reference table to include all 22 registered commands
- Previously missing: chat, compose, suggest, skills, postmortem, agent, resume

Related to #522

## Test plan
- [ ] Verify README command list matches `wave --help` output
- [ ] Verify all commands in main.go are represented