### PR TITLE
docs: add doc.go files to core internal packages

### DIFF
--- a/internal/adapter/doc.go
+++ b/internal/adapter/doc.go
@@ -1,0 +1,9 @@
+// Package adapter manages subprocess execution of external LLM adapters
+// such as Claude Code, OpenAI, and Gemini. It provides a unified
+// AdapterRunner interface for invoking adapters with sandbox configuration,
+// permission enforcement, real-time streaming event capture, and structured
+// output parsing. The package includes concrete implementations for CLI
+// subprocess execution, browser automation via chromedp, and a mock adapter
+// for testing, along with structured error classification for timeout,
+// context exhaustion, and rate-limit failures.
+package adapter

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -1,0 +1,7 @@
+// Package audit provides execution trace logging with automatic credential
+// scrubbing for Wave pipeline runs. It records tool calls, file operations,
+// step lifecycle events, and contract validation results to structured
+// NDJSON trace files under .wave/traces/. All logged output is sanitized
+// to remove API keys, tokens, secrets, and private keys before being
+// written to disk.
+package audit

--- a/internal/contract/doc.go
+++ b/internal/contract/doc.go
@@ -1,0 +1,8 @@
+// Package contract validates pipeline step outputs against structured
+// contracts before marking steps as successful. It supports multiple
+// validation backends including JSON Schema, TypeScript interfaces, test
+// suites, markdown specifications, and format checks. The package provides
+// automatic JSON recovery and repair, configurable retry strategies, and
+// detailed failure reporting. Hard validation failures block pipeline
+// progression while soft failures log warnings.
+package contract

--- a/internal/event/doc.go
+++ b/internal/event/doc.go
@@ -1,0 +1,7 @@
+// Package event provides structured progress event emission for real-time
+// monitoring of Wave pipeline execution. Events are emitted as
+// newline-delimited JSON (NDJSON) to stdout, capturing step state
+// transitions, token usage, artifact production, errors, and recovery
+// hints. The package supports dual-stream output for simultaneous
+// machine-readable logging and enhanced terminal progress visualization.
+package event

--- a/internal/manifest/doc.go
+++ b/internal/manifest/doc.go
@@ -1,0 +1,8 @@
+// Package manifest loads, parses, and validates Wave project configuration
+// files (wave.yaml). It defines typed Go structures for the full manifest
+// schema including project metadata, adapter bindings, persona definitions
+// with permissions and model selection, skill references, and runtime
+// settings such as workspace roots, concurrency limits, and timeouts.
+// Validation errors include file paths, line numbers, and actionable
+// suggestions for resolution.
+package manifest

--- a/internal/pipeline/doc.go
+++ b/internal/pipeline/doc.go
@@ -1,0 +1,9 @@
+// Package pipeline implements DAG-based pipeline orchestration for Wave.
+// It resolves step dependencies via topological sorting, executes steps
+// in isolated workspaces with artifact injection and adapter invocation,
+// validates outputs against contracts, and persists state to SQLite for
+// resumption from checkpoints. The package supports advanced composition
+// primitives (iterate, branch, gate, loop, aggregate, sub-pipeline),
+// concurrent step execution, and real-time progress tracking with ETA
+// calculation.
+package pipeline

--- a/internal/relay/doc.go
+++ b/internal/relay/doc.go
@@ -1,0 +1,7 @@
+// Package relay implements token usage monitoring and context compaction
+// for Wave pipelines. It tracks token consumption across pipeline steps
+// and triggers LLM-based summarization when approaching context window
+// limits. Compacted checkpoints capture key decisions and summaries,
+// enabling downstream steps to operate with fresh context while retaining
+// essential information from prior work.
+package relay

--- a/internal/security/doc.go
+++ b/internal/security/doc.go
@@ -1,0 +1,7 @@
+// Package security enforces input validation and access control throughout
+// Wave's pipeline execution. It prevents path traversal attacks through
+// directory allowlisting and symlink validation, detects prompt injection
+// attempts via pattern matching, sanitizes HTML and script content, and
+// validates persona configurations. Security violations are logged with
+// structured severity levels and violation types for audit trails.
+package security

--- a/internal/state/doc.go
+++ b/internal/state/doc.go
@@ -1,0 +1,7 @@
+// Package state provides SQLite-backed persistence for Wave pipeline
+// execution. It manages pipeline run records, step execution states, event
+// logs, artifacts, and performance metrics through the StateStore interface.
+// The package supports pipeline resumption, cancellation, retry tracking,
+// concurrent dashboard queries via read-only connections, and schema
+// versioning through a migration system.
+package state

--- a/internal/workspace/doc.go
+++ b/internal/workspace/doc.go
@@ -1,0 +1,8 @@
+// Package workspace manages ephemeral isolated execution environments for
+// Wave pipeline steps. It creates sandboxed workspace directories, injects
+// artifacts from prior steps, and handles cleanup. The package supports
+// configurable mounts with readonly and readwrite modes, recursive file
+// copying with intelligent skipping of large files and system directories,
+// symbolic link resolution with path traversal prevention, and workspace
+// discovery utilities for retention policies.
+package workspace

--- a/specs/530-doc-go-files/plan.md
+++ b/specs/530-doc-go-files/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan
+
+## Objective
+
+Add `doc.go` files to 10 core internal packages that currently lack package-level documentation, following the existing convention established in `internal/continuous/doc.go`.
+
+## Approach
+
+Create one `doc.go` file per package with a multi-line package comment describing:
+- What the package does (1-2 sentence overview)
+- Key responsibilities and capabilities
+- How it fits in the overall architecture
+
+Follow the existing convention: `// Package <name> ...` comment block followed by `package <name>`.
+
+## File Mapping
+
+All files are **new creations** (no modifications):
+
+| File | Package Purpose |
+|------|----------------|
+| `internal/pipeline/doc.go` | DAG pipeline orchestration, execution, resumption, and artifact management |
+| `internal/adapter/doc.go` | Subprocess execution of LLM adapters with streaming and permission enforcement |
+| `internal/contract/doc.go` | Output validation against structured contracts (JSON schema, TypeScript, test suites) |
+| `internal/manifest/doc.go` | Wave YAML configuration parsing, validation, and typed structures |
+| `internal/workspace/doc.go` | Ephemeral isolated execution environments with mount-based file mapping |
+| `internal/state/doc.go` | SQLite-backed pipeline state persistence and run tracking |
+| `internal/event/doc.go` | Structured progress event emission for real-time monitoring |
+| `internal/audit/doc.go` | Execution trace logging with credential scrubbing |
+| `internal/security/doc.go` | Input sanitization, path validation, and prompt injection prevention |
+| `internal/relay/doc.go` | Token usage monitoring and context compaction triggering |
+
+## Architecture Decisions
+
+- **No code changes**: Only new doc.go files, no modifications to existing code
+- **Convention alignment**: Match the style of `internal/continuous/doc.go`
+- **Accurate descriptions**: Each comment derived from reading the actual package source
+
+## Risks
+
+- **Minimal risk**: Adding doc.go files cannot break compilation or tests
+- Only risk is inaccurate descriptions — mitigated by reading source before writing
+
+## Testing Strategy
+
+- `go build ./...` to verify compilation
+- `go vet ./...` to verify no vet issues
+- `go test ./...` to verify no regressions
+- `go doc ./internal/<pkg>` spot-check for each package

--- a/specs/530-doc-go-files/spec.md
+++ b/specs/530-doc-go-files/spec.md
@@ -1,0 +1,32 @@
+# docs: add doc.go files to 10 core internal packages
+
+**Issue**: [#530](https://github.com/re-cinq/wave/issues/530)
+**Author**: nextlevelshit
+**Labels**: none
+**Complexity**: simple
+
+## Description
+
+25 of 28 internal packages have no doc.go file. Only continuous, defaults, and display have package-level documentation. Critical packages like pipeline, adapter, contract, audit, state, workspace, and manifest are undocumented.
+
+## Target Packages
+
+Add doc.go files to:
+1. `internal/pipeline/`
+2. `internal/adapter/`
+3. `internal/contract/`
+4. `internal/manifest/`
+5. `internal/workspace/`
+6. `internal/state/`
+7. `internal/event/`
+8. `internal/audit/`
+9. `internal/security/`
+10. `internal/relay/`
+
+## Acceptance Criteria
+
+- Each of the 10 listed packages has a `doc.go` file
+- Each doc.go follows the existing convention (`internal/continuous/doc.go`): package-level comment followed by `package <name>`
+- Package comments accurately describe the package's purpose and key responsibilities
+- `go doc ./internal/<pkg>` produces meaningful output for all 10 packages
+- All existing tests continue to pass

--- a/specs/530-doc-go-files/tasks.md
+++ b/specs/530-doc-go-files/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## Phase 1: Core Orchestration Packages
+- [X] Task 1.1: Create `internal/pipeline/doc.go` [P]
+- [X] Task 1.2: Create `internal/adapter/doc.go` [P]
+- [X] Task 1.3: Create `internal/contract/doc.go` [P]
+- [X] Task 1.4: Create `internal/manifest/doc.go` [P]
+
+## Phase 2: Infrastructure Packages
+- [X] Task 2.1: Create `internal/workspace/doc.go` [P]
+- [X] Task 2.2: Create `internal/state/doc.go` [P]
+- [X] Task 2.3: Create `internal/event/doc.go` [P]
+
+## Phase 3: Security & Observability Packages
+- [X] Task 3.1: Create `internal/audit/doc.go` [P]
+- [X] Task 3.2: Create `internal/security/doc.go` [P]
+- [X] Task 3.3: Create `internal/relay/doc.go` [P]
+
+## Phase 4: Validation
+- [X] Task 4.1: Run `go build ./...` to verify compilation
+- [X] Task 4.2: Run `go vet ./...` to verify no issues
+- [X] Task 4.3: Run `go test ./...` to verify no regressions


### PR DESCRIPTION
## Summary
- Added doc.go package documentation files to core internal packages
- Improves godoc navigability for new contributors

Related to #530

## Test plan
- [x] go test ./... passes
- [x] go doc ./internal/pipeline shows package description