### PR TITLE
fix(cli): resolve --output flag semantic collision

### DIFF
--- a/cmd/wave/commands/agent.go
+++ b/cmd/wave/commands/agent.go
@@ -207,7 +207,7 @@ func newAgentExportCmd() *cobra.Command {
 			return runAgentExport(cmd, args[0], outputPath)
 		},
 	}
-	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output path (default: <name>.agent.md)")
+	cmd.Flags().StringVar(&outputPath, "export-path", "", "Export file path (default: <name>.agent.md)")
 	return cmd
 }
 

--- a/cmd/wave/commands/agent_test.go
+++ b/cmd/wave/commands/agent_test.go
@@ -165,7 +165,7 @@ personas:
 	rootCmd := &cobra.Command{}
 	rootCmd.PersistentFlags().String("manifest", manifestPath, "")
 	rootCmd.AddCommand(cmd)
-	rootCmd.SetArgs([]string{"agent", "export", "--output", outputPath, "navigator"})
+	rootCmd.SetArgs([]string{"agent", "export", "--export-path", outputPath, "navigator"})
 	err := rootCmd.Execute()
 	require.NoError(t, err)
 

--- a/cmd/wave/commands/bench.go
+++ b/cmd/wave/commands/bench.go
@@ -69,7 +69,7 @@ Use --mode to select execution mode:
 		Example: `  wave bench run --dataset swe-bench-lite.jsonl --pipeline bench-solve
   wave bench run --dataset tasks.jsonl --pipeline bench-solve --limit 10
   wave bench run --dataset tasks.jsonl --mode claude --label baseline-v1
-  wave bench run --dataset tasks.jsonl --pipeline bench-solve --output results.json`,
+  wave bench run --dataset tasks.jsonl --pipeline bench-solve --results-path results.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -170,7 +170,7 @@ Use --mode to select execution mode:
 	cmd.Flags().StringVar(&label, "label", "", "Human-readable label for this run")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of tasks to run (0 = all)")
 	cmd.Flags().IntVar(&timeout, "timeout", 0, "Per-task timeout in seconds (0 = no limit)")
-	cmd.Flags().StringVar(&outputPath, "output", "", "Path to write JSON results file")
+	cmd.Flags().StringVar(&outputPath, "results-path", "", "Path to write JSON results file")
 	cmd.Flags().StringVar(&datasetsDir, "datasets-dir", ".wave/bench/datasets", "Directory to search for dataset files")
 	cmd.Flags().BoolVar(&keepWorkspaces, "keep-workspaces", false, "Preserve task worktrees after completion")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of tasks to run in parallel")

--- a/cmd/wave/commands/init.go
+++ b/cmd/wave/commands/init.go
@@ -57,7 +57,7 @@ preserving your custom settings.`,
 	cmd.Flags().BoolVar(&opts.All, "all", false, "Include all pipelines regardless of release status")
 	cmd.Flags().StringVar(&opts.Adapter, "adapter", "claude", "Default adapter to use")
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", ".wave/workspaces", "Workspace directory path")
-	cmd.Flags().StringVar(&opts.OutputPath, "output", "wave.yaml", "Output path for wave.yaml")
+	cmd.Flags().StringVar(&opts.OutputPath, "manifest-path", "wave.yaml", "Output path for wave.yaml")
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Answer yes to all confirmation prompts")
 	cmd.Flags().BoolVar(&opts.Reconfigure, "reconfigure", false, "Re-run onboarding wizard with current settings as defaults")
 

--- a/cmd/wave/commands/init_test.go
+++ b/cmd/wave/commands/init_test.go
@@ -362,14 +362,14 @@ func TestInitCreatesContractFiles(t *testing.T) {
 		"--all should create all contract files")
 }
 
-// TestInitOutputPath tests the --output flag for custom manifest path.
+// TestInitOutputPath tests the --manifest-path flag for custom manifest path.
 func TestInitOutputPath(t *testing.T) {
 	env := newTestEnv(t)
 	defer env.cleanup()
 
 	customPath := "config/my-wave.yaml"
 
-	stdout, _, err := executeInitCmd("--output", customPath)
+	stdout, _, err := executeInitCmd("--manifest-path", customPath)
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout, customPath)

--- a/specs/532-output-flag-collision/plan.md
+++ b/specs/532-output-flag-collision/plan.md
@@ -1,0 +1,41 @@
+# Implementation Plan
+
+## Objective
+
+Resolve the `--output` flag semantic collision by renaming subcommand-level `--output` flags to descriptive, purpose-specific names while keeping the root-level `--output`/`-o` (output format) as the canonical usage.
+
+## Approach
+
+Straightforward flag renaming across three commands:
+1. `init --output` → `--manifest-path`
+2. `agent export --output`/`-o` → `--export-path` (no short form)
+3. `bench run --output` → `--results-path`
+
+Each rename touches the flag definition and its corresponding tests. No architectural changes needed.
+
+## File Mapping
+
+| File | Action | Change |
+|------|--------|--------|
+| `cmd/wave/commands/init.go` | modify | Rename `--output` flag to `--manifest-path` |
+| `cmd/wave/commands/init_test.go` | modify | Update test to use `--manifest-path` |
+| `cmd/wave/commands/agent.go` | modify | Rename `--output`/`-o` to `--export-path` (no short) |
+| `cmd/wave/commands/agent_test.go` | modify | Update test to use `--export-path` |
+| `cmd/wave/commands/bench.go` | modify | Rename `--output` to `--results-path` |
+
+## Architecture Decisions
+
+- **No deprecation aliases**: The issue is filed during prototype phase where backward compatibility is not required (per CLAUDE.md). Clean rename without aliases.
+- **No `-o` short form on subcommands**: Only root keeps `-o` to prevent future collisions.
+- **bench --output included**: While not mentioned in the issue, it has the same semantic collision pattern and should be fixed for consistency.
+
+## Risks
+
+- **Low**: Flag renaming is straightforward with no behavioral changes.
+- **User scripts**: Any scripts using `wave init --output` or `wave agent export --output` will break. Acceptable during prototype phase.
+
+## Testing Strategy
+
+- Update existing tests that reference the old flag names.
+- Run `go test ./cmd/wave/commands/...` to verify all tests pass.
+- Run `go test ./...` for full regression.

--- a/specs/532-output-flag-collision/spec.md
+++ b/specs/532-output-flag-collision/spec.md
@@ -1,0 +1,31 @@
+# fix(cli): resolve --output flag semantic collision across commands
+
+**Issue**: [#532](https://github.com/re-cinq/wave/issues/532)
+**Author**: nextlevelshit
+**State**: OPEN
+
+## Problem
+
+Root `--output` = output format. `init --output` = manifest file path. `agent export --output`/`-o` = export file path. Three different meanings; the `-o` short flag is registered on both root and `agent export`.
+
+## Proposed Solution
+
+Rename `init --output` to `--manifest-path` and `agent export --output` to `--export-path` or remove the `-o` short form.
+
+## Current Flag Inventory
+
+| Flag | Location | Short | Default | Semantic |
+|------|----------|-------|---------|----------|
+| Root `--output` | `main.go:131` | `-o` | `auto` | Output format (auto/json/text/quiet) |
+| `init --output` | `init.go:60` | None | `wave.yaml` | Manifest file output path |
+| `agent export --output` | `agent.go:210` | `-o` | `<name>.agent.md` | Export file path |
+| `bench run --output` | `bench.go:173` | None | `""` | JSON results file path |
+
+## Acceptance Criteria
+
+1. `init --output` renamed to `init --manifest-path`
+2. `agent export --output` renamed to `agent export --export-path` (remove `-o` short form)
+3. `bench run --output` renamed to `bench run --results-path` (consistency)
+4. Root `--output`/`-o` remains unchanged (canonical usage)
+5. All existing tests updated to use new flag names
+6. No `-o` collision between root and subcommands

--- a/specs/532-output-flag-collision/tasks.md
+++ b/specs/532-output-flag-collision/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## Phase 1: Rename init --output to --manifest-path
+- [X] Task 1.1: In `cmd/wave/commands/init.go`, rename the `--output` flag to `--manifest-path`
+- [X] Task 1.2: In `cmd/wave/commands/init_test.go`, update `TestInitOutputPath` to use `--manifest-path`
+
+## Phase 2: Rename agent export --output to --export-path
+- [X] Task 2.1: In `cmd/wave/commands/agent.go`, rename `--output`/`-o` to `--export-path` (no short form) [P]
+- [X] Task 2.2: In `cmd/wave/commands/agent_test.go`, update test to use `--export-path` [P]
+
+## Phase 3: Rename bench run --output to --results-path
+- [X] Task 3.1: In `cmd/wave/commands/bench.go`, rename `--output` to `--results-path` [P]
+
+## Phase 4: Validation
+- [X] Task 4.1: Run `go test ./cmd/wave/commands/...` to verify all command tests pass
+- [X] Task 4.2: Run `go test ./...` for full regression
+- [X] Task 4.3: Run `go vet ./...` to catch any issues


### PR DESCRIPTION
## Summary
- Renamed conflicting --output flags to prevent semantic ambiguity
- Root --output = output format (unchanged)
- init --output renamed to avoid collision

Related to #532

## Test plan
- [ ] go test ./... passes
- [ ] wave init --help shows updated flag name