### PR TITLE
refactor(pipeline): extract OnFailure policy and stdout tail constants

### DIFF
--- a/internal/contract/jsonschema.go
+++ b/internal/contract/jsonschema.go
@@ -291,8 +291,7 @@ func (v *jsonSchemaValidator) Validate(cfg ContractConfig, workspacePath string)
 			validationErr.Message = validationErr.Message + " (progressive validation: warning only)"
 			validationErr.Retryable = false // Don't retry warnings
 
-			// TODO: In a real implementation, these warnings would be logged
-			// to the audit system rather than blocking the pipeline
+			// Progressive warnings are formatted but not yet routed to the audit system.
 			_ = formatter.FormatProgressiveValidationWarning(err, recoveryResult)
 		} else {
 			// Normal validation mode - schema mismatches are always retryable

--- a/internal/pipeline/dag.go
+++ b/internal/pipeline/dag.go
@@ -70,7 +70,7 @@ func (v *DAGValidator) ValidateDAG(p *Pipeline) error {
 		}
 
 		// Validate rework targets
-		if step.Retry.OnFailure == "rework" {
+		if step.Retry.OnFailure == OnFailureRework {
 			if err := v.validateReworkTarget(step.ID, step.Retry.ReworkStep, stepMap); err != nil {
 				return err
 			}
@@ -80,7 +80,7 @@ func (v *DAGValidator) ValidateDAG(p *Pipeline) error {
 	// Validate that each rework target is unique (prevent race on concurrent rework)
 	reworkTargets := make(map[string]string) // target -> source step
 	for _, step := range p.Steps {
-		if step.Retry.OnFailure == "rework" {
+		if step.Retry.OnFailure == OnFailureRework {
 			target := step.Retry.ReworkStep
 			if existing, ok := reworkTargets[target]; ok {
 				return fmt.Errorf("rework target %q is used by both step %q and step %q (each target must be unique)", target, existing, step.ID)
@@ -93,7 +93,7 @@ func (v *DAGValidator) ValidateDAG(p *Pipeline) error {
 	for _, step := range p.Steps {
 		if step.Retry.OnFailure != "" {
 			switch step.Retry.OnFailure {
-			case "fail", "skip", "continue", "rework":
+			case OnFailureFail, OnFailureSkip, OnFailureContinue, OnFailureRework:
 				// valid
 			default:
 				return fmt.Errorf("step %q has invalid on_failure value %q (must be fail, skip, continue, or rework)", step.ID, step.Retry.OnFailure)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -32,6 +32,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// maxStdoutTailChars is the maximum number of characters to retain from
+// stdout when passing output to retry/rework context. Keeps payloads
+// small while preserving the most recent (and usually most relevant) output.
+const maxStdoutTailChars = 2000
 
 type PipelineExecutor interface {
 	Execute(ctx context.Context, p *Pipeline, m *manifest.Manifest, input string) error
@@ -807,8 +811,8 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 					execution.mu.Lock()
 					if result, ok := execution.Results[step.ID]; ok {
 						if stdout, ok := result["stdout"].(string); ok {
-							if len(stdout) > 2000 {
-								stdoutTail = stdout[len(stdout)-2000:]
+							if len(stdout) > maxStdoutTailChars {
+								stdoutTail = stdout[len(stdout)-maxStdoutTailChars:]
 							} else {
 								stdoutTail = stdout
 							}
@@ -832,14 +836,14 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 			onFailure := step.Retry.OnFailure
 			if onFailure == "" {
 				if step.IsOptional() {
-					onFailure = "continue"
+					onFailure = OnFailureContinue
 				} else {
-					onFailure = "fail"
+					onFailure = OnFailureFail
 				}
 			}
 
 			switch onFailure {
-			case "skip":
+			case OnFailureSkip:
 				execution.mu.Lock()
 				execution.States[step.ID] = StateSkipped
 				execution.mu.Unlock()
@@ -855,7 +859,7 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 				})
 				return nil
 
-			case "continue":
+			case OnFailureContinue:
 				execution.mu.Lock()
 				execution.States[step.ID] = StateFailed
 				execution.mu.Unlock()
@@ -871,10 +875,10 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 				})
 				return nil
 
-			case "rework":
+			case OnFailureRework:
 				return e.executeReworkStep(ctx, execution, step, lastErr, attemptDuration)
 
-			default: // "fail"
+			default: // OnFailureFail
 				execution.mu.Lock()
 				execution.States[step.ID] = StateFailed
 				execution.mu.Unlock()
@@ -974,8 +978,8 @@ func (e *DefaultPipelineExecutor) executeReworkStep(ctx context.Context, executi
 	execution.mu.Lock()
 	if result, ok := execution.Results[failedStep.ID]; ok {
 		if stdout, ok := result["stdout"].(string); ok {
-			if len(stdout) > 2000 {
-				attemptCtx.PriorStdout = stdout[len(stdout)-2000:]
+			if len(stdout) > maxStdoutTailChars {
+				attemptCtx.PriorStdout = stdout[len(stdout)-maxStdoutTailChars:]
 			} else {
 				attemptCtx.PriorStdout = stdout
 			}
@@ -2033,7 +2037,7 @@ func (e *DefaultPipelineExecutor) buildStepPrompt(execution *PipelineExecution, 
 			sb.WriteString("\n")
 		}
 		if attemptCtx.PriorStdout != "" {
-			sb.WriteString("### Previous Output (last 2000 chars)\n```\n")
+			sb.WriteString(fmt.Sprintf("### Previous Output (last %d chars)\n```\n", maxStdoutTailChars))
 			sb.WriteString(attemptCtx.PriorStdout)
 			sb.WriteString("\n```\n\n")
 		}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -20,6 +20,15 @@ const (
 	StateReworking = string(state.StateReworking)
 )
 
+// OnFailure policy constants for contract and step failure handling.
+const (
+	OnFailureFail     = "fail"
+	OnFailureSkip     = "skip"
+	OnFailureContinue = "continue"
+	OnFailureRework   = "rework"
+	OnFailureRetry    = "retry"
+)
+
 type Pipeline struct {
 	Kind     string           `yaml:"kind"`
 	Metadata PipelineMetadata `yaml:"metadata"`
@@ -104,11 +113,11 @@ type RetryConfig struct {
 
 // Validate checks that the RetryConfig is well-formed.
 func (r RetryConfig) Validate() error {
-	if r.OnFailure == "rework" && r.ReworkStep == "" {
+	if r.OnFailure == OnFailureRework && r.ReworkStep == "" {
 		return fmt.Errorf("rework_step is required when on_failure is \"rework\"")
 	}
-	if r.ReworkStep != "" && r.OnFailure != "rework" {
-		return fmt.Errorf("rework_step is set but on_failure is %q (must be \"rework\")", r.OnFailure)
+	if r.ReworkStep != "" && r.OnFailure != OnFailureRework {
+		return fmt.Errorf("rework_step is set but on_failure is %q (must be %q)", r.OnFailure, OnFailureRework)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Extracts `OnFailureFail`, `OnFailureSkip`, `OnFailureContinue`, `OnFailureRework`, `OnFailureRetry` constants replacing string literals across executor.go and dag.go
- Extracts `maxStdoutTailChars` constant (2000) for stdout truncation in retry/rework context
- Removes unlinked TODO comment in jsonschema.go progressive validation

## Test plan
- [x] `go test ./internal/pipeline/...` passes
- [x] `go test ./internal/contract/...` passes