### PR TITLE
refactor(pipeline): use OnFailureRetry constant in adhoc steps

### DIFF
--- a/internal/pipeline/adhoc.go
+++ b/internal/pipeline/adhoc.go
@@ -85,7 +85,7 @@ func generateNavigateStep(persona, input string) Step {
 				Type:       "json_schema",
 				SchemaPath: ".wave/contracts/navigation.schema.json",
 				Source:     ".wave/output/analysis.json",
-				OnFailure:  "retry",
+				OnFailure:  OnFailureRetry,
 				MaxRetries: 2,
 			},
 		},
@@ -118,7 +118,7 @@ func generateExecuteStep(persona, input string) Step {
 				Type:       "test_suite",
 				Command:    "go test ./...",
 				MustPass:   true,
-				OnFailure:  "retry",
+				OnFailure:  OnFailureRetry,
 				MaxRetries: 3,
 			},
 			Compaction: CompactionConfig{


### PR DESCRIPTION
## Summary
Replaces string literal `"retry"` with `OnFailureRetry` constant in `adhoc.go` step generation, completing the constant extraction from PR #549.

## Test plan
- [x] `go test ./internal/pipeline/...` passes