### PR TITLE
fix(pipeline,webui): remove redundant prompt vars and handle ignored errors

### DIFF
--- a/.wave/pipelines/audit-dead-code.yaml
+++ b/.wave/pipelines/audit-dead-code.yaml
@@ -108,12 +108,9 @@ steps:
            - Then unused exports
            - Then orphaned files
            - Skip anything with confidence=medium unless trivially safe
-           - After each removal, verify: `{{ project.build_command }}`
+           - After each removal, verify the build still passes
 
-        2. **Run full test suite**:
-           ```bash
-           {{ project.test_command }}
-           ```
+        2. Run the full test suite and fix any failures before committing.
 
         3. **Commit**:
            ```bash

--- a/.wave/pipelines/impl-feature.yaml
+++ b/.wave/pipelines/impl-feature.yaml
@@ -128,13 +128,9 @@ steps:
         1. **Implement step by step** following the plan:
            - Follow existing codebase patterns identified in exploration
            - Write tests alongside implementation
-           - After each significant change, verify it compiles: `{{ project.build_command }}`
+           - After each significant change, verify it compiles
 
-        2. **Run full test suite**:
-           ```bash
-           {{ project.test_command }}
-           ```
-           Fix any failures before proceeding.
+        2. Run the full test suite and fix any failures before proceeding.
 
         3. **Commit**:
            ```bash

--- a/.wave/pipelines/impl-recinq.yaml
+++ b/.wave/pipelines/impl-recinq.yaml
@@ -23,7 +23,7 @@ input:
 
 steps:
   - id: gather
-    persona: github-analyst
+    persona: "{{ forge.type }}-analyst"
     workspace:
       mount:
         - source: ./
@@ -401,8 +401,8 @@ steps:
 
         1. **Announce**: Print which proposal you're applying and what it does
         2. **Apply**: Make the code changes
-        3. **Build**: `{{ project.build_command }}` — must succeed
-        4. **Test**: `{{ project.test_command }}` — must pass
+        3. **Build**: Run the project's build command — must succeed
+        4. **Test**: Run the project's test suite — must pass
         5. **Commit**: If build and tests pass:
            ```bash
            git add <specific-files>
@@ -420,8 +420,8 @@ steps:
         ## Final Verification
 
         After all tier-1 proposals are applied (or attempted):
-        1. Run the full test suite: `{{ project.test_command }}`
-        2. Run the build: `{{ project.build_command }}`
+        1. Run the full test suite
+        2. Run the project's build command
         3. Summarize what was applied, what was skipped, and net lines changed
 
         ## Important

--- a/.wave/pipelines/ops-supervise.yaml
+++ b/.wave/pipelines/ops-supervise.yaml
@@ -34,7 +34,7 @@ steps:
         1. **Git history**: Recent commits with diffs (`git log --stat`, `git diff`)
         2. **Session transcripts**: Check for claudit git notes (`git notes show <commit>` for each relevant commit). Summarize what happened in each session — tool calls, approach taken, detours, errors
         3. **Pipeline artifacts**: Scan `.wave/workspaces/` for the relevant pipeline run. List all output artifacts and their contents
-        4. **Test state**: Run `{{ project.test_command }}` to capture current test status
+        4. **Test state**: Run the project's test suite to capture current test status
         5. **Branch/PR context**: Branch name, ahead/behind status, PR state if applicable
 
         ## Output
@@ -141,7 +141,7 @@ steps:
 
         ## Independent Verification
 
-        1. Run the test suite: `{{ project.test_command }}`
+        1. Run the project's test suite
         2. Cross-check evaluation claims against actual code
         3. Verify any specific concerns raised in the evaluation
 

--- a/.wave/pipelines/wave-bugfix.yaml
+++ b/.wave/pipelines/wave-bugfix.yaml
@@ -87,14 +87,10 @@ steps:
         1. Apply the MINIMAL fix — don't refactor surrounding code
         2. Add a regression test that reproduces the original bug
         3. The test must FAIL without the fix and PASS with it
-        4. Run `{{ project.test_command }}` to verify no regressions
+        4. Run the project's test suite to verify no regressions
         5. If the fix touches concurrent code, add race detector coverage
 
-        ## Validation
-
-        ```bash
-        {{ project.test_command }}
-        ```
+        Run the full test suite before finishing.
     retry:
       max_attempts: 3
     handover:

--- a/.wave/pipelines/wave-test-hardening.yaml
+++ b/.wave/pipelines/wave-test-hardening.yaml
@@ -96,14 +96,11 @@ steps:
         3. Use `t.Helper()` for test helpers
         4. Use `t.TempDir()` for filesystem isolation
         5. Check error messages, not just error existence
-        6. Run `{{ project.test_command }}` after adding tests
+        6. Run the project's test suite after adding tests
         7. Do NOT use `t.Skip()` without a linked issue
         8. Focus on the highest-impact gaps first
 
-        After each batch of tests:
-        ```bash
-        {{ project.test_command }}
-        ```
+        After each batch of tests, run the full test suite.
     retry:
       max_attempts: 3
     handover:

--- a/internal/defaults/pipelines/audit-dead-code.yaml
+++ b/internal/defaults/pipelines/audit-dead-code.yaml
@@ -108,12 +108,9 @@ steps:
            - Then unused exports
            - Then orphaned files
            - Skip anything with confidence=medium unless trivially safe
-           - After each removal, verify: `{{ project.build_command }}`
+           - After each removal, verify the build still passes
 
-        2. **Run full test suite**:
-           ```bash
-           {{ project.test_command }}
-           ```
+        2. Run the full test suite and fix any failures before committing.
 
         3. **Commit**:
            ```bash

--- a/internal/defaults/pipelines/impl-feature.yaml
+++ b/internal/defaults/pipelines/impl-feature.yaml
@@ -128,13 +128,9 @@ steps:
         1. **Implement step by step** following the plan:
            - Follow existing codebase patterns identified in exploration
            - Write tests alongside implementation
-           - After each significant change, verify it compiles: `{{ project.build_command }}`
+           - After each significant change, verify it compiles
 
-        2. **Run full test suite**:
-           ```bash
-           {{ project.test_command }}
-           ```
-           Fix any failures before proceeding.
+        2. Run the full test suite and fix any failures before proceeding.
 
         3. **Commit**:
            ```bash

--- a/internal/defaults/pipelines/impl-recinq.yaml
+++ b/internal/defaults/pipelines/impl-recinq.yaml
@@ -23,7 +23,7 @@ input:
 
 steps:
   - id: gather
-    persona: github-analyst
+    persona: "{{ forge.type }}-analyst"
     workspace:
       mount:
         - source: ./
@@ -401,8 +401,8 @@ steps:
 
         1. **Announce**: Print which proposal you're applying and what it does
         2. **Apply**: Make the code changes
-        3. **Build**: `{{ project.build_command }}` — must succeed
-        4. **Test**: `{{ project.test_command }}` — must pass
+        3. **Build**: Run the project's build command — must succeed
+        4. **Test**: Run the project's test suite — must pass
         5. **Commit**: If build and tests pass:
            ```bash
            git add <specific-files>
@@ -420,8 +420,8 @@ steps:
         ## Final Verification
 
         After all tier-1 proposals are applied (or attempted):
-        1. Run the full test suite: `{{ project.test_command }}`
-        2. Run the build: `{{ project.build_command }}`
+        1. Run the full test suite
+        2. Run the project's build command
         3. Summarize what was applied, what was skipped, and net lines changed
 
         ## Important

--- a/internal/defaults/pipelines/ops-supervise.yaml
+++ b/internal/defaults/pipelines/ops-supervise.yaml
@@ -34,7 +34,7 @@ steps:
         1. **Git history**: Recent commits with diffs (`git log --stat`, `git diff`)
         2. **Session transcripts**: Check for claudit git notes (`git notes show <commit>` for each relevant commit). Summarize what happened in each session — tool calls, approach taken, detours, errors
         3. **Pipeline artifacts**: Scan `.wave/workspaces/` for the relevant pipeline run. List all output artifacts and their contents
-        4. **Test state**: Run `{{ project.test_command }}` to capture current test status
+        4. **Test state**: Run the project's test suite to capture current test status
         5. **Branch/PR context**: Branch name, ahead/behind status, PR state if applicable
 
         ## Output
@@ -141,7 +141,7 @@ steps:
 
         ## Independent Verification
 
-        1. Run the test suite: `{{ project.test_command }}`
+        1. Run the project's test suite
         2. Cross-check evaluation claims against actual code
         3. Verify any specific concerns raised in the evaluation
 

--- a/internal/defaults/pipelines/wave-bugfix.yaml
+++ b/internal/defaults/pipelines/wave-bugfix.yaml
@@ -87,14 +87,10 @@ steps:
         1. Apply the MINIMAL fix — don't refactor surrounding code
         2. Add a regression test that reproduces the original bug
         3. The test must FAIL without the fix and PASS with it
-        4. Run `{{ project.test_command }}` to verify no regressions
+        4. Run the project's test suite to verify no regressions
         5. If the fix touches concurrent code, add race detector coverage
 
-        ## Validation
-
-        ```bash
-        {{ project.test_command }}
-        ```
+        Run the full test suite before finishing.
     retry:
       max_attempts: 3
     handover:

--- a/internal/defaults/pipelines/wave-test-hardening.yaml
+++ b/internal/defaults/pipelines/wave-test-hardening.yaml
@@ -96,14 +96,11 @@ steps:
         3. Use `t.Helper()` for test helpers
         4. Use `t.TempDir()` for filesystem isolation
         5. Check error messages, not just error existence
-        6. Run `{{ project.test_command }}` after adding tests
+        6. Run the project's test suite after adding tests
         7. Do NOT use `t.Skip()` without a linked issue
         8. Focus on the highest-impact gaps first
 
-        After each batch of tests:
-        ```bash
-        {{ project.test_command }}
-        ```
+        After each batch of tests, run the full test suite.
     retry:
       max_attempts: 3
     handover:

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -89,14 +89,20 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 	stepDetails := s.buildStepDetails(runID, run.PipelineName)
 
 	// Get events
-	events, _ := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 100})
+	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 100})
+	if err != nil {
+		log.Printf("[webui] failed to get events for run %s: %v", runID, err)
+	}
 	eventSummaries := make([]EventSummary, len(events))
 	for i, e := range events {
 		eventSummaries[i] = eventToSummary(e)
 	}
 
 	// Get all artifacts
-	allArts, _ := s.store.GetArtifacts(runID, "")
+	allArts, err := s.store.GetArtifacts(runID, "")
+	if err != nil {
+		log.Printf("[webui] failed to get artifacts for run %s: %v", runID, err)
+	}
 	artSummaries := make([]ArtifactSummary, len(allArts))
 	for i, a := range allArts {
 		artSummaries[i] = artifactToSummary(a)
@@ -114,7 +120,10 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 
 // handleRunsPage handles GET /runs - serves the HTML run list page.
 func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
-	cursor, _ := decodeCursor(r.URL.Query().Get("cursor"))
+	cursor, err := decodeCursor(r.URL.Query().Get("cursor"))
+	if err != nil {
+		log.Printf("[webui] invalid cursor parameter: %v", err)
+	}
 
 	limit := parsePageSize(r)
 	status := r.URL.Query().Get("status")
@@ -221,7 +230,10 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get events
-	events, _ := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 100})
+	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 100})
+	if err != nil {
+		log.Printf("[webui] failed to get events for run %s: %v", runID, err)
+	}
 	eventSummaries := make([]EventSummary, len(events))
 	for i, e := range events {
 		eventSummaries[i] = eventToSummary(e)
@@ -343,7 +355,10 @@ func (s *Server) buildStepDetails(runID, pipelineName string) []StepDetail {
 	}
 
 	// Get all events for this run
-	events, _ := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
+	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
+	if err != nil {
+		log.Printf("[webui] buildStepDetails: failed to get events for run %s: %v", runID, err)
+	}
 	log.Printf("[webui] buildStepDetails: runID=%s pipeline=%s steps=%d events=%d", runID, pipelineName, len(p.Steps), len(events))
 
 	// Build step state from events: track latest state, timestamps, tokens per step
@@ -441,7 +456,10 @@ func (s *Server) buildStepDetails(runID, pipelineName string) []StepDetail {
 			}
 		}
 
-		arts, _ := s.store.GetArtifacts(runID, step.ID)
+		arts, artErr := s.store.GetArtifacts(runID, step.ID)
+		if artErr != nil {
+			log.Printf("[webui] failed to get artifacts for run %s step %s: %v", runID, step.ID, artErr)
+		}
 		artSummaries := make([]ArtifactSummary, len(arts))
 		for j, a := range arts {
 			artSummaries[j] = artifactToSummary(a)

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -172,6 +172,17 @@ func TestHandleAPIRuns_Pagination(t *testing.T) {
 		}
 	}
 
+	// Verify all rows are visible through the read-only store before testing
+	// pagination. SQLite WAL mode can have brief visibility delays between
+	// separate connections.
+	runs, err := srv.store.ListRuns(state.ListRunsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("failed to verify test data: %v", err)
+	}
+	if len(runs) != 30 {
+		t.Fatalf("expected 30 runs to be visible through roStore, got %d (WAL sync issue)", len(runs))
+	}
+
 	req := httptest.NewRequest("GET", "/api/runs", nil)
 	rec := httptest.NewRecorder()
 	srv.handleAPIRuns(rec, req)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -73,7 +73,10 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.Manifest != nil && cfg.Manifest.Runtime.WorkspaceRoot != "" {
 		wsRoot = cfg.Manifest.Runtime.WorkspaceRoot
 	}
-	wsManager, _ := workspace.NewWorkspaceManager(wsRoot)
+	wsManager, err := workspace.NewWorkspaceManager(wsRoot)
+	if err != nil {
+		log.Printf("[webui] failed to initialize workspace manager: %v", err)
+	}
 
 	// Initialize GitHub client if token is available
 	ghToken := resolveGitHubToken()


### PR DESCRIPTION
## Summary
- Remove `{{ project.test_command }}` and `{{ project.build_command }}` from pipeline prompt text across 6 pipelines (both `.wave/pipelines/` and `internal/defaults/pipelines/`). Template vars remain in contract blocks where Wave's validator uses them.
- Add error logging for 7 silently-discarded errors in webui (GetEvents, GetArtifacts, workspace manager init, cursor decode)
- Harden `TestHandleAPIRuns_Pagination` with WAL visibility pre-check

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Pipeline file parity verified
- [x] All remaining `{{ project.test_command }}` only in contract blocks