### PR TITLE
fix(preflight): robust skill detection in sandboxed environments

### DIFF
--- a/.wave/pipelines/impl-speckit.yaml
+++ b/.wave/pipelines/impl-speckit.yaml
@@ -8,7 +8,7 @@ requires:
   skills:
     speckit:
       check: specify check
-      install: uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+      install: uv tool install --force specify-cli --from git+https://github.com/github/spec-kit.git
       init: specify init
   tools:
     - git

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -720,12 +720,28 @@ func runDetached(opts RunOptions, p *pipeline.Pipeline, m *manifest.Manifest) er
 
 // buildDetachEnv constructs a minimal environment for detached subprocesses.
 func buildDetachEnv() []string {
-	env := []string{
-		"HOME=" + os.Getenv("HOME"),
-		"PATH=" + os.Getenv("PATH"),
+	// Ensure $HOME/.local/bin is in PATH — install tools (uv, pip, cargo)
+	// place binaries there and it may not be in PATH in sandboxed environments.
+	path := os.Getenv("PATH")
+	home := os.Getenv("HOME")
+	if home != "" {
+		toolBin := filepath.Join(home, ".local", "bin")
+		if !strings.Contains(path, toolBin) {
+			path = toolBin + string(os.PathListSeparator) + path
+		}
 	}
-	// Pass through common env vars needed by adapters.
-	for _, key := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_BEDROCK", "AWS_PROFILE", "AWS_REGION", "TERM", "USER", "SHELL"} {
+
+	env := []string{
+		"HOME=" + home,
+		"PATH=" + path,
+	}
+	// Pass through common env vars needed by adapters and tool managers.
+	for _, key := range []string{
+		"ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_BEDROCK", "AWS_PROFILE", "AWS_REGION",
+		"TERM", "USER", "SHELL",
+		// XDG dirs used by uv, pip, and other tool managers for locating data/config
+		"XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME",
+	} {
 		if val, ok := os.LookupEnv(key); ok {
 			env = append(env, key+"="+val)
 		}

--- a/cmd/wave/commands/run_detach_test.go
+++ b/cmd/wave/commands/run_detach_test.go
@@ -35,8 +35,27 @@ func TestBuildDetachEnv(t *testing.T) {
 	}
 
 	assert.Equal(t, "/home/test", envMap["HOME"])
-	assert.Equal(t, "/usr/bin", envMap["PATH"])
+	// PATH should include $HOME/.local/bin prepended for tool manager binaries
+	assert.Equal(t, "/home/test/.local/bin:/usr/bin", envMap["PATH"])
 	assert.Equal(t, "sk-test-key", envMap["ANTHROPIC_API_KEY"])
+}
+
+func TestBuildDetachEnvNoPathDuplication(t *testing.T) {
+	// When $HOME/.local/bin is already in PATH, don't duplicate it.
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("PATH", "/home/test/.local/bin:/usr/bin")
+
+	env := buildDetachEnv()
+	envMap := make(map[string]string)
+	for _, e := range env {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				envMap[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+	assert.Equal(t, "/home/test/.local/bin:/usr/bin", envMap["PATH"])
 }
 
 func TestBuildDetachEnvOmitsMissing(t *testing.T) {

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -8,7 +8,7 @@ requires:
   skills:
     speckit:
       check: specify check
-      install: uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+      install: uv tool install --force specify-cli --from git+https://github.com/github/spec-kit.git
       init: specify init
   tools:
     - git

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,9 +1,12 @@
 package preflight
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/recinq/wave/internal/skill"
@@ -74,6 +77,23 @@ func NewChecker(skills map[string]skill.SkillConfig) *Checker {
 // defaultRunCmd executes a command and returns an error if it fails.
 func defaultRunCmd(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
+	return cmd.Run()
+}
+
+// runCmdWithOutput executes a command and returns combined stdout+stderr output.
+func runCmdWithOutput(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+// runCmdWithEnv executes a command with additional environment variables.
+func runCmdWithEnv(env []string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), env...)
 	return cmd.Run()
 }
 
@@ -244,18 +264,27 @@ func (c *Checker) CheckSkills(skills []string) ([]Result, error) {
 
 		// Run install command
 		if err := c.runShellCommand(cfg.Install); err != nil {
+			// Capture output for diagnostics on failure
+			installOutput, _ := runCmdWithOutput("sh", "-c", cfg.Install)
+			msg := fmt.Sprintf("skill %q install failed: %v", name, err)
+			if installOutput != "" {
+				msg += "; output: " + truncateOutput(installOutput, 200)
+			}
 			results = append(results, Result{
 				Name:    name,
 				Kind:    "skill",
 				OK:      false,
-				Message: fmt.Sprintf("skill %q install failed: %v", name, err),
+				Message: msg,
 			})
 			failed = append(failed, name)
 			continue
 		}
 
-		// Re-check after install
-		if c.isSkillInstalled(cfg) {
+		// Re-check after install. First try with existing PATH, then retry
+		// with $HOME/.local/bin added since install tools (uv, pip, cargo)
+		// place binaries there and sandboxed/detached environments may not
+		// include it in PATH.
+		if c.isSkillInstalled(cfg) || c.isSkillInstalledWithToolBin(cfg) {
 			results = append(results, Result{
 				Name:    name,
 				Kind:    "skill",
@@ -263,11 +292,20 @@ func (c *Checker) CheckSkills(skills []string) ([]Result, error) {
 				Message: fmt.Sprintf("skill %q installed successfully", name),
 			})
 		} else {
+			// Capture check output for diagnostics
+			checkOutput, checkErr := runCmdWithOutput("sh", "-c", cfg.Check)
+			msg := fmt.Sprintf("skill %q still not detected after install", name)
+			if checkErr != nil {
+				msg += fmt.Sprintf(" (check error: %v)", checkErr)
+			}
+			if checkOutput != "" {
+				msg += "; check output: " + truncateOutput(checkOutput, 200)
+			}
 			results = append(results, Result{
 				Name:    name,
 				Kind:    "skill",
 				OK:      false,
-				Message: fmt.Sprintf("skill %q still not detected after install", name),
+				Message: msg,
 			})
 			failed = append(failed, name)
 		}
@@ -289,9 +327,41 @@ func (c *Checker) isSkillInstalled(cfg skill.SkillConfig) bool {
 	return c.runShellCommand(cfg.Check) == nil
 }
 
+// isSkillInstalledWithToolBin checks skill installation with $HOME/.local/bin
+// added to PATH. Install tools (uv, pip, cargo) place binaries there, and
+// in sandboxed or detached environments this directory may not be in PATH
+// even after a successful install.
+func (c *Checker) isSkillInstalledWithToolBin(cfg skill.SkillConfig) bool {
+	if cfg.Check == "" {
+		return false
+	}
+	// First try with existing PATH
+	if c.runShellCommand(cfg.Check) == nil {
+		return true
+	}
+	// Retry with $HOME/.local/bin prepended to PATH
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+	toolBin := filepath.Join(home, ".local", "bin")
+	currentPath := os.Getenv("PATH")
+	enhancedPath := toolBin + string(os.PathListSeparator) + currentPath
+	return runCmdWithEnv([]string{"PATH=" + enhancedPath}, "sh", "-c", cfg.Check) == nil
+}
+
 // runShellCommand executes a shell command string via sh -c.
 func (c *Checker) runShellCommand(command string) error {
 	return c.runCmd("sh", "-c", command)
+}
+
+// truncateOutput trims output to maxLen characters, adding ellipsis if truncated.
+func truncateOutput(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 // Run executes all preflight checks for the given tool and skill requirements.

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/recinq/wave/internal/skill"
@@ -530,6 +531,63 @@ func TestCheckBubblewrap(t *testing.T) {
 	}
 	if result.Kind != "tool" {
 		t.Errorf("expected kind 'tool', got %q", result.Kind)
+	}
+}
+
+func TestTruncateOutput(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"longer than max", 10, "longer tha..."},
+		{"  trimmed  ", 20, "trimmed"},
+		{"", 10, ""},
+	}
+	for _, tt := range tests {
+		got := truncateOutput(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncateOutput(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestCheckSkills_PostInstallPathFallback(t *testing.T) {
+	// Simulate: check always fails, install succeeds. The re-check via
+	// isSkillInstalledWithToolBin also fails since the binary doesn't exist.
+	// Verifies we get a diagnostic error message.
+	skills := map[string]skill.SkillConfig{
+		"myskill": {
+			Check:   "nonexistent-binary-xyz --version",
+			Install: "echo installing",
+		},
+	}
+
+	c := NewChecker(skills)
+	c.runCmd = func(name string, args ...string) error {
+		cmd := strings.Join(args, " ")
+		// Install commands succeed
+		if strings.Contains(cmd, "installing") || strings.Contains(cmd, "echo") {
+			return nil
+		}
+		// All check commands fail
+		return fmt.Errorf("not found")
+	}
+
+	results, err := c.CheckSkills([]string{"myskill"})
+	if err == nil {
+		t.Fatal("expected error for skill that fails check after install")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].OK {
+		t.Error("expected skill to fail (binary doesn't exist)")
+	}
+	if !strings.Contains(results[0].Message, "still not detected after install") {
+		t.Errorf("expected diagnostic message, got: %s", results[0].Message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preflight skill checker now detects installed skills in detached pipeline subprocesses (`--detach`) running inside bubblewrap sandboxes
- `buildDetachEnv` prepends `$HOME/.local/bin` to PATH and passes XDG env vars for tool managers (uv, pip, cargo)
- After install, `CheckSkills` retries the check with enhanced PATH fallback and captures diagnostic output on failure
- `impl-speckit.yaml` uses `uv tool install --force` to always recreate symlinks regardless of existing tool data

## Root cause
In bwrap sandbox, `$HOME/.local/bin` sits on tmpfs (ephemeral) while `$HOME/.local/share/uv` is bind-mounted (persistent). When `uv tool install` runs and finds existing tool data, it can exit 0 without recreating the symlink. The re-check then fails because `specify` isn't on PATH.

## Test plan
- [x] All existing preflight tests pass
- [x] New `TestTruncateOutput` covers output truncation helper
- [x] New `TestCheckSkills_PostInstallPathFallback` covers enhanced PATH fallback flow
- [x] New `TestBuildDetachEnvNoPathDuplication` verifies no PATH duplication
- [x] Updated `TestBuildDetachEnv` verifies `$HOME/.local/bin` prepended to PATH
- [x] `go test ./...` passes (full suite)