### PR TITLE
fix: address PR review tech debt from #602 and #603

### DIFF
--- a/internal/doctor/codebase.go
+++ b/internal/doctor/codebase.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"os/exec"
 	"time"
 
@@ -77,7 +78,9 @@ func AnalyzeCodebase(ctx context.Context, opts CodebaseOptions) (*CodebaseHealth
 			State:   "open",
 			PerPage: 100,
 		})
-		if err == nil {
+		if err != nil {
+			log.Printf("[doctor] failed to list pull requests: %v", err)
+		} else {
 			health.PRs = analyzePRs(prs, opts.now())
 		}
 
@@ -85,7 +88,9 @@ func AnalyzeCodebase(ctx context.Context, opts CodebaseOptions) (*CodebaseHealth
 			State:   "open",
 			PerPage: 100,
 		})
-		if err == nil {
+		if err != nil {
+			log.Printf("[doctor] failed to list issues: %v", err)
+		} else {
 			health.Issues = analyzeIssues(ctx, issues, opts.ForgeClient)
 		}
 	}

--- a/internal/forge/detect_test.go
+++ b/internal/forge/detect_test.go
@@ -349,10 +349,20 @@ func TestDetect_SubdomainVariants(t *testing.T) {
 }
 
 func TestDetect_SSHWithPort(t *testing.T) {
-	// SSH URLs with port: ssh://git@gitlab.example.com:2222/org/repo.git
+	// SSH URLs with port: ssh://git@github.com:2222/org/repo.git
+	// The port in the URL causes the host to include ":2222", so
+	// classifyHost won't match "github.com" — this is a known limitation.
 	info := Detect("ssh://git@github.com:2222/org/repo.git")
-	// With port, parsing may differ — verify it doesn't panic
-	_ = info
+	// Host includes port, so forge detection falls back to unknown
+	if info.Type != ForgeUnknown {
+		t.Errorf("Type = %q, want %q (port in host breaks suffix matching)", info.Type, ForgeUnknown)
+	}
+	if info.Owner != "org" {
+		t.Errorf("Owner = %q, want %q", info.Owner, "org")
+	}
+	if info.Repo != "repo" {
+		t.Errorf("Repo = %q, want %q", info.Repo, "repo")
+	}
 }
 
 func TestForgeInfo_Slug_AllForges(t *testing.T) {

--- a/internal/forge/token.go
+++ b/internal/forge/token.go
@@ -1,9 +1,11 @@
 package forge
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/recinq/wave/internal/github"
 )
@@ -31,7 +33,9 @@ func resolveGitHubToken() string {
 	if t := os.Getenv("GITHUB_TOKEN"); t != "" {
 		return t
 	}
-	out, err := exec.Command("gh", "auth", "token").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
 	if err == nil {
 		if t := strings.TrimSpace(string(out)); t != "" {
 			return t

--- a/internal/pipeline/context.go
+++ b/internal/pipeline/context.go
@@ -16,7 +16,13 @@ import (
 // These are stripped after all known variables have been substituted so that
 // missing project config fields resolve to empty strings instead of leaking
 // literal mustache syntax into prompts and contract commands.
-var unresolvedProjectVarRe = regexp.MustCompile(`\{\{\s*(?:project|ontology)\.\w+(?:\.\w+)?\s*\}\}`)
+var (
+	unresolvedProjectVarRe = regexp.MustCompile(`\{\{\s*(?:project|ontology)\.\w+(?:\.\w+)?\s*\}\}`)
+	threeDigitPrefixRe     = regexp.MustCompile(`^(\d{3})-`)
+	numericPrefixRe        = regexp.MustCompile(`(\d+)[-_]`)
+	invalidPathCharRe      = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+	consecutiveDashRe      = regexp.MustCompile(`-+`)
+)
 
 // PipelineContext holds dynamic variables for template resolution during pipeline execution
 type PipelineContext struct {
@@ -106,11 +112,6 @@ func (ctx *PipelineContext) ResolvePlaceholders(template string) string {
 	for key, value := range customVarsCopy {
 		result = replaceBoth(result, key, value)
 	}
-
-	// Handle standard template variables (both spaced and unspaced)
-	result = replaceBoth(result, "pipeline_id", ctx.PipelineID)
-	result = replaceBoth(result, "pipeline_name", ctx.PipelineName)
-	result = replaceBoth(result, "step_id", ctx.StepID)
 
 	// Strip unresolved {{ project.* }} placeholders so they don't leak into
 	// prompts or contract commands when a project field is not configured.
@@ -260,15 +261,13 @@ func getCurrentGitBranch() (string, error) {
 // extractFeatureNumber extracts feature number from branch name (supports ###-name format)
 func extractFeatureNumber(branchName string) string {
 	// Match patterns like "018-enhanced-progress", "001-feature-name", etc.
-	re := regexp.MustCompile(`^(\d{3})-`)
-	matches := re.FindStringSubmatch(branchName)
+	matches := threeDigitPrefixRe.FindStringSubmatch(branchName)
 	if len(matches) > 1 {
 		return branchName // Return full branch name as feature identifier
 	}
 
 	// Try other common patterns like "feature/123-name"
-	re2 := regexp.MustCompile(`(\d+)[-_]`)
-	matches2 := re2.FindStringSubmatch(branchName)
+	matches2 := numericPrefixRe.FindStringSubmatch(branchName)
 	if len(matches2) > 1 {
 		// Pad to 3 digits
 		num, _ := strconv.Atoi(matches2[1])
@@ -281,10 +280,10 @@ func extractFeatureNumber(branchName string) string {
 // sanitizeBranchName removes invalid characters from branch names for use in paths
 func sanitizeBranchName(branchName string) string {
 	// Replace invalid path characters
-	sanitized := regexp.MustCompile(`[^a-zA-Z0-9\-_]`).ReplaceAllString(branchName, "-")
+	sanitized := invalidPathCharRe.ReplaceAllString(branchName, "-")
 
 	// Remove consecutive dashes
-	sanitized = regexp.MustCompile(`-+`).ReplaceAllString(sanitized, "-")
+	sanitized = consecutiveDashRe.ReplaceAllString(sanitized, "-")
 
 	// Trim leading/trailing dashes
 	sanitized = strings.Trim(sanitized, "-")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -156,11 +156,7 @@ func RunTUI(deps LaunchDependencies) error {
 		repoSlug = detectRepoFromGitRemote()
 	}
 	if repoSlug != "" {
-		forgeInfo := forge.Detect(repoSlug)
-		if forgeInfo.Type == forge.ForgeUnknown {
-			// Try detecting from git remotes for full URL resolution
-			forgeInfo, _ = forge.DetectFromGitRemotes()
-		}
+		forgeInfo, _ := forge.DetectFromGitRemotes()
 		forgeClient := forge.NewClient(forgeInfo)
 		if forgeClient != nil {
 			cp.IssueProvider = NewDefaultIssueDataProvider(forgeClient, repoSlug)


### PR DESCRIPTION
## Summary
- Remove duplicate `replaceBoth` block in `context.go` (lines 110-113 duplicated 94-96)
- Hoist 4 regexes to package-level `var` in `context.go` (avoid recompiling per call)
- Log forge API errors in doctor's `AnalyzeCodebase` instead of silently swallowing
- Add assertions to SSH-with-port test in `detect_test.go` (was a no-op)
- Add 5s timeout to `gh auth token` subprocess via `exec.CommandContext`
- Simplify TUI forge detection — remove redundant `forge.Detect()` call that always returned `ForgeUnknown`

## Test plan
- [x] `go test ./internal/pipeline/... ./internal/forge/... ./internal/doctor/... ./internal/tui/... ./internal/webui/...` — all pass
- [x] `go vet` clean