### PR TITLE
fix(webui): render /compare page inside layout template with run selector

### DIFF
--- a/internal/webui/handlers_compare.go
+++ b/internal/webui/handlers_compare.go
@@ -37,25 +37,55 @@ type CompareResponse struct {
 	TokensClass   string           `json:"tokens_class"`
 }
 
+// comparePageData holds all fields the compare template can use.
+type comparePageData struct {
+	ActivePage       string
+	ShowSelector     bool
+	Error            string
+	Runs             []RunSummary
+	Left             RunSummary
+	Right            RunSummary
+	Rows             []CompareStepRow
+	DurationDelta    string
+	DurationClass    string
+	TokensDelta      string
+	TokensClass      string
+	SamePipelineRuns []RunSummary
+}
+
 // handleComparePage handles GET /compare - renders a side-by-side comparison of two runs.
 func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 	leftID := r.URL.Query().Get("left")
 	rightID := r.URL.Query().Get("right")
 
 	if leftID == "" || rightID == "" {
-		http.Error(w, "both left and right run IDs are required", http.StatusBadRequest)
+		s.renderComparePage(w, comparePageData{
+			ActivePage:   "runs",
+			ShowSelector: true,
+			Runs:         s.listRecentRuns(),
+		})
 		return
 	}
 
 	leftRun, err := s.store.GetRun(leftID)
 	if err != nil {
-		http.Error(w, "left run not found", http.StatusNotFound)
+		s.renderComparePage(w, comparePageData{
+			ActivePage:   "runs",
+			ShowSelector: true,
+			Error:        "Left run not found: " + leftID,
+			Runs:         s.listRecentRuns(),
+		})
 		return
 	}
 
 	rightRun, err := s.store.GetRun(rightID)
 	if err != nil {
-		http.Error(w, "right run not found", http.StatusNotFound)
+		s.renderComparePage(w, comparePageData{
+			ActivePage:   "runs",
+			ShowSelector: true,
+			Error:        "Right run not found: " + rightID,
+			Runs:         s.listRecentRuns(),
+		})
 		return
 	}
 
@@ -89,17 +119,7 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 		samePipelineRuns = s.listSamePipelineRuns(leftRun.PipelineName, leftID, rightID)
 	}
 
-	data := struct {
-		ActivePage       string
-		Left             RunSummary
-		Right            RunSummary
-		Rows             []CompareStepRow
-		DurationDelta    string
-		DurationClass    string
-		TokensDelta      string
-		TokensClass      string
-		SamePipelineRuns []RunSummary
-	}{
+	s.renderComparePage(w, comparePageData{
 		ActivePage:       "runs",
 		Left:             leftSummary,
 		Right:            rightSummary,
@@ -109,8 +129,11 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 		TokensDelta:      tokensDelta,
 		TokensClass:      tokensClass,
 		SamePipelineRuns: samePipelineRuns,
-	}
+	})
+}
 
+// renderComparePage renders the compare template with the given data.
+func (s *Server) renderComparePage(w http.ResponseWriter, data comparePageData) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	tmpl := s.templates["templates/compare.html"]
 	if tmpl == nil {
@@ -121,6 +144,20 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[webui] template error rendering compare page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
+}
+
+// listRecentRuns fetches recent runs for the compare selector.
+func (s *Server) listRecentRuns() []RunSummary {
+	runs, err := s.store.ListRuns(state.ListRunsOptions{Limit: 50})
+	if err != nil {
+		log.Printf("[webui] compare: failed to list recent runs: %v", err)
+		return nil
+	}
+	summaries := make([]RunSummary, 0, len(runs))
+	for _, r := range runs {
+		summaries = append(summaries, runToSummary(r))
+	}
+	return summaries
 }
 
 // handleAPICompare handles GET /api/compare - returns comparison data as JSON.

--- a/internal/webui/handlers_compare_test.go
+++ b/internal/webui/handlers_compare_test.go
@@ -91,8 +91,42 @@ func TestHandleComparePage_MissingParams(t *testing.T) {
 	req := httptest.NewRequest("GET", "/compare", nil)
 	rec := httptest.NewRecorder()
 	srv.handleComparePage(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !contains(body, "<select") {
+		t.Error("expected body to contain <select> elements for run selector")
+	}
+	if !contains(body, "compare-left-select") {
+		t.Error("expected body to contain left select element")
+	}
+	if !contains(body, "compare-right-select") {
+		t.Error("expected body to contain right select element")
+	}
+	if !contains(body, "<nav") {
+		t.Error("expected body to contain navbar (layout template)")
+	}
+}
+
+func TestHandleComparePage_RunNotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequest("GET", "/compare?left=nonexistent&right=also-nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.handleComparePage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !contains(body, "not found") {
+		t.Error("expected body to contain error message about run not found")
+	}
+	if !contains(body, "<nav") {
+		t.Error("expected body to contain navbar (layout template)")
+	}
+	if !contains(body, "<select") {
+		t.Error("expected body to contain selector form for retry")
 	}
 }
 

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -50,7 +50,7 @@ func testTemplates(t *testing.T) map[string]*template.Template {
 		"templates/health.html":         `<html><body>{{range .Checks}}<div>{{.Name}}: {{.Status}}</div>{{end}}</body></html>`,
 		"templates/ontology.html":       `<html><body>{{if .HasOntology}}<div>{{.Telos}}</div>{{range .Contexts}}<div>{{.Name}}</div>{{end}}{{end}}</body></html>`,
 		"templates/notfound.html":       `<html><body>Page not found</body></html>`,
-		"templates/compare.html":        `<html><body>{{.Left.RunID}} vs {{.Right.RunID}}{{range .Rows}}<tr>{{.StepID}}</tr>{{end}}</body></html>`,
+		"templates/compare.html":        `<html><body><nav>nav</nav>{{if .Error}}<div class="alert alert-error">{{.Error}}</div>{{end}}{{if .ShowSelector}}<select id="compare-left-select" name="left"></select><select id="compare-right-select" name="right"></select>{{end}}{{if not .ShowSelector}}{{.Left.RunID}} vs {{.Right.RunID}}{{range .Rows}}<tr>{{.StepID}}</tr>{{end}}{{end}}</body></html>`,
 		"templates/analytics.html":      `<html><body><h1>Token Usage Analytics</h1><div>{{formatTokens .Analytics.TotalTokens}}</div><div>{{.Analytics.TotalRuns}} {{pluralize .Analytics.TotalRuns "run" "runs"}}</div></body></html>`,
 		"templates/retros.html":         `<html><body>{{if .HasData}}<div>retros</div>{{end}}</body></html>`,
 		"templates/webhook_detail.html": `<html><body><div>{{.Webhook.Name}}</div>{{range .Deliveries}}<div>{{.Event}}</div>{{end}}</body></html>`,

--- a/internal/webui/templates/compare.html
+++ b/internal/webui/templates/compare.html
@@ -7,6 +7,42 @@
     </div>
 </div>
 
+{{if .Error}}
+<div class="card">
+    <div class="alert alert-error">{{.Error}}</div>
+</div>
+{{end}}
+
+{{if .ShowSelector}}
+<div class="card">
+    <h2>Select Runs to Compare</h2>
+    <form id="compare-selector-form" class="compare-swap-form" method="get" action="/compare">
+        <div class="compare-selector-fields">
+            <div>
+                <label for="compare-left-select">Left run:</label>
+                <select id="compare-left-select" name="left" class="compare-swap-select">
+                    <option value="">-- Select a run --</option>
+                    {{range .Runs}}
+                    <option value="{{.RunID}}">{{.PipelineName}} — {{.RunID}} ({{.Status}}{{if .Duration}}, {{.Duration}}{{end}})</option>
+                    {{end}}
+                </select>
+            </div>
+            <div>
+                <label for="compare-right-select">Right run:</label>
+                <select id="compare-right-select" name="right" class="compare-swap-select">
+                    <option value="">-- Select a run --</option>
+                    {{range .Runs}}
+                    <option value="{{.RunID}}">{{.PipelineName}} — {{.RunID}} ({{.Status}}{{if .Duration}}, {{.Duration}}{{end}})</option>
+                    {{end}}
+                </select>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary" id="compare-selector-btn" disabled>Compare</button>
+    </form>
+</div>
+{{end}}
+
+{{if not .ShowSelector}}
 <div class="compare-headers">
     <div class="compare-header compare-left">
         <h3><a href="/runs/{{.Left.RunID}}">{{.Left.PipelineName}}</a></h3>
@@ -99,11 +135,26 @@
     </form>
 </div>
 {{end}}
+{{end}}
 
 {{end}}
 {{define "scripts"}}
 <script>
 (function() {
+    // Selector form: enable button when both selects have values
+    var leftSelect = document.getElementById('compare-left-select');
+    var rightSelect = document.getElementById('compare-right-select');
+    var selectorBtn = document.getElementById('compare-selector-btn');
+
+    if (leftSelect && rightSelect && selectorBtn) {
+        function updateSelectorBtn() {
+            selectorBtn.disabled = !(leftSelect.value && rightSelect.value);
+        }
+        leftSelect.addEventListener('change', updateSelectorBtn);
+        rightSelect.addEventListener('change', updateSelectorBtn);
+    }
+
+    // Swap form: enable button when select has value
     var swapSelect = document.getElementById('compare-swap-select');
     var swapBtn = document.getElementById('compare-swap-btn');
     var swapForm = document.getElementById('compare-swap-form');

--- a/specs/688-compare-page-layout/plan.md
+++ b/specs/688-compare-page-layout/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan
+
+## Objective
+
+Replace raw `http.Error()` responses in `handleComparePage` with template-rendered pages that use the standard layout (navbar, styling). When no run IDs are provided, show a run-selector form. When runs are not found, show a styled error within the layout.
+
+## Approach
+
+1. **Modify the handler** (`handlers_compare.go`): Instead of `http.Error()` for the missing-params case, render the compare template with a new "selector mode" — pass empty `Left`/`Right` and a `Runs` list so the template can render a run-selector form. For not-found errors, render the template with an `Error` field.
+
+2. **Extend the compare template** (`compare.html`): Add conditional blocks — when `Left`/`Right` are empty (no RunID), render a run-selector form with two dropdowns and a "Compare" button. When `Error` is set, show a styled alert. The existing comparison UI renders only when both runs are present.
+
+3. **Update tests**: The existing `TestHandleComparePage_MissingParams` expects HTTP 400 — update it to expect 200 with the selector form. Add a test for the not-found error rendering within layout.
+
+## File Mapping
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/webui/handlers_compare.go` | modify | Replace `http.Error()` calls with template rendering; add `Runs []RunSummary` to template data; load recent runs for selector |
+| `internal/webui/templates/compare.html` | modify | Add run-selector form for empty state; add styled error alert block; wrap comparison content in conditional |
+| `internal/webui/handlers_compare_test.go` | modify | Update missing-params test to expect 200+HTML; add not-found-within-layout test |
+
+## Architecture Decisions
+
+1. **No new template file** — the compare template already exists. Add conditional blocks (`{{if .Error}}`, `{{if not .Left.RunID}}`) rather than creating a separate selector page. This keeps routing simple (single `/compare` endpoint).
+
+2. **Reuse `listSamePipelineRuns` pattern** — the handler already fetches runs for the swap dropdown. For the selector mode, use `store.ListRuns` with a reasonable limit (50) to populate two dropdowns.
+
+3. **Template data struct extension** — add `Error string`, `Runs []RunSummary`, and `ShowSelector bool` fields to the anonymous struct passed to the template. `ShowSelector` is true when both `left` and `right` query params are empty.
+
+4. **Error states stay HTTP 200** — when rendering errors within the layout template, use HTTP 200 (the page rendered successfully, it just contains an error message). This matches standard web UI patterns where the error is part of the page content.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Template nil pointer if `Left`/`Right` are zero-value `RunSummary` | Use `{{if .ShowSelector}}` guard to skip comparison blocks entirely |
+| Large run list overwhelming the dropdowns | Cap at 50 most recent runs; same limit used elsewhere |
+| Existing tests break from status code change | Explicitly update test expectations |
+
+## Testing Strategy
+
+1. **Unit test: missing params returns 200 with selector form** — verify response contains "select" elements and layout navbar
+2. **Unit test: invalid run IDs render styled error within layout** — verify response contains error message and navbar, not raw text
+3. **Unit test: successful comparison still works** — existing `TestHandleComparePage_Success` should pass unchanged
+4. **Verify API endpoint unchanged** — `handleAPICompare` still returns JSON errors (no change needed)

--- a/specs/688-compare-page-layout/spec.md
+++ b/specs/688-compare-page-layout/spec.md
@@ -1,0 +1,26 @@
+# fix(webui): /compare page renders raw error without layout template
+
+**Issue**: [re-cinq/wave#688](https://github.com/re-cinq/wave/issues/688)
+**Parent**: #687 (item 1)
+**Author**: nextlevelshit
+**State**: OPEN
+**Labels**: none
+
+## Problem
+
+Visiting `/compare` without query params renders `both left and right run IDs are required` as **unstyled plain text** — no navbar, no layout, no HTML structure at all. This is because `handleComparePage` calls `http.Error()` which bypasses the template system.
+
+## Expected
+
+The compare page should render inside the standard layout template with a form/UI to select two runs for comparison, or at minimum show a styled error within the layout.
+
+## Files to investigate
+
+- `internal/webui/handlers_compare.go` — the error path bypasses templates
+- `internal/webui/templates/compare.html` — needs an empty-state / run-selector UI
+
+## Acceptance Criteria
+
+- [ ] `/compare` without params renders inside the layout with navbar
+- [ ] User can select two runs to compare (dropdown or input)
+- [ ] Error states render styled, not as raw text

--- a/specs/688-compare-page-layout/tasks.md
+++ b/specs/688-compare-page-layout/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## Phase 1: Handler Changes
+- [X] Task 1.1: Modify `handleComparePage` to render template for missing-params case — load recent runs from store, pass `ShowSelector: true` and `Runs` list to template instead of calling `http.Error()`
+- [X] Task 1.2: Modify `handleComparePage` to render template for not-found errors — pass `Error` string to template instead of calling `http.Error()`
+
+## Phase 2: Template Changes
+- [X] Task 2.1: Add run-selector form to `compare.html` — two `<select>` dropdowns populated from `.Runs`, a "Compare" button, rendered when `.ShowSelector` is true [P]
+- [X] Task 2.2: Add styled error alert block to `compare.html` — rendered when `.Error` is non-empty, styled consistently with the rest of the UI [P]
+- [X] Task 2.3: Wrap existing comparison content in `{{if not .ShowSelector}}` guard to skip it when in selector mode
+
+## Phase 3: Testing
+- [X] Task 3.1: Update `TestHandleComparePage_MissingParams` — expect HTTP 200, verify response contains `<select>` elements and navbar markup
+- [X] Task 3.2: Add `TestHandleComparePage_RunNotFound` — request with invalid IDs, expect HTTP 200, verify response contains error message and navbar
+- [X] Task 3.3: Verify `TestHandleComparePage_Success` still passes unchanged
+- [X] Task 3.4: Run `go test ./internal/webui/...` to confirm all tests pass


### PR DESCRIPTION
## Summary
- Replace `http.Error()` calls in `handleComparePage` with template-rendered responses so `/compare` always renders inside the standard layout with navbar
- Add a run-selector UI to the compare template allowing users to pick two runs via dropdowns
- Fetch available runs from the store to populate the selector when no query params are provided
- Style error states within the layout template instead of returning raw plain text
- Add test coverage for the empty-state (no params) rendering path

Related to #688

## Changes
- `internal/webui/handlers_compare.go` — refactored error handling to render through templates; added run-fetching logic for the selector UI
- `internal/webui/templates/compare.html` — added run-selector form with dropdowns and styled empty/error states
- `internal/webui/handlers_compare_test.go` — added tests for the no-params layout rendering path
- `internal/webui/handlers_test.go` — minor test adjustment
- `specs/688-compare-page-layout/` — spec, plan, and task artifacts

## Test Plan
- `go test ./internal/webui/...` passes — covers the new handler paths
- Manual: visiting `/compare` without params now shows the full layout with navbar and run selector
- Manual: selecting two runs and submitting navigates to the comparison view