### PR TITLE
fix(webui): enrich PR list with additions/deletions from individual PR endpoint

### DIFF
--- a/internal/webui/handlers_prs.go
+++ b/internal/webui/handlers_prs.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/state"
@@ -196,6 +197,36 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 
 const prsPerPage = 50
 
+// enrichPRStats concurrently fetches individual PR details to populate
+// Additions/Deletions/ChangedFiles, which the list endpoint omits.
+func enrichPRStats(ctx context.Context, client forge.Client, owner, repo string, prs []*forge.PullRequest) {
+	const workers = 5
+	ch := make(chan int, len(prs))
+	for i := range prs {
+		ch <- i
+	}
+	close(ch)
+
+	var wg sync.WaitGroup
+	for range min(workers, len(prs)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range ch {
+				detail, err := client.GetPullRequest(ctx, owner, repo, prs[idx].Number)
+				if err != nil {
+					log.Printf("[webui] failed to enrich PR #%d: %v", prs[idx].Number, err)
+					continue
+				}
+				prs[idx].Additions = detail.Additions
+				prs[idx].Deletions = detail.Deletions
+				prs[idx].ChangedFiles = detail.ChangedFiles
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	if s.forgeClient == nil || s.repoSlug == "" {
 		return PRListResponse{
@@ -238,6 +269,8 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	if hasMore {
 		prs = prs[:prsPerPage]
 	}
+
+	enrichPRStats(ctx, s.forgeClient, owner, repo, prs)
 
 	var summaries []PRSummary
 	for _, pr := range prs {

--- a/internal/webui/handlers_prs_test.go
+++ b/internal/webui/handlers_prs_test.go
@@ -1,15 +1,66 @@
 package webui
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/state"
 )
+
+// mockForgeClient implements forge.Client with configurable responses.
+type mockForgeClient struct {
+	listPRs   func(ctx context.Context, owner, repo string, opts forge.ListPullRequestsOptions) ([]*forge.PullRequest, error)
+	getPR     func(ctx context.Context, owner, repo string, number int) (*forge.PullRequest, error)
+}
+
+func (m *mockForgeClient) GetIssue(context.Context, string, string, int) (*forge.Issue, error) {
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) ListIssues(context.Context, string, string, forge.ListIssuesOptions) ([]*forge.Issue, error) {
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*forge.PullRequest, error) {
+	if m.getPR != nil {
+		return m.getPR(ctx, owner, repo, number)
+	}
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) ListPullRequests(ctx context.Context, owner, repo string, opts forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
+	if m.listPRs != nil {
+		return m.listPRs(ctx, owner, repo, opts)
+	}
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) ListPullRequestCommits(context.Context, string, string, int) ([]*forge.Commit, error) {
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) GetCommitChecks(context.Context, string, string, string) ([]*forge.CheckRun, error) {
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) ListIssueComments(context.Context, string, string, int, int) ([]*forge.Comment, error) {
+	return nil, forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) CreatePullRequestReview(context.Context, string, string, int, string, string) error {
+	return forge.ErrNotSupported
+}
+
+func (m *mockForgeClient) ForgeType() forge.ForgeType {
+	return forge.ForgeGitHub
+}
 
 func TestHandleAPIPRs_NoGitHubClient(t *testing.T) {
 	srv, _ := testServer(t)
@@ -215,5 +266,128 @@ func TestRunToSummary_LongInputTruncated(t *testing.T) {
 	}
 	if !strings.HasSuffix(summary.InputPreview, "...") {
 		t.Error("expected truncated input to end with '...'")
+	}
+}
+
+func TestGetPRListData_EnrichedStats(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.repoSlug = "owner/repo"
+	srv.forgeClient = &mockForgeClient{
+		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
+			return []*forge.PullRequest{
+				{Number: 1, Title: "PR 1", State: "open", Author: "alice", CreatedAt: time.Now()},
+				{Number: 2, Title: "PR 2", State: "open", Author: "bob", CreatedAt: time.Now()},
+			}, nil
+		},
+		getPR: func(_ context.Context, _, _ string, number int) (*forge.PullRequest, error) {
+			switch number {
+			case 1:
+				return &forge.PullRequest{Number: 1, Additions: 10, Deletions: 3, ChangedFiles: 2}, nil
+			case 2:
+				return &forge.PullRequest{Number: 2, Additions: 50, Deletions: 20, ChangedFiles: 8}, nil
+			default:
+				return nil, fmt.Errorf("unknown PR %d", number)
+			}
+		},
+	}
+
+	data := srv.getPRListData("open", 1)
+
+	if len(data.PullRequests) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(data.PullRequests))
+	}
+
+	pr1 := data.PullRequests[0]
+	if pr1.Additions != 10 || pr1.Deletions != 3 || pr1.ChangedFiles != 2 {
+		t.Errorf("PR #1: expected additions=10 deletions=3 changed=2, got additions=%d deletions=%d changed=%d",
+			pr1.Additions, pr1.Deletions, pr1.ChangedFiles)
+	}
+
+	pr2 := data.PullRequests[1]
+	if pr2.Additions != 50 || pr2.Deletions != 20 || pr2.ChangedFiles != 8 {
+		t.Errorf("PR #2: expected additions=50 deletions=20 changed=8, got additions=%d deletions=%d changed=%d",
+			pr2.Additions, pr2.Deletions, pr2.ChangedFiles)
+	}
+}
+
+func TestGetPRListData_PartialEnrichmentFailure(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.repoSlug = "owner/repo"
+	srv.forgeClient = &mockForgeClient{
+		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
+			return []*forge.PullRequest{
+				{Number: 1, Title: "Good PR", State: "open", Author: "alice", CreatedAt: time.Now()},
+				{Number: 2, Title: "Bad PR", State: "open", Author: "bob", CreatedAt: time.Now()},
+			}, nil
+		},
+		getPR: func(_ context.Context, _, _ string, number int) (*forge.PullRequest, error) {
+			if number == 1 {
+				return &forge.PullRequest{Number: 1, Additions: 15, Deletions: 5, ChangedFiles: 3}, nil
+			}
+			return nil, fmt.Errorf("API error for PR #%d", number)
+		},
+	}
+
+	data := srv.getPRListData("open", 1)
+
+	if len(data.PullRequests) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(data.PullRequests))
+	}
+
+	pr1 := data.PullRequests[0]
+	if pr1.Additions != 15 || pr1.Deletions != 5 || pr1.ChangedFiles != 3 {
+		t.Errorf("PR #1: expected enriched stats, got additions=%d deletions=%d changed=%d",
+			pr1.Additions, pr1.Deletions, pr1.ChangedFiles)
+	}
+
+	pr2 := data.PullRequests[1]
+	if pr2.Additions != 0 || pr2.Deletions != 0 || pr2.ChangedFiles != 0 {
+		t.Errorf("PR #2: expected zero stats on failure, got additions=%d deletions=%d changed=%d",
+			pr2.Additions, pr2.Deletions, pr2.ChangedFiles)
+	}
+}
+
+func TestGetPRListData_Labels(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.repoSlug = "owner/repo"
+	srv.forgeClient = &mockForgeClient{
+		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
+			return []*forge.PullRequest{
+				{
+					Number:    1,
+					Title:     "Labeled PR",
+					State:     "open",
+					Author:    "alice",
+					Labels:    []string{"bug", "priority:high"},
+					CreatedAt: time.Now(),
+				},
+				{
+					Number:    2,
+					Title:     "No Labels",
+					State:     "open",
+					Author:    "bob",
+					CreatedAt: time.Now(),
+				},
+			}, nil
+		},
+		getPR: func(_ context.Context, _, _ string, number int) (*forge.PullRequest, error) {
+			return &forge.PullRequest{Number: number}, nil
+		},
+	}
+
+	data := srv.getPRListData("open", 1)
+
+	if len(data.PullRequests) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(data.PullRequests))
+	}
+
+	pr1 := data.PullRequests[0]
+	if len(pr1.Labels) != 2 || pr1.Labels[0] != "bug" || pr1.Labels[1] != "priority:high" {
+		t.Errorf("PR #1: expected labels [bug, priority:high], got %v", pr1.Labels)
+	}
+
+	pr2 := data.PullRequests[1]
+	if len(pr2.Labels) != 0 {
+		t.Errorf("PR #2: expected no labels, got %v", pr2.Labels)
 	}
 }

--- a/specs/692-pr-list-columns/plan.md
+++ b/specs/692-pr-list-columns/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan
+
+## Objective
+
+Fix the PR list page so that the CHANGES column shows additions/deletions/changed-files counts and LABELS display as badges. The root cause is that GitHub's list-PRs REST endpoint omits `additions`, `deletions`, and `changed_files` — these fields are only on the individual PR endpoint.
+
+## Approach
+
+After fetching the PR list via `ListPullRequests`, concurrently call `GetPullRequest` for each PR to enrich it with additions/deletions/changed_files data. Use a bounded worker pool (e.g., 5 concurrent goroutines) to stay within API rate limits. Merge the enriched fields back into the PR structs before building `PRSummary` objects.
+
+Labels already work from the list endpoint — the fix is verified by adding test coverage.
+
+## File Mapping
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `internal/webui/handlers_prs.go` | Modify | Add `enrichPRStats()` function with concurrent individual PR fetches |
+| `internal/webui/handlers_prs_test.go` | Modify | Add tests with mock forge client verifying enrichment and label rendering |
+
+## Architecture Decisions
+
+1. **Enrichment in handler, not forge layer**: The forge `ListPullRequests` stays generic — it returns what the API gives. The webui handler owns the enrichment because it's a presentation concern (the list page needs this data, other consumers of `ListPullRequests` might not).
+
+2. **Bounded concurrency with goroutine pool**: Use a fixed worker pool (5 workers) to avoid hitting GitHub's rate limit. A `sync.WaitGroup` + channel pattern keeps it simple.
+
+3. **Graceful degradation**: If `GetPullRequest` fails for a specific PR, log the error and leave that PR's stats at zero (template renders `--`). Don't fail the entire page.
+
+4. **No caching**: PR stats change with each push. Caching adds complexity without clear benefit for a page that's typically loaded once per interaction.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| N+1 API calls (up to 50 per page) could be slow | Bounded concurrency (5 workers) parallelizes calls; typical latency ~1-3s for 50 PRs |
+| GitHub rate limit (5000/hr for authenticated, 60/hr unauthenticated) | 50 calls per page load is fine for authenticated use; unauthenticated users hit limits fast regardless |
+| Individual PR fetch failures | Graceful degradation — log and skip, don't crash the page |
+| Context cancellation during enrichment | Pass handler context through; workers respect cancellation |
+
+## Testing Strategy
+
+1. **Mock forge client**: Create a `mockForgeClient` implementing `forge.Client` that returns configurable PR data for both `ListPullRequests` and `GetPullRequest`
+2. **Enrichment test**: Verify that `getPRListData` returns enriched stats when `GetPullRequest` provides them
+3. **Partial failure test**: Verify graceful degradation when `GetPullRequest` fails for some PRs
+4. **Label test**: Verify labels from list endpoint flow through to response
+5. **No forge client test**: Existing tests already cover this path

--- a/specs/692-pr-list-columns/spec.md
+++ b/specs/692-pr-list-columns/spec.md
@@ -1,0 +1,33 @@
+# fix(webui): PR list shows empty CHANGES and LABELS columns
+
+**Issue**: [re-cinq/wave#692](https://github.com/re-cinq/wave/issues/692)
+**Parent**: #687 (item 6)
+**Author**: nextlevelshit
+**State**: OPEN
+**Labels**: (none)
+
+## Problem
+
+The Pull Requests page shows `--` for the CHANGES column and empty LABELS for all PRs. The GitHub API data for additions/deletions/labels isn't being fetched or mapped into the template.
+
+## Root Cause Analysis
+
+The GitHub REST API's `GET /repos/{owner}/{repo}/pulls` (list endpoint) does **not** return `additions`, `deletions`, or `changed_files` fields. These fields are only available from the individual PR endpoint (`GET /repos/{owner}/{repo}/pulls/{number}`).
+
+The existing code correctly maps these fields at every layer (GitHub client -> forge adapter -> webui handler -> template), but the list endpoint returns them as zero. Since the template condition `{{if or .Additions .Deletions .ChangedFiles}}` is false when all are zero, it renders `--`.
+
+For **labels**: The list endpoint DOES return labels. The code correctly parses them. Labels appear empty only when PRs genuinely have no labels assigned. However, there are no tests verifying label rendering with a mock forge client.
+
+## Files to Investigate
+
+- `internal/webui/handlers_prs.go` — `getPRListData()` needs enrichment after fetching list
+- `internal/forge/github.go` — `ListPullRequests()` returns incomplete data from list endpoint
+- `internal/webui/templates/prs.html` — template logic is correct, data is the problem
+
+## Acceptance Criteria
+
+- [ ] PR list shows additions+deletions count in CHANGES column
+- [ ] PR labels are displayed as badges
+- [ ] Enrichment is concurrent with bounded parallelism to avoid API rate limits
+- [ ] Graceful degradation: if individual PR fetch fails, show `--` for that row
+- [ ] Tests verify enrichment logic and label rendering

--- a/specs/692-pr-list-columns/tasks.md
+++ b/specs/692-pr-list-columns/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Phase 1: Core Fix
+
+- [X] Task 1.1: Add `enrichPRStats` function to `internal/webui/handlers_prs.go` — takes a slice of `*forge.PullRequest`, the forge client, owner, repo, and context; concurrently fetches individual PR details to populate Additions/Deletions/ChangedFiles; uses bounded worker pool (5 goroutines)
+- [X] Task 1.2: Wire `enrichPRStats` into `getPRListData` — call after `ListPullRequests` returns, before building `PRSummary` objects
+
+## Phase 2: Testing
+
+- [X] Task 2.1: Create `mockForgeClient` in test file implementing `forge.Client` with configurable `ListPullRequests` and `GetPullRequest` responses [P]
+- [X] Task 2.2: Add test `TestGetPRListData_EnrichedStats` — verify enrichment populates Additions/Deletions/ChangedFiles in response [P]
+- [X] Task 2.3: Add test `TestGetPRListData_PartialEnrichmentFailure` — verify graceful degradation when some GetPullRequest calls fail [P]
+- [X] Task 2.4: Add test `TestGetPRListData_Labels` — verify labels from list endpoint appear in PRSummary [P]
+
+## Phase 3: Validation
+
+- [X] Task 3.1: Run `go test ./internal/webui/...` — all tests pass
+- [X] Task 3.2: Run `go vet ./...` — no issues
+- [X] Task 3.3: Run `golangci-lint run ./internal/webui/...` — no lint errors


### PR DESCRIPTION
## Summary

- Add `enrichPRStats` function that concurrently fetches individual PR details (5 workers) to populate additions/deletions/changed-files data missing from the list endpoint
- Wire enrichment into `getPRListData` so the CHANGES column displays actual values instead of `--`
- Labels were already flowing through from the list endpoint — no template changes needed

Related to #692

## Changes

- `internal/webui/handlers_prs.go` — new `enrichPRStats` concurrent enrichment function, called from `getPRListData` after fetching the PR list
- `internal/webui/handlers_prs_test.go` — new `mockForgeClient`, tests for enriched stats, partial failure resilience, and label passthrough
- `specs/692-pr-list-columns/` — spec, plan, and task artifacts

## Test Plan

- `go test ./internal/webui/...` passes — covers enriched stats, partial API failure (graceful degradation), and label propagation
- `go test -race ./internal/webui/...` passes — concurrent enrichment is race-free