### PR TITLE
fix(pipeline): chain wave-validate steps for graph walker

### DIFF
--- a/.wave/pipelines/wave-validate.yaml
+++ b/.wave/pipelines/wave-validate.yaml
@@ -62,17 +62,21 @@ steps:
         source: .wave/output/config-check.json
         schema_path: .wave/contracts/hello-world-result.schema.json
         on_failure: retry
+    edges:
+      - target: sub-pipeline-test
 
   # Step 2: Sub-pipeline composition — validates child pipeline invocation
   - id: sub-pipeline-test
     type: pipeline
     pipeline: ops-hello-world
     dependencies: [check-config]
+    edges:
+      - target: run-tests
 
   # Step 3: Command step — validates shell execution without adapter
   - id: run-tests
     type: command
-    dependencies: [check-config]
+    dependencies: [sub-pipeline-test]
     workspace:
       mount:
         - source: ./
@@ -85,7 +89,7 @@ steps:
     type: conditional
     dependencies: [run-tests]
     edges:
-      - target: generate-report
+      - target: approval-gate
         condition: "outcome=success"
       - target: diagnose-failure
 
@@ -110,7 +114,7 @@ steps:
         type: non_empty_file
         source: .wave/output/diagnosis.md
     edges:
-      - target: generate-report
+      - target: approval-gate
 
   # Step 6: Human gate — validates approval workflow (auto-approved)
   - id: approval-gate
@@ -126,7 +130,6 @@ steps:
           target: _fail
       default: "a"
       timeout: "10s"
-    dependencies: [test-gate, diagnose-failure]
 
   # Step 7: LLM-as-judge — validates subjective quality assessment
   - id: generate-report

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
           mkdir -p "$HOME/.local/share/uv"
           mkdir -p "$HOME/notes"
           touch -a "$HOME/.local/bin/wave"
+          touch -a "$HOME/.local/bin/opencode-patched"
           touch -a "$HOME/.claude.json"
 
           BWRAP_ARGS=(
@@ -163,6 +164,7 @@
             # Read-only: local tools
             --ro-bind-try "$HOME/.local/bin/notesium" "$HOME/.local/bin/notesium"
             --ro-bind-try "$HOME/.local/bin/claudit" "$HOME/.local/bin/claudit"
+            --ro-bind-try "$HOME/.local/bin/opencode-patched" "$HOME/.local/bin/opencode-patched"
 
             # Writable: wave binary (go build target)
             --bind-try "$HOME/.local/bin/wave" "$HOME/.local/bin/wave"
@@ -255,7 +257,7 @@
                 echo "  Read-only:  / (entire root)"
                 echo "              ~/.ssh, ~/.gitconfig, ~/.config/git"
                 echo "              ~/.config/gh, ~/.npmrc, ~/.config/nvm"
-                echo "              ~/.local/notesium, ~/.local/claudit"
+                echo "              ~/.local/bin/{notesium,claudit,opencode-patched}"
                 echo ""
                 exec wave-sandbox ${pkgs.bash}/bin/bash --rcfile <(cat << 'WAVE_BASHRC'
                   PS1="[sandbox] \w \$ "


### PR DESCRIPTION
## Summary
- Fix wave-validate pipeline: graph walker edges are routing (pick-one), not fan-out — steps 3–7 were silently skipped
- Chain check-config → sub-pipeline-test → run-tests via explicit edges so all 7 steps execute
- Route test-gate and diagnose-failure to approval-gate (not directly to generate-report)
- Add opencode-patched to bwrap sandbox allowed binaries in flake.nix

## Test plan
- [x] `wave validate` passes
- [x] `wave run wave-validate` completes with 6/7 steps visited (diagnose-failure correctly skipped on success path)
- [ ] Verify approval-gate works via WebUI for non-detached runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)