### PR TITLE
fix(pipelines): remove thread from parallel review steps in ops-pr-review

### DIFF
--- a/.wave/pipelines/ops-pr-review.yaml
+++ b/.wave/pipelines/ops-pr-review.yaml
@@ -170,7 +170,6 @@ steps:
 
   - id: security-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [security]
     dependencies: [diff-analysis]
@@ -291,7 +290,6 @@ steps:
 
   - id: quality-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [validation]
     dependencies: [diff-analysis]
@@ -405,7 +403,6 @@ steps:
 
   - id: slop-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [validation]
     dependencies: [diff-analysis]

--- a/internal/defaults/pipelines/ops-pr-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-review.yaml
@@ -170,7 +170,6 @@ steps:
 
   - id: security-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [security]
     dependencies: [diff-analysis]
@@ -291,7 +290,6 @@ steps:
 
   - id: quality-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [validation]
     dependencies: [diff-analysis]
@@ -405,7 +403,6 @@ steps:
 
   - id: slop-review
     persona: reviewer
-    thread: review
     model: strongest
     contexts: [validation]
     dependencies: [diff-analysis]


### PR DESCRIPTION
## Summary

- Remove `thread: review` from security-review, quality-review, and slop-review steps
- These steps run in parallel (all depend only on diff-analysis) — thread validation requires a dependency chain which conflicts with parallel execution
- Root cause of 0ms DAG validation failures in recent runs

Closes #723

## Test plan

- [x] `wave validate --pipeline ops-pr-review` passes
- [x] Validation run launched
- [ ] CI green