### PR TITLE
refactor(pipelines): consolidate dead-code family, add missing pipeline_outputs

### DIFF
--- a/internal/defaults/pipelines/audit-dead-code-issue.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-issue.yaml
@@ -7,7 +7,7 @@ metadata:
     issue with a structured task list of findings. Use this for periodic
     hygiene checks when you want a tracked issue rather than an immediate PR.
     Each finding includes confidence level, location, and suggested action.
-  release: true
+  release: false
 
 requires:
   tools:

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -31,6 +31,14 @@ hooks:
     command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
     blocking: false
 
+pipeline_outputs:
+  assessment:
+    step: fetch-assess
+    artifact: assessment
+  plan:
+    step: plan
+    artifact: impl-plan
+
 skills:
   - "{{ project.skill }}"
   - gh-cli

--- a/internal/defaults/pipelines/wave-land.yaml
+++ b/internal/defaults/pipelines/wave-land.yaml
@@ -28,6 +28,11 @@ chat_context:
     - "PR creation and merge status"
     - "Post-merge verification"
 
+pipeline_outputs:
+  pr:
+    step: ship
+    artifact: ship-result
+
 hooks:
   - name: log-start
     event: run_start
@@ -136,6 +141,10 @@ steps:
     dependencies: [commit]
     workspace:
       ref: commit
+    output_artifacts:
+      - name: ship-result
+        path: .wave/output/ship-result.json
+        type: json
     exec:
       type: prompt
       source: |
@@ -208,9 +217,13 @@ steps:
           needed for diagnosing the failure.
 
         OUTPUT FORMAT:
-        No explicit artifact is produced. The outcome is: changes merged to main,
-        binary rebuilt and installed, feature branch cleaned up. Report any failures
-        in the step output.
+        After creating the PR, write a JSON file to .wave/output/ship-result.json with
+        the PR URL and number:
+        ```json
+        { "pr_url": "<full PR URL>", "pr_number": <number>, "merged": true }
+        ```
+        If the merge fails, set "merged" to false and add a "failure" field with
+        the error message.
 
         QUALITY BAR:
         A good ship step completes all 7 steps cleanly: branch pushed, PR created and


### PR DESCRIPTION
## Summary

- **Disable audit-dead-code-issue** (`release: false`): its scan step duplicates `audit-dead-code`'s scan, and the issue-creation workflow is niche. Users should use `audit-dead-code` for cleanup or `audit-dead-code-review` for PR review gates.
- **Add `pipeline_outputs` to impl-issue-core**: exposes `assessment` and `plan` artifacts for composition pipelines (`impl-review-loop` uses this as a sub-pipeline).
- **Add `pipeline_outputs` and `ship-result` artifact to wave-land**: exposes PR URL for composition pipelines (`impl-review-loop` references `create-pr.output.pr_url`).

## Test plan

- [x] `go test ./internal/defaults/...` passes
- [ ] Verify `audit-dead-code-issue` no longer appears in `wave list pipelines`
- [ ] Verify `impl-review-loop` can resolve sub-pipeline outputs from `impl-issue-core` and `wave-land`

Closes #729