### PR TITLE
fix(pipeline): collect iterate sub-pipeline outputs for downstream aggregate steps

### DIFF
--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -166,6 +166,8 @@ func (c *CompositionExecutor) executeIterate(ctx context.Context, p *Pipeline, s
 }
 
 func (c *CompositionExecutor) executeIterateSequential(ctx context.Context, p *Pipeline, step *Step, pipelineNameTmpl string, items []json.RawMessage) error {
+	resolvedNames := make([]string, 0, len(items))
+
 	for i, item := range items {
 		select {
 		case <-ctx.Done():
@@ -190,6 +192,7 @@ func (c *CompositionExecutor) executeIterateSequential(ctx context.Context, p *P
 		if err != nil {
 			return fmt.Errorf("item %d: failed to resolve pipeline name: %w", i, err)
 		}
+		resolvedNames = append(resolvedNames, resolvedName)
 
 		// Resolve input template
 		input, err := c.resolveStepInput(step)
@@ -202,6 +205,10 @@ func (c *CompositionExecutor) executeIterateSequential(ctx context.Context, p *P
 			return fmt.Errorf("item %d: pipeline %q failed: %w", i, resolvedName, err)
 		}
 	}
+
+	// Collect outputs from all child sub-pipelines and register under the
+	// iterate step's ID so downstream steps can reference {{ stepID.output }}.
+	c.collectIterateOutputs(step, resolvedNames)
 
 	c.emit(event.Event{
 		Timestamp:  time.Now(),
@@ -220,40 +227,48 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 		maxConcurrent = len(items)
 	}
 
+	// Pre-resolve all pipeline names so we can track them for output collection.
+	resolvedNames := make([]string, len(items))
+	resolvedInputs := make([]string, len(items))
+	for i, item := range items {
+		localCtx := NewTemplateContext(c.tmplCtx.Input, c.tmplCtx.WorkspaceRoot)
+		for k, v := range c.tmplCtx.StepOutputs {
+			localCtx.StepOutputs[k] = v
+		}
+		localCtx.Item = item
+
+		name, err := ResolveTemplate(pipelineNameTmpl, localCtx)
+		if err != nil {
+			return fmt.Errorf("item %d: failed to resolve pipeline name: %w", i, err)
+		}
+		resolvedNames[i] = name
+
+		input := c.tmplCtx.Input
+		if step.SubInput != "" {
+			input, err = ResolveTemplate(step.SubInput, localCtx)
+			if err != nil {
+				return fmt.Errorf("item %d: %w", i, err)
+			}
+		}
+		resolvedInputs[i] = input
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrent)
 
-	for i, item := range items {
+	for i := range items {
+		resolvedName := resolvedNames[i]
+		input := resolvedInputs[i]
+
+		c.emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: p.Metadata.Name,
+			StepID:     step.ID,
+			State:      event.StateIterationProgress,
+			Message:    fmt.Sprintf("parallel item %d/%d: %s", i+1, len(items), resolvedName),
+		})
+
 		g.Go(func() error {
-			// Each goroutine needs its own template context for item
-			localCtx := NewTemplateContext(c.tmplCtx.Input, c.tmplCtx.WorkspaceRoot)
-			for k, v := range c.tmplCtx.StepOutputs {
-				localCtx.StepOutputs[k] = v
-			}
-			localCtx.Item = item
-
-			// Resolve pipeline name per item
-			resolvedName, err := ResolveTemplate(pipelineNameTmpl, localCtx)
-			if err != nil {
-				return fmt.Errorf("item %d: failed to resolve pipeline name: %w", i, err)
-			}
-
-			c.emit(event.Event{
-				Timestamp:  time.Now(),
-				PipelineID: p.Metadata.Name,
-				StepID:     step.ID,
-				State:      event.StateIterationProgress,
-				Message:    fmt.Sprintf("parallel item %d/%d: %s", i+1, len(items), resolvedName),
-			})
-
-			input := c.tmplCtx.Input
-			if step.SubInput != "" {
-				input, err = ResolveTemplate(step.SubInput, localCtx)
-				if err != nil {
-					return fmt.Errorf("item %d: %w", i, err)
-				}
-			}
-
 			return c.runSubPipeline(gctx, resolvedName, input)
 		})
 	}
@@ -261,6 +276,10 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 	if err := g.Wait(); err != nil {
 		return err
 	}
+
+	// Collect outputs from all child sub-pipelines and register under the
+	// iterate step's ID so downstream steps can reference {{ stepID.output }}.
+	c.collectIterateOutputs(step, resolvedNames)
 
 	c.emit(event.Event{
 		Timestamp:  time.Now(),
@@ -271,6 +290,33 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 	})
 
 	return nil
+}
+
+// collectIterateOutputs assembles the outputs from all child sub-pipelines into
+// a JSON array and registers it under the iterate step's own ID. This allows
+// downstream steps to reference {{ stepID.output }} to get the collected result.
+func (c *CompositionExecutor) collectIterateOutputs(step *Step, resolvedNames []string) {
+	collected := make([]json.RawMessage, 0, len(resolvedNames))
+	for _, name := range resolvedNames {
+		data, ok := c.tmplCtx.StepOutputs[name]
+		if !ok || len(data) == 0 {
+			collected = append(collected, json.RawMessage("null"))
+			continue
+		}
+		if json.Valid(data) {
+			collected = append(collected, json.RawMessage(data))
+		} else {
+			quoted, _ := json.Marshal(string(data))
+			collected = append(collected, json.RawMessage(quoted))
+		}
+	}
+
+	arrayBytes, err := json.Marshal(collected)
+	if err != nil {
+		return
+	}
+
+	c.tmplCtx.SetStepOutput(step.ID, arrayBytes)
 }
 
 // executeBranch evaluates a condition and runs the matching pipeline.

--- a/internal/pipeline/composition_test.go
+++ b/internal/pipeline/composition_test.go
@@ -363,6 +363,109 @@ func TestCompositionExecutor_SubPipelineBackwardCompatibility(t *testing.T) {
 	}
 }
 
+// TestCompositionExecutor_IterateCollectsOutputs verifies that after an iterate
+// step completes, the collected output is registered under the step's ID in the
+// template context so {{ stepID.output }} resolves for downstream steps.
+func TestCompositionExecutor_IterateCollectsOutputs(t *testing.T) {
+	ctx := NewTemplateContext("test-input", "/tmp")
+
+	// Simulate what runSubPipeline does: store output per child pipeline name
+	ctx.SetStepOutput("audit-alpha", []byte(`{"findings": ["a1", "a2"]}`))
+	ctx.SetStepOutput("audit-beta", []byte(`{"findings": ["b1"]}`))
+	ctx.SetStepOutput("audit-gamma", []byte(`{"findings": ["c1", "c2", "c3"]}`))
+
+	ce := &CompositionExecutor{tmplCtx: ctx}
+
+	step := &Step{ID: "run-audits"}
+	resolvedNames := []string{"audit-alpha", "audit-beta", "audit-gamma"}
+
+	ce.collectIterateOutputs(step, resolvedNames)
+
+	// Verify the iterate step's output was registered
+	data, ok := ctx.StepOutputs["run-audits"]
+	if !ok {
+		t.Fatal("expected output for iterate step 'run-audits'")
+	}
+
+	// Verify it's a valid JSON array with 3 entries
+	var collected []json.RawMessage
+	if err := json.Unmarshal(data, &collected); err != nil {
+		t.Fatalf("collected output is not valid JSON array: %v", err)
+	}
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(collected))
+	}
+
+	// Verify each entry matches the original child output
+	var first map[string]interface{}
+	if err := json.Unmarshal(collected[0], &first); err != nil {
+		t.Fatalf("entry 0 is not valid JSON: %v", err)
+	}
+	findings, ok := first["findings"].([]interface{})
+	if !ok || len(findings) != 2 {
+		t.Errorf("entry 0: expected findings with 2 items, got %v", first["findings"])
+	}
+
+	// Verify the output can be resolved via {{ run-audits.output }}
+	resolved, err := ResolveTemplate("{{ run-audits.output }}", ctx)
+	if err != nil {
+		t.Fatalf("failed to resolve {{ run-audits.output }}: %v", err)
+	}
+	if resolved == "" {
+		t.Error("resolved output should not be empty")
+	}
+
+	// Verify the resolved output is a valid JSON array
+	var resolvedArr []json.RawMessage
+	if err := json.Unmarshal([]byte(resolved), &resolvedArr); err != nil {
+		t.Fatalf("resolved output is not a valid JSON array: %v", err)
+	}
+	if len(resolvedArr) != 3 {
+		t.Errorf("expected 3 entries in resolved output, got %d", len(resolvedArr))
+	}
+}
+
+// TestCompositionExecutor_IterateCollectsOutputs_NullForMissing verifies that
+// missing child outputs are represented as null in the collected array.
+func TestCompositionExecutor_IterateCollectsOutputs_NullForMissing(t *testing.T) {
+	ctx := NewTemplateContext("test-input", "/tmp")
+
+	// Only one of three children produced output
+	ctx.SetStepOutput("audit-alpha", []byte(`{"ok": true}`))
+
+	ce := &CompositionExecutor{tmplCtx: ctx}
+
+	step := &Step{ID: "run-audits"}
+	resolvedNames := []string{"audit-alpha", "audit-beta", "audit-gamma"}
+
+	ce.collectIterateOutputs(step, resolvedNames)
+
+	data, ok := ctx.StepOutputs["run-audits"]
+	if !ok {
+		t.Fatal("expected output for iterate step")
+	}
+
+	var collected []json.RawMessage
+	if err := json.Unmarshal(data, &collected); err != nil {
+		t.Fatalf("not valid JSON array: %v", err)
+	}
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(collected))
+	}
+
+	// First entry should be valid JSON
+	if string(collected[0]) == "null" {
+		t.Error("entry 0 should not be null")
+	}
+	// Entries for missing children should be null
+	if string(collected[1]) != "null" {
+		t.Errorf("entry 1: expected null, got %s", string(collected[1]))
+	}
+	if string(collected[2]) != "null" {
+		t.Errorf("entry 2: expected null, got %s", string(collected[2]))
+	}
+}
+
 func TestCompositionExecutor_Execute_Gate_Auto(t *testing.T) {
 	emitter := testutil.NewEventCollector()
 	m := &manifest.Manifest{}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -5016,29 +5016,45 @@ func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execu
 
 	// Extract child artifacts and merge context variables
 	childExec := childExecutor.LastExecution()
-	if step.Config != nil && childExec != nil {
-		// Determine parent workspace for artifact extraction
-		parentWorkspace := "."
-		execution.mu.Lock()
-		if ws, ok := execution.WorkspacePaths[step.ID]; ok && ws != "" {
-			parentWorkspace = ws
-		}
-		execution.mu.Unlock()
+	if childExec != nil {
+		if step.Config != nil {
+			// Determine parent workspace for artifact extraction
+			parentWorkspace := "."
+			execution.mu.Lock()
+			if ws, ok := execution.WorkspacePaths[step.ID]; ok && ws != "" {
+				parentWorkspace = ws
+			}
+			execution.mu.Unlock()
 
-		if len(step.Config.Extract) > 0 {
-			if err := extractSubPipelineArtifacts(step.Config, childExec.Context, pipelineName, execution.Context, parentWorkspace); err != nil {
-				return fmt.Errorf("failed to extract sub-pipeline artifacts: %w", err)
+			if len(step.Config.Extract) > 0 {
+				if err := extractSubPipelineArtifacts(step.Config, childExec.Context, pipelineName, execution.Context, parentWorkspace); err != nil {
+					return fmt.Errorf("failed to extract sub-pipeline artifacts: %w", err)
+				}
+			}
+
+			// Evaluate stop condition if configured
+			if step.Config.StopCondition != "" {
+				if evaluateStopCondition(step.Config.StopCondition, childExec.Context) {
+					execution.Context.SetCustomVariable("sub_pipeline_stop", "true")
+				}
 			}
 		}
 
 		// Merge child context variables into parent (last-writer-wins)
 		execution.Context.MergeFrom(childExec.Context, pipelineName)
 
-		// Evaluate stop condition if configured
-		if step.Config.StopCondition != "" {
-			if evaluateStopCondition(step.Config.StopCondition, childExec.Context) {
-				execution.Context.SetCustomVariable("sub_pipeline_stop", "true")
-			}
+		// Propagate child execution-level artifact paths into the parent context
+		// so that iterate steps can collect outputs from all child sub-pipelines.
+		childExec.mu.Lock()
+		childArtifacts := make(map[string]string, len(childExec.ArtifactPaths))
+		for k, v := range childExec.ArtifactPaths {
+			childArtifacts[k] = v
+		}
+		childExec.mu.Unlock()
+
+		for key, path := range childArtifacts {
+			nsKey := pipelineName + "." + key
+			execution.Context.SetArtifactPath(nsKey, path)
 		}
 	}
 
@@ -5091,7 +5107,9 @@ func (e *DefaultPipelineExecutor) executeIterateInDAG(ctx context.Context, execu
 		return e.executeIterateParallelInDAG(ctx, execution, step, pipelineNameTmpl, items)
 	}
 
-	// Sequential iterate
+	// Sequential iterate — track resolved pipeline names so we can collect outputs.
+	resolvedNames := make([]string, 0, len(items))
+
 	for i, item := range items {
 		select {
 		case <-ctx.Done():
@@ -5107,6 +5125,7 @@ func (e *DefaultPipelineExecutor) executeIterateInDAG(ctx context.Context, execu
 		if err != nil {
 			return fmt.Errorf("iterate item %d: failed to resolve pipeline name: %w", i, err)
 		}
+		resolvedNames = append(resolvedNames, resolvedName)
 
 		// Resolve input
 		input := execution.Input
@@ -5132,6 +5151,12 @@ func (e *DefaultPipelineExecutor) executeIterateInDAG(ctx context.Context, execu
 		}
 	}
 
+	// Collect outputs from all child sub-pipelines and register under the
+	// iterate step's ID so downstream steps can reference {{ stepID.output }}.
+	if err := e.collectIterateOutputs(execution, step, resolvedNames); err != nil {
+		return fmt.Errorf("iterate: failed to collect outputs: %w", err)
+	}
+
 	e.emit(event.Event{
 		Timestamp:      time.Now(),
 		PipelineID:     pipelineID,
@@ -5153,17 +5178,18 @@ func (e *DefaultPipelineExecutor) executeIterateParallelInDAG(ctx context.Contex
 		maxConcurrent = len(items)
 	}
 
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrent)
-
+	// Pre-resolve all pipeline names so we can track them for output collection.
+	resolvedNames := make([]string, len(items))
+	resolvedInputs := make([]string, len(items))
 	for i, item := range items {
 		tmplCtx := NewTemplateContext(execution.Input, "")
 		tmplCtx.Item = item
 
-		resolvedName, err := ResolveTemplate(pipelineNameTmpl, tmplCtx)
+		name, err := ResolveTemplate(pipelineNameTmpl, tmplCtx)
 		if err != nil {
 			return fmt.Errorf("iterate item %d: failed to resolve pipeline name: %w", i, err)
 		}
+		resolvedNames[i] = name
 
 		input := execution.Input
 		if step.SubInput != "" {
@@ -5172,6 +5198,15 @@ func (e *DefaultPipelineExecutor) executeIterateParallelInDAG(ctx context.Contex
 				return fmt.Errorf("iterate item %d: failed to resolve input: %w", i, err)
 			}
 		}
+		resolvedInputs[i] = input
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrent)
+
+	for i := range items {
+		resolvedName := resolvedNames[i]
+		input := resolvedInputs[i]
 
 		e.emit(event.Event{
 			Timestamp:  time.Now(),
@@ -5190,6 +5225,12 @@ func (e *DefaultPipelineExecutor) executeIterateParallelInDAG(ctx context.Contex
 		return err
 	}
 
+	// Collect outputs from all child sub-pipelines and register under the
+	// iterate step's ID so downstream steps can reference {{ stepID.output }}.
+	if err := e.collectIterateOutputs(execution, step, resolvedNames); err != nil {
+		return fmt.Errorf("iterate: failed to collect outputs: %w", err)
+	}
+
 	e.emit(event.Event{
 		Timestamp:  time.Now(),
 		PipelineID: pipelineID,
@@ -5201,12 +5242,92 @@ func (e *DefaultPipelineExecutor) executeIterateParallelInDAG(ctx context.Contex
 	return nil
 }
 
+// collectIterateOutputs scans the parent execution's context for artifacts
+// merged from child sub-pipelines (via MergeFrom) and assembles them into a
+// JSON array. The collected output is written to .wave/output/<stepID>-collected.json
+// and registered in execution.ArtifactPaths so {{ stepID.output }} resolves to
+// the combined result for downstream aggregate steps.
+func (e *DefaultPipelineExecutor) collectIterateOutputs(execution *PipelineExecution, step *Step, resolvedNames []string) error {
+	if execution.Context == nil {
+		return nil
+	}
+
+	// For each child pipeline name, find the first artifact path that was
+	// merged under its namespace (e.g. "audit-alpha.scan:output") and read
+	// its content. Order matches the original items array.
+	collected := make([]json.RawMessage, 0, len(resolvedNames))
+	execution.Context.mu.Lock()
+	artifactSnapshot := make(map[string]string, len(execution.Context.ArtifactPaths))
+	for k, v := range execution.Context.ArtifactPaths {
+		artifactSnapshot[k] = v
+	}
+	execution.Context.mu.Unlock()
+
+	for _, name := range resolvedNames {
+		prefix := name + "."
+		var artPath string
+		for key, path := range artifactSnapshot {
+			if strings.HasPrefix(key, prefix) {
+				artPath = path
+				break
+			}
+		}
+
+		if artPath == "" {
+			// No artifact found for this child — include null placeholder
+			// to keep the array aligned with the items array.
+			collected = append(collected, json.RawMessage("null"))
+			continue
+		}
+
+		data, err := os.ReadFile(artPath)
+		if err != nil {
+			collected = append(collected, json.RawMessage("null"))
+			continue
+		}
+
+		// If the content is valid JSON, include it raw; otherwise wrap as a string.
+		if json.Valid(data) {
+			collected = append(collected, json.RawMessage(data))
+		} else {
+			quoted, _ := json.Marshal(string(data))
+			collected = append(collected, json.RawMessage(quoted))
+		}
+	}
+
+	arrayBytes, err := json.Marshal(collected)
+	if err != nil {
+		return fmt.Errorf("failed to marshal collected outputs: %w", err)
+	}
+
+	// Write to .wave/output/<stepID>-collected.json
+	outputDir := filepath.Join(".wave", "output")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	outputPath := filepath.Join(outputDir, step.ID+"-collected.json")
+	if err := os.WriteFile(outputPath, arrayBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write collected output: %w", err)
+	}
+
+	// Register in execution.ArtifactPaths so resolveStepOutputRef can find it
+	// via the standard "stepID:<artifactName>" key convention.
+	execution.mu.Lock()
+	execution.ArtifactPaths[step.ID+":collected-output"] = outputPath
+	execution.mu.Unlock()
+
+	return nil
+}
+
 // executeAggregateInDAG collects outputs from prior steps and writes them to a file.
 func (e *DefaultPipelineExecutor) executeAggregateInDAG(_ context.Context, execution *PipelineExecution, step *Step) error {
 	pipelineID := execution.Status.ID
 
-	// Resolve the source expression
+	// Resolve the source expression — step output references like
+	// {{ run-audits.output }} must be resolved before context placeholders.
 	sourceExpr := step.Aggregate.From
+	sourceExpr = e.resolveStepOutputRef(sourceExpr, execution)
 	if execution.Context != nil {
 		sourceExpr = execution.Context.ResolvePlaceholders(sourceExpr)
 	}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -5933,6 +5933,252 @@ steps:
 		"adapter should be called at least 3 times (once per parallel item)")
 }
 
+// TestIterateInDAG_CollectsOutputs verifies that after an iterate step completes,
+// the collected output is registered under the step's ID in ArtifactPaths so
+// downstream steps can reference {{ stepID.output }}.
+func TestIterateInDAG_CollectsOutputs(t *testing.T) {
+	collector := testutil.NewEventCollector()
+	capAdapter := &allConfigCapturingAdapter{
+		MockAdapter: adapter.NewMockAdapter(
+			adapter.WithStdoutJSON(`{"findings": ["issue-1"]}`),
+			adapter.WithTokensUsed(100),
+		),
+	}
+
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+
+	pipelinesDir := filepath.Join(tmpDir, ".wave", "pipelines")
+	require.NoError(t, os.MkdirAll(pipelinesDir, 0755))
+
+	// Child pipelines that produce a stdout artifact so it gets stored
+	childYAML := `kind: WavePipeline
+metadata:
+  name: %s
+steps:
+  - id: scan
+    persona: navigator
+    exec:
+      type: prompt
+      source: "scan"
+    output_artifacts:
+      - name: result
+        source: stdout
+`
+	for _, name := range []string{"audit-alpha", "audit-beta", "audit-gamma"} {
+		path := filepath.Join(pipelinesDir, name+".yaml")
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(childYAML, name)), 0644))
+	}
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "iterate-collect-test"},
+		Steps: []Step{
+			{
+				ID:          "run-audits",
+				SubPipeline: "{{ item }}",
+				Iterate: &IterateConfig{
+					Over: `["audit-alpha", "audit-beta", "audit-gamma"]`,
+					Mode: "sequential",
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.NoError(t, err)
+
+	// Verify that ArtifactPaths has the collected output under the iterate step's ID
+	exec := executor.LastExecution()
+	require.NotNil(t, exec)
+
+	collectedPath, ok := exec.ArtifactPaths["run-audits:collected-output"]
+	assert.True(t, ok, "ArtifactPaths should contain run-audits:collected-output")
+	assert.NotEmpty(t, collectedPath, "collected output path should not be empty")
+
+	// Read the collected file and verify it's a JSON array
+	data, err := os.ReadFile(collectedPath)
+	require.NoError(t, err)
+
+	var collected []json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &collected))
+	assert.Len(t, collected, 3, "collected output should have 3 entries")
+
+	// Each entry should be the stdout JSON from the child pipeline
+	for i, entry := range collected {
+		var parsed map[string]interface{}
+		err := json.Unmarshal(entry, &parsed)
+		require.NoError(t, err, "entry %d should be valid JSON", i)
+		assert.Contains(t, parsed, "findings", "entry %d should contain findings key", i)
+	}
+}
+
+// TestIterateInDAG_Parallel_CollectsOutputs verifies parallel iterate also collects outputs.
+func TestIterateInDAG_Parallel_CollectsOutputs(t *testing.T) {
+	collector := testutil.NewEventCollector()
+	capAdapter := &allConfigCapturingAdapter{
+		MockAdapter: adapter.NewMockAdapter(
+			adapter.WithStdoutJSON(`{"status": "done"}`),
+			adapter.WithTokensUsed(100),
+		),
+	}
+
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+
+	pipelinesDir := filepath.Join(tmpDir, ".wave", "pipelines")
+	require.NoError(t, os.MkdirAll(pipelinesDir, 0755))
+
+	childYAML := `kind: WavePipeline
+metadata:
+  name: %s
+steps:
+  - id: process
+    persona: navigator
+    exec:
+      type: prompt
+      source: "process"
+    output_artifacts:
+      - name: output
+        source: stdout
+`
+	for _, name := range []string{"job-a", "job-b"} {
+		path := filepath.Join(pipelinesDir, name+".yaml")
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(childYAML, name)), 0644))
+	}
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "parallel-collect-test"},
+		Steps: []Step{
+			{
+				ID:          "fan-out",
+				SubPipeline: "{{ item }}",
+				Iterate: &IterateConfig{
+					Over: `["job-a", "job-b"]`,
+					Mode: "parallel",
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.NoError(t, err)
+
+	exec := executor.LastExecution()
+	require.NotNil(t, exec)
+
+	collectedPath, ok := exec.ArtifactPaths["fan-out:collected-output"]
+	assert.True(t, ok, "ArtifactPaths should contain fan-out:collected-output")
+
+	data, err := os.ReadFile(collectedPath)
+	require.NoError(t, err)
+
+	var collected []json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &collected))
+	assert.Len(t, collected, 2, "collected output should have 2 entries")
+}
+
+// TestIterateInDAG_OutputResolvesInAggregate verifies the end-to-end flow:
+// iterate step produces collected output, then aggregate step references it
+// via {{ stepID.output }}.
+func TestIterateInDAG_OutputResolvesInAggregate(t *testing.T) {
+	collector := testutil.NewEventCollector()
+	capAdapter := &allConfigCapturingAdapter{
+		MockAdapter: adapter.NewMockAdapter(
+			adapter.WithStdoutJSON(`{"findings": ["f1"]}`),
+			adapter.WithTokensUsed(100),
+		),
+	}
+
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+
+	pipelinesDir := filepath.Join(tmpDir, ".wave", "pipelines")
+	require.NoError(t, os.MkdirAll(pipelinesDir, 0755))
+
+	childYAML := `kind: WavePipeline
+metadata:
+  name: %s
+steps:
+  - id: scan
+    persona: navigator
+    exec:
+      type: prompt
+      source: "scan"
+    output_artifacts:
+      - name: result
+        source: stdout
+`
+	for _, name := range []string{"audit-a", "audit-b"} {
+		path := filepath.Join(pipelinesDir, name+".yaml")
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(childYAML, name)), 0644))
+	}
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputPath := filepath.Join(tmpDir, ".wave", "output", "merged.json")
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "iterate-aggregate-test"},
+		Steps: []Step{
+			{
+				ID:          "run-audits",
+				SubPipeline: "{{ item }}",
+				Iterate: &IterateConfig{
+					Over: `["audit-a", "audit-b"]`,
+					Mode: "sequential",
+				},
+			},
+			{
+				ID:           "merge-findings",
+				Dependencies: []string{"run-audits"},
+				Aggregate: &AggregateConfig{
+					From:     "{{ run-audits.output }}",
+					Into:     outputPath,
+					Strategy: "merge_arrays",
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.NoError(t, err)
+
+	// Verify the aggregate output was written
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	// The merged output should be a flattened array from both child pipelines
+	var merged []json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &merged))
+	assert.GreaterOrEqual(t, len(merged), 2,
+		"merged output should contain entries from both child pipelines")
+}
+
 // TestAggregateInDAG verifies the aggregate primitive merges output to a file.
 func TestAggregateInDAG(t *testing.T) {
 	collector := testutil.NewEventCollector()


### PR DESCRIPTION
## Summary
- After an iterate step completes, collected child sub-pipeline outputs are now registered under the iterate step's own ID, enabling `{{ stepID.output }}` resolution in downstream aggregate steps
- Both execution paths are fixed: `DefaultPipelineExecutor` (DAG mode) writes a collected JSON array to `.wave/output/<stepID>-collected.json` and registers in `execution.ArtifactPaths`; `CompositionExecutor` assembles child outputs from `tmplCtx.StepOutputs` into a JSON array under the step ID
- `runNamedSubPipeline` restructured to propagate child artifacts even without explicit `Config`, and `executeAggregateInDAG` now calls `resolveStepOutputRef` before context placeholder resolution

## Test plan
- [x] `TestIterateInDAG_CollectsOutputs` -- sequential iterate with 3 child pipelines producing stdout artifacts, verifies `ArtifactPaths[stepID:collected-output]` exists with valid JSON array
- [x] `TestIterateInDAG_Parallel_CollectsOutputs` -- parallel iterate with 2 child pipelines, verifies collected output
- [x] `TestIterateInDAG_OutputResolvesInAggregate` -- end-to-end iterate then aggregate, verifies `{{ run-audits.output }}` resolves and merged output file is written
- [x] `TestCompositionExecutor_IterateCollectsOutputs` -- unit test for CompositionExecutor output collection, verifies `{{ stepID.output }}` resolves via template context
- [x] `TestCompositionExecutor_IterateCollectsOutputs_NullForMissing` -- verifies missing child outputs appear as `null` in collected array
- [x] All existing iterate tests still pass

Closes #714