### PR TITLE
fix(pipelines): audit-dx outputs JSON findings for composition compatibility

### DIFF
--- a/internal/defaults/pipelines/audit-dx.yaml
+++ b/internal/defaults/pipelines/audit-dx.yaml
@@ -148,12 +148,10 @@ steps:
         You must produce TWO output artifacts:
 
         1. **JSON findings** conforming to the contract schema — one finding object per
-           issue discovered. Use `"type": "dx"` for all findings. Map severity ratings:
-           excellent/good = no finding needed, fair = `"medium"` or `"low"`, poor = `"high"`
-           or `"critical"` depending on impact. Set `"recommendation"` to the most
-           appropriate action (`"fix"`, `"refactor"`, `"document"`, `"investigate"`).
-           Include the `"file"` and `"line"` fields when a finding references a specific
-           location. Provide a one-line `"summary"` and set `"scan_type"` to `"dx"`.
+           issue discovered. All findings use type `"dx"`. Map your severity ratings to
+           schema severities: areas rated excellent/good need no finding entry, fair maps
+           to `"medium"` or `"low"`, poor maps to `"high"` or `"critical"` depending on
+           impact to contributor velocity.
 
         2. **Markdown report** — the human-readable version with these sections:
            - **Executive Summary** (2-3 sentences: overall DX rating and top concern)

--- a/internal/defaults/pipelines/audit-dx.yaml
+++ b/internal/defaults/pipelines/audit-dx.yaml
@@ -22,6 +22,7 @@ input:
 chat_context:
   artifact_summaries:
     - findings
+    - report
   suggested_questions:
     - "What are the biggest DX friction points?"
     - "Which improvements would have the most impact for new contributors?"
@@ -46,6 +47,9 @@ pipeline_outputs:
   findings:
     step: audit
     artifact: findings
+  report:
+    step: audit
+    artifact: report
 
 steps:
   - id: audit
@@ -141,12 +145,25 @@ steps:
 
         ## Output Format
 
-        A markdown report at the output artifact path defined above with these sections:
-        - **Executive Summary** (2-3 sentences: overall DX rating and top concern)
-        - **Area-by-Area Findings** (one subsection per area, each with severity badge,
-          evidence citations, and improvement recommendations)
-        - **Quick Wins** (highest-impact, lowest-effort fixes — maximum 5)
-        - **Prioritized Roadmap** (ordered list of improvements by impact)
+        You must produce TWO output artifacts:
+
+        1. **JSON findings** conforming to the contract schema — one finding object per
+           issue discovered. Use `"type": "dx"` for all findings. Map severity ratings:
+           excellent/good = no finding needed, fair = `"medium"` or `"low"`, poor = `"high"`
+           or `"critical"` depending on impact. Set `"recommendation"` to the most
+           appropriate action (`"fix"`, `"refactor"`, `"document"`, `"investigate"`).
+           Include the `"file"` and `"line"` fields when a finding references a specific
+           location. Provide a one-line `"summary"` and set `"scan_type"` to `"dx"`.
+
+        2. **Markdown report** — the human-readable version with these sections:
+           - **Executive Summary** (2-3 sentences: overall DX rating and top concern)
+           - **Area-by-Area Findings** (one subsection per area, each with severity badge,
+             evidence citations, and improvement recommendations)
+           - **Quick Wins** (highest-impact, lowest-effort fixes — maximum 5)
+           - **Prioritized Roadmap** (ordered list of improvements by impact)
+
+        Both artifacts must be consistent — every finding in the JSON must appear in the
+        markdown report and vice versa.
 
         ## Quality Bar
 
@@ -156,9 +173,14 @@ steps:
         praise or ungrounded criticism fails the quality bar.
     output_artifacts:
       - name: findings
+        path: .wave/output/findings.json
+        type: json
+      - name: report
         path: .wave/output/findings.md
         type: markdown
     handover:
       contract:
-        type: non_empty_file
-        source: .wave/output/findings.md
+        type: json_schema
+        source: .wave/output/findings.json
+        schema_path: .wave/contracts/shared-findings.schema.json
+        on_failure: skip


### PR DESCRIPTION
## Summary

- `audit-dx` previously output only `findings.md` (markdown) with a `non_empty_file` handover contract, which broke `ops-parallel-audit` composition since the aggregate step expects all sub-pipelines to emit JSON conforming to `shared-findings.schema.json`
- Adds `findings.json` as the primary output artifact validated against `shared-findings.schema.json`, keeping `findings.md` as a secondary human-readable report
- Strips schema field enumeration from the prompt to comply with AGENTS.md constraint #4 (buildContractPrompt injects the full schema at runtime)

Closes #716

## Test plan

- [x] `go test ./internal/defaults/...` passes
- [ ] Run `audit-dx` pipeline and verify it produces both `findings.json` and `findings.md`
- [ ] Verify `findings.json` validates against `shared-findings.schema.json`
- [ ] Run `ops-parallel-audit` to confirm all three sub-pipelines produce mergeable output