### PR TITLE
feat(routing): replace fastest tier with balanced, add --force-model flag

### DIFF
--- a/.wave/pipelines/impl-issue.yaml
+++ b/.wave/pipelines/impl-issue.yaml
@@ -150,7 +150,7 @@ steps:
 
   - id: fix-implement
     persona: craftsman
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       type: worktree

--- a/.wave/pipelines/ops-pr-fix-review.yaml
+++ b/.wave/pipelines/ops-pr-fix-review.yaml
@@ -203,7 +203,7 @@ steps:
   - id: triage
     persona: navigator
     contexts: [configuration, execution]
-    model: fastest
+    model: balanced
     dependencies: [fetch-review]
     memory:
       inject_artifacts:
@@ -517,7 +517,7 @@ steps:
   - id: retry-fixes
     persona: craftsman
     thread: fix
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       type: worktree

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -57,6 +57,7 @@ type RunOptions struct {
 	Detach            bool   // --detach flag for background execution
 	AutoApprove       bool   // --auto-approve flag for skipping approval gates
 	NoRetro           bool   // --no-retro flag to skip retrospective generation
+	ForceModel        bool   // --force-model overrides all step/persona model tiers
 }
 
 func NewRunCmd() *cobra.Command {
@@ -168,7 +169,8 @@ Model formats vary by adapter: claude uses "haiku"/"opus", opencode uses
 	cmd.Flags().StringVar(&opts.Manifest, "manifest", "wave.yaml", "Path to manifest file")
 	cmd.Flags().BoolVar(&opts.Mock, "mock", false, "Use mock adapter (for testing)")
 	cmd.Flags().StringVar(&opts.RunID, "run", "", "Resume from a specific run (uses that run's input)")
-	cmd.Flags().StringVar(&opts.Model, "model", "", "Override adapter model for this run (e.g. haiku, opus)")
+	cmd.Flags().StringVar(&opts.Model, "model", "", "Model for this run — tier name (cheapest/balanced/strongest) or literal (haiku/opus). Takes the cheaper of CLI and step tiers unless --force-model is set.")
+	cmd.Flags().BoolVar(&opts.ForceModel, "force-model", false, "Force --model on all steps, ignoring per-step and per-persona model tiers")
 	cmd.Flags().StringVar(&opts.Adapter, "adapter", "", "Override adapter for this run (e.g. claude, gemini, opencode, codex)")
 	cmd.Flags().BoolVar(&opts.PreserveWorkspace, "preserve-workspace", false, "Preserve workspace from previous run (for debugging)")
 	cmd.Flags().StringVar(&opts.Steps, "steps", "", "Run only the named steps (comma-separated)")
@@ -427,6 +429,9 @@ func runRun(opts RunOptions, debug bool) error {
 	}
 	if opts.Model != "" {
 		execOpts = append(execOpts, pipeline.WithModelOverride(opts.Model))
+	}
+	if opts.ForceModel {
+		execOpts = append(execOpts, pipeline.WithForceModel(true))
 	}
 	registry := adapter.NewAdapterRegistry(nil)
 	if opts.Mock {
@@ -746,6 +751,9 @@ func runDetached(opts RunOptions, p *pipeline.Pipeline, _ *manifest.Manifest) er
 	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
+	}
+	if opts.ForceModel {
+		args = append(args, "--force-model")
 	}
 	if opts.Adapter != "" {
 		args = append(args, "--adapter", opts.Adapter)

--- a/docs/adr/004-multi-adapter-architecture.md
+++ b/docs/adr/004-multi-adapter-architecture.md
@@ -241,5 +241,5 @@ This ADR has been implemented. Key details:
 - **Step-level `adapter:`** in pipeline YAML — per-step override in the pipeline manifest.
 - **Supported adapters**: claude, opencode, gemini, codex.
 - **Fallback chains**: infrastructure in place via `FallbackRunner`, triggered on provider-level failures (rate limiting, timeout, context exhaustion) but not on contract or validation failures.
-- **Tier Models**: Each adapter can define `tier_models` mapping (`cheapest`, `fastest`, `strongest`) for automatic model selection based on step complexity.
+- **Tier Models**: Each adapter can define `tier_models` mapping (`cheapest`, `balanced`, `strongest`) for automatic model selection based on step complexity.
 - **Complexity Classification**: Steps are classified into tiers based on persona keywords and step type. `cheapest` personas (navigator, summarizer, auditor, planner) use cost-optimized models. `strongest` personas (craftsman, implementer, debugger, researcher) use capability-optimized models.

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -32,7 +32,7 @@ adapters:
       - .claude/settings.json
     tier_models:                     # Model selection by complexity tier
       cheapest: haiku                # Cost-optimized model
-      fastest: ""                    # Use adapter default (empty)
+      balanced: ""                    # Use adapter default (empty)
       strongest: opus                # Capability-optimized model
     default_permissions:              # Base permissions for all personas
       allowed_tools: ["Read", "Write", "Edit", "Bash"]
@@ -48,7 +48,7 @@ adapters:
 | `mode` | Always `"headless"` — Wave runs adapters as subprocesses, never interactive terminals. |
 | `output_format` | How to parse adapter output. `"json"` is the standard. |
 | `project_files` | Files copied into every workspace that uses this adapter. Useful for tool-specific config. |
-| `tier_models` | Maps complexity tiers (`cheapest`, `fastest`, `strongest`) to model identifiers for auto-routing. |
+| `tier_models` | Maps complexity tiers (`cheapest`, `balanced`, `strongest`) to model identifiers for auto-routing. |
 | `default_permissions` | Base tool permissions. Personas can override these. |
 | `hooks_template` | Directory of hook scripts copied into workspaces. |
 

--- a/docs/guide/model-routing.md
+++ b/docs/guide/model-routing.md
@@ -9,7 +9,7 @@ Wave classifies pipeline steps into three complexity tiers based on persona and 
 | Tier | Intent | Use Case |
 |------|--------|----------|
 | `cheapest` | Cost-optimized | Navigation, summarization, scanning |
-| `fastest` | Latency-optimized | Balanced speed/cost for standard tasks |
+| `balanced` | Latency-optimized | Balanced speed/cost for standard tasks |
 | `strongest` | Capability-optimized | Complex reasoning, code generation |
 
 ## Adapter Tier Models
@@ -23,14 +23,14 @@ adapters:
     default_model: sonnet
     tier_models:
       cheapest: haiku
-      fastest: ""
+      balanced: ""
       strongest: opus
   opencode:
     binary: opencode
     default_model: opencode/big-pickle
     tier_models:
       cheapest: opencode/big-pickle
-      fastest: opencode/big-pickle
+      balanced: opencode/big-pickle
       strongest: opencode/big-pickle
 ```
 
@@ -45,7 +45,7 @@ routing:
   auto_route: true
   complexity_map:
     cheapest: haiku
-    fastest: ""
+    balanced: ""
     strongest: opus
 ```
 

--- a/docs/reference/pipeline-schema.md
+++ b/docs/reference/pipeline-schema.md
@@ -59,7 +59,7 @@ chat_context:
 steps:
   - id: analyze
     persona: navigator
-    model: fastest
+    model: balanced
     memory:
       strategy: fresh
     workspace:
@@ -145,7 +145,7 @@ steps:
 | `id` | **yes** | - | Unique step identifier |
 | `persona` | conditional | - | Persona from wave.yaml (required for prompt steps) |
 | `adapter` | no | - | Step-level adapter override (e.g., `codex`, `gemini`) |
-| `model` | no | - | Step-level model tier or name (e.g., `fastest`, `strongest`, `claude-haiku-4-5`) |
+| `model` | no | - | Step-level model tier or name (e.g., `balanced`, `strongest`, `claude-haiku-4-5`) |
 | `exec.type` | conditional | - | `prompt`, `command`, or `slash_command` |
 | `exec.source` | conditional | - | Prompt template or shell command |
 | `exec.source_path` | no | - | Path to a prompt file (alternative to inline `source`) |
@@ -314,7 +314,7 @@ Override the model tier or specific model at the step level. See the [Model Rout
 steps:
   - id: triage
     persona: navigator
-    model: fastest
+    model: balanced
     exec:
       type: prompt
       source: "Classify the issue"
@@ -327,7 +327,7 @@ steps:
       source: "Implement the solution"
 ```
 
-Valid model tiers: `cheapest`, `fastest`, `strongest`. You can also specify exact model names (e.g., `claude-haiku-4-5`).
+Valid model tiers: `cheapest`, `balanced`, `strongest`. You can also specify exact model names (e.g., `claude-haiku-4-5`).
 
 ---
 

--- a/internal/defaults/pipelines/impl-feature.yaml
+++ b/internal/defaults/pipelines/impl-feature.yaml
@@ -417,7 +417,7 @@ steps:
   - id: fix-implement
     persona: craftsman
     thread: impl
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       type: worktree

--- a/internal/defaults/pipelines/impl-hotfix.yaml
+++ b/internal/defaults/pipelines/impl-hotfix.yaml
@@ -267,7 +267,7 @@ steps:
 
   - id: fix-retry
     persona: craftsman
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       mount:

--- a/internal/defaults/pipelines/impl-issue.yaml
+++ b/internal/defaults/pipelines/impl-issue.yaml
@@ -150,7 +150,7 @@ steps:
 
   - id: fix-implement
     persona: craftsman
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       type: worktree

--- a/internal/defaults/pipelines/ops-pr-fix-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-fix-review.yaml
@@ -203,7 +203,7 @@ steps:
   - id: triage
     persona: navigator
     contexts: [configuration, execution]
-    model: fastest
+    model: balanced
     dependencies: [fetch-review]
     memory:
       inject_artifacts:
@@ -517,7 +517,7 @@ steps:
   - id: retry-fixes
     persona: craftsman
     thread: fix
-    model: fastest
+    model: balanced
     rework_only: true
     workspace:
       type: worktree

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -75,7 +75,7 @@ type Adapter struct {
 	DefaultPermissions Permissions `yaml:"default_permissions,omitempty"`
 	HooksTemplate      string      `yaml:"hooks_template,omitempty"`
 	// TierModels maps complexity tiers to model identifiers for auto-routing.
-	// Tiers: "cheapest" (cost-optimized), "fastest" (latency-optimized), "strongest" (capability-optimized).
+	// Tiers: "cheapest" (cost-optimized), "balanced" (quality/cost), "strongest" (capability-optimized).
 	// If not set, falls back to routing.complexity_map, then adapter default_model.
 	TierModels map[string]string `yaml:"tier_models,omitempty"`
 }
@@ -253,12 +253,12 @@ type RoutingConfig struct {
 	AutoRoute bool `yaml:"auto_route,omitempty"`
 
 	// ComplexityMap maps complexity tier names to model identifiers.
-	// Tiers: "cheapest" (cost-optimized), "fastest" (latency-optimized), "strongest" (capability-optimized).
-	// Default mapping: "cheapest" -> "claude-haiku-4-5", "fastest" -> "" (adapter default), "strongest" -> "claude-opus-4".
+	// Tiers: "cheapest" (cost-optimized), "balanced" (quality/cost), "strongest" (capability-optimized).
+	// Default mapping: "cheapest" -> "claude-haiku-4-5", "balanced" -> "" (adapter default), "strongest" -> "claude-opus-4".
 	ComplexityMap map[string]string `yaml:"complexity_map,omitempty"`
 
 	// DefaultTier is the fallback complexity tier when classification is inconclusive.
-	// Defaults to "fastest" if not set.
+	// Defaults to "balanced" if not set.
 	DefaultTier string `yaml:"default_tier,omitempty"`
 }
 
@@ -266,14 +266,14 @@ type RoutingConfig struct {
 func DefaultComplexityMap() map[string]string {
 	return map[string]string{
 		"cheapest":  "claude-haiku-4-5",
-		"fastest":   "",
+		"balanced":  "",
 		"strongest": "claude-opus-4",
 	}
 }
 
 // ResolveComplexityModel returns the model for a given complexity tier,
 // consulting the configured ComplexityMap first, then falling back to defaults.
-// Returns empty string for the "fastest" tier (use adapter default).
+// Returns empty string for the "balanced" tier (use adapter default).
 func (r *RoutingConfig) ResolveComplexityModel(tier string) string {
 	if r != nil && len(r.ComplexityMap) > 0 {
 		if model, ok := r.ComplexityMap[tier]; ok {
@@ -284,12 +284,12 @@ func (r *RoutingConfig) ResolveComplexityModel(tier string) string {
 	return defaults[tier]
 }
 
-// EffectiveDefaultTier returns the configured default tier, falling back to "fastest".
+// EffectiveDefaultTier returns the configured default tier, falling back to "balanced".
 func (r *RoutingConfig) EffectiveDefaultTier() string {
 	if r != nil && r.DefaultTier != "" {
 		return r.DefaultTier
 	}
-	return "fastest"
+	return "balanced"
 }
 
 // RoutingRule defines a rule for matching work items to pipelines.

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -16,31 +16,31 @@ func getDefaultTierModels(adapter string) map[string]string {
 	case "claude":
 		return map[string]string{
 			"cheapest":  "haiku",
-			"fastest":   "",
+			"balanced":   "",
 			"strongest": "opus",
 		}
 	case "opencode":
 		return map[string]string{
 			"cheapest":  "opencode/big-pickle",
-			"fastest":   "opencode/big-pickle",
+			"balanced":   "opencode/big-pickle",
 			"strongest": "opencode/big-pickle",
 		}
 	case "gemini":
 		return map[string]string{
 			"cheapest":  "gemini-2.5-flash-lite",
-			"fastest":   "gemini-2.5-flash-lite",
+			"balanced":   "gemini-2.5-flash-lite",
 			"strongest": "gemini-2.0-pro",
 		}
 	case "codex":
 		return map[string]string{
 			"cheapest":  "gpt-4o-mini",
-			"fastest":   "gpt-4o",
+			"balanced":   "gpt-4o",
 			"strongest": "o3",
 		}
 	default:
 		return map[string]string{
 			"cheapest":  "",
-			"fastest":   "",
+			"balanced":   "",
 			"strongest": "",
 		}
 	}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -80,6 +80,7 @@ type DefaultPipelineExecutor struct {
 	stepTimeoutOverride time.Duration
 	// Model override (from CLI --model flag)
 	modelOverride   string
+	forceModel      bool
 	adapterOverride string
 	// Cross-pipeline artifacts from prior stages in a sequence
 	crossPipelineArtifacts map[string]map[string][]byte // pipelineName -> artifactName -> data
@@ -157,6 +158,10 @@ func WithStepTimeout(d time.Duration) ExecutorOption {
 
 func WithModelOverride(model string) ExecutorOption {
 	return func(ex *DefaultPipelineExecutor) { ex.modelOverride = model }
+}
+
+func WithForceModel(force bool) ExecutorOption {
+	return func(ex *DefaultPipelineExecutor) { ex.forceModel = force }
 }
 
 func WithAdapterOverride(adapter string) ExecutorOption {
@@ -3247,19 +3252,57 @@ func (e *DefaultPipelineExecutor) runStepExecution(ctx context.Context, executio
 	return nil
 }
 
-// resolveModel applies model precedence (strongest to weakest):
-// 1. CLI --model flag
-// 2. Step-level model in pipeline YAML
-// 3. Persona-level model in wave.yaml
-// 4. Auto-routing based on complexity heuristics (when routing.auto_route is enabled)
-// 5. Adapter default (empty string)
+// resolveModel applies model precedence:
+//
+// When --model is a tier name (cheapest/balanced/strongest):
+//
+//	The effective tier is the CHEAPER of the CLI tier and the step/persona tier.
+//	This means --model balanced + step model: cheapest → cheapest (step wins).
+//	The CLI flag sets a ceiling, not a floor.
+//
+// When --model is a literal model name (e.g., "haiku", "sonnet"):
+//
+//	The literal model is used for all steps regardless of YAML tiers.
+//
+// When --force-model is set:
+//
+//	The CLI model overrides everything unconditionally.
+//
+// Otherwise: step model > persona model > auto-route > adapter default.
 func (e *DefaultPipelineExecutor) resolveModel(step *Step, persona *manifest.Persona, routing *manifest.RoutingConfig, personaName string) string {
+	// Force override — bypasses all tier logic
+	if e.forceModel {
+		if e.modelOverride != "" {
+			return e.modelOverride
+		}
+	}
+
+	// Determine step-level tier (if any)
+	stepTier := ""
+	if step != nil && step.Model != "" {
+		stepTier = step.Model
+	} else if persona.Model != "" {
+		stepTier = persona.Model
+	}
+
 	if e.modelOverride != "" {
+		overrideRank := TierRank(e.modelOverride)
+		if overrideRank >= 0 && stepTier != "" {
+			// Both are tiers — use the cheaper one
+			effectiveTier := CheaperTier(e.modelOverride, stepTier)
+			if resolved, isTier := resolveTierModel(effectiveTier, routing); isTier {
+				return resolved
+			}
+			return effectiveTier
+		}
+		// CLI is a literal model name — use it directly
 		return e.modelOverride
 	}
+
+	// No CLI override — use step, persona, auto-route
 	if step != nil && step.Model != "" {
 		if resolved, isTier := resolveTierModel(step.Model, routing); isTier {
-			return resolved // may be empty (adapter default)
+			return resolved
 		}
 		return step.Model
 	}
@@ -3269,7 +3312,6 @@ func (e *DefaultPipelineExecutor) resolveModel(step *Step, persona *manifest.Per
 		}
 		return persona.Model
 	}
-	// Tier 4: auto-route based on complexity heuristics
 	if routing != nil && routing.AutoRoute {
 		tier := ClassifyStepComplexity(step, persona, personaName)
 		if model := routing.ResolveComplexityModel(tier); model != "" {
@@ -3279,12 +3321,12 @@ func (e *DefaultPipelineExecutor) resolveModel(step *Step, persona *manifest.Per
 	return ""
 }
 
-// resolveTierModel checks if a model string is a tier name (cheapest/fastest/strongest)
+// resolveTierModel checks if a model string is a tier name (cheapest/balanced/strongest)
 // and resolves it to an actual model via the routing complexity map.
 // Returns (resolved model, true) if input is a tier name, or ("", false) if it's a literal model.
 func resolveTierModel(model string, routing *manifest.RoutingConfig) (string, bool) {
 	switch model {
-	case TierCheapest, TierFastest, TierStrongest:
+	case TierCheapest, TierBalanced, TierStrongest:
 		return routing.ResolveComplexityModel(model), true
 	default:
 		return "", false

--- a/internal/pipeline/routing.go
+++ b/internal/pipeline/routing.go
@@ -7,10 +7,10 @@ import (
 )
 
 // Complexity tier constants returned by ClassifyStepComplexity.
-// These tiers guide model selection: cheapest (cost), fastest (latency), strongest (capability).
+// Three tiers: cheapest (cost), balanced (quality/cost), strongest (capability).
 const (
 	TierCheapest  = "cheapest"
-	TierFastest   = "fastest"
+	TierBalanced  = "balanced"
 	TierStrongest = "strongest"
 )
 
@@ -36,12 +36,12 @@ var strongestPersonaKeywords = []string{
 }
 
 // ClassifyStepComplexity returns a complexity tier for the given step and persona.
-// The tier is one of TierCheapest, TierFastest, or TierStrongest.
+// The tier is one of TierCheapest, TierBalanced, or TierStrongest.
 //
 // Classification heuristics (evaluated in order):
 //   - cheapest: persona name contains a lightweight keyword, OR step type is "command"/"conditional"
 //   - strongest: persona name contains a complex keyword, OR step uses sub_pipeline/loop/branch/aggregate
-//   - fastest: fallthrough for everything else (balance of cost and capability)
+//   - balanced: fallthrough for everything else (balance of cost and capability)
 func ClassifyStepComplexity(step *Step, persona *manifest.Persona, personaName string) string {
 	// Normalize persona name for keyword matching.
 	lowerName := strings.ToLower(personaName)
@@ -66,5 +66,36 @@ func ClassifyStepComplexity(step *Step, persona *manifest.Persona, personaName s
 		}
 	}
 
-	return TierFastest
+	return TierBalanced
+}
+
+// TierRank returns the cost rank of a tier (lower = cheaper).
+// Used to resolve conflicts: when multiple tiers apply, the cheaper one wins.
+func TierRank(tier string) int {
+	switch tier {
+	case TierCheapest:
+		return 0
+	case TierBalanced:
+		return 1
+	case TierStrongest:
+		return 2
+	default:
+		return -1 // not a tier (literal model name)
+	}
+}
+
+// CheaperTier returns the cheaper of two tier names.
+// If either is not a recognized tier, it returns the other.
+func CheaperTier(a, b string) string {
+	ra, rb := TierRank(a), TierRank(b)
+	if ra < 0 {
+		return b
+	}
+	if rb < 0 {
+		return a
+	}
+	if ra <= rb {
+		return a
+	}
+	return b
 }

--- a/internal/pipeline/routing_test.go
+++ b/internal/pipeline/routing_test.go
@@ -161,19 +161,19 @@ func TestClassifyStepComplexity(t *testing.T) {
 		},
 		// Fastest tier: fallthrough
 		{
-			name:        "generic step and persona routes to fastest",
+			name:        "generic step and persona routes to balanced",
 			step:        &Step{},
 			persona:     &manifest.Persona{},
 			personaName: "generic-persona",
-			want:        TierFastest,
+			want:        TierBalanced,
 		},
 		// Fastest tier: nil step
 		{
-			name:        "nil step with generic persona routes to fastest",
+			name:        "nil step with generic persona routes to balanced",
 			step:        nil,
 			persona:     &manifest.Persona{},
 			personaName: "generic-persona",
-			want:        TierFastest,
+			want:        TierBalanced,
 		},
 		// Priority: step type beats persona name (command step with strongest persona)
 		{
@@ -249,7 +249,7 @@ func TestResolveModelWithAutoRouting(t *testing.T) {
 			want:        "claude-opus-4",
 		},
 		{
-			name:        "auto-routing returns empty for fastest tier (adapter default)",
+			name:        "auto-routing returns empty for balanced tier (adapter default)",
 			override:    "",
 			step:        &Step{},
 			persona:     &manifest.Persona{},
@@ -342,9 +342,9 @@ func TestResolveModelWithAutoRouting(t *testing.T) {
 			want:        "claude-opus-4",
 		},
 		{
-			name:        "step model as tier name 'fastest' resolves to empty (adapter default)",
+			name:        "step model as tier name 'balanced' resolves to empty (adapter default)",
 			override:    "",
-			step:        &Step{Model: "fastest"},
+			step:        &Step{Model: "balanced"},
 			persona:     &manifest.Persona{},
 			routing:     &manifest.RoutingConfig{AutoRoute: true},
 			personaName: "any",
@@ -413,9 +413,9 @@ func TestRoutingConfigResolveComplexityModel(t *testing.T) {
 			want:    "claude-opus-4",
 		},
 		{
-			name:    "nil routing uses defaults for fastest (empty = adapter default)",
+			name:    "nil routing uses defaults for balanced (empty = adapter default)",
 			routing: nil,
-			tier:    "fastest",
+			tier:    "balanced",
 			want:    "",
 		},
 		{
@@ -467,14 +467,14 @@ func TestRoutingConfigEffectiveDefaultTier(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "nil routing returns fastest",
+			name:    "nil routing returns balanced",
 			routing: nil,
-			want:    "fastest",
+			want:    "balanced",
 		},
 		{
-			name:    "empty default tier returns fastest",
+			name:    "empty default tier returns balanced",
 			routing: &manifest.RoutingConfig{},
-			want:    "fastest",
+			want:    "balanced",
 		},
 		{
 			name: "custom default tier is returned",
@@ -496,7 +496,7 @@ func TestRoutingConfigEffectiveDefaultTier(t *testing.T) {
 func TestDefaultComplexityMap(t *testing.T) {
 	m := manifest.DefaultComplexityMap()
 	assert.Equal(t, "claude-haiku-4-5", m["cheapest"])
-	assert.Equal(t, "", m["fastest"])
+	assert.Equal(t, "", m["balanced"])
 	assert.Equal(t, "claude-opus-4", m["strongest"])
 	assert.Len(t, m, 3)
 }

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -366,8 +366,8 @@ func friendlyModelFunc(model string) string {
 		return "Haiku"
 	case m == "cheapest":
 		return "Cheapest"
-	case m == "fastest":
-		return "Fastest"
+	case m == "balanced":
+		return "Balanced"
 	case m == "strongest":
 		return "Strongest"
 	default:


### PR DESCRIPTION
## Summary

- **Three tiers**: cheapest, balanced (new), strongest. Removes "fastest" entirely.
- **--model precedence**: when CLI passes a tier name, the effective tier is the **cheaper** of CLI and step tier. The flag sets a ceiling, not a force override.
- **--force-model**: new flag that bypasses all tier logic — forces the exact model on every step.

## Changes

- `internal/pipeline/routing.go` — new `TierBalanced`, `TierRank()`, `CheaperTier()` functions
- `internal/pipeline/executor.go` — `resolveModel` rewritten with tier comparison logic, `forceModel` field
- `internal/manifest/types.go` — default complexity map updated
- `internal/onboarding/onboarding.go` — adapter presets updated
- `cmd/wave/commands/run.go` — `--force-model` flag, updated help text
- 4 pipeline YAMLs — `fastest` -> `balanced` (rework/retry steps)
- 4 doc files — updated tier references
- `internal/webui/embed.go` — display badge

## Test plan

- [x] `go build ./...` passes
- [x] All routing/manifest/defaults tests pass
- [ ] CI green