### PR TITLE
fix(pipelines): reduce implement step max_attempts from 3 to 2

### DIFF
--- a/.wave/pipelines/impl-improve.yaml
+++ b/.wave/pipelines/impl-improve.yaml
@@ -275,7 +275,7 @@ steps:
         so that regressions are hard to isolate.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/.wave/pipelines/impl-issue.yaml
+++ b/.wave/pipelines/impl-issue.yaml
@@ -135,7 +135,7 @@ steps:
       source_path: .wave/prompts/implement/implement.md
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: fix-implement
     handover:

--- a/.wave/pipelines/impl-speckit.yaml
+++ b/.wave/pipelines/impl-speckit.yaml
@@ -251,7 +251,7 @@ steps:
       source_path: .wave/prompts/speckit-flow/implement.md
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contracts:
         - type: test_suite

--- a/.wave/pipelines/ops-pr-fix-review.yaml
+++ b/.wave/pipelines/ops-pr-fix-review.yaml
@@ -504,7 +504,7 @@ steps:
         fixes that were not in the triage verdict.
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: retry-fixes
     handover:

--- a/.wave/pipelines/plan-research.yaml
+++ b/.wave/pipelines/plan-research.yaml
@@ -127,7 +127,7 @@ steps:
         type: json
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: json_schema
@@ -537,7 +537,7 @@ steps:
         label: "Research Comment"
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: json_schema

--- a/.wave/pipelines/wave-bugfix.yaml
+++ b/.wave/pipelines/wave-bugfix.yaml
@@ -228,7 +228,7 @@ steps:
         A bad fix is overly broad, lacks a regression test, or introduces new failures.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/.wave/pipelines/wave-test-hardening.yaml
+++ b/.wave/pipelines/wave-test-hardening.yaml
@@ -257,7 +257,7 @@ steps:
         coupled to implementation that they break on any refactor.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/audit-dead-code.yaml
+++ b/internal/defaults/pipelines/audit-dead-code.yaml
@@ -241,7 +241,7 @@ steps:
         A good clean step processes findings incrementally, catches build failures immediately by reverting individual removals, and produces a commit where every change is a clear dead-code deletion with no behavioral side effects. The commit message lists every removed item by finding ID. A bad clean step applies all removals at once, debugs cascading failures, or includes unrelated changes in the commit.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/impl-feature.yaml
+++ b/internal/defaults/pipelines/impl-feature.yaml
@@ -397,7 +397,7 @@ steps:
         requires multiple rework cycles to pass the contract.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: fix-implement
     handover:

--- a/internal/defaults/pipelines/impl-hotfix.yaml
+++ b/internal/defaults/pipelines/impl-hotfix.yaml
@@ -252,7 +252,7 @@ steps:
         while leaving the root cause intact.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: fix-retry
     handover:

--- a/internal/defaults/pipelines/impl-improve.yaml
+++ b/internal/defaults/pipelines/impl-improve.yaml
@@ -275,7 +275,7 @@ steps:
         so that regressions are hard to isolate.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -134,7 +134,7 @@ steps:
       source_path: .wave/prompts/implement/implement.md
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/impl-issue.yaml
+++ b/internal/defaults/pipelines/impl-issue.yaml
@@ -135,7 +135,7 @@ steps:
       source_path: .wave/prompts/implement/implement.md
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: fix-implement
     handover:

--- a/internal/defaults/pipelines/impl-recinq.yaml
+++ b/internal/defaults/pipelines/impl-recinq.yaml
@@ -751,7 +751,7 @@ steps:
         changes into single commits, or introduces test failures.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/impl-refactor.yaml
+++ b/internal/defaults/pipelines/impl-refactor.yaml
@@ -391,7 +391,7 @@ steps:
         or sneaks in behavioral changes alongside the structural change.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -251,7 +251,7 @@ steps:
       source_path: .wave/prompts/speckit-flow/implement.md
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contracts:
         - type: test_suite

--- a/internal/defaults/pipelines/ops-bootstrap.yaml
+++ b/internal/defaults/pipelines/ops-bootstrap.yaml
@@ -282,7 +282,7 @@ steps:
         project's actual structure.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite

--- a/internal/defaults/pipelines/ops-debug.yaml
+++ b/internal/defaults/pipelines/ops-debug.yaml
@@ -482,7 +482,7 @@ steps:
         of the root cause.
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     output_artifacts:
       - name: fix
         path: .wave/output/fix-summary.md

--- a/internal/defaults/pipelines/ops-pr-fix-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-fix-review.yaml
@@ -504,7 +504,7 @@ steps:
         fixes that were not in the triage verdict.
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
       on_failure: rework
       rework_step: retry-fixes
     handover:

--- a/internal/defaults/pipelines/plan-research.yaml
+++ b/internal/defaults/pipelines/plan-research.yaml
@@ -127,7 +127,7 @@ steps:
         type: json
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: json_schema
@@ -537,7 +537,7 @@ steps:
         label: "Research Comment"
     retry:
       policy: aggressive
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: json_schema

--- a/internal/defaults/pipelines/test-gen.yaml
+++ b/internal/defaults/pipelines/test-gen.yaml
@@ -273,7 +273,7 @@ steps:
         A good test generation produces tests that catch real bugs: if someone introduced a regression, at least one of these tests would fail. Tests have descriptive names that document what they verify. Table-driven tests cover the input space systematically. Mocks are minimal and focused. A bad test generation produces tests that only exercise the happy path, use meaningless assertions, or test implementation details that break when the code is refactored without behavioral change.
     retry:
       policy: standard
-      max_attempts: 3
+      max_attempts: 2
     handover:
       contract:
         type: test_suite


### PR DESCRIPTION
## Summary
- Reduced `max_attempts` from 3 to 2 across all pipeline implement steps (14 files in `internal/defaults/pipelines/`, 7 files in `.wave/pipelines/`)
- Pipelines with existing rework steps (impl-issue, impl-feature, impl-hotfix, ops-pr-fix-review) already route failures to a dedicated fix step that receives failure context -- 3 retries before rework was wasteful
- Pipelines without rework steps also reduced to 2 since retrying with the same prompt rarely succeeds on the third attempt

## Test plan
- [x] `go test ./internal/defaults/...` passes
- [x] No remaining `max_attempts: 3` in any pipeline implement step
- [ ] Run a pipeline end-to-end to confirm retry/rework behavior unchanged