### PR TITLE
feat(pipeline): inject contract failure context into retry attempts

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1640,8 +1640,11 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 						"error":         err.Error(),
 					},
 				)
-				// Set up attempt context for prompt adaptation on next retry
-				if step.Retry.AdaptPrompt {
+				// Always inject failure context into the next retry attempt.
+				// Previously gated behind AdaptPrompt, but contract failures
+				// are the most common retry trigger and agents need to know
+				// *what* failed to avoid starting from scratch.
+				{
 					errMsg := err.Error()
 					// Capture stdout tail from results if available
 					stdoutTail := ""
@@ -1657,13 +1660,26 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 					}
 					execution.mu.Unlock()
 
+					// Extract contract-specific errors when the failure came
+					// from contract validation so the agent gets actionable
+					// detail about which contract failed and why.
+					var contractErrors []string
+					if strings.Contains(errMsg, "contract validation failed") {
+						inner := err
+						for uw := errors.Unwrap(inner); uw != nil; uw = errors.Unwrap(inner) {
+							inner = uw
+						}
+						contractErrors = append(contractErrors, inner.Error())
+					}
+
 					execution.mu.Lock()
 					execution.AttemptContexts[step.ID] = &AttemptContext{
-						Attempt:      attempt + 1,
-						MaxAttempts:  maxAttempts,
-						PriorError:   errMsg,
-						FailureClass: failureClass,
-						PriorStdout:  stdoutTail,
+						Attempt:        attempt + 1,
+						MaxAttempts:    maxAttempts,
+						PriorError:     errMsg,
+						FailureClass:   failureClass,
+						PriorStdout:    stdoutTail,
+						ContractErrors: contractErrors,
 					}
 					execution.mu.Unlock()
 				}
@@ -3702,7 +3718,11 @@ func (e *DefaultPipelineExecutor) buildStepPrompt(execution *PipelineExecution, 
 			sb.WriteString(fmt.Sprintf("A review agent found issues with the previous implementation. Structured feedback is available at: `%s`\n", attemptCtx.ReviewFeedbackPath))
 			sb.WriteString("Read this file to understand the specific issues and suggestions before making changes.\n\n")
 		}
-		sb.WriteString("Please address the issues from the previous attempt and try a different approach if needed.\n\n---\n\n")
+		if len(attemptCtx.ContractErrors) > 0 {
+			sb.WriteString("Fix the specific failure above. Do not start from scratch.\n\n---\n\n")
+		} else {
+			sb.WriteString("Please address the issues from the previous attempt and try a different approach if needed.\n\n---\n\n")
+		}
 		sb.WriteString(prompt)
 		prompt = sb.String()
 	}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -6317,3 +6317,87 @@ func TestBranchInDAG_Skip(t *testing.T) {
 	assert.Equal(t, 0, len(configs),
 		"skip branch should not invoke any adapter")
 }
+
+// TestRetryInjectsContractFailureContext verifies that when a step's contract
+// validation fails and the step retries, the next attempt's prompt includes
+// the contract failure details so the agent can fix the specific error.
+func TestRetryInjectsContractFailureContext(t *testing.T) {
+	// Use a counting adapter that captures every prompt. Both attempts
+	// succeed at the adapter level — the failure comes from the contract.
+	capAdapter := &countingFailAdapter{
+		failCount:   0, // adapter always succeeds
+		successMock: adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status":"ok"}`)),
+	}
+
+	collector := testutil.NewEventCollector()
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+
+	executor := NewDefaultPipelineExecutor(capAdapter,
+		WithEmitter(collector),
+	)
+
+	// Create a shell script that fails on the first call and succeeds on
+	// the second. Uses a counter file to track invocations.
+	counterFile := filepath.Join(tmpDir, "contract_counter")
+	scriptFile := filepath.Join(tmpDir, "contract_check.sh")
+	scriptContent := fmt.Sprintf(`#!/bin/sh
+count=$(cat "%s" 2>/dev/null || echo 0)
+count=$((count+1))
+echo $count > "%s"
+if [ $count -le 1 ]; then
+  echo "FAIL: TestWidget expected 42 got 0"
+  exit 1
+fi
+`, counterFile, counterFile)
+	require.NoError(t, os.WriteFile(scriptFile, []byte(scriptContent), 0755))
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "retry-contract-ctx"},
+		Steps: []Step{
+			{
+				ID:      "step-1",
+				Persona: "navigator",
+				Exec:    ExecConfig{Source: "implement the feature"},
+				Retry: RetryConfig{
+					MaxAttempts: 2,
+					BaseDelay:   "1ms",
+				},
+				Handover: HandoverConfig{
+					Contract: ContractConfig{
+						Type:      "test_suite",
+						Command:   scriptFile,
+						OnFailure: OnFailureFail,
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test input")
+	assert.NoError(t, err, "pipeline should succeed on second attempt after contract passes")
+
+	// The adapter should have been called exactly twice
+	configs := capAdapter.getLastConfigs()
+	require.Equal(t, 2, len(configs), "adapter should be called twice (first attempt + retry)")
+
+	// First attempt: no retry context in prompt
+	assert.NotContains(t, configs[0].Prompt, "RETRY CONTEXT",
+		"first attempt should NOT have retry context")
+
+	// Second attempt: must contain retry context with contract failure details
+	secondPrompt := configs[1].Prompt
+	assert.Contains(t, secondPrompt, "RETRY CONTEXT",
+		"second attempt should have RETRY CONTEXT header")
+	assert.Contains(t, secondPrompt, "attempt 2 of 2",
+		"second attempt should show attempt number")
+	assert.Contains(t, secondPrompt, "Contract Validation Errors",
+		"second attempt should contain contract validation errors section")
+	assert.Contains(t, secondPrompt, "TestWidget",
+		"second attempt should contain the specific test failure output")
+	assert.Contains(t, secondPrompt, "Fix the specific failure above",
+		"second attempt should instruct agent not to start from scratch")
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -135,7 +135,7 @@ type RetryConfig struct {
 	Backoff     string `yaml:"backoff,omitempty"`      // "fixed", "linear", "exponential". Default: "linear"
 	BaseDelay   string `yaml:"base_delay,omitempty"`   // Duration string like "2s". Default: "1s"
 	MaxDelay    string `yaml:"max_delay,omitempty"`    // Maximum delay cap. Default: "30s"
-	AdaptPrompt bool   `yaml:"adapt_prompt,omitempty"` // Inject prior failure context. Default: false
+	AdaptPrompt bool   `yaml:"adapt_prompt,omitempty"` // Deprecated: failure context is now always injected on retry. Kept for YAML compat.
 	OnFailure   string `yaml:"on_failure,omitempty"`   // "fail", "skip", "continue", "rework". Default: "fail"
 	ReworkStep  string `yaml:"rework_step,omitempty"`  // Step ID to execute when on_failure is "rework"
 }


### PR DESCRIPTION
## Summary

- Always inject failure context into retry prompts (previously gated behind `adapt_prompt: true`)
- Extract contract-specific errors from wrapped error chains and populate `ContractErrors` in `AttemptContext`
- Use a targeted instruction ("Fix the specific failure above. Do not start from scratch.") when retrying after contract failures
- Deprecate the `adapt_prompt` field (kept for YAML compatibility)

## Test plan

- [x] New test `TestRetryInjectsContractFailureContext` verifies:
  - First attempt prompt has no retry context
  - Second attempt prompt contains `RETRY CONTEXT` header, attempt count, contract error details, test output, and fix instruction
- [x] Existing `TestExecuteStep_AdaptPrompt_InjectsFailureContext` still passes (no regression)
- [x] Full `go test -race ./internal/pipeline/` passes