### PR TITLE
feat(webui): expandable running-pipelines section on runs overview

### DIFF
--- a/internal/contract/testsuite.go
+++ b/internal/contract/testsuite.go
@@ -123,19 +123,11 @@ func resolveContractDir(dir, workspacePath string) (string, error) {
 	}
 
 	if dir == "project_root" {
-		// First, determine the git root to bound our upward search.
+		// Walk up from workspacePath to find the real project root.
 		// Workspace dirs often have their own git init (for Claude Code path anchoring),
 		// so git rev-parse may return the workspace dir instead of the actual project root.
-		// We walk up looking for project markers, but stop at the git root to avoid
-		// overshooting into system directories that may contain stray marker files.
-		gitCmd := exec.Command("git", "rev-parse", "--show-toplevel")
-		gitCmd.Dir = workspacePath
-		gitRoot := ""
-		if out, err := gitCmd.Output(); err == nil {
-			gitRoot = strings.TrimSpace(string(out))
-		}
-
-		projectMarkers := []string{"go.mod", "package.json", "Cargo.toml", "pyproject.toml"}
+		// Look for project markers (go.mod, package.json, etc.) to find the real root.
+		projectMarkers := []string{"go.mod", "package.json", "Cargo.toml", "pyproject.toml", ".git"}
 		candidate := workspacePath
 		for {
 			for _, marker := range projectMarkers {
@@ -143,19 +135,17 @@ func resolveContractDir(dir, workspacePath string) (string, error) {
 					return candidate, nil
 				}
 			}
-			// Stop at the git root — don't walk above the repository boundary.
-			if gitRoot != "" && candidate == gitRoot {
-				break
-			}
 			parent := filepath.Dir(candidate)
 			if parent == candidate {
 				break // reached filesystem root
 			}
 			candidate = parent
 		}
-		// Use git root if available (covers repos with no standard marker files).
-		if gitRoot != "" {
-			return gitRoot, nil
+		// Fallback: try git rev-parse (works when project has no marker files)
+		cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+		cmd.Dir = workspacePath
+		if out, err := cmd.Output(); err == nil {
+			return strings.TrimSpace(string(out)), nil
 		}
 		// Last resort: use process CWD
 		if cwd, err := os.Getwd(); err == nil {

--- a/internal/webui/handlers_pipelines.go
+++ b/internal/webui/handlers_pipelines.go
@@ -63,14 +63,27 @@ func (s *Server) handlePipelinesPage(w http.ResponseWriter, r *http.Request) {
 		return pipelines[i].Name < pipelines[j].Name
 	})
 
+	// Top frequent pipelines (run count > 0, capped at 8)
+	var frequent []PipelineSummary
+	for _, p := range pipelines {
+		if p.RunCount > 0 {
+			frequent = append(frequent, p)
+			if len(frequent) >= 8 {
+				break
+			}
+		}
+	}
+
 	data := struct {
-		ActivePage string
-		Pipelines  []PipelineSummary
-		Categories []string
+		ActivePage         string
+		Pipelines          []PipelineSummary
+		Categories         []string
+		FrequentPipelines  []PipelineSummary
 	}{
-		ActivePage: "pipelines",
-		Pipelines:  pipelines,
-		Categories: catList,
+		ActivePage:        "pipelines",
+		Pipelines:         pipelines,
+		Categories:        catList,
+		FrequentPipelines: frequent,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -185,11 +185,18 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		runs = runs[:limit]
 	}
 
-	allSummaries := make([]RunSummary, len(runs))
-	for i, run := range runs {
-		allSummaries[i] = runToSummary(run)
+	allSummaries := make([]RunSummary, 0, len(runs))
+	filteredRuns := make([]state.RunRecord, 0, len(runs))
+	for _, run := range runs {
+		// Running runs are always shown in the dedicated running-pipelines section;
+		// exclude them from the main list to avoid duplication.
+		if run.Status == "running" {
+			continue
+		}
+		allSummaries = append(allSummaries, runToSummary(run))
+		filteredRuns = append(filteredRuns, run)
 	}
-	s.enrichRunSummaries(allSummaries, runs)
+	s.enrichRunSummaries(allSummaries, filteredRuns)
 	summaries := nestChildRuns(allSummaries)
 
 	var nextCursor string

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -208,6 +208,33 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		pipelines = append(pipelines, name)
 	}
 
+	// Query running runs for the running-pipelines section (FR-008: filter applied)
+	runningRecs, err := s.store.ListRuns(state.ListRunsOptions{
+		Status:       "running",
+		PipelineName: pipelineFilter,
+		Limit:        0,
+	})
+	if err != nil {
+		log.Printf("[webui] failed to list running runs: %v", err)
+		runningRecs = nil
+	}
+	runningRuns := make([]RunSummary, 0)
+	for _, rec := range runningRecs {
+		if rec.ParentRunID != "" {
+			continue // exclude child runs
+		}
+		runningRuns = append(runningRuns, runToSummary(rec))
+	}
+	s.enrichRunSummaries(runningRuns, func() []state.RunRecord {
+		var top []state.RunRecord
+		for _, rec := range runningRecs {
+			if rec.ParentRunID == "" {
+				top = append(top, rec)
+			}
+		}
+		return top
+	}())
+
 	data := struct {
 		ActivePage     string
 		Runs           []RunSummary
@@ -216,6 +243,8 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		Pipelines      []string
 		FilterStatus   string
 		FilterPipeline string
+		RunningRuns    []RunSummary
+		RunningCount   int
 	}{
 		ActivePage:     "runs",
 		Runs:           summaries,
@@ -224,6 +253,8 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		Pipelines:      pipelines,
 		FilterStatus:   status,
 		FilterPipeline: pipelineFilter,
+		RunningRuns:    runningRuns,
+		RunningCount:   len(runningRuns),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/webui/handlers_runs_test.go
+++ b/internal/webui/handlers_runs_test.go
@@ -880,6 +880,105 @@ steps:
 	}
 }
 
+// TestHandleRunsPage_RunningSection_Populated verifies that a running run
+// appears in the rp-section with the correct count badge and a link to the run.
+func TestHandleRunsPage_RunningSection_Populated(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	runID, err := rwStore.CreateRun("test-pipeline", "input")
+	if err != nil {
+		t.Fatalf("failed to create run: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(runID, "running", "", 0); err != nil {
+		t.Fatalf("failed to update run status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/runs", nil)
+	rec := httptest.NewRecorder()
+	srv.handleRunsPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "rp-section") {
+		t.Error("expected rp-section in response body")
+	}
+	if !strings.Contains(body, "rp-badge") {
+		t.Error("expected rp-badge in response body")
+	}
+	if !strings.Contains(body, `href="/runs/`+runID+`"`) {
+		t.Errorf("expected link to run %q in response body", runID)
+	}
+}
+
+// TestHandleRunsPage_RunningSection_Empty verifies that the empty-state CTA
+// is shown when no pipelines are running.
+func TestHandleRunsPage_RunningSection_Empty(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	// Create a completed run — should not appear in running section
+	runID, _ := rwStore.CreateRun("test-pipeline", "input")
+	if err := rwStore.UpdateRunStatus(runID, "completed", "", 0); err != nil {
+		t.Fatalf("failed to update run status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/runs", nil)
+	rec := httptest.NewRecorder()
+	srv.handleRunsPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "rp-empty") {
+		t.Error("expected rp-empty class when no running pipelines")
+	}
+	if !strings.Contains(body, `href="/pipelines"`) {
+		t.Error("expected CTA link to /pipelines in empty state")
+	}
+}
+
+// TestHandleRunsPage_RunningSection_FilterRespected verifies that the pipeline
+// filter query parameter is applied to the running section (FR-008).
+func TestHandleRunsPage_RunningSection_FilterRespected(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	run1ID, err := rwStore.CreateRun("pipeline-alpha", "input")
+	if err != nil {
+		t.Fatalf("failed to create run1: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(run1ID, "running", "", 0); err != nil {
+		t.Fatalf("failed to update run1 status: %v", err)
+	}
+
+	run2ID, err := rwStore.CreateRun("pipeline-beta", "input")
+	if err != nil {
+		t.Fatalf("failed to create run2: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(run2ID, "running", "", 0); err != nil {
+		t.Fatalf("failed to update run2 status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/runs?pipeline=pipeline-alpha", nil)
+	rec := httptest.NewRecorder()
+	srv.handleRunsPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/runs/`+run1ID+`"`) {
+		t.Errorf("expected link to run1 %q for pipeline-alpha filter", run1ID)
+	}
+	if strings.Contains(body, `href="/runs/`+run2ID+`"`) {
+		t.Errorf("did not expect link to run2 %q when filtered to pipeline-alpha", run2ID)
+	}
+}
+
 func TestFormatSmartTime(t *testing.T) {
 	now := time.Now()
 	tests := []struct {

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -39,7 +39,7 @@ func testTemplates(t *testing.T) map[string]*template.Template {
 		},
 	}
 	pages := map[string]string{
-		"templates/runs.html":           `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav>{{range .Runs}}<div>{{.RunID}}</div>{{end}}</body></html>`,
+		"templates/runs.html":           `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav><div class="rp-section"><span class="rp-badge">{{.RunningCount}}</span>{{if eq .RunningCount 0}}<div class="rp-empty"><a href="/pipelines">Start a pipeline</a></div>{{else}}{{range .RunningRuns}}<a href="/runs/{{.RunID}}" class="wr-run"><span>{{.PipelineName}}</span></a>{{end}}{{end}}</div>{{range .Runs}}<div>{{.RunID}}</div>{{end}}</body></html>`,
 		"templates/run_detail.html":     `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav><div>{{.Run.RunID}}</div></body></html>`,
 		"templates/personas.html":       `<html><body>{{range .Personas}}<div>{{.Name}}</div>{{end}}</body></html>`,
 		"templates/pipelines.html":      `<html><body>{{range .Pipelines}}<div>{{.Name}}</div>{{end}}</body></html>`,

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -3125,6 +3125,22 @@ body > .main-content > .card:last-of-type:has(h2) { display: none !important; }
 /* Empty state */
 .wr-empty { text-align: center; padding: 2rem; color: var(--color-text-muted); font-size: 0.85rem; }
 
+/* ── Running Pipelines Section ── */
+.rp-section { margin-bottom: 0.6rem; }
+.rp-header { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; padding: 0.25rem 0.4rem; border-radius: 4px; user-select: none; }
+.rp-header:hover { background: var(--color-bg-tertiary); }
+.rp-label { font-size: 0.78rem; font-weight: 700; color: var(--color-text-secondary); }
+.rp-badge { display: inline-block; padding: 0.1em 0.5em; font-size: 0.7rem; font-weight: 600; border-radius: 2em; line-height: 1.4; background: var(--color-running-bg); color: var(--color-running); }
+.rp-chevron { font-size: 0.75rem; color: var(--color-text-muted); transition: transform 0.2s ease; margin-left: auto; }
+.rp-body { display: block; }
+.rp-runs { display: flex; flex-direction: column; gap: 0.35rem; margin-top: 0.3rem; }
+.rp-empty { display: flex; flex-direction: column; align-items: center; padding: 1rem; color: var(--color-text-muted); font-size: 0.82rem; gap: 0.4rem; }
+.rp-empty p { margin: 0; }
+.rp-cta { padding: 0.25rem 0.8rem; border-radius: 4px; font-size: 0.75rem; color: var(--color-link); border: 1px solid rgba(99,102,241,0.3); background: rgba(99,102,241,0.06); cursor: pointer; text-decoration: none; transition: background 0.15s; }
+.rp-cta:hover { background: rgba(99,102,241,0.12); }
+.rp-section.collapsed .rp-body { display: none; }
+.rp-section.collapsed .rp-chevron { transform: rotate(-90deg); }
+
 /* ── Load More Button ── */
 .wr-load-more { text-align: center; padding: 0.6rem; }
 .wr-load-more button {

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -56,7 +56,7 @@
     /* Step shape layout tokens */
     --ws-pad-x: 0.55rem;       /* horizontal content padding inside step shapes */
     --ws-pad-y-top: 0.25rem;   /* top padding for step row1 */
-    --ws-pad-y-bot: 0.2rem;    /* bottom padding for step I/O row */
+    --ws-pad-y-bot: 0.25rem;   /* bottom padding for step I/O row */
     --ws-gap: 0.3rem;          /* gap between items in step rows */
     --ws-tab-pad-y: 0.4rem;    /* vertical padding for tab buttons */
     --ws-tab-pad-right: 0.75rem; /* right padding for tab buttons */
@@ -3064,9 +3064,9 @@ body > .main-content > .card:last-of-type:has(h2) { display: none !important; }
 /* Filter bar */
 .wr-toolbar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.6rem; gap: 0.5rem; flex-wrap: wrap; }
 .wr-filters { display: flex; gap: 0.3rem; align-items: center; flex-wrap: wrap; }
-.wr-filter { padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.72rem; color: var(--color-text-muted); border: 1px solid var(--color-border); background: none; cursor: pointer; text-decoration: none; }
-.wr-filter:hover { background: var(--color-bg-tertiary); color: var(--color-text-secondary); }
-.wr-filter.active { background: var(--color-running-bg); border-color: rgba(99,102,241,0.3); color: var(--color-link-hover); }
+.wr-filter { padding: 0.2rem 0.6rem; border-radius: 4px; font-size: 0.72rem; font-weight: 500; color: var(--color-text-muted); border: none; background: none; cursor: pointer; text-decoration: none; transition: color 0.15s; }
+.wr-filter:hover { color: var(--color-text-secondary); }
+.wr-filter.active { background: var(--color-bg-tertiary); color: var(--color-text-primary); font-weight: 600; }
 .wr-controls { display: flex; gap: 0.3rem; align-items: center; }
 .wr-select { padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.72rem; color: var(--color-text-secondary); border: 1px solid var(--color-border); background: var(--color-bg-tertiary); cursor: pointer; font-family: var(--font-sans); max-width: 220px; }
 .wr-select:focus { border-color: var(--wave-primary); outline: none; }
@@ -3095,6 +3095,7 @@ body > .main-content > .card:last-of-type:has(h2) { display: none !important; }
 .wr-accent.st-running { background: var(--color-running); }
 .wr-accent.st-pending { background: var(--color-border); }
 .wr-accent.st-cancelled { background: var(--color-border); }
+.wr-accent.st-defined { background: var(--wave-primary); opacity: 0.4; }
 
 /* Main content area */
 .wr-body { padding: 0.4rem 0.6rem; min-width: 0; }
@@ -3126,20 +3127,40 @@ body > .main-content > .card:last-of-type:has(h2) { display: none !important; }
 .wr-empty { text-align: center; padding: 2rem; color: var(--color-text-muted); font-size: 0.85rem; }
 
 /* ── Running Pipelines Section ── */
-.rp-section { margin-bottom: 0.6rem; }
-.rp-header { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; padding: 0.25rem 0.4rem; border-radius: 4px; user-select: none; }
-.rp-header:hover { background: var(--color-bg-tertiary); }
+.rp-section { margin-bottom: 0.75rem; background: var(--color-bg-primary); border-radius: 5px; border: 1px solid var(--color-border); overflow: hidden; }
+.rp-header { display: flex; align-items: center; gap: 0.4rem; padding: 0.35rem 0.5rem; user-select: none; border-bottom: 1px solid transparent; }
+.rp-section:not(.collapsed) .rp-header { border-bottom-color: var(--color-border); }
+.rp-header-clickable { cursor: pointer; }
+.rp-header-clickable:hover { background: var(--color-bg-tertiary); }
 .rp-label { font-size: 0.78rem; font-weight: 700; color: var(--color-text-secondary); }
 .rp-badge { display: inline-block; padding: 0.1em 0.5em; font-size: 0.7rem; font-weight: 600; border-radius: 2em; line-height: 1.4; background: var(--color-running-bg); color: var(--color-running); }
 .rp-chevron { font-size: 0.75rem; color: var(--color-text-muted); transition: transform 0.2s ease; margin-left: auto; }
-.rp-body { display: block; }
-.rp-runs { display: flex; flex-direction: column; gap: 0.35rem; margin-top: 0.3rem; }
-.rp-empty { display: flex; flex-direction: column; align-items: center; padding: 1rem; color: var(--color-text-muted); font-size: 0.82rem; gap: 0.4rem; }
+.rp-body { display: block; padding: 0.35rem 0.5rem 0.5rem; }
+.rp-runs { display: flex; flex-direction: column; gap: 0.35rem; }
+.rp-empty { display: flex; flex-direction: column; align-items: center; padding: 0.75rem; color: var(--color-text-muted); font-size: 0.82rem; gap: 0.4rem; }
 .rp-empty p { margin: 0; }
 .rp-cta { padding: 0.25rem 0.8rem; border-radius: 4px; font-size: 0.75rem; color: var(--color-link); border: 1px solid rgba(99,102,241,0.3); background: rgba(99,102,241,0.06); cursor: pointer; text-decoration: none; transition: background 0.15s; }
 .rp-cta:hover { background: rgba(99,102,241,0.12); }
 .rp-section.collapsed .rp-body { display: none; }
 .rp-section.collapsed .rp-chevron { transform: rotate(-90deg); }
+
+/* ── Pipelines page ── */
+.wr-search { padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.72rem; color: var(--color-text-secondary); border: 1px solid var(--color-border); background: var(--color-bg-tertiary); font-family: var(--font-sans); width: 180px; }
+.wr-count { font-size: 0.72rem; color: var(--color-text-muted); }
+.pl-desc { color: var(--color-text-secondary); font-size: 0.78rem; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; max-width: 48rem; }
+.pl-meta { color: var(--color-text-muted); font-size: 0.72rem; }
+.pl-run-btn { font-size: 0.65rem; padding: 0.1rem 0.35rem; opacity: 0.7; }
+.badge-composition { font-size: 0.65rem; background: rgba(139,92,246,0.12); color: #c4b5fd; }
+.badge-category { font-size: 0.65rem; background: rgba(99,102,241,0.12); color: #a5b4fc; }
+.badge-disabled { font-size: 0.65rem; background: rgba(239,68,68,0.1); color: #fca5a5; }
+.badge-skill { font-size: 0.65rem; background: rgba(34,211,238,0.1); color: #67e8f9; }
+
+/* Compact frequent pipeline list */
+.fp-list { display: flex; flex-direction: column; }
+.fp-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0.5rem; text-decoration: none; color: inherit; border-bottom: 1px solid var(--color-border); transition: background 0.1s; }
+.fp-row:last-child { border-bottom: none; }
+.fp-row:hover { background: var(--color-bg-tertiary); text-decoration: none; color: inherit; }
+.fp-stat { font-size: 0.68rem; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
 
 /* ── Load More Button ── */
 .wr-load-more { text-align: center; padding: 0.6rem; }

--- a/internal/webui/templates/layout.html
+++ b/internal/webui/templates/layout.html
@@ -30,7 +30,7 @@
                     <svg class="nav-group-chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="4 6 8 10 12 6"/></svg>
                 </button>
                 <ul class="nav-group-items">
-                    <li><a href="/runs" class="nav-item{{if eq .ActivePage "runs"}} active{{end}}">
+                    <li><a href="/runs?status=completed" class="nav-item{{if eq .ActivePage "runs"}} active{{end}}">
                         <svg class="nav-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="8"/><polygon points="8,6.5 13,10 8,13.5" fill="currentColor" stroke="none"/></svg>
                         <span>Runs</span>
                     </a></li>
@@ -184,7 +184,7 @@
             }
             if (gPending) {
                 gPending = false;
-                if (e.key === 'r') { e.preventDefault(); window.location.href = '/runs'; return; }
+                if (e.key === 'r') { e.preventDefault(); window.location.href = '/runs?status=completed'; return; }
                 if (e.key === 'p') { e.preventDefault(); window.location.href = '/pipelines'; return; }
                 if (e.key === 'h') { e.preventDefault(); window.location.href = '/health'; return; }
                 return;

--- a/internal/webui/templates/pipelines.html
+++ b/internal/webui/templates/pipelines.html
@@ -5,18 +5,45 @@
 </div>
 
 {{if .Pipelines}}
+
 <!-- Category filters -->
 {{if .Categories}}
 <div class="wr-toolbar">
     <div class="wr-filters">
-        <button class="wr-filter active" data-cat="frequent" onclick="filterPipelines(this)">Frequent</button>
-        <button class="wr-filter" data-cat="" onclick="filterPipelines(this)">All</button>
+        <button class="wr-filter active" data-cat="" onclick="filterPipelines(this)">All</button>
         {{range .Categories}}<button class="wr-filter" data-cat="{{.}}" onclick="filterPipelines(this)">{{.}}</button>{{end}}
     </div>
     <div class="wr-controls">
-        <input type="text" id="pipeline-search" placeholder="Search pipelines..." style="padding:0.2rem 0.4rem;border-radius:4px;font-size:0.72rem;color:var(--color-text-secondary);border:1px solid var(--color-border);background:var(--color-bg-tertiary);font-family:var(--font-sans);width:180px;" oninput="applyFilters()">
-        <span style="font-size:0.72rem;color:var(--color-text-muted);" id="pipeline-count">{{len .Pipelines}} pipelines</span>
+        <input type="text" id="pipeline-search" class="wr-search" placeholder="Search pipelines..." oninput="applyFilters()">
+        <span class="wr-count" id="pipeline-count">{{len .Pipelines}} pipelines</span>
     </div>
+</div>
+{{end}}
+
+<!-- Frequent pipelines section -->
+{{if .FrequentPipelines}}
+<div class="rp-section" id="fp-section">
+  <div class="rp-header rp-header-clickable" role="button" tabindex="0" aria-expanded="true"
+       onclick="toggleFrequentSection()"
+       onkeydown="if(event.key==='Enter'||event.key===' '){toggleFrequentSection();event.preventDefault()}">
+    <span class="rp-label">Frequent</span>
+    <span class="rp-badge" style="background:rgba(99,102,241,0.15);color:#a5b4fc;">{{len .FrequentPipelines}}</span>
+    <span class="rp-chevron">▾</span>
+  </div>
+  <div class="rp-body" style="padding:0;">
+    <div class="fp-list">
+    {{range .FrequentPipelines}}
+      <a href="/pipelines/{{.Name}}" class="fp-row">
+        <span class="wr-name" style="font-size:0.8rem;">{{.Name}}</span>
+        {{if .Description}}<span class="wr-input">{{.Description}}</span>{{end}}
+        <span class="wr-right">
+          <span class="fp-stat">{{.RunCount}}</span>
+          <button class="btn btn-sm pl-run-btn" onclick="event.preventDefault();event.stopPropagation();showQuickStart('{{.Name}}')">run</button>
+        </span>
+      </a>
+    {{end}}
+    </div>
+  </div>
 </div>
 {{end}}
 
@@ -27,20 +54,20 @@
         <div class="wr-body">
             <div class="wr-row1">
                 <span class="wr-name">{{.Name}}</span>
-                {{if .IsComposition}}<span class="badge" style="font-size:0.65rem;background:rgba(139,92,246,0.12);color:#c4b5fd;">composition</span>
-                {{else if .Category}}<span class="badge" style="font-size:0.65rem;background:rgba(99,102,241,0.12);color:#a5b4fc;">{{.Category}}</span>{{end}}
-                {{if .Disabled}}<span class="badge" style="font-size:0.65rem;background:rgba(239,68,68,0.1);color:#fca5a5;">disabled</span>{{end}}
+                {{if .IsComposition}}<span class="badge badge-composition">composition</span>
+                {{else if .Category}}<span class="badge badge-category">{{.Category}}</span>{{end}}
+                {{if .Disabled}}<span class="badge badge-disabled">disabled</span>{{end}}
             </div>
-            {{if .Description}}<div class="wr-row2"><span style="color:var(--color-text-secondary);font-size:0.78rem;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;max-width:48rem;">{{.Description}}</span></div>{{end}}
-            <div class="wr-row2" style="margin-top:0.15rem;">
-                <span style="color:var(--color-text-muted);font-size:0.72rem;"><b>{{.StepCount}}</b> steps</span>
-                {{if .RunCount}}<span style="color:var(--color-text-muted);font-size:0.72rem;"><b>{{.RunCount}}</b> runs</span>{{end}}
-                {{range .Skills}}<span class="badge" style="font-size:0.65rem;background:rgba(34,211,238,0.1);color:#67e8f9;">{{.}}</span>{{end}}
+            {{if .Description}}<div class="wr-row2"><span class="pl-desc">{{.Description}}</span></div>{{end}}
+            <div class="wr-row2">
+                <span class="pl-meta"><b>{{.StepCount}}</b> steps</span>
+                {{if .RunCount}}<span class="pl-meta"><b>{{.RunCount}}</b> runs</span>{{end}}
+                {{range .Skills}}<span class="badge badge-skill">{{.}}</span>{{end}}
             </div>
         </div>
-        <div class="wr-meta" style="display:flex;flex-direction:column;align-items:flex-end;justify-content:center;gap:0.15rem;">
-            {{if .RunCount}}<span class="wr-date" style="font-size:0.68rem;">{{.RunCount}} runs</span>{{end}}
-            <button class="btn btn-sm" onclick="event.preventDefault();event.stopPropagation();showQuickStart('{{.Name}}')" style="font-size:0.65rem;padding:0.1rem 0.35rem;opacity:0.7;">run</button>
+        <div class="wr-meta">
+            {{if .RunCount}}<span class="wr-date">{{.RunCount}} runs</span>{{end}}
+            <button class="btn btn-sm pl-run-btn" onclick="event.preventDefault();event.stopPropagation();showQuickStart('{{.Name}}')">run</button>
         </div>
     </a>
 {{end}}
@@ -102,7 +129,7 @@ function populateAdapters(selectId) {
     }).catch(function(){});
 }
 
-// Combined category + text filtering
+// Category + text filtering
 function filterPipelines(btn) {
     document.querySelectorAll('.wr-filter').forEach(function(f) { f.classList.remove('active'); });
     btn.classList.add('active');
@@ -114,22 +141,13 @@ function applyFilters() {
     var q = (document.getElementById('pipeline-search') || {}).value || '';
     q = q.toLowerCase().trim();
     var list = document.getElementById('pipeline-list');
+    if (!list) return;
     var cards = Array.from(list.querySelectorAll('.wr-run'));
-    // Sort: frequent by run count desc, everything else alphabetical
-    if (activeCat === 'frequent') {
-        cards.sort(function(a, b) { return (parseInt(b.dataset.runs||'0',10)) - (parseInt(a.dataset.runs||'0',10)); });
-    } else {
-        cards.sort(function(a, b) { var na = a.querySelector('.wr-name'); var nb = b.querySelector('.wr-name'); return (na?na.textContent:'').localeCompare(nb?nb.textContent:''); });
-    }
+    cards.sort(function(a, b) { var na = a.querySelector('.wr-name'); var nb = b.querySelector('.wr-name'); return (na?na.textContent:'').localeCompare(nb?nb.textContent:''); });
     var visible = 0;
     cards.forEach(function(card) {
-        list.appendChild(card); // re-order in DOM
-        var catMatch;
-        if (activeCat === 'frequent') {
-            catMatch = parseInt(card.dataset.runs || '0', 10) > 0;
-        } else {
-            catMatch = !activeCat || card.dataset.category === activeCat;
-        }
+        list.appendChild(card);
+        var catMatch = !activeCat || card.dataset.category === activeCat;
         var textMatch = !q || card.textContent.toLowerCase().indexOf(q) !== -1;
         var show = catMatch && textMatch;
         card.style.display = show ? '' : 'none';
@@ -138,8 +156,28 @@ function applyFilters() {
     var countEl = document.getElementById('pipeline-count');
     if (countEl) countEl.textContent = visible + ' pipeline' + (visible !== 1 ? 's' : '');
 }
-// Apply "Frequent" filter on page load
 document.addEventListener('DOMContentLoaded', function() { applyFilters(); });
+
+// Frequent section collapse with localStorage persistence
+var FP_KEY = 'wave.fp.collapsed';
+function toggleFrequentSection() {
+    var section = document.getElementById('fp-section');
+    if (!section) return;
+    var header = section.querySelector('.rp-header');
+    var collapsed = section.classList.toggle('collapsed');
+    if (header) header.setAttribute('aria-expanded', String(!collapsed));
+    try { localStorage.setItem(FP_KEY, collapsed ? '1' : '0'); } catch(e) {}
+}
+(function(){
+    try {
+        if (localStorage.getItem(FP_KEY) === '1') {
+            var section = document.getElementById('fp-section');
+            var header = section && section.querySelector('.rp-header');
+            if (section) section.classList.add('collapsed');
+            if (header) header.setAttribute('aria-expanded', 'false');
+        }
+    } catch(e) {}
+})();
 
 // Quickstart dialog
 var quickStartPipeline = '';

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -27,6 +27,52 @@
     </div>
 </div>
 
+<!-- Running pipelines section -->
+<div class="rp-section">
+  <div class="rp-header" role="button" tabindex="0"
+       aria-expanded="true" aria-controls="rp-section-body"
+       onclick="toggleRunningSection()"
+       onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();event.preventDefault()}">
+    <span class="rp-label">Running</span>
+    <span class="rp-badge">{{.RunningCount}}</span>
+    <span class="rp-chevron">▾</span>
+  </div>
+  <div id="rp-section-body" class="rp-body">
+    {{if eq .RunningCount 0}}
+    <div class="rp-empty">
+      <p>No pipelines running</p>
+      <a href="/pipelines" class="rp-cta">Start a pipeline →</a>
+    </div>
+    {{else}}
+    <div class="rp-runs">
+    {{range .RunningRuns}}
+      <a href="/runs/{{.RunID}}" class="wr-run">
+        <div class="wr-accent st-{{.Status}}"></div>
+        <div class="wr-body">
+          <div class="wr-row1">
+            <span class="wr-name">{{.PipelineName}}</span>
+            {{if .InputPreview}}<span class="wr-input">{{richInput .InputPreview .LinkedURL}}</span>{{end}}
+            <span class="wr-right">
+              <span class="badge wr-status {{statusClass .Status}}">{{.Status}}</span>
+              {{if .Duration}}<span class="wr-dur">{{.Duration}}</span>{{end}}
+            </span>
+          </div>
+          <div class="wr-row2">
+            {{if gt .StepsTotal 0}}<span>{{.StepsCompleted}}/{{.StepsTotal}}</span>{{end}}
+            {{range .Models}}<span class="badge badge-model {{modelTierClass .}}">{{friendlyModel .}}</span>{{end}}
+            {{if .TotalTokens}}<span>{{formatTokens .TotalTokens}}</span>{{end}}
+            <span class="wr-right">
+              <span class="wr-date">{{.FormattedStartedAt}}</span>
+            </span>
+          </div>
+        </div>
+      </a>
+    {{end}}
+    </div>
+    {{end}}
+  </div>
+</div>
+
 <!-- Run list -->
 <div class="wr-list" id="run-list">
 {{if .Runs}}
@@ -95,6 +141,14 @@
 {{end}}
 {{define "scripts"}}
 <script>
+function toggleRunningSection() {
+    var section = document.querySelector('.rp-section');
+    var header = section.querySelector('.rp-header');
+    var body = document.getElementById('rp-section-body');
+    var expanded = header.getAttribute('aria-expanded') === 'true';
+    header.setAttribute('aria-expanded', String(!expanded));
+    section.classList.toggle('collapsed', expanded);
+}
 // Client-side search filter for run cards
 function filterRuns(query) {
     var q = query.toLowerCase().trim();

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -8,7 +8,6 @@
 <!-- Filters bar -->
 <div class="wr-toolbar">
     <div class="wr-filters">
-        <a href="/runs?status=running" class="wr-filter{{if eq .FilterStatus "running"}} active{{end}}">Running</a>
         <a href="/runs?status=completed" class="wr-filter{{if eq .FilterStatus "completed"}} active{{end}}">Completed</a>
         <a href="/runs?status=failed" class="wr-filter{{if eq .FilterStatus "failed"}} active{{end}}">Failed</a>
         <a href="/runs?status=cancelled" class="wr-filter{{if eq .FilterStatus "cancelled"}} active{{end}}">Cancelled</a>
@@ -29,13 +28,13 @@
 
 <!-- Running pipelines section -->
 <div class="rp-section">
-  <div class="rp-header" role="button" tabindex="0"
-       aria-expanded="true" aria-controls="rp-section-body"
+  <div class="rp-header{{if gt .RunningCount 0}} rp-header-clickable{{end}}"
+       {{if gt .RunningCount 0}}role="button" tabindex="0" aria-expanded="true" aria-controls="rp-section-body"
        onclick="toggleRunningSection()"
-       onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();event.preventDefault()}">
+       onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();event.preventDefault()}"{{end}}>
     <span class="rp-label">Running</span>
     <span class="rp-badge">{{.RunningCount}}</span>
-    <span class="rp-chevron">▾</span>
+    {{if gt .RunningCount 0}}<span class="rp-chevron">▾</span>{{end}}
   </div>
   <div id="rp-section-body" class="rp-body">
     {{if eq .RunningCount 0}}
@@ -141,14 +140,24 @@
 {{end}}
 {{define "scripts"}}
 <script>
+var RP_KEY = 'wave.rp.collapsed';
 function toggleRunningSection() {
     var section = document.querySelector('.rp-section');
     var header = section.querySelector('.rp-header');
-    var body = document.getElementById('rp-section-body');
-    var expanded = header.getAttribute('aria-expanded') === 'true';
-    header.setAttribute('aria-expanded', String(!expanded));
-    section.classList.toggle('collapsed', expanded);
+    var collapsed = section.classList.toggle('collapsed');
+    header.setAttribute('aria-expanded', String(!collapsed));
+    try { localStorage.setItem(RP_KEY, collapsed ? '1' : '0'); } catch(e) {}
 }
+(function(){
+    try {
+        if (localStorage.getItem(RP_KEY) === '1') {
+            var section = document.querySelector('.rp-section');
+            var header = section && section.querySelector('.rp-header');
+            if (section) { section.classList.add('collapsed'); }
+            if (header) { header.setAttribute('aria-expanded', 'false'); }
+        }
+    } catch(e) {}
+})();
 // Client-side search filter for run cards
 function filterRuns(query) {
     var q = query.toLowerCase().trim();

--- a/specs/772-webui-running-pipelines/checklists/accessibility.md
+++ b/specs/772-webui-running-pipelines/checklists/accessibility.md
@@ -1,0 +1,23 @@
+# Accessibility Requirements Quality Checklist
+
+**Feature**: `772-webui-running-pipelines`  
+**Checklist Type**: Accessibility Requirements Completeness  
+**Generated**: 2026-04-11
+
+Tests the quality of accessibility requirements for the running-pipelines section toggle
+and run card keyboard navigation.
+
+---
+
+## Completeness
+
+- [ ] CHK-A001 — Does FR-010 specify that `aria-controls` must reference the exact element ID of the collapsible body (`rp-section-body`), or is the target element ID left unspecified? [Completeness]
+- [ ] CHK-A002 — Does the spec define keyboard-operability for the run card links themselves (Tab focus order through cards, Enter to navigate)? FR-010 addresses the toggle control only. [Completeness]
+- [ ] CHK-A003 — Does the spec define accessible label text for the chevron icon (decorative vs. labelled) and the count badge (whether a screen reader should announce the number)? [Completeness]
+- [ ] CHK-A004 — Is there a requirement for focus management after the toggle action (where keyboard focus should remain after collapse/expand)? [Completeness]
+
+---
+
+## Clarity
+
+- [ ] CHK-A005 — Does SC-005 ("passes automated accessibility checks") specify which tool or standard (WCAG 2.1 AA, axe-core, etc.) defines "passing"? Without this, the success criterion is not measurable by an automated test. [Clarity]

--- a/specs/772-webui-running-pipelines/checklists/filter-behavior.md
+++ b/specs/772-webui-running-pipelines/checklists/filter-behavior.md
@@ -1,0 +1,22 @@
+# Filter Interaction Requirements Quality Checklist
+
+**Feature**: `772-webui-running-pipelines`  
+**Checklist Type**: Filter/Search Interaction Completeness  
+**Generated**: 2026-04-11
+
+Tests the quality of requirements for the pipeline-name filter's effect on the
+running-pipelines section (FR-008, SC-006).
+
+---
+
+## Completeness
+
+- [ ] CHK-F001 — Does FR-008 specify what the running-pipelines section must display when the active filter matches zero running runs — does it show the standard empty-state CTA (FR-005) or simply render an empty card list? [Completeness]
+- [ ] CHK-F002 — Does FR-009 (section header count badge) specify whether the displayed count reflects the filtered count or the total running count when a pipeline-name filter is active? [Completeness]
+
+---
+
+## Clarity
+
+- [ ] CHK-F003 — Does SC-006 define "reduces the running-pipelines section to show only matching active runs" precisely enough to be testable? Does "reduces" mean the section can reach zero cards (triggering empty-state) or only that non-matching cards are hidden? [Clarity]
+- [ ] CHK-F004 — Does the spec clarify whether the pipeline-name filter is applied server-side (new request) or client-side (DOM filter)? FR-008 says the section "must respect" the filter but does not define the mechanism, which affects how the filter requirement is tested. [Clarity]

--- a/specs/772-webui-running-pipelines/checklists/requirements.md
+++ b/specs/772-webui-running-pipelines/checklists/requirements.md
@@ -1,0 +1,61 @@
+# Requirements Quality Checklist: 772-webui-running-pipelines
+
+## Specification Quality
+
+- [x] Feature name is descriptive and matches branch name
+- [x] Feature branch is specified correctly (`772-webui-running-pipelines`)
+- [x] Created date is set
+- [x] Status is set to Draft
+
+## User Stories
+
+- [x] At least 3 user stories defined
+- [x] Each story has a priority (P1/P2/P3)
+- [x] Each story describes a complete user journey, not just a feature
+- [x] Each story is independently testable
+- [x] Each story explains WHY it has its priority level
+- [x] Acceptance scenarios use Given/When/Then format
+- [x] Acceptance scenarios are unambiguous and testable
+- [x] No implementation details in user stories (no "click a div", no JS function names)
+
+## Edge Cases
+
+- [x] At least 3 edge cases documented
+- [x] Edge cases cover boundary conditions (zero items, many items)
+- [x] Edge cases cover error/transition states
+- [x] Filter interaction edge case covered
+- [x] Mobile/viewport edge case covered
+
+## Functional Requirements
+
+- [x] At least 5 functional requirements defined
+- [x] Each requirement uses "MUST" for mandatory behavior
+- [x] Each requirement is independently testable
+- [x] No implementation details (no HTML/CSS class names, no function names)
+- [x] Requirements are technology-agnostic where possible
+- [x] Accessibility requirement included (FR-010)
+- [x] No more than 3 `[NEEDS CLARIFICATION]` markers (actual: 2)
+
+## Key Entities
+
+- [x] Key entities section present (feature involves data)
+- [x] Entities describe WHAT and WHY, not HOW
+- [x] Relationships between entities described
+
+## Success Criteria
+
+- [x] At least 4 success criteria defined
+- [x] Each criterion is measurable (quantified with %, count, or boolean pass/fail)
+- [x] Criteria are technology-agnostic
+- [x] Criteria cover the main user stories (visibility, default state, navigation, empty state, accessibility, filter)
+
+## Overall Quality
+
+- [x] Spec focuses on WHAT and WHY, not HOW
+- [x] No references to specific Go templates, JavaScript functions, or CSS classes
+- [x] All placeholders from template replaced with real content
+- [x] Feature request fully covered by stories + requirements
+
+## Validation Result
+
+**PASS** — All checklist items satisfied. Spec is complete and ready for planning.

--- a/specs/772-webui-running-pipelines/checklists/review.md
+++ b/specs/772-webui-running-pipelines/checklists/review.md
@@ -1,0 +1,48 @@
+# Requirements Quality Review Checklist
+
+**Feature**: `772-webui-running-pipelines`  
+**Checklist Type**: Overall Requirements Quality  
+**Generated**: 2026-04-11
+
+Tests the quality of requirements, not the implementation.
+Each item is a unit-test assertion about requirement completeness, clarity, consistency, or coverage.
+
+---
+
+## Completeness
+
+- [ ] CHK001 — Are all acceptance scenarios for User Story 3 (empty state) aligned with FR-005? Does FR-005 specify both the placeholder message AND the CTA element, or only one? [Completeness]
+- [ ] CHK002 — Is the CTA destination URL (`/pipelines`) formally encoded in a functional requirement (FR-005), or does it exist only in implementation artifacts (plan.md, template task T010)? [Completeness]
+- [ ] CHK003 — Are error states defined for a failure of the secondary `ListRuns(status=running)` query (e.g., store unavailability)? [Completeness]
+- [ ] CHK004 — Are the exact data fields displayed on each running run card specified (pipeline name, status badge, progress %, duration) as a requirement, or only inferred from "same visual pattern as main runs list"? [Completeness]
+- [ ] CHK005 — Does the spec define whether sub-runs (child runs with `ParentRunID != ""`) are excluded from the running-pipelines section as a stated requirement, or is this an unspecified implementation detail? [Completeness]
+
+---
+
+## Clarity
+
+- [ ] CHK006 — Is "expanded by default on every page load" in FR-002 unambiguous about whether this applies to all page loads or only the first? (US2-AC3 says collapse is NOT persisted, which implies every load — are spec + story consistent in wording?) [Clarity]
+- [ ] CHK007 — Is "same run card visual pattern as the main runs list" in FR-004 precise enough to be testable without ambiguity? Does it define which specific visual attributes must match? [Clarity]
+- [ ] CHK008 — Does FR-009 specify the exact label text ("Running") as normative, or is "or equivalent" an intentional implementation choice left to the developer? [Clarity]
+- [ ] CHK009 — Does FR-010 explicitly list both `aria-expanded` AND `aria-controls` attribute names, and their expected values at initial load? Or are "appropriate ARIA attributes" underspecified? [Clarity]
+- [ ] CHK010 — Does FR-008 explicitly define the filter's behavior when no filter is active (i.e., all running runs are shown, unfiltered)? Or is the default (no filter = show all) only implied? [Clarity]
+
+---
+
+## Consistency
+
+- [ ] CHK011 — Does FR-007 (completed/failed card navigation) add a distinct requirement beyond FR-006 (all run cards are navigable links), or is it redundant? If redundant, does the duplication create ambiguity about whether only running-status cards are navigable? [Consistency]
+- [ ] CHK012 — Is the "expanded by default" invariant in FR-002 consistent with SC-002 (100% of page loads)? Do both use identical scope language, or is one stricter? [Consistency]
+- [ ] CHK013 — Does FR-008's filter requirement for the running section match the edge-case statement that "the running-pipelines section should reflect the filter"? Is "reflect" (edge case) and "respect" (FR-008) used consistently? [Consistency]
+- [ ] CHK014 — Is CL-001 (page-reload-only updates) consistently reflected in all relevant acceptance scenarios? Does US3-AC3 avoid implying real-time behavior, and do all story scenarios align with this constraint? [Consistency]
+- [ ] CHK015 — Are the run card fields listed in the `RunSummary` entity (`RunID`, `PipelineName`, `Status`, `Progress`, `StepsCompleted`, `StepsTotal`, `Duration`, `FormattedStartedAt`) consistent with what "same visual pattern as main runs list" (FR-004) would render? Is there a formal mapping? [Consistency]
+
+---
+
+## Coverage
+
+- [ ] CHK016 — Are all 4 user stories (US1–US4) traceable to at least one functional requirement (FR-001–FR-010) AND at least one success criterion (SC-001–SC-006)? [Coverage]
+- [ ] CHK017 — Is the mobile/responsive behavior formally specified as a functional requirement, or does it only appear in the edge-cases section? If only edge-case, is it explicitly accepted as out-of-scope for v1? [Coverage]
+- [ ] CHK018 — Is the filter interaction from FR-008 covered by a dedicated success criterion? SC-006 addresses filter behavior — does SC-006 define what happens when a filter is applied but zero running runs match (empty-state vs. empty section)? [Coverage]
+- [ ] CHK019 — Does the spec formally require or define the behavior for running runs appearing in BOTH the running-pipelines section AND the main runs list simultaneously? The edge-case mentions it but no FR mandates the duplication policy. [Coverage]
+- [ ] CHK020 — Is there a requirement or success criterion covering the section's behavior when the running count changes between the time the page is rendered and when the user reads it (stale state, per CL-001)? [Coverage]

--- a/specs/772-webui-running-pipelines/contracts/handler-data-contract.md
+++ b/specs/772-webui-running-pipelines/contracts/handler-data-contract.md
@@ -1,0 +1,36 @@
+# Contract: handleRunsPage Template Data
+
+**Type**: Structural (Go template data contract)  
+**Feature**: `772-webui-running-pipelines`
+
+## Description
+
+The `handleRunsPage` handler in `internal/webui/handlers_runs.go` must populate
+the following template data struct fields for the running-pipelines section to
+render correctly.
+
+## Required Fields (additions to existing struct)
+
+```go
+RunningRuns  []RunSummary  // must be non-nil (empty slice when no running runs)
+RunningCount int           // must equal len(RunningRuns)
+```
+
+## Invariants
+
+1. `RunningRuns` contains ONLY runs with `Status == "running"`.
+2. `RunningCount == len(RunningRuns)` always (no discrepancy).
+3. `RunningRuns` respects `FilterPipeline` — if `FilterPipeline != ""`, only
+   runs matching that pipeline name are included.
+4. `RunningRuns` does NOT respect `FilterStatus` — the section always shows
+   running runs regardless of the active status tab.
+5. Each entry in `RunningRuns` has been processed by `enrichRunSummaries` so
+   `Progress`, `StepsCompleted`, `StepsTotal`, `Models`, `TotalTokens` are
+   populated.
+6. `RunningRuns` does NOT contain child runs (top-level runs only — `ParentRunID == ""`).
+
+## Verification
+
+- Unit test: `TestHandleRunsPage_RunningSection` in `handlers_runs_test.go`
+- Checks: `RunningRuns` populated when running runs exist, empty slice (not nil)
+  when no running runs, `RunningCount` matches len.

--- a/specs/772-webui-running-pipelines/contracts/template-rendering-contract.md
+++ b/specs/772-webui-running-pipelines/contracts/template-rendering-contract.md
@@ -1,0 +1,64 @@
+# Contract: runs.html Template Rendering
+
+**Type**: Behavioral (template output contract)  
+**Feature**: `772-webui-running-pipelines`
+
+## Description
+
+The `runs.html` Go template, when rendered with the extended template data,
+must produce HTML output conforming to these structural requirements for the
+running-pipelines section.
+
+## Required HTML Structure
+
+```html
+<!-- Section container — always present in page output -->
+<div class="rp-section" id="rp-section">
+
+  <!-- Header — always rendered, always keyboard-accessible -->
+  <div class="rp-header"
+       id="rp-section-header"
+       role="button"
+       tabindex="0"
+       aria-expanded="true"
+       aria-controls="rp-section-body"
+       onclick="toggleRunningSection()"
+       onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();}">
+    <span class="rp-label">Running</span>
+    <span class="rp-badge" aria-label="N running pipelines">N</span>
+    <span class="rp-chevron" aria-hidden="true">▾</span>
+  </div>
+
+  <!-- Body — hidden attribute removed/added by toggleRunningSection() -->
+  <div class="rp-body" id="rp-section-body">
+
+    <!-- CASE A: No running pipelines -->
+    <div class="rp-empty">
+      <!-- Message text present -->
+      <a href="/pipelines" class="rp-cta"><!-- CTA text present --></a>
+    </div>
+
+    <!-- CASE B: Running pipelines present (one per RunSummary) -->
+    <a href="/runs/{RunID}" class="wr-run">
+      <!-- Same card structure as main list -->
+    </a>
+
+  </div>
+</div>
+```
+
+## Invariants
+
+1. `.rp-section` is always present in the rendered output (SC-001).
+2. On initial render, `aria-expanded="true"` and body does NOT have `hidden` attribute (SC-002).
+3. When `RunningCount > 0`: each `RunSummary` in `RunningRuns` produces exactly one
+   `<a href="/runs/{RunID}" class="wr-run">` element in `.rp-body` (SC-003).
+4. When `RunningCount == 0`: `.rp-empty` is rendered and contains exactly one `<a class="rp-cta">` (SC-004).
+5. `aria-expanded` value matches the actual expanded/collapsed state of `.rp-body` (SC-005).
+6. The `.rp-section` block appears AFTER `.wr-toolbar` and BEFORE `.wr-list` in document order (FR-001).
+
+## Verification
+
+- Visual inspection of rendered `/runs` page in browser
+- Accessibility check: `aria-expanded` reflects state, Enter/Space operable
+- Template test: parse rendered HTML and assert structural invariants

--- a/specs/772-webui-running-pipelines/data-model.md
+++ b/specs/772-webui-running-pipelines/data-model.md
@@ -1,0 +1,153 @@
+# Data Model: Expandable Running Pipelines Section
+
+**Feature**: `772-webui-running-pipelines`  
+**Phase**: 1 — Design & Contracts  
+**Date**: 2026-04-11
+
+## Overview
+
+This feature adds a read-only UI section to the runs overview. No new persistent data types are
+introduced. The implementation extends the existing `handleRunsPage` template data struct with
+a pre-filtered slice of running runs and a count.
+
+---
+
+## Existing Entities (unchanged)
+
+### RunSummary (`internal/webui/types.go:17`)
+
+The central entity for all run list views. The running-pipelines section is a **filtered view**
+of this type — no new struct required.
+
+| Field | Type | Used by running section |
+|-------|------|------------------------|
+| `RunID` | `string` | Link href: `/runs/{RunID}` |
+| `PipelineName` | `string` | Card title, filter match |
+| `Status` | `string` | Always `"running"` in this section |
+| `Progress` | `int` | Step progress bar (0–100) |
+| `StepsCompleted` | `int` | `N/M` display in row 2 |
+| `StepsTotal` | `int` | `N/M` display in row 2 |
+| `Duration` | `string` | Duration in row 1 right |
+| `FormattedStartedAt` | `string` | Timestamp in row 2 right |
+| `InputPreview` | `string` | Optional input preview in row 1 |
+| `LinkedURL` | `string` | Optional GitHub link in row 1 |
+| `Models` | `[]string` | Model tier badge in row 2 |
+| `TotalTokens` | `int` | Token count in row 2 |
+| `ChildRuns` | `[]RunSummary` | Not rendered in running section (child runs excluded) |
+
+### state.ListRunsOptions (`internal/state/types.go`)
+
+Used to query the database for runs. The running-section query uses:
+
+| Field | Value |
+|-------|-------|
+| `Status` | `"running"` (always, regardless of page status filter) |
+| `PipelineName` | `pipelineFilter` from query param (respects FR-008) |
+| `Limit` | `0` — no pagination for running section (unbounded, CL-002) |
+
+---
+
+## Template Data Extension
+
+The anonymous `data` struct in `handleRunsPage` gains two fields:
+
+```go
+data := struct {
+    ActivePage     string
+    Runs           []RunSummary  // main list (existing)
+    HasMore        bool
+    NextCursor     string
+    Pipelines      []string
+    FilterStatus   string
+    FilterPipeline string
+    // NEW:
+    RunningRuns  []RunSummary  // filtered to status=running, respects pipeline filter
+    RunningCount int           // len(RunningRuns), pre-computed for header badge
+}{...}
+```
+
+**Why `RunningRuns` is separate from `Runs`**:
+- `Runs` reflects the user's status filter tab (may be "completed", "failed", etc.)
+- `RunningRuns` always shows currently running pipelines regardless of tab
+- Avoids template-side filtering (Go templates have no `filter` function)
+
+**`RunningCount` is pre-computed** because Go templates cannot call `len()` on slices without
+a custom template function. Pre-computing avoids adding a new template func.
+
+---
+
+## UI State Model
+
+The running-pipelines section has **transient** (not persisted) UI state:
+
+| State | Type | Initial Value | Storage |
+|-------|------|---------------|---------|
+| `expanded` | bool | `true` | DOM attribute `aria-expanded` on header |
+
+The collapsed/expanded state is toggled by `toggleRunningSection()` in inline JS and reset to
+`true` on every page load (FR-002). No `localStorage` involvement (contrast with sidebar nav
+groups which persist collapse state).
+
+---
+
+## Empty-State Entity
+
+When `RunningCount == 0`, the section renders an empty-state placeholder. No struct needed —
+rendered directly in the template as a conditional block:
+
+```html
+{{if eq .RunningCount 0}}
+<div class="rp-empty">
+    <p>No pipelines running</p>
+    <a href="/pipelines" class="rp-cta">Start a pipeline →</a>
+</div>
+{{else}}
+... run cards ...
+{{end}}
+```
+
+---
+
+## CSS Classes (new, to be added to style.css)
+
+| Class | Element | Purpose |
+|-------|---------|---------|
+| `.rp-section` | `<div>` wrapper | Container for the entire running section |
+| `.rp-header` | `<div>` header | Clickable header with label, badge, chevron |
+| `.rp-label` | `<span>` | "Running" label text |
+| `.rp-badge` | `<span>` | Count badge (styled like existing `.badge`) |
+| `.rp-chevron` | `<span>` | Collapse/expand chevron indicator (▾/▸) |
+| `.rp-body` | `<div>` | Collapsible content area |
+| `.rp-empty` | `<div>` | Empty-state placeholder |
+| `.rp-cta` | `<a>` | CTA link in empty state |
+
+**Design note**: Run cards inside `.rp-body` reuse `.wr-run`, `.wr-accent`, `.wr-body`, etc.
+unchanged — the running section is visually consistent with the main list.
+
+---
+
+## Data Flow
+
+```
+GET /runs?pipeline=<name>&status=<tab>
+         ↓
+handleRunsPage()
+    ├─ pipelineFilter = r.URL.Query().Get("pipeline")
+    ├─ status = r.URL.Query().Get("status") || "all"
+    │
+    ├─ [NEW] runningOpts = ListRunsOptions{Status:"running", PipelineName: pipelineFilter}
+    ├─ [NEW] runningRecs = s.store.ListRuns(runningOpts)
+    ├─ [NEW] runningRuns = enrichRunSummaries(runningRecs)  // step progress, models, tokens
+    │
+    ├─ mainOpts = ListRunsOptions{Status: queryStatus, PipelineName: pipelineFilter, ...}
+    ├─ runs = s.store.ListRuns(mainOpts)
+    ├─ summaries = nestChildRuns(enrichRunSummaries(runs))
+    │
+    └─ render runs.html with data{RunningRuns: runningRuns, RunningCount: len, Runs: summaries, ...}
+         ↓
+    runs.html
+    ├─ [NEW] rp-section (above wr-list)
+    │   ├─ rp-header: "Running" label + count badge + chevron
+    │   └─ rp-body: run cards or empty-state
+    └─ wr-list (existing main list, unchanged)
+```

--- a/specs/772-webui-running-pipelines/plan.md
+++ b/specs/772-webui-running-pipelines/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Expandable Running Pipelines Section
+
+**Branch**: `772-webui-running-pipelines` | **Date**: 2026-04-11 | **Spec**: `specs/772-webui-running-pipelines/spec.md`  
+**Input**: Feature specification from `specs/772-webui-running-pipelines/spec.md`
+
+## Summary
+
+Add an expandable "Running Pipelines" section to the runs overview (`/runs`) that sits between
+the filter toolbar and the main run list. The section is always visible, expanded by default,
+shows an empty-state CTA when no runs are active, and respects the pipeline-name filter.
+Implementation is pure SSR: one additional `store.ListRuns(status=running)` query in the page
+handler, two new template fields, a new `rp-section` block in `runs.html`, and new CSS classes
+in `style.css`. No new routes, no JavaScript frameworks, no new data types.
+
+## Technical Context
+
+**Language/Version**: Go 1.23+  
+**Primary Dependencies**: `html/template` (stdlib), `net/http` (stdlib)  
+**Storage**: SQLite via `internal/state` — read-only `ListRuns` query  
+**Testing**: `go test ./...` — existing `handlers_runs_test.go`  
+**Target Platform**: Web browser (served by Wave's embedded HTTP server)  
+**Project Type**: Single Go binary with embedded web UI  
+**Performance Goals**: No new N+1 queries; running section query is O(running-runs count), typically low  
+**Constraints**: SSR only (no new fetch/SSE); vanilla JS inline in template; no new dependencies  
+**Scale/Scope**: Single operator, low concurrency ceiling; unbounded display (CL-002)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | No new runtime deps; vanilla JS inline in template |
+| P2: Manifest as SSOT | N/A | No manifest changes; pure UI feature |
+| P3: Persona-Scoped Execution | N/A | UI-only; no persona/pipeline changes |
+| P4: Fresh Memory | N/A | UI-only |
+| P5: Navigator-First | N/A | UI-only |
+| P6: Contracts at Handover | PASS | Contracts defined in `contracts/` directory |
+| P7: Relay | N/A | UI-only |
+| P8: Ephemeral Workspaces | N/A | UI-only |
+| P9: Credentials | N/A | UI-only; no credentials touched |
+| P10: Observable Progress | N/A | UI-only; no pipeline state changes |
+| P11: Bounded Recursion | N/A | UI-only |
+| P12: Step State Machine | N/A | UI-only |
+| P13: Test Ownership | PASS | `handlers_runs_test.go` must be extended; `go test ./...` required |
+
+**Verdict**: No constitution violations. Feature is a pure UI change with no impact on
+pipeline execution, personas, contracts, or manifest.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/772-webui-running-pipelines/
+├── plan.md                                    # This file
+├── spec.md                                    # Feature specification
+├── research.md                                # Phase 0 research findings
+├── data-model.md                              # Phase 1 data model
+├── contracts/
+│   ├── handler-data-contract.md              # handleRunsPage data struct invariants
+│   └── template-rendering-contract.md        # runs.html output structure invariants
+├── checklists/
+│   └── requirements.md                       # Requirements checklist (from specify step)
+└── tasks.md                                   # Phase 2 output (not yet created)
+```
+
+### Source Code (files to modify)
+
+```
+internal/webui/
+├── handlers_runs.go         # Add running runs query + extend template data struct
+├── templates/
+│   └── runs.html            # Insert rp-section block between toolbar and wr-list
+├── static/
+│   └── style.css            # Add .rp-section, .rp-header, .rp-body, .rp-empty CSS
+└── handlers_runs_test.go    # Add TestHandleRunsPage_RunningSection test cases
+```
+
+**Structure Decision**: Single Go project, standard wave webui layout. All changes are
+confined to `internal/webui/` — no new files, only modifications to existing source.
+
+## Complexity Tracking
+
+_No constitution violations — table not applicable._
+
+## Implementation Phases
+
+### Phase 0 — Research (Complete)
+
+See `research.md`. Key findings:
+- Collapse/expand pattern: reuse `step_card.html` inline-JS approach with `aria-expanded`
+- Data access: second `ListRuns(status=running)` in handler (SSR, no client fetch)
+- Filter integration: apply `pipelineFilter` to running query; ignore status tab
+- Accessibility: `role="button"`, `tabindex="0"`, Enter/Space keyboard handler
+- CSS: new `.rp-*` classes; run cards reuse existing `.wr-run` classes unchanged
+- Empty-state CTA: link to `/pipelines`
+
+### Phase 1 — Design & Contracts (Complete)
+
+See `data-model.md` and `contracts/`.
+
+**Template data extension**:
+```go
+// Added to anonymous struct in handleRunsPage
+RunningRuns  []RunSummary  // always non-nil; filtered to status=running + pipeline filter
+RunningCount int           // == len(RunningRuns)
+```
+
+**Handler change** (`handlers_runs.go`):
+1. After parsing `pipelineFilter`, execute a second `s.store.ListRuns` with
+   `Status: "running"`, `PipelineName: pipelineFilter`, `Limit: 0` (unbounded).
+2. Convert results to `[]RunSummary`, enrich with `s.enrichRunSummaries`.
+3. Filter to top-level only (`ParentRunID == ""`).
+4. Assign to `RunningRuns`; compute `RunningCount`.
+
+**Template change** (`runs.html`):
+- Insert `<div class="rp-section">` block after `</div>` closing `.wr-toolbar` and
+  before `<div class="wr-list">`.
+- Header: `role="button"`, `aria-expanded="true"`, `aria-controls="rp-section-body"`,
+  toggle JS inline.
+- Body: conditional on `RunningCount` — empty-state CTA or run cards using existing
+  `.wr-run` card markup.
+- Toggle function `toggleRunningSection()` added to `{{define "scripts"}}` block.
+
+**CSS change** (`style.css`):
+- `.rp-section`: margin-bottom spacing matching `.wr-toolbar`.
+- `.rp-header`: flex row, cursor pointer, hover state matching existing interactive elements.
+- `.rp-badge`: inherits `.badge` base styles, uses `--color-running` background.
+- `.rp-chevron`: rotates 90° when collapsed (CSS transform via `.rp-section.collapsed`).
+- `.rp-body`: no special styles beyond default block display.
+- `.rp-empty`: centered flex column, muted text color, spacing.
+- `.rp-cta`: styled as a secondary button/link.
+
+### Phase 2 — Tasks (Pending)
+
+`tasks.md` to be generated by `/speckit.tasks` command.

--- a/specs/772-webui-running-pipelines/research.md
+++ b/specs/772-webui-running-pipelines/research.md
@@ -1,0 +1,140 @@
+# Research: Expandable Running Pipelines Section
+
+**Feature**: `772-webui-running-pipelines`  
+**Phase**: 0 — Outline & Research  
+**Date**: 2026-04-11
+
+## Summary
+
+This feature adds an expandable "Running Pipelines" section to the runs overview page (`/runs`).
+The section sits between the filter/search toolbar and the main run list. Research covers four
+areas: existing collapse/expand patterns, data-access patterns for running runs, filter
+integration, and accessibility requirements.
+
+---
+
+## Finding 1: Collapse/Expand Pattern
+
+**Decision**: Reuse the `step_card.html` inline-JS toggle pattern.
+
+**Rationale**: `step_card.html` already establishes the project's expand/collapse idiom with
+`role="button"`, `tabindex="0"`, `aria-expanded`, `aria-controls`, `onclick`, and `onkeydown`
+handlers — all inline vanilla JS, no dependencies. The sidebar uses `localStorage` for
+persistence, but FR-002 explicitly requires collapse state NOT to be persisted across page
+loads. A simple `data-expanded` attribute on the section container is sufficient.
+
+**Implementation pattern** (from `step_card.html`):
+```html
+<div id="rp-section-header"
+     role="button" tabindex="0"
+     aria-expanded="true"
+     aria-controls="rp-section-body"
+     onclick="toggleRunningSection()"
+     onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();}">
+```
+
+**Alternatives rejected**:
+- `<details>/<summary>` HTML element: accessible by default, but cross-browser `open` attribute
+  styling is inconsistent with the existing design language, and overriding the default triangle
+  requires non-trivial CSS resets. Not used anywhere else in the codebase.
+- CSS-only checkbox hack: no JavaScript, but harder to manage `aria-expanded` synchronisation
+  and inconsistent with the rest of the UI.
+
+---
+
+## Finding 2: Running Runs Data Access
+
+**Decision**: Fetch running runs in `handleRunsPage` using `state.ListRunsOptions{Status: "running"}`.
+
+**Rationale**: `handleRunsPage` already accepts a `status` query parameter and converts it to
+`ListRunsOptions.Status` for the DB query. Adding a second parallel query for `status=running`
+(ignoring the user-supplied status filter for the section data, then applying it in Go) is the
+minimal change: one extra `s.store.ListRuns()` call at handler start, before the main list
+query. No new API endpoints, no client-side fetch, no SSE (CL-001 resolved as page-reload-only).
+
+**Template data extension**: The handler's anonymous `data` struct gains two fields:
+- `RunningRuns []RunSummary` — running-only subset (post-enrichment, pre-nesting)
+- `RunningCount int` — `len(RunningRuns)` for the header badge
+
+**Alternatives rejected**:
+- Separate `/api/runs?status=running` fetch in JavaScript: requires client-side fetch on page
+  load, adds latency, inconsistent with the SSR pattern used for all other list data.
+- Reusing the existing `Runs` field filtered in the template: Go templates cannot filter slices;
+  would require a custom template function, which is more invasive than a handler change.
+
+---
+
+## Finding 3: Pipeline-Name Filter Integration (FR-008)
+
+**Decision**: Apply `FilterPipeline` to the running runs query in the handler.
+
+**Rationale**: The existing filter bar sends `?pipeline=<name>` as a query parameter. The
+`handleRunsPage` handler already reads `pipelineFilter := r.URL.Query().Get("pipeline")` and
+passes it to `ListRunsOptions.PipelineName`. The running-runs query should use the same
+`pipelineFilter` value so the section respects the active filter. Status filter tabs are
+irrelevant for the running section (it always shows running runs), but pipeline-name filter
+applies. The `FilterStatus` tabs change the main list view; they should NOT suppress the running
+section (the section always shows running runs regardless of which status tab is active).
+
+**Alternatives rejected**:
+- Client-side filtering in JS after page load: inconsistent with server-side filtering approach;
+  the existing `filterRuns()` JS function is for the in-page text-search input only, not
+  server-side pipeline filter.
+
+---
+
+## Finding 4: Accessibility (FR-010)
+
+**Decision**: Follow the `step_card.html` pattern — `role="button"`, `tabindex="0"`,
+`aria-expanded`, `aria-controls`, keyboard handler for Enter/Space.
+
+**Rationale**: This is already the established accessible pattern in the codebase. The section
+body `<div>` gets `id="rp-section-body"` so `aria-controls` on the header can reference it.
+`aria-expanded` is toggled by the inline JS function.
+
+**Count badge** (FR-009): `aria-label="N running pipelines"` on the badge span is sufficient.
+
+**Empty state CTA** (FR-005): Standard `<a href="/pipelines">` link — native link semantics,
+keyboard-accessible by default.
+
+---
+
+## Finding 5: CSS / Styling
+
+**Decision**: Reuse existing `.wr-*` CSS classes with a new `.rp-section` wrapper; no new
+CSS classes for the run cards themselves.
+
+**Rationale**: The existing `.wr-run`, `.wr-accent`, `.wr-body`, `.wr-row1`, `.wr-row2`,
+`.wr-name`, `.wr-status`, `.wr-dur`, `.wr-date` classes (and their `.st-running` status
+variant) already provide correct run card styling. The section needs only a container with a
+header and a collapsible body. New CSS needed: `.rp-section` container, `.rp-header` with
+toggle chevron, `.rp-body[hidden]` for collapsed state.
+
+**Collapsed state**: Use `hidden` attribute on body `<div>` — CSS `[hidden] { display: none }`
+is standard and requires no extra CSS. Toggled via JS: `el.hidden = !el.hidden`.
+
+---
+
+## Finding 6: Empty-State CTA Destination
+
+**Decision**: Link to `/pipelines` page.
+
+**Rationale**: The empty-state CTA (FR-005, US-3) should direct users where they can start a
+pipeline run. Wave's webui has a `/pipelines` route (routes.go) that lists available pipelines.
+Clicking a pipeline on that page presents the start-run form. This is the natural starting point
+for initiating a new run, and it exists in the current codebase.
+
+**Alternatives rejected**:
+- Direct "Run pipeline" button that POSTs to `/api/runs`: requires knowing the pipeline name and
+  input upfront; inappropriate in an empty state.
+
+---
+
+## File Impact Summary
+
+| File | Change Type | Reason |
+|------|-------------|--------|
+| `internal/webui/handlers_runs.go` | Modify | Add second `ListRuns` query for running runs; extend template data struct |
+| `internal/webui/templates/runs.html` | Modify | Insert `rp-section` block between toolbar and `wr-list`; add toggle JS |
+| `internal/webui/static/style.css` | Modify | Add `.rp-section`, `.rp-header`, `.rp-body`, `.rp-empty` styles |
+| `internal/webui/handlers_runs_test.go` | Modify | Add test cases for running section data (RunningRuns field) |

--- a/specs/772-webui-running-pipelines/spec.md
+++ b/specs/772-webui-running-pipelines/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Expandable Running Pipelines Section
+
+**Feature Branch**: `772-webui-running-pipelines`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "feat(webui): add expandable running-pipelines section to runs overview — expandable section sits below filter/search bar, expanded by default on first load, shows placeholder CTA when no pipelines running, clicking completed/failed runs navigates to run detail"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - View Active Pipelines at a Glance (Priority: P1)
+
+An operator opens the runs overview page and immediately sees all currently running pipelines in a dedicated section at the top, without having to scroll through completed or failed runs. This gives instant situational awareness of live work.
+
+**Why this priority**: The most critical value proposition is surfacing active work instantly. Operators need to know what is happening right now without filtering or scrolling.
+
+**Independent Test**: Load the runs overview page while at least one pipeline is running. The running pipelines section renders at the top, below the filter bar, with all active runs listed. Delivers value as a standalone feature: users can monitor active pipelines independently of any other story.
+
+**Acceptance Scenarios**:
+
+1. **Given** at least one pipeline has status `running`, **When** the user navigates to the runs overview (`/runs`), **Then** the running-pipelines section is visible below the filter/search bar and displays all pipelines with status `running`.
+2. **Given** the runs overview page has loaded, **When** the running-pipelines section is present, **Then** it is expanded by default (i.e., the run cards are visible without any user interaction).
+3. **Given** multiple pipelines are running, **When** the section renders, **Then** each running pipeline is shown as a card consistent with the existing run card layout (pipeline name, status badge, progress, duration).
+
+---
+
+### User Story 2 - Collapse/Expand Running Pipelines Section (Priority: P2)
+
+An operator who already knows what is running wants to focus on completed or failed runs below. They can collapse the running-pipelines section to reclaim vertical space and expand it again when needed.
+
+**Why this priority**: Secondary to visibility — once you have the section, the ability to manage screen real estate is important but not blocking core value.
+
+**Independent Test**: With the running-pipelines section visible and expanded, click the section header toggle. The section collapses (run cards hidden, only header visible). Click again to expand. Works independently of navigation or CTA stories.
+
+**Acceptance Scenarios**:
+
+1. **Given** the running-pipelines section is expanded, **When** the user clicks the section header/toggle control, **Then** the section collapses and the run cards are hidden.
+2. **Given** the running-pipelines section is collapsed, **When** the user clicks the section header/toggle control, **Then** the section expands and the run cards become visible.
+3. **Given** the user has collapsed the section and refreshes the page, **Then** the section is expanded by default again (collapse state is NOT persisted across page loads — first-load default is always expanded).
+
+---
+
+### User Story 3 - Empty State: No Running Pipelines (Priority: P3)
+
+An operator opens the runs overview when no pipelines are currently running. The running-pipelines section still appears but shows a clear placeholder that communicates the idle state and provides a call-to-action (CTA) to start a pipeline.
+
+**Why this priority**: Required for completeness and avoids a confusing blank section, but the empty state delivers less operational value than the populated section.
+
+**Independent Test**: Load the runs overview when zero pipelines have status `running`. The section renders with an empty-state placeholder message and a CTA element (e.g., a link or button to trigger a pipeline). Can be tested independently by clearing all active runs.
+
+**Acceptance Scenarios**:
+
+1. **Given** no pipeline has status `running`, **When** the user loads the runs overview, **Then** the running-pipelines section is visible and expanded, displaying an empty-state placeholder (not an empty card list).
+2. **Given** the empty-state placeholder is shown, **When** the user views it, **Then** a CTA is present that links to a path where the user can initiate a new pipeline run (e.g., the pipelines list or a trigger endpoint).
+3. **Given** pipelines transition from running to completed during the session, **When** the last running pipeline finishes, **Then** the section updates to show the empty-state placeholder on the next page reload (no real-time SSE update in v1 — the existing SSE infrastructure targets single run detail pages only, not the runs overview list).
+
+---
+
+### User Story 4 - Navigate to Run Detail from Running Section (Priority: P2)
+
+An operator sees a completed or failed run card (which may briefly appear in the running section during transition) and clicks it to navigate to the run detail page for investigation.
+
+**Why this priority**: Navigation to detail is fundamental to the workflow — operators need to inspect results. Ranked P2 alongside collapse because detail navigation is equally important to usability.
+
+**Independent Test**: Click any run card within the running-pipelines section. Browser navigates to `/runs/{runID}`. Works independently — verifiable with any run card that has a valid run ID.
+
+**Acceptance Scenarios**:
+
+1. **Given** the running-pipelines section shows run cards, **When** the user clicks a run card, **Then** the browser navigates to `/runs/{runID}` (the run detail page for that run).
+2. **Given** a run card in the section has status `completed` or `failed` (e.g., visible during a status transition), **When** the user clicks it, **Then** navigation to `/runs/{runID}` succeeds and shows the completed/failed run detail.
+3. **Given** the run detail page is loaded, **When** the user navigates back, **Then** they return to the runs overview with the running-pipelines section in its default expanded state.
+
+---
+
+### Edge Cases
+
+- What happens when a running pipeline completes while the page is open and no SSE update mechanism refreshes the section? The stale card remains until the user refreshes (acceptable baseline; real-time behavior is a separate concern).
+- How does the system handle a very large number of simultaneously running pipelines (e.g., 50+)? The section shows all running pipelines without artificial truncation, relying on normal scroll. No "see all running" link is needed in v1 — Wave is a single-operator tool with a low expected concurrency ceiling, so unbounded display is acceptable and consistent with how the main runs list works.
+- What happens if the running-pipelines section and the main run list below it both show the same runs? Running runs appear in the dedicated section only; the main list below either excludes running status by default or shows all. The spec requires the section to be additive — it surfaces running runs at the top without removing them from the main list unless the design explicitly filters them out.
+- What happens when the user applies a pipeline-name filter while running pipelines are displayed? The running-pipelines section should reflect the filter (only show running runs matching the selected pipeline).
+- What happens on mobile/narrow viewports? The section must remain usable; card layout adapts consistently with the existing run card responsive behavior.
+
+## Clarifications
+
+### CL-001: Real-time update behavior (resolved)
+
+**Question**: Should the running-pipelines section update in real-time via SSE when the last running pipeline finishes, or only on page reload?
+
+**Resolution**: Page reload only (v1 baseline). The existing SSE infrastructure (`/api/runs/{id}/events`) is scoped to the single run detail page and does not broadcast list-level events to the runs overview. Adding a global "run status changed" SSE topic to the runs overview is out of scope for this feature. The spec edge-case note is updated to reflect this: stale cards persist until the user reloads, which is acceptable baseline behavior.
+
+**Rationale**: Consistent with how the main runs list works today — it is a server-rendered page with no live updates.
+
+---
+
+### CL-002: Maximum count display for 50+ concurrent runs (resolved)
+
+**Question**: Should a maximum count be shown with a "see all running" link when many pipelines run concurrently (e.g., 50+)?
+
+**Resolution**: No truncation or "see all" link. Show all running pipelines with standard scroll. Wave is a single-operator orchestration tool — the realistic ceiling for simultaneous runs is low. Matching the unbounded behavior of the existing main runs list avoids added complexity for a niche scenario.
+
+**Rationale**: Consistent with the main list's unbounded display. The header count badge (FR-009) already communicates total volume at a glance.
+
+---
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The runs overview page MUST display a dedicated "Running Pipelines" section positioned below the filter/search bar and above the main runs list.
+- **FR-002**: The running-pipelines section MUST be expanded by default on every page load (no persisted collapse state).
+- **FR-003**: The running-pipelines section MUST include a toggle control in its header that collapses and expands the section contents.
+- **FR-004**: When at least one pipeline has status `running`, the section MUST display those pipeline run cards using the same run card visual pattern as the main runs list.
+- **FR-005**: When no pipelines have status `running`, the section MUST display an empty-state placeholder with a CTA that directs the user toward initiating a new pipeline run.
+- **FR-006**: Each run card in the running-pipelines section MUST be a navigable link to `/runs/{runID}`.
+- **FR-007**: Clicking a run card with status `completed` or `failed` MUST navigate to the run detail page for that run.
+- **FR-008**: The running-pipelines section MUST respect the active pipeline-name filter applied in the filter/search bar (only show running runs matching the current filter).
+- **FR-009**: The section header MUST display the label "Running" (or equivalent) and a count of currently running pipelines.
+- **FR-010**: The section MUST be accessible: the toggle control MUST have appropriate ARIA attributes (`aria-expanded`, `aria-controls`) and be keyboard-operable.
+
+### Key Entities _(include if feature involves data)_
+
+- **RunSummary (running subset)**: A pipeline run with `Status = "running"`. Key attributes: `RunID`, `PipelineName`, `Status`, `Progress` (%), `StepsCompleted`, `StepsTotal`, `Duration`, `FormattedStartedAt`. Relationship: same entity shown in main runs list; the section is a filtered view, not a separate data type.
+- **Running Pipelines Section**: A UI container on the runs overview. Attributes: expanded/collapsed state (transient, not persisted), filtered run set, empty-state vs. populated state. Relationship: appears between filter bar and main `RunSummary` list.
+- **Empty State / CTA**: Displayed when the running subset is empty. Attributes: placeholder message text, CTA link destination (pipeline list or run trigger endpoint).
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The running-pipelines section is visible on the runs overview page on 100% of page loads, regardless of how many pipelines are running.
+- **SC-002**: The section is in expanded state on initial page load 100% of the time (zero cases where it loads collapsed).
+- **SC-003**: When pipelines are running, 100% of active run cards in the section link correctly to their respective run detail pages (zero broken navigation links).
+- **SC-004**: The empty-state placeholder renders correctly (CTA present, no blank/empty section) when zero pipelines are running.
+- **SC-005**: The toggle control passes automated accessibility checks: `aria-expanded` reflects actual expanded/collapsed state, and the control is reachable and operable via keyboard navigation.
+- **SC-006**: Applying a pipeline-name filter reduces the running-pipelines section to show only matching active runs (filter applies to both the section and the main list simultaneously).

--- a/specs/772-webui-running-pipelines/tasks.md
+++ b/specs/772-webui-running-pipelines/tasks.md
@@ -1,0 +1,158 @@
+# Tasks: Expandable Running Pipelines Section
+
+**Feature**: `772-webui-running-pipelines`  
+**Branch**: `772-webui-running-pipelines`  
+**Generated**: 2026-04-11  
+**Spec**: `specs/772-webui-running-pipelines/spec.md`  
+**Plan**: `specs/772-webui-running-pipelines/plan.md`
+
+## Summary
+
+4 phases, 17 tasks. Pure UI change: handler data extension, template block insertion,
+CSS additions, and test coverage. No new routes, no new files, no new dependencies.
+
+All source changes are confined to `internal/webui/`:
+- `handlers_runs.go` — add `RunningRuns`/`RunningCount` to template data struct (Phase 2)
+- `templates/runs.html` — insert `rp-section` block (Phase 3)
+- `static/style.css` — add `.rp-*` CSS classes (Phase 3, parallelizable)
+- `handlers_runs_test.go` — extend with `TestHandleRunsPage_RunningSection` cases (Phase 4)
+
+---
+
+## Phase 1 — Setup
+
+> Verify the development environment and understand the test harness before modifying code.
+
+- [X] T001 [P1] Run `go test ./internal/webui/... -run TestHandleRunsPage` to confirm existing runs page tests pass as baseline. File: `internal/webui/handlers_runs_test.go`
+- [X] T002 [P1] Read `internal/webui/handlers_runs.go:155–233` to understand the full `handleRunsPage` handler structure, especially the `data` struct and existing `ListRuns` call pattern.
+- [X] T003 [P1] Read `internal/webui/templates/runs.html` in full to understand the current template structure (toolbar position, `.wr-list` class, `{{define "scripts"}}` block).
+- [X] T004 [P1] Read `internal/webui/static/style.css` (`.wr-*` block and `.badge` definitions) to understand the CSS patterns the new `.rp-*` classes must match.
+
+---
+
+## Phase 2 — Handler Extension (US1 + US3 + FR-008 prerequisite)
+
+> Extend `handleRunsPage` to query and expose running runs. This is the blocking prerequisite
+> for all template and test work.
+
+**User Story 1**: View Active Pipelines at a Glance (P1)  
+**User Story 3**: Empty State — No Running Pipelines (P3)  
+**FR-008**: Filter integration (pipeline filter applied to running query)
+
+- [X] T005 [P1][S1] In `internal/webui/handlers_runs.go`, after line 159 (`pipelineFilter := ...`), add a second `ListRuns` query: `opts := state.ListRunsOptions{Status: "running", PipelineName: pipelineFilter, Limit: 0}`. Assign result to `runningRecs`. File: `internal/webui/handlers_runs.go`
+- [X] T006 [P1][S1] Convert `runningRecs` to `[]RunSummary` using the same `runToSummary` loop pattern used for the main list (lines 188–192). Apply `enrichRunSummaries`. Filter to top-level only (exclude `ParentRunID != ""`). Assign to `runningRuns []RunSummary`. File: `internal/webui/handlers_runs.go`
+- [X] T007 [P1][S1] Extend the anonymous `data` struct (line 211) with two new fields: `RunningRuns []RunSummary` and `RunningCount int`. Populate them: `RunningRuns: runningRuns, RunningCount: len(runningRuns)`. File: `internal/webui/handlers_runs.go`
+- [X] T008 [P1][S1] Verify `RunningRuns` is initialized as an empty slice (not nil) when no running runs exist — use `make([]RunSummary, 0)` if `runningRecs` is empty. Ensures template `{{if eq .RunningCount 0}}` renders correctly. File: `internal/webui/handlers_runs.go`
+
+---
+
+## Phase 3 — Template + CSS (US1, US2, US3, US4)
+
+> Add the `rp-section` HTML block to `runs.html` and the supporting CSS classes.
+> T009–T012 (template) and T013–T014 (CSS) are independent and can be worked in parallel
+> after Phase 2 is complete.
+
+**User Story 1**: View Active Pipelines at a Glance (P1)  
+**User Story 2**: Collapse/Expand Running Pipelines Section (P2)  
+**User Story 3**: Empty State — No Running Pipelines (P3)  
+**User Story 4**: Navigate to Run Detail from Running Section (P2)
+
+### 3a — Template (runs.html)
+
+- [X] T009 [P] [S1,S2,S3,S4] In `internal/webui/templates/runs.html`, insert a `<div class="rp-section">` container block immediately after the closing `</div>` of `.wr-toolbar` and before `<div class="wr-list">`. The block structure:
+  ```html
+  <div class="rp-section">
+    <div class="rp-header" role="button" tabindex="0"
+         aria-expanded="true" aria-controls="rp-section-body"
+         onclick="toggleRunningSection()"
+         onkeydown="if(event.key==='Enter'||event.key===' '){toggleRunningSection();event.preventDefault()}">
+      <span class="rp-label">Running</span>
+      <span class="rp-badge">{{.RunningCount}}</span>
+      <span class="rp-chevron">▾</span>
+    </div>
+    <div id="rp-section-body" class="rp-body">
+      ...empty-state or run cards (T010, T011)...
+    </div>
+  </div>
+  ```
+  File: `internal/webui/templates/runs.html`
+
+- [X] T010 [P] [S3] Inside `<div class="rp-body">`, add the `{{if eq .RunningCount 0}}` empty-state block:
+  ```html
+  {{if eq .RunningCount 0}}
+  <div class="rp-empty">
+    <p>No pipelines running</p>
+    <a href="/pipelines" class="rp-cta">Start a pipeline →</a>
+  </div>
+  {{else}}
+  ...run cards (T011)...
+  {{end}}
+  ```
+  File: `internal/webui/templates/runs.html`
+
+- [X] T011 [P] [S1,S4] In the `{{else}}` branch of T010, add a `{{range .RunningRuns}}` loop that renders each run card. Reuse the existing `.wr-run` card markup pattern from the main list (copy the `<a href="/runs/{{.RunID}}">` card structure). Each card must be a navigable `<a>` link to `/runs/{{.RunID}}`. File: `internal/webui/templates/runs.html`
+
+- [X] T012 [S2] In the `{{define "scripts"}}` block of `runs.html`, add the `toggleRunningSection()` JS function:
+  ```js
+  function toggleRunningSection() {
+    const section = document.querySelector('.rp-section');
+    const header = section.querySelector('.rp-header');
+    const body = document.getElementById('rp-section-body');
+    const expanded = header.getAttribute('aria-expanded') === 'true';
+    header.setAttribute('aria-expanded', String(!expanded));
+    section.classList.toggle('collapsed', expanded);
+  }
+  ```
+  File: `internal/webui/templates/runs.html`
+
+### 3b — CSS (style.css)
+
+- [X] T013 [P] [S1,S2,S3] Add the following new CSS rule blocks to `internal/webui/static/style.css` in the "runs overview" section (near `.wr-*` rules). Classes to add:
+  - `.rp-section` — `margin-bottom` matching `.wr-toolbar`
+  - `.rp-header` — `display: flex; align-items: center; gap: …; cursor: pointer;` with hover state
+  - `.rp-label` — typography matching existing section headings
+  - `.rp-badge` — inherits `.badge` base; uses `var(--color-running)` background
+  - `.rp-chevron` — `transition: transform …;` for rotate animation
+  - `.rp-body` — `display: block;`
+  - `.rp-empty` — `display: flex; flex-direction: column; align-items: center; padding: …; color: var(--color-muted);`
+  - `.rp-cta` — styled as secondary button/link (match existing button patterns)
+  File: `internal/webui/static/style.css`
+
+- [X] T014 [P] [S2] Add collapse CSS rules for when `.rp-section.collapsed` is active:
+  ```css
+  .rp-section.collapsed .rp-body { display: none; }
+  .rp-section.collapsed .rp-chevron { transform: rotate(-90deg); }
+  ```
+  File: `internal/webui/static/style.css`
+
+---
+
+## Phase 4 — Tests (All Stories)
+
+> Extend `handlers_runs_test.go` with test cases covering all contract invariants.
+> Tests verify handler data correctness (SSR only — no browser test needed).
+
+- [X] T015 [P1][S1,S3] Add `TestHandleRunsPage_RunningSection_Populated` to `internal/webui/handlers_runs_test.go`. Setup: insert a run record with `Status="running"` into the test store. Assert: response body contains `rp-section`, `rp-badge` with count "1", and a link `href="/runs/{runID}"`. File: `internal/webui/handlers_runs_test.go`
+
+- [X] T016 [P1][S3] Add `TestHandleRunsPage_RunningSection_Empty` to `internal/webui/handlers_runs_test.go`. Setup: no running runs in test store. Assert: response body contains `rp-empty` and `href="/pipelines"` CTA. File: `internal/webui/handlers_runs_test.go`
+
+- [X] T017 [P1][S1] Add `TestHandleRunsPage_RunningSection_FilterRespected` to `internal/webui/handlers_runs_test.go`. Setup: two running runs with different pipeline names; request with `?pipeline=<name1>`. Assert: response body contains only the run card for `name1`, not `name2`. Verifies FR-008 (filter applied to running section). File: `internal/webui/handlers_runs_test.go`
+
+---
+
+## Dependency Order
+
+```
+T001–T004 (read/verify)
+    ↓
+T005–T008 (handler extension — sequential, each builds on prior)
+    ↓
+T009–T014 (template + CSS — T009→T010→T011→T012 sequential; T013–T014 parallel with T009–T012)
+    ↓
+T015–T017 (tests — parallel with each other; sequential after all source changes)
+```
+
+## Parallelizable Tasks
+
+T009, T010, T011 (template work) can proceed in parallel with T013, T014 (CSS) after Phase 2.  
+T015, T016, T017 (tests) are independent of each other and can run in parallel.


### PR DESCRIPTION
## Summary

Adds expandable running-pipelines section to the runs overview and frequent-pipelines section to the pipelines page, with several UX polish fixes.

### Runs page
- **Running section**: dedicated collapsible card at the top showing currently running pipelines
- Running runs excluded from main list to prevent duplication
- Removed redundant "Running" filter tab (section replaces it)
- Collapse state persisted in `localStorage` across navigation
- Caret hidden when no pipelines running (non-interactive header)
- Section has visible contrast: darker bg, border, separator

### Pipelines page
- **Frequent section**: collapsible section showing top 8 most-used pipelines
- Compact flat-row design with truncated inline descriptions
- Collapse state persisted in `localStorage`
- Replaced "Frequent" filter tab with dedicated section
- Moved inline styles to proper CSS classes (badges, search, meta)

### Shared
- Filter tabs restyled: borderless text-nav with clean active highlight
- Runs nav item defaults to `?status=completed`
- Step I/O row padding balanced (top = bottom)

## Test plan
- [ ] Runs page: running section shows/hides correctly, no duplicate entries
- [ ] Runs page: collapse persists across filter tab clicks
- [ ] Pipelines page: frequent section shows pipelines with run count > 0
- [ ] Pipelines page: category filters still work after Frequent tab removal
- [ ] Light mode: running/frequent sections have visible contrast