### PR TITLE
docs: add sidebar navigation for orphaned docs/guide pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -120,16 +120,75 @@ export default withMermaid(
             items: [
               { text: 'CI/CD Integration', link: '/guides/ci-cd' },
               { text: 'GitHub Integration', link: '/guides/github-integration' },
-              { text: 'Enterprise Patterns', link: '/guides/enterprise' }
+              { text: 'Enterprise Patterns', link: '/guides/enterprise' },
+              { text: 'Web Dashboard', link: '/guides/web-dashboard' },
+              { text: 'Secure CLI Patterns', link: '/guides/secure-cli-patterns' }
             ]
           },
           {
             text: 'Advanced',
             items: [
               { text: 'Audit Logging', link: '/guides/audit-logging' },
-                { text: 'State & Resumption', link: '/guides/state-resumption' },
+              { text: 'State & Resumption', link: '/guides/state-resumption' },
               { text: 'Context Relay', link: '/guides/relay-compaction' },
-              { text: 'Meta-Pipelines', link: '/guides/meta-pipelines' }
+              { text: 'Meta-Pipelines', link: '/guides/meta-pipelines' },
+              { text: 'Contract Chaining', link: '/guides/contract-chaining' },
+              { text: 'Adapter Development', link: '/guides/adapter-development' }
+            ]
+          },
+          {
+            text: 'Platform Setup',
+            items: [
+              { text: 'Forge Setup', link: '/guides/forge-setup' }
+            ]
+          },
+          {
+            text: 'Maintenance',
+            items: [
+              { text: 'Upgrade Guide', link: '/guides/upgrade-guide' }
+            ]
+          }
+        ],
+        '/guide/': [
+          {
+            text: 'Core Concepts',
+            items: [
+              { text: 'Pipelines', link: '/guide/pipelines' },
+              { text: 'Contracts', link: '/guide/contracts' },
+              { text: 'Personas', link: '/guide/personas' },
+              { text: 'Outcomes', link: '/guide/outcomes' },
+              { text: 'Validation', link: '/guide/validation' }
+            ]
+          },
+          {
+            text: 'Configuration',
+            items: [
+              { text: 'Configuration', link: '/guide/configuration' },
+              { text: 'Installation', link: '/guide/installation' },
+              { text: 'Quick Start', link: '/guide/quick-start' },
+              { text: 'Relay', link: '/guide/relay' }
+            ]
+          },
+          {
+            text: 'Advanced Patterns',
+            items: [
+              { text: 'Composition', link: '/guide/composition' },
+              { text: 'Graph Loops', link: '/guide/graph-loops' },
+              { text: 'Human Gates', link: '/guide/human-gates' },
+              { text: 'Threads', link: '/guide/threads' },
+              { text: 'Retry Policies', link: '/guide/retry-policies' },
+              { text: 'Model Routing', link: '/guide/model-routing' }
+            ]
+          },
+          {
+            text: 'Skills',
+            items: [
+              { text: 'Skills', link: '/guide/skills' },
+              { text: 'Skill Configuration', link: '/guide/skill-configuration' },
+              { text: 'Skill Ecosystems', link: '/guide/skill-ecosystems' },
+              { text: 'TUI', link: '/guide/tui' },
+              { text: 'Chat Context', link: '/guide/chat-context' },
+              { text: 'Pipeline Outputs', link: '/guide/pipeline-outputs' }
             ]
           }
         ],


### PR DESCRIPTION
## Summary

Automated documentation sync to fix 28 INCOMPLETE findings from the doc-fix scan. Added sidebar navigation sections for 21 orphaned `/guide/` pages and added 6 missing pages to the `/guides/` sidebar.

- **28 findings fixed** out of 28 total scan findings
- **Types addressed**: INCOMPLETE (orphan pages not in sidebar navigation)
- **All HIGH severity issues resolved**: 22 orphaned `/guide/` pages now accessible via sidebar
- **All MEDIUM severity issues resolved**: 6 missing `/guides/` pages added to sidebar

## Changes

Single file modified: `docs/.vitepress/config.ts`

1. **Added new `/guide/` sidebar section** with 4 categories organizing 21 orphaned pages:
   - Core Concepts (5 pages): pipelines, contracts, personas, outcomes, validation
   - Configuration (4 pages): configuration, installation, quick-start, relay
   - Advanced Patterns (6 pages): composition, graph-loops, human-gates, threads, retry-policies, model-routing
   - Skills (6 pages): skills, skill-configuration, skill-ecosystems, tui, chat-context, pipeline-outputs

2. **Added missing pages to `/guides/` sidebar**:
   - Adoption category: web-dashboard, secure-cli-patterns
   - Advanced category: contract-chaining, adapter-development
   - New Platform Setup category: forge-setup
   - New Maintenance category: upgrade-guide

## Findings Addressed

### HIGH Priority (22 findings)
| ID | Title | File |
|----|-------|------|
| DOC-0001 | docs/guide/ directory has no sidebar navigation section | docs/.vitepress/config.ts |
| DOC-0002 | chat-context.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0003 | composition.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0004 | configuration.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0005 | contracts.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0006 | graph-loops.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0007 | human-gates.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0008 | installation.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0009 | model-routing.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0010 | outcomes.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0011 | personas.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0012 | pipeline-outputs.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0013 | pipelines.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0014 | quick-start.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0015 | relay.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0016 | retry-policies.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0017 | skill-configuration.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0018 | skill-ecosystems.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0019 | skills.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0020 | threads.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0021 | tui.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0022 | validation.md not in sidebar | docs/.vitepress/config.ts |

### MEDIUM Priority (6 findings)
| ID | Title | File |
|----|-------|------|
| DOC-0023 | adapter-development.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0024 | contract-chaining.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0025 | forge-setup.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0026 | secure-cli-patterns.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0027 | upgrade-guide.md not in sidebar | docs/.vitepress/config.ts |
| DOC-0028 | web-dashboard.md not in sidebar | docs/.vitepress/config.ts |

## Skipped

None - all 28 findings were addressed.

## Test Plan

- All documentation changes are docs-only (no source code modifications)
- Markdown formatting verified after edits
- Internal links checked for validity
- Commit: 76a09bd8b0f951ed3e3f614979e0abbba901ee14