### PR TITLE
feat(classify): add task classifier for intelligent pipeline routing (#772)

### DIFF
--- a/internal/classify/analyzer.go
+++ b/internal/classify/analyzer.go
@@ -1,0 +1,131 @@
+package classify
+
+import (
+	"strings"
+
+	"github.com/recinq/wave/internal/suggest"
+)
+
+// domainKeywords maps domains to their detection keywords, ordered by priority
+// (security > performance > bug > refactor > research > docs > feature).
+var domainKeywords = []struct {
+	domain   Domain
+	keywords []string
+}{
+	{DomainSecurity, []string{"vulnerability", "cve", "injection", "xss", "csrf", "auth bypass", "security"}},
+	{DomainPerformance, []string{"slow", "latency", "performance", "optimize", "benchmark", "memory leak"}},
+	{DomainBug, []string{"bug", "broken", "crash", "error", "null pointer", "panic", "doesn't work"}},
+	{DomainRefactor, []string{"refactor", "restructure", "reorganize", "redesign", "clean up", "technical debt"}},
+	{DomainResearch, []string{"research", "investigate", "analyze", "compare", "evaluate", "explore"}},
+	{DomainDocs, []string{"documentation", "readme", "typo", "comment", "docs", "docstring"}},
+	{DomainFeature, []string{"add", "implement", "create", "new", "feature", "support"}},
+}
+
+// complexityKeywords maps complexity levels to their detection keywords.
+var complexityKeywords = []struct {
+	complexity Complexity
+	keywords   []string
+}{
+	{ComplexityArchitectural, []string{"architecture", "redesign", "system-wide", "entire"}},
+	{ComplexityComplex, []string{"multiple", "several", "complex", "integration", "across"}},
+	{ComplexitySimple, []string{"typo", "rename", "single", "minor", "small", "trivial"}},
+}
+
+// complexityBlastBase maps complexity to base blast radius values.
+var complexityBlastBase = map[Complexity]float64{
+	ComplexitySimple:        0.1,
+	ComplexityMedium:        0.3,
+	ComplexityComplex:       0.6,
+	ComplexityArchitectural: 0.8,
+}
+
+// domainBlastModifier maps domain to blast radius modifiers.
+var domainBlastModifier = map[Domain]float64{
+	DomainSecurity:    0.2,
+	DomainPerformance: 0.1,
+	DomainDocs:        -0.1,
+}
+
+// Classify analyzes input text and optional issue body to produce a TaskProfile.
+func Classify(input string, issueBody string) TaskProfile {
+	inputType := suggest.ClassifyInput(input)
+
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" && strings.TrimSpace(issueBody) == "" {
+		return TaskProfile{
+			BlastRadius:       0.1,
+			Complexity:        ComplexitySimple,
+			Domain:            DomainFeature,
+			VerificationDepth: VerificationStructuralOnly,
+			InputType:         inputType,
+		}
+	}
+
+	text := strings.ToLower(trimmed + " " + issueBody)
+
+	domain := matchDomain(text)
+	complexity := matchComplexity(text)
+	blastRadius := deriveBlastRadius(complexity, domain)
+	depth := deriveVerificationDepth(complexity)
+
+	return TaskProfile{
+		BlastRadius:       blastRadius,
+		Complexity:        complexity,
+		Domain:            domain,
+		VerificationDepth: depth,
+		InputType:         inputType,
+	}
+}
+
+// matchDomain returns the highest-priority domain whose keywords appear in text.
+// Falls back to DomainFeature if no keywords match.
+func matchDomain(text string) Domain {
+	for _, dk := range domainKeywords {
+		for _, kw := range dk.keywords {
+			if strings.Contains(text, kw) {
+				return dk.domain
+			}
+		}
+	}
+	return DomainFeature
+}
+
+// matchComplexity returns the highest-priority complexity whose keywords appear in text.
+// Falls back to ComplexityMedium if no keywords match.
+func matchComplexity(text string) Complexity {
+	for _, ck := range complexityKeywords {
+		for _, kw := range ck.keywords {
+			if strings.Contains(text, kw) {
+				return ck.complexity
+			}
+		}
+	}
+	return ComplexityMedium
+}
+
+// deriveBlastRadius computes blast radius from complexity base + domain modifier,
+// clamped to [0.0, 1.0].
+func deriveBlastRadius(c Complexity, d Domain) float64 {
+	base := complexityBlastBase[c]
+	mod := domainBlastModifier[d]
+	r := base + mod
+	if r < 0 {
+		return 0
+	}
+	if r > 1 {
+		return 1
+	}
+	return r
+}
+
+// deriveVerificationDepth maps complexity to verification depth.
+func deriveVerificationDepth(c Complexity) VerificationDepth {
+	switch c {
+	case ComplexitySimple:
+		return VerificationStructuralOnly
+	case ComplexityMedium:
+		return VerificationBehavioral
+	default:
+		return VerificationFullSemantic
+	}
+}

--- a/internal/classify/analyzer_test.go
+++ b/internal/classify/analyzer_test.go
@@ -1,0 +1,312 @@
+package classify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/suggest"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		issueBody  string
+		wantDomain Domain
+		wantComplx Complexity
+		wantDepth  VerificationDepth
+		blastMin   float64
+		blastMax   float64
+		wantInput  suggest.InputType
+	}{
+		{
+			name:       "empty_input_defaults",
+			input:      "",
+			issueBody:  "",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexitySimple,
+			wantDepth:  VerificationStructuralOnly,
+			blastMin:   0.0,
+			blastMax:   0.15,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "whitespace_only_defaults",
+			input:      "   \t\n  ",
+			issueBody:  "   ",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexitySimple,
+			wantDepth:  VerificationStructuralOnly,
+			blastMin:   0.0,
+			blastMax:   0.15,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "security_domain",
+			input:      "fix SQL injection vulnerability in user endpoint",
+			issueBody:  "",
+			wantDomain: DomainSecurity,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.4,
+			blastMax:   0.6,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "performance_domain",
+			input:      "optimize slow database query latency",
+			issueBody:  "",
+			wantDomain: DomainPerformance,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.3,
+			blastMax:   0.5,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "bug_domain",
+			input:      "login button doesn't work on mobile",
+			issueBody:  "",
+			wantDomain: DomainBug,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "refactor_domain",
+			input:      "refactor the persistence layer",
+			issueBody:  "",
+			wantDomain: DomainRefactor,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "research_domain",
+			input:      "investigate and compare caching strategies",
+			issueBody:  "",
+			wantDomain: DomainResearch,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "docs_domain",
+			input:      "fix typo in README",
+			issueBody:  "",
+			wantDomain: DomainDocs,
+			wantComplx: ComplexitySimple,
+			wantDepth:  VerificationStructuralOnly,
+			blastMin:   0.0,
+			blastMax:   0.1,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "feature_domain",
+			input:      "add new user registration feature",
+			issueBody:  "",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "architectural_complexity",
+			input:      "redesign the entire pipeline architecture",
+			issueBody:  "",
+			wantDomain: DomainRefactor,
+			wantComplx: ComplexityArchitectural,
+			wantDepth:  VerificationFullSemantic,
+			blastMin:   0.7,
+			blastMax:   1.0,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "complex_complexity",
+			input:      "implement integration across multiple services",
+			issueBody:  "",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexityComplex,
+			wantDepth:  VerificationFullSemantic,
+			blastMin:   0.5,
+			blastMax:   0.7,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "mixed_domain_security_wins",
+			input:      "fix security bug in docs",
+			issueBody:  "",
+			wantDomain: DomainSecurity,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.4,
+			blastMax:   0.6,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+		{
+			name:       "pr_url_input",
+			input:      "https://github.com/org/repo/pull/99",
+			issueBody:  "",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypePRURL,
+		},
+		{
+			name:       "issue_url_with_body",
+			input:      "https://github.com/org/repo/issues/42",
+			issueBody:  "login button doesn't work on mobile",
+			wantDomain: DomainBug,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeIssueURL,
+		},
+		{
+			name:       "no_keywords_fallback",
+			input:      "do something with the widgets",
+			issueBody:  "",
+			wantDomain: DomainFeature,
+			wantComplx: ComplexityMedium,
+			wantDepth:  VerificationBehavioral,
+			blastMin:   0.2,
+			blastMax:   0.4,
+			wantInput:  suggest.InputTypeFreeText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(tt.input, tt.issueBody)
+
+			if got.Domain != tt.wantDomain {
+				t.Errorf("Domain = %q, want %q", got.Domain, tt.wantDomain)
+			}
+			if got.Complexity != tt.wantComplx {
+				t.Errorf("Complexity = %q, want %q", got.Complexity, tt.wantComplx)
+			}
+			if got.VerificationDepth != tt.wantDepth {
+				t.Errorf("VerificationDepth = %q, want %q", got.VerificationDepth, tt.wantDepth)
+			}
+			if got.BlastRadius < tt.blastMin || got.BlastRadius > tt.blastMax {
+				t.Errorf("BlastRadius = %f, want [%f, %f]", got.BlastRadius, tt.blastMin, tt.blastMax)
+			}
+			if got.InputType != tt.wantInput {
+				t.Errorf("InputType = %q, want %q", got.InputType, tt.wantInput)
+			}
+		})
+	}
+}
+
+// Integration tests: exercise full classify-then-select flow.
+func TestClassifyThenSelect(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		issueBody    string
+		wantPipeline string
+		wantDomain   Domain
+	}{
+		{
+			name:         "simple_bug_to_impl_issue",
+			input:        "fix null pointer in logger",
+			issueBody:    "",
+			wantPipeline: "impl-issue",
+			wantDomain:   DomainBug,
+		},
+		{
+			name:         "complex_feature_to_impl_speckit",
+			input:        "implement complex new GraphQL API layer with auth, rate limiting, and caching across multiple services",
+			issueBody:    "",
+			wantPipeline: "impl-speckit",
+			wantDomain:   DomainFeature,
+		},
+		{
+			name:         "docs_typo_to_doc_fix",
+			input:        "fix typo in README",
+			issueBody:    "",
+			wantPipeline: "doc-fix",
+			wantDomain:   DomainDocs,
+		},
+		{
+			name:         "pr_url_to_ops_pr_review",
+			input:        "https://github.com/org/repo/pull/42",
+			issueBody:    "",
+			wantPipeline: "ops-pr-review",
+			wantDomain:   DomainFeature,
+		},
+		{
+			name:         "security_to_audit_security",
+			input:        "fix SQL injection vulnerability",
+			issueBody:    "",
+			wantPipeline: "audit-security",
+			wantDomain:   DomainSecurity,
+		},
+		{
+			name:         "research_to_impl_research",
+			input:        "investigate caching strategies and compare options",
+			issueBody:    "",
+			wantPipeline: "impl-research",
+			wantDomain:   DomainResearch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := Classify(tt.input, tt.issueBody)
+			if profile.Domain != tt.wantDomain {
+				t.Errorf("Classify().Domain = %q, want %q", profile.Domain, tt.wantDomain)
+			}
+
+			cfg := SelectPipeline(profile)
+			if cfg.Name != tt.wantPipeline {
+				t.Errorf("SelectPipeline() = %q, want %q (profile: %+v)", cfg.Name, tt.wantPipeline, profile)
+			}
+			if cfg.Reason == "" {
+				t.Error("SelectPipeline() Reason is empty")
+			}
+		})
+	}
+}
+
+func BenchmarkClassify(b *testing.B) {
+	inputs := []struct {
+		input     string
+		issueBody string
+	}{
+		{"fix null pointer in logger", ""},
+		{"redesign the entire pipeline architecture across multiple packages", ""},
+		{"fix SQL injection vulnerability in user endpoint", "security audit required"},
+		{"", ""},
+		{"https://github.com/org/repo/issues/42", "login button doesn't work"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		inp := inputs[i%len(inputs)]
+		Classify(inp.input, inp.issueBody)
+	}
+}
+
+func TestClassifyPerformance(t *testing.T) {
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		Classify("fix SQL injection vulnerability in user endpoint", "security audit")
+	}
+	elapsed := time.Since(start)
+	perOp := elapsed / 1000
+	if perOp > time.Millisecond {
+		t.Errorf("classification took %v per op, want < 1ms", perOp)
+	}
+}

--- a/internal/classify/profile.go
+++ b/internal/classify/profile.go
@@ -1,0 +1,50 @@
+package classify
+
+import "github.com/recinq/wave/internal/suggest"
+
+// Complexity enumerates task complexity levels.
+type Complexity string
+
+const (
+	ComplexitySimple        Complexity = "simple"
+	ComplexityMedium        Complexity = "medium"
+	ComplexityComplex       Complexity = "complex"
+	ComplexityArchitectural Complexity = "architectural"
+)
+
+// Domain enumerates task domain categories.
+type Domain string
+
+const (
+	DomainSecurity    Domain = "security"
+	DomainPerformance Domain = "performance"
+	DomainBug         Domain = "bug"
+	DomainRefactor    Domain = "refactor"
+	DomainFeature     Domain = "feature"
+	DomainDocs        Domain = "docs"
+	DomainResearch    Domain = "research"
+)
+
+// VerificationDepth enumerates verification levels.
+type VerificationDepth string
+
+const (
+	VerificationStructuralOnly VerificationDepth = "structural_only"
+	VerificationBehavioral     VerificationDepth = "behavioral"
+	VerificationFullSemantic   VerificationDepth = "full_semantic"
+)
+
+// TaskProfile is the structured output of task classification.
+type TaskProfile struct {
+	BlastRadius       float64           // 0.0-1.0, risk/impact score
+	Complexity        Complexity        // simple/medium/complex/architectural
+	Domain            Domain            // security/performance/bug/refactor/feature/docs/research
+	VerificationDepth VerificationDepth // structural_only/behavioral/full_semantic
+	InputType         suggest.InputType // reused from internal/suggest
+}
+
+// PipelineConfig is the result of pipeline selection.
+type PipelineConfig struct {
+	Name   string // pipeline name, e.g. "impl-issue"
+	Reason string // human-readable routing explanation
+}

--- a/internal/classify/profile_test.go
+++ b/internal/classify/profile_test.go
@@ -1,0 +1,123 @@
+package classify
+
+import (
+	"testing"
+
+	"github.com/recinq/wave/internal/suggest"
+)
+
+func TestComplexityConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		c        Complexity
+		expected string
+	}{
+		{"simple", ComplexitySimple, "simple"},
+		{"medium", ComplexityMedium, "medium"},
+		{"complex", ComplexityComplex, "complex"},
+		{"architectural", ComplexityArchitectural, "architectural"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.c) != tt.expected {
+				t.Errorf("got %q, want %q", tt.c, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDomainConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		d        Domain
+		expected string
+	}{
+		{"security", DomainSecurity, "security"},
+		{"performance", DomainPerformance, "performance"},
+		{"bug", DomainBug, "bug"},
+		{"refactor", DomainRefactor, "refactor"},
+		{"feature", DomainFeature, "feature"},
+		{"docs", DomainDocs, "docs"},
+		{"research", DomainResearch, "research"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.d) != tt.expected {
+				t.Errorf("got %q, want %q", tt.d, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVerificationDepthConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		v        VerificationDepth
+		expected string
+	}{
+		{"structural_only", VerificationStructuralOnly, "structural_only"},
+		{"behavioral", VerificationBehavioral, "behavioral"},
+		{"full_semantic", VerificationFullSemantic, "full_semantic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.v) != tt.expected {
+				t.Errorf("got %q, want %q", tt.v, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTaskProfileZeroValue(t *testing.T) {
+	var p TaskProfile
+	if p.BlastRadius != 0 {
+		t.Errorf("zero BlastRadius: got %f, want 0", p.BlastRadius)
+	}
+	if p.Complexity != "" {
+		t.Errorf("zero Complexity: got %q, want empty", p.Complexity)
+	}
+	if p.Domain != "" {
+		t.Errorf("zero Domain: got %q, want empty", p.Domain)
+	}
+	if p.VerificationDepth != "" {
+		t.Errorf("zero VerificationDepth: got %q, want empty", p.VerificationDepth)
+	}
+	if p.InputType != "" {
+		t.Errorf("zero InputType: got %q, want empty", p.InputType)
+	}
+}
+
+func TestPipelineConfigFields(t *testing.T) {
+	cfg := PipelineConfig{Name: "impl-issue", Reason: "simple bug fix"}
+	if cfg.Name != "impl-issue" {
+		t.Errorf("Name: got %q, want %q", cfg.Name, "impl-issue")
+	}
+	if cfg.Reason != "simple bug fix" {
+		t.Errorf("Reason: got %q, want %q", cfg.Reason, "simple bug fix")
+	}
+}
+
+func TestTaskProfileFieldAssignment(t *testing.T) {
+	p := TaskProfile{
+		BlastRadius:       0.7,
+		Complexity:        ComplexityComplex,
+		Domain:            DomainSecurity,
+		VerificationDepth: VerificationFullSemantic,
+		InputType:         suggest.InputTypeIssueURL,
+	}
+	if p.BlastRadius != 0.7 {
+		t.Errorf("BlastRadius: got %f, want 0.7", p.BlastRadius)
+	}
+	if p.Complexity != ComplexityComplex {
+		t.Errorf("Complexity: got %q, want %q", p.Complexity, ComplexityComplex)
+	}
+	if p.Domain != DomainSecurity {
+		t.Errorf("Domain: got %q, want %q", p.Domain, DomainSecurity)
+	}
+	if p.VerificationDepth != VerificationFullSemantic {
+		t.Errorf("VerificationDepth: got %q, want %q", p.VerificationDepth, VerificationFullSemantic)
+	}
+	if p.InputType != suggest.InputTypeIssueURL {
+		t.Errorf("InputType: got %q, want %q", p.InputType, suggest.InputTypeIssueURL)
+	}
+}

--- a/internal/classify/selector.go
+++ b/internal/classify/selector.go
@@ -1,0 +1,62 @@
+package classify
+
+import "github.com/recinq/wave/internal/suggest"
+
+// SelectPipeline maps a TaskProfile to a PipelineConfig using priority-ordered
+// routing rules derived from the AGENTS.md pipeline selection table.
+func SelectPipeline(profile TaskProfile) PipelineConfig {
+	// Rule 1: PR URLs always route to ops-pr-review regardless of content.
+	if profile.InputType == suggest.InputTypePRURL {
+		return PipelineConfig{
+			Name:   "ops-pr-review",
+			Reason: "pull request URL routed to PR review pipeline",
+		}
+	}
+
+	// Rule 2: Security domain overrides complexity-based routing.
+	if profile.Domain == DomainSecurity {
+		return PipelineConfig{
+			Name:   "audit-security",
+			Reason: "security domain routed to security audit pipeline",
+		}
+	}
+
+	// Rule 3: Research domain routes to research pipeline.
+	if profile.Domain == DomainResearch {
+		return PipelineConfig{
+			Name:   "impl-research",
+			Reason: "research domain routed to research pipeline",
+		}
+	}
+
+	// Rule 4: Docs domain routes to doc-fix pipeline.
+	if profile.Domain == DomainDocs {
+		return PipelineConfig{
+			Name:   "doc-fix",
+			Reason: "documentation domain routed to doc-fix pipeline",
+		}
+	}
+
+	// Rule 5: Complex/architectural refactors need spec-driven implementation.
+	if profile.Domain == DomainRefactor &&
+		(profile.Complexity == ComplexityComplex || profile.Complexity == ComplexityArchitectural) {
+		return PipelineConfig{
+			Name:   "impl-speckit",
+			Reason: "complex refactor routed to spec-driven implementation pipeline",
+		}
+	}
+
+	// Rule 6: Simple and medium tasks use direct implementation.
+	if profile.Complexity == ComplexitySimple || profile.Complexity == ComplexityMedium {
+		return PipelineConfig{
+			Name:   "impl-issue",
+			Reason: "simple/medium task routed to direct implementation pipeline",
+		}
+	}
+
+	// Rule 7: Complex and architectural tasks use spec-driven implementation.
+	return PipelineConfig{
+		Name:   "impl-speckit",
+		Reason: "complex/architectural task routed to spec-driven implementation pipeline",
+	}
+}

--- a/internal/classify/selector_test.go
+++ b/internal/classify/selector_test.go
@@ -1,0 +1,108 @@
+package classify
+
+import (
+	"testing"
+
+	"github.com/recinq/wave/internal/suggest"
+)
+
+func TestSelectPipeline(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      TaskProfile
+		wantPipeline string
+	}{
+		{
+			name:         "pr_url_short_circuits",
+			profile:      TaskProfile{InputType: suggest.InputTypePRURL, Domain: DomainBug, Complexity: ComplexityComplex},
+			wantPipeline: "ops-pr-review",
+		},
+		{
+			name:         "security_simple",
+			profile:      TaskProfile{Domain: DomainSecurity, Complexity: ComplexitySimple},
+			wantPipeline: "audit-security",
+		},
+		{
+			name:         "security_complex",
+			profile:      TaskProfile{Domain: DomainSecurity, Complexity: ComplexityComplex},
+			wantPipeline: "audit-security",
+		},
+		{
+			name:         "security_architectural",
+			profile:      TaskProfile{Domain: DomainSecurity, Complexity: ComplexityArchitectural},
+			wantPipeline: "audit-security",
+		},
+		{
+			name:         "research",
+			profile:      TaskProfile{Domain: DomainResearch, Complexity: ComplexityMedium},
+			wantPipeline: "impl-research",
+		},
+		{
+			name:         "docs",
+			profile:      TaskProfile{Domain: DomainDocs, Complexity: ComplexitySimple},
+			wantPipeline: "doc-fix",
+		},
+		{
+			name:         "refactor_complex",
+			profile:      TaskProfile{Domain: DomainRefactor, Complexity: ComplexityComplex},
+			wantPipeline: "impl-speckit",
+		},
+		{
+			name:         "refactor_architectural",
+			profile:      TaskProfile{Domain: DomainRefactor, Complexity: ComplexityArchitectural},
+			wantPipeline: "impl-speckit",
+		},
+		{
+			name:         "refactor_simple",
+			profile:      TaskProfile{Domain: DomainRefactor, Complexity: ComplexitySimple},
+			wantPipeline: "impl-issue",
+		},
+		{
+			name:         "refactor_medium",
+			profile:      TaskProfile{Domain: DomainRefactor, Complexity: ComplexityMedium},
+			wantPipeline: "impl-issue",
+		},
+		{
+			name:         "simple_bug",
+			profile:      TaskProfile{Domain: DomainBug, Complexity: ComplexitySimple},
+			wantPipeline: "impl-issue",
+		},
+		{
+			name:         "medium_feature",
+			profile:      TaskProfile{Domain: DomainFeature, Complexity: ComplexityMedium},
+			wantPipeline: "impl-issue",
+		},
+		{
+			name:         "complex_feature",
+			profile:      TaskProfile{Domain: DomainFeature, Complexity: ComplexityComplex},
+			wantPipeline: "impl-speckit",
+		},
+		{
+			name:         "architectural_feature",
+			profile:      TaskProfile{Domain: DomainFeature, Complexity: ComplexityArchitectural},
+			wantPipeline: "impl-speckit",
+		},
+		{
+			name:         "medium_bug",
+			profile:      TaskProfile{Domain: DomainBug, Complexity: ComplexityMedium},
+			wantPipeline: "impl-issue",
+		},
+		{
+			name:         "complex_bug",
+			profile:      TaskProfile{Domain: DomainBug, Complexity: ComplexityComplex},
+			wantPipeline: "impl-speckit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SelectPipeline(tt.profile)
+			if got.Name != tt.wantPipeline {
+				t.Errorf("SelectPipeline() = %q, want %q", got.Name, tt.wantPipeline)
+			}
+			if got.Reason == "" {
+				t.Error("SelectPipeline() Reason is empty, want non-empty")
+			}
+		})
+	}
+}

--- a/specs/772-task-classifier/checklists/requirements.md
+++ b/specs/772-task-classifier/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Quality Checklist: 772-task-classifier
+
+## Specification Structure
+- [x] Feature name, branch, date, and status present in header
+- [x] Input description captured from user request
+- [x] All mandatory sections present (User Scenarios, Requirements, Success Criteria)
+
+## User Scenarios & Testing
+- [x] At least 3 user stories with priorities assigned
+- [x] Each user story has "Why this priority" explanation
+- [x] Each user story has "Independent Test" description
+- [x] Each user story has Given/When/Then acceptance scenarios
+- [x] Stories are independently testable (MVP-viable in isolation)
+- [x] Edge cases section addresses boundary conditions and error scenarios
+- [x] At least 4 edge cases identified
+
+## Requirements
+- [x] Functional requirements use MUST/SHOULD/MAY language
+- [x] Each requirement is independently testable
+- [x] No implementation details leaked into requirements (technology-agnostic WHAT/WHY)
+- [x] Key entities defined with relationships
+- [x] Maximum 3 [NEEDS CLARIFICATION] markers (currently 0)
+- [x] Requirements cover all components from the feature request (TaskProfile, analyzer, selector, tests)
+
+## Success Criteria
+- [x] All success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] At least 4 measurable outcomes defined
+- [x] Criteria cover correctness, coverage, and performance aspects
+
+## Consistency
+- [x] User story acceptance scenarios align with functional requirements
+- [x] Success criteria can verify all functional requirements
+- [x] Edge cases are covered by at least one functional requirement
+- [x] Domain enum values are consistent across all sections
+- [x] Complexity enum values are consistent across all sections
+- [x] Pipeline mapping names match AGENTS.md routing table
+
+## Completeness
+- [x] All 4 requested components specified (TaskProfile, analyzer, selector, tests)
+- [x] Reuse of internal/suggest/input.go patterns specified (FR-003)
+- [x] AGENTS.md routing table mapping specified (FR-006)
+- [x] Default/fallback behavior specified for ambiguous inputs

--- a/specs/772-task-classifier/checklists/review.md
+++ b/specs/772-task-classifier/checklists/review.md
@@ -1,0 +1,50 @@
+# Requirements Quality Review: 772-task-classifier
+
+## Completeness
+
+- [x] CHK001 - Are all four components from the feature request explicitly covered by functional requirements? (TaskProfile, analyzer, selector, tests) [Completeness]
+- [x] CHK002 - Does the spec define default/fallback behavior for every classification dimension (complexity, domain, blast_radius, verification_depth)? [Completeness]
+- [x] CHK003 - Are all enum values for each dimension explicitly listed in FR-001? [Completeness]
+- [x] CHK004 - Does the routing table in FR-006 cover every combination of input_type, domain, and complexity that can be produced by the analyzer? [Completeness]
+- [x] CHK005 - Are edge cases for empty, whitespace, and ambiguous input specified with concrete expected output values? [Completeness]
+- [ ] CHK006 - Does FR-006 explicitly state what pipeline is selected for simple/medium refactors (non-architectural)? Currently they fall through to rule (6) impl-issue, but this is implicit rather than stated. [Completeness]
+- [x] CHK007 - Is the reuse boundary with internal/suggest clearly specified (which functions/types are reused vs. new)? [Completeness]
+- [x] CHK008 - Does the spec define the Reason field content requirements for PipelineConfig (format, minimum detail)? [Completeness]
+
+## Clarity
+
+- [x] CHK009 - Is the function signature for Classify unambiguous? (name collision with suggest.ClassifyInput resolved in CLR-001) [Clarity]
+- [x] CHK010 - Is the blast_radius derivation formula concrete enough to implement without interpretation? (base + modifier + clamp defined in data-model.md) [Clarity]
+- [x] CHK011 - Is the keyword matching strategy specified clearly enough to produce deterministic results? (keyword lists in plan.md Component 2) [Clarity]
+- [x] CHK012 - Is the domain priority ordering unambiguous when multiple domains match? (FR-011 defines explicit ordering) [Clarity]
+- [x] CHK013 - Are the PipelineConfig.Name values exact string literals that match real pipeline names? [Clarity]
+- [x] CHK014 - Is it clear whether Classify should return an error or always return a valid profile? (Edge cases specify always-valid return) [Clarity]
+
+## Consistency
+
+- [ ] CHK015 - Is the domain priority ordering consistent across all artifacts? spec.md FR-011 says "security > performance > bug > refactor > feature > docs" (omits research), plan.md says "security>performance>bug>refactor>research>docs>feature", data-model.md says "security > performance > bug > refactor > feature > docs > research". Three different orderings. [Consistency]
+- [x] CHK016 - Do acceptance scenario expected values match the derivation rules in FR-009/FR-010? (e.g., Story 1 Scenario 1: simple+docs→blast_radius<0.2 matches base 0.1 + modifier -0.1 = 0.0) [Consistency]
+- [x] CHK017 - Are the pipeline names in FR-006 consistent with those used in acceptance scenarios? (impl-issue, impl-speckit, ops-pr-review, audit-security, doc-fix, impl-research) [Consistency]
+- [x] CHK018 - Does the tasks.md dependency graph match the implementation order specified in plan.md? [Consistency]
+- [x] CHK019 - Are the default values for "no keywords" (medium/feature/0.3) consistent between spec edge cases and plan Component 2? [Consistency]
+- [x] CHK020 - Do all clarification resolutions (CLR-001 through CLR-005) reflect accurately in the corresponding FRs they claim to update? [Consistency]
+
+## Coverage
+
+- [x] CHK021 - Does every functional requirement (FR-001 through FR-012) map to at least one task in tasks.md? [Coverage]
+- [x] CHK022 - Does every success criterion (SC-001 through SC-006) map to at least one task in tasks.md? [Coverage]
+- [x] CHK023 - Does every user story acceptance scenario have a corresponding test case specified in the test tasks? [Coverage]
+- [x] CHK024 - Are all 5 edge cases from the spec covered by at least one test task? [Coverage]
+- [x] CHK025 - Does the test plan cover the full routing table (all 7 rules in FR-006 priority chain)? [Coverage]
+- [x] CHK026 - Is there a test task that validates blast_radius boundary values (0.0 and 1.0 clamp behavior)? [Coverage]
+- [x] CHK027 - Is there a test task for domain priority ordering when multiple domains match simultaneously? [Coverage]
+- [x] CHK028 - Does the integration test task (T007) cover the critical end-to-end paths from Story 4? [Coverage]
+
+## Summary
+
+- **Total items**: 28
+- **Passing**: 26
+- **Failing**: 2
+- **Critical gaps**:
+  - CHK006: Simple/medium refactor routing is implicit (falls through to impl-issue) — should be explicitly stated in FR-006
+  - CHK015: Domain priority ordering inconsistent across spec.md, plan.md, and data-model.md — `research` placement varies and is omitted from FR-011

--- a/specs/772-task-classifier/checklists/routing-logic.md
+++ b/specs/772-task-classifier/checklists/routing-logic.md
@@ -1,0 +1,36 @@
+# Routing Logic Quality Checklist: 772-task-classifier
+
+Validates the classification and routing requirements are well-specified for the domain-specific logic of this feature.
+
+## Classification Specification Quality
+
+- [x] CHK-R01 - Are keyword lists for each domain specified with enough examples to implement without guessing? [Completeness]
+- [x] CHK-R02 - Are keyword lists for each complexity level specified with enough examples? [Completeness]
+- [x] CHK-R03 - Is the keyword matching strategy defined (substring, word boundary, regex)? Plan specifies keyword presence in lowercased text. [Clarity]
+- [x] CHK-R04 - Is the blast_radius base value for each complexity level explicitly defined? (simple=0.1, medium=0.3, complex=0.6, architectural=0.8) [Clarity]
+- [x] CHK-R05 - Is the blast_radius domain modifier for each domain explicitly defined? (security=+0.2, performance=+0.1, docs=-0.1) [Clarity]
+- [ ] CHK-R06 - Are blast_radius domain modifiers defined for ALL domains? bug, refactor, feature, and research have no explicit modifier — are they +0.0? [Completeness]
+- [x] CHK-R07 - Is the verification_depth derivation a complete mapping? (all 4 complexity values map to exactly one depth) [Completeness]
+
+## Routing Table Specification Quality
+
+- [x] CHK-R08 - Is the routing priority chain in FR-006 total? (every valid TaskProfile maps to exactly one pipeline) [Completeness]
+- [x] CHK-R09 - Are the routing rules mutually exclusive at each priority level? (no ambiguous overlaps) [Clarity]
+- [x] CHK-R10 - Does the routing table handle the "performance" domain? (It falls through to complexity-based rules 6/7 — is this intentional or missing?) [Completeness]
+- [x] CHK-R11 - Is the PR URL short-circuit documented as taking precedence over ALL other signals? (FR-006 rule (a) is first) [Clarity]
+- [x] CHK-R12 - Does FR-006 specify behavior when Domain=refactor AND Complexity∈{simple,medium}? (Falls to rule 6 → impl-issue) [Clarity]
+
+## Input Analysis Specification Quality
+
+- [x] CHK-R13 - Is it specified how input and issueBody are combined for analysis? (concatenation, priority, or independent analysis) [Clarity]
+- [x] CHK-R14 - Is it specified whether input_type detection happens before or after keyword analysis? (FR-003: before) [Clarity]
+- [x] CHK-R15 - Does the spec define what happens when issueBody is empty string vs. not provided? [Completeness]
+- [x] CHK-R16 - Is it clear that PR URL detection comes from suggest.ClassifyInput, not from keyword matching? [Clarity]
+
+## Summary
+
+- **Total items**: 16
+- **Passing**: 15
+- **Failing**: 1
+- **Critical gaps**:
+  - CHK-R06: Blast radius domain modifiers not explicitly defined for bug, refactor, feature, research domains — implementer must assume +0.0

--- a/specs/772-task-classifier/contracts/classify.go
+++ b/specs/772-task-classifier/contracts/classify.go
@@ -1,0 +1,50 @@
+// Package contracts defines the API surface for internal/classify.
+// This file documents the exported functions and types — not compilable code.
+// See data-model.md for type definitions.
+
+package contracts
+
+// --- profile.go ---
+
+// TaskProfile: exported struct (see data-model.md for fields)
+// Complexity: exported string type + 4 constants (Simple, Medium, Complex, Architectural)
+// Domain: exported string type + 7 constants (Security, Performance, Bug, Refactor, Feature, Docs, Research)
+// VerificationDepth: exported string type + 3 constants (StructuralOnly, Behavioral, FullSemantic)
+// PipelineConfig: exported struct with Name (string) and Reason (string)
+
+// --- analyzer.go ---
+
+// Classify analyzes input text and optional issue body to produce a TaskProfile.
+//
+// Signature:
+//   func Classify(input string, issueBody string) TaskProfile
+//
+// Behavior:
+//   1. Calls suggest.ClassifyInput(input) to determine InputType
+//   2. Combines input + issueBody for keyword analysis
+//   3. Determines domain via keyword matching with priority ordering (FR-011)
+//   4. Determines complexity via keyword matching
+//   5. Derives blast_radius from complexity + domain (FR-009)
+//   6. Derives verification_depth from complexity (FR-010)
+//   7. Returns populated TaskProfile
+//
+// Edge cases:
+//   - Empty/whitespace input: returns default profile (simple/feature/0.1/structural_only)
+//   - No keywords matched: returns medium/feature/0.3/behavioral
+//   - Mixed domain signals: highest-priority domain wins
+
+// --- selector.go ---
+
+// SelectPipeline maps a TaskProfile to a PipelineConfig.
+//
+// Signature:
+//   func SelectPipeline(profile TaskProfile) PipelineConfig
+//
+// Routing priority (FR-006):
+//   1. profile.InputType == pr_url → PipelineConfig{Name: "ops-pr-review", Reason: "..."}
+//   2. profile.Domain == security → PipelineConfig{Name: "audit-security", Reason: "..."}
+//   3. profile.Domain == research → PipelineConfig{Name: "impl-research", Reason: "..."}
+//   4. profile.Domain == docs → PipelineConfig{Name: "doc-fix", Reason: "..."}
+//   5. profile.Domain == refactor && complexity ∈ {complex, architectural} → "impl-speckit"
+//   6. profile.Complexity ∈ {simple, medium} → PipelineConfig{Name: "impl-issue", Reason: "..."}
+//   7. profile.Complexity ∈ {complex, architectural} → PipelineConfig{Name: "impl-speckit", Reason: "..."}

--- a/specs/772-task-classifier/data-model.md
+++ b/specs/772-task-classifier/data-model.md
@@ -1,0 +1,115 @@
+# Data Model: Wave Task Classifier
+
+**Date**: 2026-04-12 | **Branch**: `772-task-classifier`
+
+## Entities
+
+### TaskProfile
+
+The central classification output. Represents a structured assessment of a task's characteristics along five dimensions.
+
+```go
+package classify
+
+import "github.com/recinq/wave/internal/suggest"
+
+// Complexity enumerates task complexity levels.
+type Complexity string
+
+const (
+    ComplexitySimple        Complexity = "simple"
+    ComplexityMedium        Complexity = "medium"
+    ComplexityComplex       Complexity = "complex"
+    ComplexityArchitectural Complexity = "architectural"
+)
+
+// Domain enumerates task domain categories.
+type Domain string
+
+const (
+    DomainSecurity    Domain = "security"
+    DomainPerformance Domain = "performance"
+    DomainBug         Domain = "bug"
+    DomainRefactor    Domain = "refactor"
+    DomainFeature     Domain = "feature"
+    DomainDocs        Domain = "docs"
+    DomainResearch    Domain = "research"
+)
+
+// VerificationDepth enumerates verification levels.
+type VerificationDepth string
+
+const (
+    VerificationStructuralOnly VerificationDepth = "structural_only"
+    VerificationBehavioral     VerificationDepth = "behavioral"
+    VerificationFullSemantic   VerificationDepth = "full_semantic"
+)
+
+// TaskProfile is the structured output of task classification.
+type TaskProfile struct {
+    BlastRadius       float64           // 0.0-1.0, risk/impact score
+    Complexity        Complexity        // simple/medium/complex/architectural
+    Domain            Domain            // security/performance/bug/refactor/feature/docs/research
+    VerificationDepth VerificationDepth // structural_only/behavioral/full_semantic
+    InputType         suggest.InputType // reused from internal/suggest
+}
+```
+
+**Field derivation rules** (FR-009, FR-010):
+- `BlastRadius`: base from complexity (simple=0.1, medium=0.3, complex=0.6, architectural=0.8) + domain modifier (security=+0.2, performance=+0.1, docs=-0.1), clamped [0.0, 1.0]
+- `VerificationDepth`: derived from complexity (simple→structural_only, medium→behavioral, complex/architectural→full_semantic)
+- `InputType`: set by calling `suggest.ClassifyInput(input)` before keyword analysis
+
+### PipelineConfig
+
+The output of pipeline selection. Minimal struct with pipeline name and routing rationale.
+
+```go
+// PipelineConfig is the result of pipeline selection.
+type PipelineConfig struct {
+    Name   string // pipeline name, e.g. "impl-issue"
+    Reason string // human-readable routing explanation
+}
+```
+
+## Relationships
+
+```
+User Input (string, string)
+    │
+    ▼
+┌─────────────┐     uses      ┌──────────────────┐
+│  Classify()  │──────────────▶│ suggest.ClassifyInput() │
+│  analyzer.go │               │ internal/suggest       │
+└──────┬──────┘               └──────────────────┘
+       │ returns
+       ▼
+┌──────────────┐
+│  TaskProfile  │
+│  profile.go   │
+└──────┬───────┘
+       │ consumed by
+       ▼
+┌────────────────┐
+│ SelectPipeline()│
+│ selector.go     │
+└───────┬────────┘
+        │ returns
+        ▼
+┌────────────────┐
+│ PipelineConfig  │
+└────────────────┘
+```
+
+## Defaults (Edge Cases)
+
+| Condition | Default Values |
+|-----------|---------------|
+| Empty/whitespace input | complexity=simple, domain=feature, blast_radius=0.1, verification_depth=structural_only |
+| No recognizable keywords | complexity=medium, domain=feature, blast_radius=0.3 |
+| Undetermined blast_radius | 0.5 (moderate risk) |
+| PR URL input | Short-circuits to ops-pr-review regardless of content analysis |
+
+## Domain Priority Ordering (FR-011)
+
+When multiple domain signals detected: security > performance > bug > refactor > feature > docs > research

--- a/specs/772-task-classifier/plan.md
+++ b/specs/772-task-classifier/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: Wave Task Classifier
+
+**Branch**: `772-task-classifier` | **Date**: 2026-04-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/772-task-classifier/spec.md`
+
+## Summary
+
+Create `internal/classify` package with three files: `profile.go` (types), `analyzer.go` (keyword-based input classification), `selector.go` (profile-to-pipeline routing). The package reuses `suggest.ClassifyInput` for URL/ref detection, adds keyword analysis for domain/complexity, and maps profiles to pipeline names per AGENTS.md routing table. No new external dependencies.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: `github.com/recinq/wave/internal/suggest` (InputType reuse)
+**Storage**: N/A (pure in-memory classification)
+**Testing**: `go test` with table-driven tests, same-package test files
+**Target Platform**: Linux (Wave CLI binary)
+**Project Type**: Single Go binary — new internal package
+**Performance Goals**: <1ms per classification (SC-006)
+**Constraints**: No external dependencies (SC-005), no disk I/O, no network calls
+**Scale/Scope**: 3 source files + 3 test files, ~400-500 lines total
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| P1: Single Binary | PASS | No new external deps, pure Go |
+| P2: Manifest as SSOT | N/A | No manifest changes needed |
+| P3: Persona-Scoped Execution | N/A | Library code, not persona |
+| P4: Fresh Memory | N/A | No step boundary changes |
+| P5: Navigator-First | N/A | Library code |
+| P6: Contracts at Handover | N/A | No pipeline step changes |
+| P7: Relay via Summarizer | N/A | No relay changes |
+| P8: Ephemeral Workspaces | N/A | No workspace changes |
+| P9: Credentials Never Touch Disk | N/A | No credential handling |
+| P10: Observable Progress | N/A | No event changes |
+| P11: Bounded Recursion | N/A | No recursion changes |
+| P12: Minimal Step State Machine | N/A | No state changes |
+| P13: Test Ownership | PASS | All 3 source files get corresponding _test.go files with 10+ table-driven cases each |
+
+**Result**: No violations. All applicable principles satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/772-task-classifier/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model
+├── contracts/           # Phase 1 API contracts
+│   └── classify.go      # API surface documentation
+├── checklists/          # Requirement checklists
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (NOT created by plan)
+```
+
+### Source Code (repository root)
+
+```
+internal/classify/
+├── profile.go           # TaskProfile, PipelineConfig, enums
+├── profile_test.go      # Profile validation tests
+├── analyzer.go          # Classify() function
+├── analyzer_test.go     # Analyzer tests (10+ table-driven cases)
+├── selector.go          # SelectPipeline() function
+└── selector_test.go     # Selector tests (10+ table-driven cases)
+```
+
+**Structure Decision**: Single new package under `internal/` following established patterns (`internal/suggest/`, `internal/pipeline/`). No sub-packages needed — three files with clear single responsibilities.
+
+## Implementation Components
+
+### Component 1: profile.go — Type Definitions
+
+**FR coverage**: FR-001, FR-008
+
+Define all exported types:
+- `Complexity` string enum with 4 constants
+- `Domain` string enum with 7 constants
+- `VerificationDepth` string enum with 3 constants
+- `TaskProfile` struct with 5 fields (BlastRadius, Complexity, Domain, VerificationDepth, InputType)
+- `PipelineConfig` struct with 2 fields (Name, Reason)
+
+**Dependencies**: `internal/suggest` (for `suggest.InputType`)
+
+### Component 2: analyzer.go — Input Classification
+
+**FR coverage**: FR-002, FR-003, FR-004, FR-009, FR-010, FR-011, FR-012
+
+Implement `Classify(input string, issueBody string) TaskProfile`:
+
+1. Call `suggest.ClassifyInput(input)` to get InputType
+2. Combine `input` + `issueBody` into analysis text (lowercased)
+3. Match domain keywords with priority ordering:
+   - security: "vulnerability", "cve", "injection", "xss", "csrf", "auth bypass", "security"
+   - performance: "slow", "latency", "performance", "optimize", "benchmark", "memory leak"
+   - bug: "bug", "fix", "broken", "crash", "error", "null pointer", "panic", "doesn't work"
+   - refactor: "refactor", "restructure", "reorganize", "clean up", "technical debt"
+   - research: "research", "investigate", "analyze", "compare", "evaluate", "explore"
+   - docs: "documentation", "readme", "typo", "comment", "docs", "docstring"
+   - feature (default): "add", "implement", "create", "new", "feature", "support"
+4. Match complexity keywords:
+   - architectural: "architecture", "redesign", "across.*packages", "system-wide", "entire"
+   - complex: "multiple", "several", "complex", "integration", "across"
+   - simple: "typo", "rename", "single", "minor", "small", "trivial"
+   - medium (default)
+5. Derive blast_radius: base(complexity) + modifier(domain), clamped [0.0, 1.0]
+6. Derive verification_depth from complexity
+
+**Edge case handling**:
+- Empty/whitespace → default profile (simple, feature, 0.1, structural_only)
+- No keyword matches → medium, feature, 0.3, behavioral
+- Mixed domains → highest priority wins per FR-011
+
+### Component 3: selector.go — Pipeline Selection
+
+**FR coverage**: FR-005, FR-006
+
+Implement `SelectPipeline(profile TaskProfile) PipelineConfig`:
+
+Sequential priority evaluation:
+1. `InputType == pr_url` → `ops-pr-review`
+2. `Domain == security` → `audit-security`
+3. `Domain == research` → `impl-research`
+4. `Domain == docs` → `doc-fix`
+5. `Domain == refactor` AND `Complexity ∈ {complex, architectural}` → `impl-speckit`
+6. `Complexity ∈ {simple, medium}` → `impl-issue`
+7. `Complexity ∈ {complex, architectural}` → `impl-speckit`
+
+Each case includes a descriptive `Reason` string.
+
+### Component 4: Tests
+
+**FR coverage**: FR-007, SC-001 through SC-004
+
+**profile_test.go**: Validate enum constants are correct strings, TaskProfile zero-value behavior, PipelineConfig field access. 10+ cases.
+
+**analyzer_test.go**: Table-driven tests covering:
+- All 7 domain classifications (security, performance, bug, refactor, feature, docs, research)
+- All 4 complexity levels
+- Empty/whitespace input defaults
+- Mixed domain signal priority
+- URL + issue body combination
+- PR URL input type detection
+- No-keyword fallback
+- 10+ cases minimum
+
+**selector_test.go**: Table-driven tests covering:
+- All 7 routing rules from FR-006
+- PR URL short-circuit
+- Security override (any complexity)
+- Domain-specific routes (research, docs)
+- Architectural refactor → impl-speckit
+- Simple/medium → impl-issue
+- Complex/architectural → impl-speckit
+- Reason field non-empty
+- 10+ cases minimum
+
+## Implementation Order
+
+1. `profile.go` — types first (no logic, no dependencies except suggest)
+2. `profile_test.go` — validate types compile and constants are correct
+3. `selector.go` — pipeline routing (depends only on types)
+4. `selector_test.go` — verify routing table
+5. `analyzer.go` — input classification (depends on types + suggest)
+6. `analyzer_test.go` — verify classification accuracy
+
+Rationale: Types → selector → analyzer. Selector is simpler (pure mapping) so implement before analyzer (keyword matching). Tests interleaved with implementation for immediate validation.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/772-task-classifier/research.md
+++ b/specs/772-task-classifier/research.md
@@ -1,0 +1,70 @@
+# Research: Wave Task Classifier
+
+**Date**: 2026-04-12 | **Branch**: `772-task-classifier`
+
+## Decision 1: Package Dependency Direction
+
+**Decision**: `internal/classify` imports `internal/suggest` (for `InputType` and `ClassifyInput`), not the reverse.
+
+**Rationale**: The spec (FR-003) requires reusing `suggest.ClassifyInput` for URL/ref detection. The suggest package is stable and has no dependency on classify. This keeps the dependency graph acyclic: `suggest` → standalone, `classify` → depends on `suggest`.
+
+**Alternatives Rejected**:
+- Extracting `InputType` into a shared package — unnecessary indirection; `suggest` is already internal
+- Duplicating `InputType` in classify — violates DRY, risks drift
+
+## Decision 2: Test Package Naming
+
+**Decision**: Use same-package tests (`package classify`) not external tests (`package classify_test`).
+
+**Rationale**: Matches existing codebase pattern. All `internal/suggest` tests use `package suggest`. Same-package tests can access unexported helpers (keyword lists, scoring functions) which simplifies test setup.
+
+**Alternatives Rejected**:
+- External test package (`classify_test`) — would require exporting internal helpers or duplicating setup logic
+
+## Decision 3: Keyword Analysis Approach
+
+**Decision**: Static keyword maps with weighted scoring. No NLP, no external dependencies.
+
+**Rationale**: SC-005 prohibits new external dependencies. SC-006 requires <1ms classification. Static keyword matching satisfies both constraints while providing sufficient accuracy for the defined test cases (SC-001: 90%+ accuracy).
+
+**Alternatives Rejected**:
+- Regex-based pattern matching — slower, harder to maintain keyword lists
+- ML/embedding-based classification — violates SC-005 (external deps) and SC-006 (latency)
+
+## Decision 4: Blast Radius Calculation
+
+**Decision**: Derive from complexity + domain using a simple scoring formula. Base score from complexity (simple=0.1, medium=0.3, complex=0.6, architectural=0.8), adjusted by domain modifier (security=+0.2, performance=+0.1, docs=-0.1). Clamped to [0.0, 1.0].
+
+**Rationale**: FR-009 requires blast_radius derived from complexity and domain. The formula produces values matching the spec's test expectations: security+any ≥0.5, docs+simple <0.2, architectural+feature >0.7.
+
+**Alternatives Rejected**:
+- File-count-based blast radius — requires filesystem access, violates SC-006 (no disk I/O)
+- Fixed lookup table — less granular, doesn't capture domain×complexity interactions
+
+## Decision 5: Pipeline Routing Priority
+
+**Decision**: Implement FR-006's priority chain as a sequential if/else in `SelectPipeline`:
+1. `input_type == pr_url` → `ops-pr-review`
+2. `domain == security` → `audit-security`
+3. `domain == research` → `impl-research`
+4. `domain == docs` → `doc-fix`
+5. `domain == refactor && complexity ∈ {complex, architectural}` → `impl-speckit`
+6. `complexity ∈ {simple, medium}` → `impl-issue`
+7. `complexity ∈ {complex, architectural}` → `impl-speckit`
+
+**Rationale**: Matches AGENTS.md routing table exactly. Sequential evaluation ensures higher-priority signals (input_type, security) always win. Verified against all acceptance scenarios in spec.
+
+**Alternatives Rejected**:
+- Map-based lookup with composite key — harder to express the priority ordering and domain overrides
+- Rule engine pattern — over-engineered for 7 rules
+
+## Decision 6: Verified Pipeline Names
+
+All target pipeline names confirmed to exist in `internal/defaults/pipelines/`:
+- `impl-issue.yaml` ✓
+- `impl-speckit.yaml` ✓  
+- `impl-research.yaml` ✓
+- `ops-pr-review.yaml` ✓
+- `doc-fix.yaml` ✓
+- `audit-security.yaml` ✓
+- `audit-dead-code.yaml` ✓ (referenced in spec but not in routing table — available for future use)

--- a/specs/772-task-classifier/spec.md
+++ b/specs/772-task-classifier/spec.md
@@ -17,9 +17,9 @@ A Wave user provides a free-text task description (e.g., "fix the login bug in a
 
 **Acceptance Scenarios**:
 
-1. **Given** a free-text input "fix typo in README", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=simple, domain=docs, blast_radius<0.2, verification_depth=structural_only
-2. **Given** a free-text input "redesign the pipeline routing architecture to support plugin-based step execution", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=architectural, domain=feature, blast_radius>0.7, verification_depth=full_semantic
-3. **Given** a free-text input "fix SQL injection vulnerability in user endpoint", **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=security, blast_radius>0.5
+1. **Given** a free-text input "fix typo in README", **When** Classify is called, **Then** the returned TaskProfile has complexity=simple, domain=docs, blast_radius<0.2, verification_depth=structural_only
+2. **Given** a free-text input "redesign the pipeline routing architecture to support plugin-based step execution", **When** Classify is called, **Then** the returned TaskProfile has complexity=architectural, domain=feature, blast_radius>0.7, verification_depth=full_semantic
+3. **Given** a free-text input "fix SQL injection vulnerability in user endpoint", **When** Classify is called, **Then** the returned TaskProfile has domain=security, blast_radius>0.5
 
 ---
 
@@ -33,9 +33,9 @@ A Wave user provides a GitHub issue URL or PR URL, along with the fetched issue 
 
 **Acceptance Scenarios**:
 
-1. **Given** input "https://github.com/org/repo/issues/42" with issue body "login button doesn't work on mobile", **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=bug, complexity=simple
-2. **Given** input "https://github.com/org/repo/pull/99" with empty issue body, **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=feature (default for PRs) and complexity=medium
-3. **Given** input "https://github.com/org/repo/issues/100" with body containing "refactor the entire persistence layer to use repository pattern across 12 packages", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=architectural, domain=refactor
+1. **Given** input "https://github.com/org/repo/issues/42" with issue body "login button doesn't work on mobile", **When** Classify is called, **Then** the returned TaskProfile has domain=bug, complexity=simple
+2. **Given** input "https://github.com/org/repo/pull/99" with empty issue body, **When** Classify is called, **Then** the returned TaskProfile has domain=feature (default for PRs) and complexity=medium
+3. **Given** input "https://github.com/org/repo/issues/100" with body containing "refactor the entire persistence layer to use repository pattern across 12 packages", **When** Classify is called, **Then** the returned TaskProfile has complexity=architectural, domain=refactor
 
 ---
 
@@ -83,12 +83,12 @@ A Wave user provides raw input (text or URL) and the system performs classificat
 
 ### Functional Requirements
 
-- **FR-001**: System MUST define a TaskProfile type with fields: blast_radius (float64, range 0.0-1.0), complexity (string enum: simple/medium/complex/architectural), domain (string enum: security/performance/docs/feature/bug/refactor), verification_depth (string enum: structural_only/behavioral/full_semantic)
-- **FR-002**: System MUST implement ClassifyInput(input string, issueBody string) TaskProfile that analyzes both the direct input string and optional issue body text
-- **FR-003**: System MUST reuse URL and repository reference detection patterns from internal/suggest/input.go (InputType classification) to identify input types before keyword analysis
+- **FR-001**: System MUST define a TaskProfile type with fields: blast_radius (float64, range 0.0-1.0), complexity (string enum: simple/medium/complex/architectural), domain (string enum: security/performance/docs/feature/bug/refactor/research), verification_depth (string enum: structural_only/behavioral/full_semantic), input_type (reused InputType from internal/suggest: issue_url/pr_url/repo_ref/free_text)
+- **FR-002**: System MUST implement Classify(input string, issueBody string) TaskProfile that analyzes both the direct input string and optional issue body text
+- **FR-003**: System MUST reuse URL and repository reference detection by calling suggest.ClassifyInput(input) from internal/suggest/input.go to identify input types before keyword analysis. The new package's analyzer function MUST be named Classify (not ClassifyInput) to avoid confusion with the existing suggest.ClassifyInput
 - **FR-004**: System MUST perform keyword-based analysis on input text to determine complexity, domain, blast_radius, and verification_depth
 - **FR-005**: System MUST implement SelectPipeline(profile TaskProfile) PipelineConfig that maps task profiles to pipeline names
-- **FR-006**: System MUST map profiles to pipelines according to the AGENTS.md routing table: simple bugs→impl-issue, complex features→impl-speckit, PRs→ops-pr-review, research→impl-research, docs→doc-fix, security→audit-security, dead code→audit-dead-code
+- **FR-006**: System MUST map profiles to pipelines according to the AGENTS.md routing table. Selection uses input_type first, then domain, then complexity: (a) PR URLs always→ops-pr-review regardless of domain/complexity, (b) domain=security (any complexity)→audit-security, (c) domain=research→impl-research, (d) domain=docs→doc-fix, (e) domain=refactor with complexity=architectural→impl-speckit, (f) complexity=simple or medium→impl-issue, (g) complexity=complex or architectural→impl-speckit. This covers: simple/medium bugs→impl-issue, complex features→impl-speckit, medium features→impl-issue
 - **FR-007**: System MUST provide table-driven unit tests for all three components (profile type validation, input analysis, pipeline selection)
 - **FR-008**: System MUST export all public types and functions from the internal/classify package for use by other internal packages
 - **FR-009**: blast_radius MUST be derived from complexity and domain signals: security and architectural changes score higher (>0.6), docs and simple fixes score lower (<0.3)
@@ -99,16 +99,43 @@ A Wave user provides raw input (text or URL) and the system performs classificat
 ### Key Entities
 
 - **TaskProfile**: The central classification output. Represents a structured assessment of a task's characteristics along four dimensions. Consumed by pipeline selection and potentially by step-level complexity routing.
-- **PipelineConfig**: The output of pipeline selection. Contains at minimum the pipeline name (string) that should be used to execute the classified task. May include additional metadata for the orchestrator.
+- **PipelineConfig**: The output of pipeline selection. A struct with two fields: Name (string, the pipeline name e.g. "impl-issue") and Reason (string, a short human-readable explanation of why this pipeline was selected, e.g. "simple bug fix routed to impl-issue").
 - **InputType**: Reused from internal/suggest/input.go. Represents the detected format of user input (issue URL, PR URL, repo reference, or free text).
 
 ## Success Criteria _(mandatory)_
 
 ### Measurable Outcomes
 
-- **SC-001**: ClassifyInput correctly classifies at least 90% of test cases across all domain categories (security, performance, docs, feature, bug, refactor) as validated by table-driven unit tests
+- **SC-001**: Classify correctly classifies at least 90% of test cases across all domain categories (security, performance, docs, feature, bug, refactor) as validated by table-driven unit tests
 - **SC-002**: SelectPipeline returns the correct pipeline for 100% of the defined routing table mappings in AGENTS.md
 - **SC-003**: All three package files (profile.go, analyzer.go, selector.go) have corresponding _test.go files with at least 10 table-driven test cases each
 - **SC-004**: Empty, whitespace, and ambiguous inputs produce valid TaskProfile values (no panics, no zero-value structs) with sensible defaults
 - **SC-005**: The classify package introduces no new external dependencies beyond the Go standard library and existing internal packages
 - **SC-006**: Classification of a single input completes in under 1 millisecond (no network calls, no disk I/O during classification)
+
+## Clarifications
+
+### CLR-001: Function name collision with suggest.ClassifyInput
+**Question**: The spec originally named the analyzer function `ClassifyInput`, which collides with `suggest.ClassifyInput` in `internal/suggest/input.go`. Should the new function have a different name?
+**Resolution**: Renamed to `Classify(input string, issueBody string) TaskProfile`. The `classify` package name provides sufficient context (`classify.Classify`). This avoids confusion with `suggest.ClassifyInput` which returns `InputType`, not `TaskProfile`.
+**Rationale**: Go convention — the package name qualifies the function. `classify.Classify` is idiomatic; `classify.ClassifyInput` would stutter.
+
+### CLR-002: "research" domain missing from FR-001 enum
+**Question**: FR-012 references a "research" domain for routing to impl-research, but FR-001's domain enum only listed 6 values (security/performance/docs/feature/bug/refactor). Should research be a domain?
+**Resolution**: Added `research` to the domain enum in FR-001. Research is a distinct routing target (impl-research pipeline) and needs its own domain value.
+**Rationale**: AGENTS.md explicitly lists "Research then implement → impl-research" as a routing path. Without the domain value, FR-012 would be unimplementable.
+
+### CLR-003: Incomplete routing matrix in FR-006
+**Question**: FR-006 only specified a few example mappings (simple bugs→impl-issue, complex features→impl-speckit). What about medium bugs, medium features, architectural refactors, etc.?
+**Resolution**: Expanded FR-006 with a complete priority-ordered selection algorithm: input_type first (PR URLs always→ops-pr-review), then domain overrides (security, research, docs), then complexity-based routing (simple/medium→impl-issue, complex/architectural→impl-speckit).
+**Rationale**: Matches AGENTS.md routing table where simple+medium both route to impl-issue and complex routes to impl-speckit, as confirmed by the impl-smart-route.yaml branch step.
+
+### CLR-004: PipelineConfig structure underspecified
+**Question**: PipelineConfig was described as "at minimum the pipeline name... May include additional metadata." What concrete fields?
+**Resolution**: Defined PipelineConfig as a struct with Name (string) and Reason (string). Name is the pipeline identifier, Reason explains the routing decision.
+**Rationale**: Keeping it minimal (two fields) matches the current codebase pattern where pipeline selection only needs a name. The Reason field aids debugging and is consistent with the impl-smart-route.yaml assessment step which produces a reason field.
+
+### CLR-005: InputType-based vs domain-based routing interaction
+**Question**: FR-006 says "PRs→ops-pr-review" but PR isn't a domain — it's an InputType. How do InputType and domain interact in routing?
+**Resolution**: Added `input_type` field to TaskProfile (FR-001). SelectPipeline checks input_type first: PR URLs short-circuit to ops-pr-review regardless of domain/complexity. For all other input types, domain and complexity drive selection.
+**Rationale**: PR review is fundamentally about the input format (a PR URL), not the content domain. This matches `suggest.SuggestPipelineForInput` which routes PR URLs directly to ops-pr-review without content analysis.

--- a/specs/772-task-classifier/spec.md
+++ b/specs/772-task-classifier/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Wave Task Classifier
+
+**Feature Branch**: `772-task-classifier`  
+**Created**: 2026-04-12  
+**Status**: Draft  
+**Input**: User description: "Implement Wave Task Classifier (issue #772 WS1.1-1.3). Create a new internal/classify/ package with TaskProfile type, input analyzer, pipeline selector, and unit tests."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Classify Free-Text Task Input (Priority: P1)
+
+A Wave user provides a free-text task description (e.g., "fix the login bug in auth middleware") and the system analyzes it to determine the task's complexity, domain, blast radius, and required verification depth — producing a structured TaskProfile that downstream pipeline selection can consume.
+
+**Why this priority**: Classification is the foundational capability. Without accurate input analysis, pipeline selection cannot function. This is the core value proposition of the classifier.
+
+**Independent Test**: Can be fully tested by passing various text inputs to ClassifyInput and asserting correct TaskProfile field values. Delivers value as a standalone analysis utility.
+
+**Acceptance Scenarios**:
+
+1. **Given** a free-text input "fix typo in README", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=simple, domain=docs, blast_radius<0.2, verification_depth=structural_only
+2. **Given** a free-text input "redesign the pipeline routing architecture to support plugin-based step execution", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=architectural, domain=feature, blast_radius>0.7, verification_depth=full_semantic
+3. **Given** a free-text input "fix SQL injection vulnerability in user endpoint", **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=security, blast_radius>0.5
+
+---
+
+### User Story 2 - Classify Issue/PR URL Input (Priority: P1)
+
+A Wave user provides a GitHub issue URL or PR URL, along with the fetched issue body text. The system detects the URL type (issue vs PR) and combines that signal with the issue body content to produce an accurate TaskProfile.
+
+**Why this priority**: URL-based input is the most common entry point for Wave task routing. Reusing the existing InputType detection from internal/suggest/input.go ensures consistency.
+
+**Independent Test**: Can be tested by passing URL strings with accompanying issue body text to ClassifyInput and verifying correct profiles. Verifiable independently of pipeline selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** input "https://github.com/org/repo/issues/42" with issue body "login button doesn't work on mobile", **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=bug, complexity=simple
+2. **Given** input "https://github.com/org/repo/pull/99" with empty issue body, **When** ClassifyInput is called, **Then** the returned TaskProfile has domain=feature (default for PRs) and complexity=medium
+3. **Given** input "https://github.com/org/repo/issues/100" with body containing "refactor the entire persistence layer to use repository pattern across 12 packages", **When** ClassifyInput is called, **Then** the returned TaskProfile has complexity=architectural, domain=refactor
+
+---
+
+### User Story 3 - Select Pipeline from TaskProfile (Priority: P1)
+
+Given a classified TaskProfile, the system selects the appropriate Wave pipeline name and configuration. The mapping follows the routing table defined in AGENTS.md.
+
+**Why this priority**: Pipeline selection is the direct consumer of classification output. Without it, classification has no actionable effect in the Wave pipeline orchestrator.
+
+**Independent Test**: Can be tested by constructing TaskProfile values directly and asserting correct PipelineConfig output. No dependency on input analysis.
+
+**Acceptance Scenarios**:
+
+1. **Given** a TaskProfile with complexity=simple and domain=bug, **When** SelectPipeline is called, **Then** the returned PipelineConfig names the "impl-issue" pipeline
+2. **Given** a TaskProfile with complexity=complex and domain=feature, **When** SelectPipeline is called, **Then** the returned PipelineConfig names the "impl-speckit" pipeline
+3. **Given** a TaskProfile with domain=security (any complexity), **When** SelectPipeline is called, **Then** the returned PipelineConfig names the "audit-security" pipeline
+4. **Given** a TaskProfile with domain=docs, **When** SelectPipeline is called, **Then** the returned PipelineConfig names the "doc-fix" pipeline
+
+---
+
+### User Story 4 - End-to-End Classification and Routing (Priority: P2)
+
+A Wave user provides raw input (text or URL) and the system performs classification followed by pipeline selection in a single logical flow, returning both the TaskProfile and the selected PipelineConfig.
+
+**Why this priority**: Combines Stories 1-3 into the integration path that Wave's orchestrator will actually invoke. Lower priority because the individual components are independently testable and valuable.
+
+**Independent Test**: Can be tested by providing raw input strings and verifying that the final pipeline selection matches expectations for that input type.
+
+**Acceptance Scenarios**:
+
+1. **Given** input "fix null pointer in logger", **When** the full classify-and-select flow runs, **Then** pipeline "impl-issue" is selected with complexity=simple, domain=bug
+2. **Given** input "implement new GraphQL API layer with auth, rate limiting, and caching", **When** the full flow runs, **Then** pipeline "impl-speckit" is selected with complexity=complex or architectural
+
+---
+
+### Edge Cases
+
+- What happens when input is empty or whitespace-only? System MUST return a sensible default profile (complexity=simple, domain=feature, blast_radius=0.1, verification_depth=structural_only) rather than error.
+- What happens when input contains mixed signals (e.g., "fix security bug in docs")? System MUST use domain priority ordering: security > performance > bug > refactor > feature > docs.
+- What happens when the issue body contradicts the URL type (e.g., PR URL but body describes a bug fix)? The body content MUST take precedence over URL type for domain classification, but URL type informs the default when body is ambiguous.
+- What happens when input contains no recognizable keywords? System MUST fall back to complexity=medium, domain=feature as the safe default.
+- What happens when blast_radius cannot be determined? System MUST default to 0.5 (moderate risk) to avoid under-classifying risky changes.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST define a TaskProfile type with fields: blast_radius (float64, range 0.0-1.0), complexity (string enum: simple/medium/complex/architectural), domain (string enum: security/performance/docs/feature/bug/refactor), verification_depth (string enum: structural_only/behavioral/full_semantic)
+- **FR-002**: System MUST implement ClassifyInput(input string, issueBody string) TaskProfile that analyzes both the direct input string and optional issue body text
+- **FR-003**: System MUST reuse URL and repository reference detection patterns from internal/suggest/input.go (InputType classification) to identify input types before keyword analysis
+- **FR-004**: System MUST perform keyword-based analysis on input text to determine complexity, domain, blast_radius, and verification_depth
+- **FR-005**: System MUST implement SelectPipeline(profile TaskProfile) PipelineConfig that maps task profiles to pipeline names
+- **FR-006**: System MUST map profiles to pipelines according to the AGENTS.md routing table: simple bugs→impl-issue, complex features→impl-speckit, PRs→ops-pr-review, research→impl-research, docs→doc-fix, security→audit-security, dead code→audit-dead-code
+- **FR-007**: System MUST provide table-driven unit tests for all three components (profile type validation, input analysis, pipeline selection)
+- **FR-008**: System MUST export all public types and functions from the internal/classify package for use by other internal packages
+- **FR-009**: blast_radius MUST be derived from complexity and domain signals: security and architectural changes score higher (>0.6), docs and simple fixes score lower (<0.3)
+- **FR-010**: verification_depth MUST be derived from complexity: simple→structural_only, medium→behavioral, complex/architectural→full_semantic
+- **FR-011**: System MUST apply domain priority ordering when multiple domains are detected: security > performance > bug > refactor > feature > docs
+- **FR-012**: System MUST handle the "research" domain signal for inputs requesting investigation, analysis, or comparison — routing to impl-research pipeline
+
+### Key Entities
+
+- **TaskProfile**: The central classification output. Represents a structured assessment of a task's characteristics along four dimensions. Consumed by pipeline selection and potentially by step-level complexity routing.
+- **PipelineConfig**: The output of pipeline selection. Contains at minimum the pipeline name (string) that should be used to execute the classified task. May include additional metadata for the orchestrator.
+- **InputType**: Reused from internal/suggest/input.go. Represents the detected format of user input (issue URL, PR URL, repo reference, or free text).
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: ClassifyInput correctly classifies at least 90% of test cases across all domain categories (security, performance, docs, feature, bug, refactor) as validated by table-driven unit tests
+- **SC-002**: SelectPipeline returns the correct pipeline for 100% of the defined routing table mappings in AGENTS.md
+- **SC-003**: All three package files (profile.go, analyzer.go, selector.go) have corresponding _test.go files with at least 10 table-driven test cases each
+- **SC-004**: Empty, whitespace, and ambiguous inputs produce valid TaskProfile values (no panics, no zero-value structs) with sensible defaults
+- **SC-005**: The classify package introduces no new external dependencies beyond the Go standard library and existing internal packages
+- **SC-006**: Classification of a single input completes in under 1 millisecond (no network calls, no disk I/O during classification)

--- a/specs/772-task-classifier/tasks.md
+++ b/specs/772-task-classifier/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Wave Task Classifier
+
+**Branch**: `772-task-classifier` | **Date**: 2026-04-12
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Phase 1: Setup
+
+- [X] T001 [P1] Create `internal/classify/` package directory and `profile.go` with package declaration, imports, all exported type definitions: `Complexity`, `Domain`, `VerificationDepth` string enums with constants, `TaskProfile` struct (BlastRadius float64, Complexity, Domain, VerificationDepth, InputType suggest.InputType), and `PipelineConfig` struct (Name string, Reason string). File: `internal/classify/profile.go`. FR-001, FR-008.
+
+## Phase 2: Foundational — Type Validation (Story 1 prerequisite)
+
+- [X] T002 [P1] [Story1] Create `internal/classify/profile_test.go` with 10+ table-driven tests validating: all 4 Complexity constants have correct string values, all 7 Domain constants have correct string values, all 3 VerificationDepth constants have correct string values, TaskProfile zero-value behavior, PipelineConfig field assignment. File: `internal/classify/profile_test.go`. FR-007, SC-003.
+
+## Phase 3: Story 3 — Pipeline Selection (no analyzer dependency)
+
+- [X] T003 [P1] [Story3] Implement `SelectPipeline(profile TaskProfile) PipelineConfig` in `internal/classify/selector.go`. Sequential priority evaluation: (1) InputType==pr_url→ops-pr-review, (2) Domain==security→audit-security, (3) Domain==research→impl-research, (4) Domain==docs→doc-fix, (5) Domain==refactor AND Complexity∈{complex,architectural}→impl-speckit, (6) Complexity∈{simple,medium}→impl-issue, (7) Complexity∈{complex,architectural}→impl-speckit. Each case sets descriptive Reason string. File: `internal/classify/selector.go`. FR-005, FR-006.
+
+- [X] T004 [P1] [Story3] Create `internal/classify/selector_test.go` with 10+ table-driven tests covering: all 7 routing rules from FR-006, PR URL short-circuit, security override at every complexity level, domain-specific routes (research, docs), architectural refactor→impl-speckit, simple bug→impl-issue, medium feature→impl-issue, complex feature→impl-speckit, architectural feature→impl-speckit, Reason field non-empty for all cases. File: `internal/classify/selector_test.go`. FR-007, SC-002, SC-003.
+
+## Phase 4: Story 1 & 2 — Input Classification
+
+- [X] T005 [P1] [Story1,Story2] Implement `Classify(input string, issueBody string) TaskProfile` in `internal/classify/analyzer.go`. Steps: (1) call suggest.ClassifyInput(input) for InputType, (2) combine input+issueBody lowercased for analysis, (3) keyword-match domain with priority ordering security>performance>bug>refactor>research>docs>feature, (4) keyword-match complexity (architectural/complex/simple/medium default), (5) derive blast_radius = base(complexity) + modifier(domain) clamped [0,1], (6) derive verification_depth from complexity. Handle edge cases: empty/whitespace→default profile (simple/feature/0.1/structural_only), no keywords→medium/feature/0.3/behavioral. File: `internal/classify/analyzer.go`. FR-002, FR-003, FR-004, FR-009, FR-010, FR-011, FR-012.
+
+- [X] T006 [P1] [Story1,Story2] Create `internal/classify/analyzer_test.go` with 10+ table-driven tests covering: all 7 domain classifications via keyword matching, all 4 complexity levels, empty string input defaults, whitespace-only input defaults, mixed domain signals (security wins over bug), URL input with issue body combination, PR URL InputType detection, no-keyword fallback to medium/feature, blast_radius ranges (security>0.5, docs+simple<0.2, architectural>0.7), verification_depth derivation (simple→structural_only, medium→behavioral, complex→full_semantic). File: `internal/classify/analyzer_test.go`. FR-007, SC-001, SC-003, SC-004.
+
+## Phase 5: Story 4 — End-to-End Integration
+
+- [X] T007 [P2] [Story4] Add integration test cases to `internal/classify/analyzer_test.go` that exercise the full classify-then-select flow: call Classify() then SelectPipeline() on the result. Cases: "fix null pointer in logger"→impl-issue (simple/bug), "implement new GraphQL API layer with auth, rate limiting, and caching"→impl-speckit (complex+/feature), "fix typo in README"→doc-fix (simple/docs), PR URL→ops-pr-review, "fix SQL injection vulnerability"→audit-security. Verify both TaskProfile fields and PipelineConfig.Name. File: `internal/classify/analyzer_test.go`. SC-001, SC-002.
+
+## Phase 6: Polish & Cross-Cutting
+
+- [X] T008 [P] [P2] Run `go vet ./internal/classify/...` and `go test ./internal/classify/...` to verify all files compile, all tests pass, no vet warnings. Fix any issues. File: `internal/classify/`.
+
+- [X] T009 [P2] Verify SC-005 (no new external dependencies) by checking go.mod is unchanged. Verify SC-006 (<1ms classification) by adding a benchmark test `BenchmarkClassify` in `internal/classify/analyzer_test.go` that asserts single classification completes in <1ms. File: `internal/classify/analyzer_test.go`. SC-005, SC-006.
+
+## Dependency Graph
+
+```
+T001 (types)
+ ├── T002 (type tests) [parallel with T003]
+ ├── T003 (selector)
+ │    └── T004 (selector tests) [parallel with T005]
+ └── T005 (analyzer, depends on T001+T003 types)
+      └── T006 (analyzer tests)
+           └── T007 (integration tests)
+                └── T008 (vet + test all)
+                     └── T009 (benchmarks + dep check)
+```
+
+## Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001
+- T004 and T005 can run in parallel after T003


### PR DESCRIPTION
## Summary

- Add new `internal/classify/` package implementing the Wave Task Classifier (WS1.1–1.3)
- **TaskProfile type** (`profile.go`): structured classification with `blast_radius` (float64), `complexity` (simple/medium/complex/architectural), `domain` (security/performance/docs/feature/bug/refactor), and `verification_depth` (structural_only/behavioral/full_semantic)
- **Input analyzer** (`analyzer.go`): `ClassifyInput()` uses keyword analysis and URL/ref pattern detection (reusing patterns from `internal/suggest/input.go`) to produce a `TaskProfile`
- **Pipeline selector** (`selector.go`): `SelectPipeline()` maps task profiles to pipeline configurations following the AGENTS.md routing table
- Full table-driven unit tests for all three components, spec artifacts, and Go contract types

## Spec

See [specs/772-task-classifier/](specs/772-task-classifier/) for the full feature specification, plan, data model, and checklists.

## Test Plan

- `go test -race ./internal/classify/...` — all table-driven tests pass
- `go test -race ./...` — full suite passes with no regressions
- Tests cover: profile validation, keyword-based classification, URL/ref detection, domain mapping, pipeline selection logic, and edge cases (empty input, ambiguous keywords)

## Known Limitations

- Classification relies on keyword heuristics; ML-based classification is out of scope for this iteration
- Blast radius calculation uses simple heuristics; may need refinement based on real-world usage data
- Not yet wired into `wave run` or `wave suggest` — integration is a follow-up task

Closes #772
