### PR TITLE
feat: #772 P1 — gate smoke test, lore stubs, toast notifications, V&V docs

### DIFF
--- a/.wave/pipelines/wave-smoke-gates.yaml
+++ b/.wave/pipelines/wave-smoke-gates.yaml
@@ -1,0 +1,58 @@
+kind: WavePipeline
+metadata:
+  name: wave-smoke-gates
+  description: >-
+    Smoke test for gate steps. Creates a marker file, waits at a timer gate,
+    then verifies the gate resolved before writing the result.
+  release: false
+  category: wave
+
+input:
+  source: cli
+  example: "verify gate steps work"
+
+steps:
+  - id: prepare
+    type: command
+    script: |
+      mkdir -p .wave/output
+      echo '{"gate_test": "pending", "created_at": "'$(date -Iseconds)'"}' \
+        > .wave/output/gate-marker.json
+      echo "Gate marker written"
+    output_artifacts:
+      - name: gate-marker
+        path: .wave/output/gate-marker.json
+        type: json
+    handover:
+      contract:
+        type: non_empty_file
+        source: .wave/output/gate-marker.json
+        on_failure: fail
+
+  - id: approval-gate
+    dependencies: [prepare]
+    gate:
+      type: timer
+      timeout: "5s"
+      message: "Smoke-test timer gate — auto-resolves in 5 seconds"
+
+  - id: verify
+    type: command
+    dependencies: [approval-gate]
+    script: |
+      if [ ! -f .wave/output/gate-marker.json ]; then
+        echo "FAIL: gate-marker.json missing"
+        exit 1
+      fi
+      echo '{"gate_test": "passed", "verified_at": "'$(date -Iseconds)'"}' \
+        > .wave/output/gate-result.json
+      echo "Gate smoke test passed"
+    output_artifacts:
+      - name: gate-result
+        path: .wave/output/gate-result.json
+        type: json
+    handover:
+      contract:
+        type: non_empty_file
+        source: .wave/output/gate-result.json
+        on_failure: fail

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,6 +135,7 @@ export default withMermaid(
               { text: 'Context Relay', link: '/guides/relay-compaction' },
               { text: 'Meta-Pipelines', link: '/guides/meta-pipelines' },
               { text: 'Contract Chaining', link: '/guides/contract-chaining' },
+              { text: 'V&V Patterns', link: '/guides/vv-patterns' },
               { text: 'Adapter Development', link: '/guides/adapter-development' }
             ]
           },

--- a/docs/guides/vv-patterns.md
+++ b/docs/guides/vv-patterns.md
@@ -1,0 +1,194 @@
+# Verification & Validation Patterns
+
+Wave provides built-in contract types that verify step outputs before execution continues. This guide covers each contract type, common composition patterns, and how to combine them effectively.
+
+## Contract Types Reference
+
+| Type | Purpose | Requires LLM | Rework-able |
+|------|---------|:---:|:---:|
+| `non_empty_file` | Assert a file exists and is non-empty | No | No |
+| `json_schema` | Validate JSON output against a JSON Schema | No | Yes |
+| `format` | Check file format (JSON, YAML, etc.) | No | Yes |
+| `llm_judge` | LLM evaluates output against criteria | Yes | Yes |
+| `source_diff` | Verify meaningful source changes were made | No | No |
+| `agent_review` | Full agent review of step output | Yes | Yes |
+| `spec_derived_test` | Generate and run tests from a specification | Yes | Yes |
+| `test_suite` | Run an existing test suite | No | Yes |
+| `markdown_spec` | Validate markdown structure | No | Yes |
+| `typescript_interface` | Check TypeScript interface conformance | No | Yes |
+
+## Basic Contract Usage
+
+Every step can declare a `handover.contract` block:
+
+```yaml
+steps:
+  - id: generate-code
+    persona: implementer
+    handover:
+      contract:
+        type: json_schema
+        source: .wave/output/result.json
+        schema_path: .wave/contracts/result.schema.json
+        on_failure: rework   # or: fail, warn
+        max_rework: 3
+```
+
+### on_failure Modes
+
+- **`fail`** — Stop the pipeline immediately. Use for hard gates.
+- **`rework`** — Re-run the step with the validation error as feedback. The step sees what went wrong and can fix it.
+- **`warn`** — Log the violation but continue. Use for advisory checks.
+
+## Rework Loops
+
+When `on_failure: rework` is set, Wave feeds the contract error back into the step's prompt and re-executes. This creates a self-correcting loop:
+
+```
+Step executes → Contract validates → Fail? → Feed error back → Re-execute
+                                       ↓
+                                    Pass? → Continue to next step
+```
+
+Configure bounds with `max_rework`:
+
+```yaml
+handover:
+  contract:
+    type: json_schema
+    source: output.json
+    schema_path: schema.json
+    on_failure: rework
+    max_rework: 3        # give up after 3 attempts
+```
+
+Each rework attempt is recorded as a `step_attempt` in the state database, giving full visibility into retry history.
+
+## Gate Patterns
+
+Gates pause pipeline execution until a condition is met:
+
+```yaml
+- id: human-review
+  gate:
+    type: approval
+    message: "Review the generated code before continuing"
+    timeout: "2h"
+    choices:
+      - label: "Approve"
+        key: "a"
+      - label: "Reject"
+        key: "r"
+        target: "_fail"
+```
+
+### Gate Types
+
+| Type | Behavior |
+|------|----------|
+| `approval` | Wait for human choice (CLI, TUI, or WebUI) |
+| `timer` | Auto-resolve after a duration |
+| `pr_merge` | Poll GitHub until a PR is merged |
+| `ci_pass` | Poll CI status on open PRs |
+
+Gates can be auto-approved for CI/batch contexts:
+
+```yaml
+gate:
+  type: approval
+  auto: true
+  timeout: "30m"
+  default: "a"
+```
+
+## LLM Judge
+
+The `llm_judge` contract uses a separate LLM call to evaluate output quality:
+
+```yaml
+handover:
+  contract:
+    type: llm_judge
+    source: .wave/output/review.md
+    criteria: |
+      - Contains at least 3 specific findings
+      - Each finding references a file path
+      - Severity levels are assigned (low/medium/high/critical)
+    model: cheapest
+    on_failure: rework
+    max_rework: 2
+```
+
+The judge runs independently from the step's LLM — it evaluates the output file against the criteria and returns pass/fail with reasoning.
+
+## Composition V&V
+
+When composing pipelines via `branch:` or command steps, contracts bridge the boundary:
+
+### Output Contract → Input Expectation
+
+The producing pipeline's final step should write a well-defined artifact:
+
+```yaml
+# Producer pipeline
+- id: analyze
+  persona: auditor
+  output_artifacts:
+    - name: findings
+      path: .wave/output/findings.json
+  handover:
+    contract:
+      type: json_schema
+      source: .wave/output/findings.json
+      schema_path: .wave/contracts/shared-findings.schema.json
+      on_failure: rework
+```
+
+The consuming pipeline can then rely on that schema:
+
+```yaml
+# Consumer pipeline
+- id: triage
+  persona: navigator
+  exec:
+    type: prompt
+    source: |
+      Read .wave/output/findings.json and prioritize the findings...
+```
+
+### Shared Schemas
+
+Place reusable schemas in `.wave/contracts/shared-*.schema.json`. See the [Contract Chaining](/guides/contract-chaining) guide for details on shared schema conventions.
+
+## Combining Multiple Contracts
+
+A step can only have one `handover.contract` block. To apply multiple validations, use a script contract that runs several checks:
+
+```yaml
+handover:
+  contract:
+    type: test_suite
+    source: ./scripts/validate-output.sh
+    on_failure: fail
+```
+
+Or chain steps — one produces output, the next validates it with a different contract type.
+
+## Decision Logging
+
+Every contract evaluation is recorded in the `decision_log` table with category `"contract"`. Query decision history with:
+
+```bash
+wave analyze --decisions
+```
+
+This shows contract pass/fail rates per pipeline, helping identify steps that frequently need rework.
+
+## Best Practices
+
+1. **Start with `non_empty_file`** — cheapest possible gate. Catches steps that produce nothing.
+2. **Add `json_schema` for structured output** — catches format drift without LLM cost.
+3. **Reserve `llm_judge` for semantic quality** — use when structure alone can't verify correctness.
+4. **Set `max_rework` conservatively** — 2-3 attempts is usually enough. More suggests a prompt problem.
+5. **Use `warn` during development** — switch to `fail` or `rework` once the pipeline is stable.
+6. **Use `cheapest` model for judges** — validation doesn't need the strongest model.

--- a/internal/classify/analyzer.go
+++ b/internal/classify/analyzer.go
@@ -71,6 +71,11 @@ func Classify(input string, issueBody string) TaskProfile {
 
 	domain := matchDomain(text)
 	complexity := matchComplexity(text)
+
+	// Lore enrichment: if keyword matching fell through to defaults,
+	// let high-confidence lore hints fill in the gap.
+	domain, complexity = applyLoreHints(domain, complexity, input)
+
 	blastRadius := deriveBlastRadius(complexity, domain)
 	depth := deriveVerificationDepth(complexity)
 
@@ -122,6 +127,29 @@ func deriveBlastRadius(c Complexity, d Domain) float64 {
 		return 1
 	}
 	return r
+}
+
+// applyLoreHints enriches domain/complexity with lore provider hints when
+// keyword matching fell through to defaults (DomainFeature / ComplexityMedium).
+// Lore hints only fill gaps — they never override a positive keyword match.
+func applyLoreHints(domain Domain, complexity Complexity, input string) (Domain, Complexity) {
+	hints := loreProvider().Hints(input)
+	if len(hints) == 0 {
+		return domain, complexity
+	}
+	const minConfidence = 0.5
+	for _, h := range hints {
+		if h.Confidence < minConfidence {
+			continue
+		}
+		if domain == DomainFeature && h.Domain != "" {
+			domain = h.Domain
+		}
+		if complexity == ComplexityMedium && h.Complexity != "" {
+			complexity = h.Complexity
+		}
+	}
+	return domain, complexity
 }
 
 // deriveVerificationDepth maps complexity to verification depth.

--- a/internal/classify/lore.go
+++ b/internal/classify/lore.go
@@ -1,0 +1,40 @@
+package classify
+
+// LoreProvider supplies historical hints that enrich task classification.
+// Implementations may pull from past orchestration decisions, retrospectives,
+// or external knowledge bases.
+type LoreProvider interface {
+	// Hints returns domain/complexity hints for the given input text.
+	// Returned hints are advisory — they enrich but never override keyword matching.
+	Hints(input string) []LoreHint
+}
+
+// LoreHint is a single advisory signal from historical data.
+type LoreHint struct {
+	Domain     Domain     // suggested domain (empty = no opinion)
+	Complexity Complexity // suggested complexity (empty = no opinion)
+	Confidence float64    // 0.0–1.0 confidence in this hint
+	Source     string     // e.g. "orchestration_history", "retrospective"
+}
+
+// NoOpLoreProvider returns no hints. Used as the default when no lore source is configured.
+type NoOpLoreProvider struct{}
+
+// Hints always returns nil for the no-op provider.
+func (NoOpLoreProvider) Hints(string) []LoreHint { return nil }
+
+var activeLoreProvider LoreProvider = NoOpLoreProvider{}
+
+// RegisterLoreProvider sets the active lore provider. Not concurrency-safe;
+// call during init or startup before any classification runs.
+func RegisterLoreProvider(p LoreProvider) {
+	if p == nil {
+		p = NoOpLoreProvider{}
+	}
+	activeLoreProvider = p
+}
+
+// loreProvider returns the currently registered provider.
+func loreProvider() LoreProvider {
+	return activeLoreProvider
+}

--- a/internal/classify/lore_test.go
+++ b/internal/classify/lore_test.go
@@ -1,0 +1,98 @@
+package classify
+
+import "testing"
+
+func TestNoOpLoreProvider(t *testing.T) {
+	p := NoOpLoreProvider{}
+	hints := p.Hints("fix a bug")
+	if hints != nil {
+		t.Errorf("NoOpLoreProvider.Hints() = %v, want nil", hints)
+	}
+}
+
+func TestRegisterLoreProvider(t *testing.T) {
+	// Save and restore original provider.
+	orig := activeLoreProvider
+	defer func() { activeLoreProvider = orig }()
+
+	// Register a custom provider that always returns a security hint.
+	RegisterLoreProvider(&stubLoreProvider{
+		domain:     DomainSecurity,
+		complexity: ComplexityComplex,
+		confidence: 0.8,
+	})
+
+	hints := loreProvider().Hints("anything")
+	if len(hints) != 1 {
+		t.Fatalf("expected 1 hint, got %d", len(hints))
+	}
+	if hints[0].Domain != DomainSecurity {
+		t.Errorf("hint domain = %q, want %q", hints[0].Domain, DomainSecurity)
+	}
+	if hints[0].Confidence != 0.8 {
+		t.Errorf("hint confidence = %f, want 0.8", hints[0].Confidence)
+	}
+
+	// Register nil reverts to no-op.
+	RegisterLoreProvider(nil)
+	hints = loreProvider().Hints("anything")
+	if hints != nil {
+		t.Errorf("after nil register, Hints() = %v, want nil", hints)
+	}
+}
+
+func TestLoreEnrichesClassify(t *testing.T) {
+	orig := activeLoreProvider
+	defer func() { activeLoreProvider = orig }()
+
+	// Without lore: "do something" → DomainFeature (no keyword match).
+	base := Classify("do something", "")
+	if base.Domain != DomainFeature {
+		t.Fatalf("base domain = %q, want %q", base.Domain, DomainFeature)
+	}
+
+	// With lore hint for security at high confidence.
+	RegisterLoreProvider(&stubLoreProvider{
+		domain:     DomainSecurity,
+		complexity: "",
+		confidence: 0.9,
+	})
+
+	enriched := Classify("do something", "")
+	if enriched.Domain != DomainSecurity {
+		t.Errorf("enriched domain = %q, want %q (lore should enrich fallback)", enriched.Domain, DomainSecurity)
+	}
+}
+
+func TestLoreDoesNotOverrideKeywords(t *testing.T) {
+	orig := activeLoreProvider
+	defer func() { activeLoreProvider = orig }()
+
+	// "fix a bug" → DomainBug via keywords.
+	RegisterLoreProvider(&stubLoreProvider{
+		domain:     DomainDocs,
+		complexity: ComplexitySimple,
+		confidence: 0.9,
+	})
+
+	profile := Classify("fix a bug", "")
+	if profile.Domain != DomainBug {
+		t.Errorf("domain = %q, want %q (keywords should win over lore)", profile.Domain, DomainBug)
+	}
+}
+
+// stubLoreProvider returns a single hint with fixed values.
+type stubLoreProvider struct {
+	domain     Domain
+	complexity Complexity
+	confidence float64
+}
+
+func (s *stubLoreProvider) Hints(string) []LoreHint {
+	return []LoreHint{{
+		Domain:     s.domain,
+		Complexity: s.complexity,
+		Confidence: s.confidence,
+		Source:     "test_stub",
+	}}
+}

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -1271,6 +1271,8 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
 .toast.toast-dismiss { animation: toast-out 0.3s ease forwards; }
 .toast-error { background: var(--color-failed-bg); color: var(--color-failed); border: 1px solid var(--color-failed); }
 .toast-success { background: var(--color-completed-bg); color: var(--color-completed); border: 1px solid var(--color-completed); }
+.toast-info { background: var(--color-running-bg); color: var(--color-running); border: 1px solid var(--color-running); }
+.toast-warning { background: #fef3c7; color: #92400e; border: 1px solid #f59e0b; }
 
 /* Connection Status Banner */
 .connection-banner {

--- a/internal/webui/templates/layout.html
+++ b/internal/webui/templates/layout.html
@@ -207,12 +207,13 @@
     </script>
     <script src="/static/app.js"></script>
     <script>
-    // Attention classifier — SSE listener updates brand logo state
+    // Attention classifier — SSE listener updates brand logo state + toast notifications
     (function() {
         var brand = document.getElementById('wave-brand');
         if (!brand) return;
         var winddownTimer = null;
         var wasRunning = false;
+        var lastWorst = '';
         var es = new EventSource('/api/attention/events');
         es.addEventListener('attention', function(e) {
             try {
@@ -221,14 +222,29 @@
                 if (s.total_runs > 0) {
                     wasRunning = true;
                     brand.className = 'wave-brand-link attention-' + s.worst_state;
+
+                    // Toast on state transitions
+                    if (s.worst_state !== lastWorst) {
+                        if (s.worst_state === 'needs_review') {
+                            showToast(s.needs_review + ' run(s) need review', 'info');
+                        } else if (s.worst_state === 'failed') {
+                            showToast(s.failed + ' run(s) failed', 'error');
+                        }
+                    }
+                    lastWorst = s.worst_state;
                 } else if (wasRunning) {
                     wasRunning = false;
+                    if (lastWorst !== 'failed') {
+                        showToast('All runs completed', 'success');
+                    }
+                    lastWorst = '';
                     brand.className = 'wave-brand-link attention-winddown';
                     winddownTimer = setTimeout(function() {
                         brand.className = 'wave-brand-link';
                     }, 3000);
                 } else {
                     brand.className = 'wave-brand-link';
+                    lastWorst = '';
                 }
 
                 var parts = [];


### PR DESCRIPTION
## Summary
- **P1a**: `wave-smoke-gates.yaml` — 3-step smoke test (command → timer gate 5s → verify). Validated via `wave run`.
- **P1b**: `LoreProvider` interface + `NoOpLoreProvider` in `internal/classify/lore.go`. Soft enrichment wired into `Classify()` — fills fallback defaults, never overrides keyword matches. 4 tests.
- **P1c**: Toast notifications via attention SSE in `layout.html`. Fires on state transitions: needs_review → info, failed → error, all-done → success. Added `.toast-info` / `.toast-warning` CSS.
- **P1d**: `docs/guides/vv-patterns.md` — contract types reference, rework loops, gate patterns, LLM judge, composition V&V. Linked from VitePress sidebar.

## Test plan
- [x] `go test ./internal/classify/...` — all pass
- [x] `go build ./...` clean, `go vet` clean
- [x] `wave run wave-smoke-gates --auto-approve` — 3/3 steps pass
- [x] VitePress `npm run build` — clean, `vv-patterns.html` in dist
- [x] WebUI renders, attention SSE delivers events, toast CSS served

Closes partial #772