### PR TITLE
feat: #772 P2 — provenance CLI and sub-pipeline diff fix

### DIFF
--- a/cmd/wave/commands/analyze.go
+++ b/cmd/wave/commands/analyze.go
@@ -13,6 +13,7 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/doctor"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -40,6 +41,7 @@ func NewAnalyzeCmd() *cobra.Command {
 	var deepFlag bool
 	var evolveFlag bool
 	var applyFlag bool
+	var decisionsFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "analyze",
@@ -52,16 +54,21 @@ By default, performs a deterministic scan using directory structure and
 package detection. Use --deep for AI-assisted analysis that extracts
 invariants, domain vocabulary, and key decisions from code and tests.
 Use --evolve to propose ontology updates based on pipeline run history.
-Use --apply to auto-write proposed contexts to wave.yaml.`,
+Use --apply to auto-write proposed contexts to wave.yaml.
+Use --decisions to show orchestration decision provenance table.`,
 		Example: `  wave analyze
   wave analyze --json
   wave analyze --deep
   wave analyze --evolve
-  wave analyze --apply`,
+  wave analyze --apply
+  wave analyze --decisions`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
+			if decisionsFlag {
+				return runAnalyzeDecisions(cmd)
+			}
 			if deepFlag {
 				return runAnalyzeDeep(cmd)
 			}
@@ -72,6 +79,7 @@ Use --apply to auto-write proposed contexts to wave.yaml.`,
 	cmd.Flags().BoolVar(&deepFlag, "deep", false, "Use AI-assisted analysis (requires adapter)")
 	cmd.Flags().BoolVar(&evolveFlag, "evolve", false, "Propose updates based on pipeline run history")
 	cmd.Flags().BoolVar(&applyFlag, "apply", false, "Auto-write proposed contexts to wave.yaml")
+	cmd.Flags().BoolVar(&decisionsFlag, "decisions", false, "Show orchestration decision provenance")
 
 	return cmd
 }
@@ -800,4 +808,48 @@ func generateDeepSkillContent(ctx deepContextResult, _ string) string {
 	}
 
 	return b.String()
+}
+
+// runAnalyzeDecisions shows orchestration decision provenance as a table.
+func runAnalyzeDecisions(cmd *cobra.Command) error {
+	store, err := state.NewStateStore(".wave/state.db")
+	if err != nil {
+		return NewCLIError(CodeInternalError,
+			fmt.Sprintf("failed to open state database: %s", err),
+			"Check that .wave/state.db exists")
+	}
+	defer store.Close()
+
+	summaries, err := store.ListOrchestrationDecisionSummary(50)
+	if err != nil {
+		return NewCLIError(CodeInternalError,
+			fmt.Sprintf("failed to query decisions: %s", err),
+			"Check state database integrity")
+	}
+
+	f := display.NewFormatter()
+
+	if len(summaries) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "\n  No orchestration decisions recorded yet.\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s Run 'wave do <task>' to create orchestrated pipeline runs.\n\n", f.Muted("Hint:"))
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\n  %s\n\n", f.Colorize("Orchestration Decisions:", "\033[1;37m"))
+
+	// Header
+	fmt.Fprintf(cmd.OutOrStdout(), "  %-14s %-16s %-24s %6s %8s %10s %12s\n",
+		f.Muted("DOMAIN"), f.Muted("COMPLEXITY"), f.Muted("PIPELINE"),
+		f.Muted("TOTAL"), f.Muted("SUCCESS"), f.Muted("AVG TOKENS"), f.Muted("AVG DURATION"))
+	fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", f.Muted(strings.Repeat("─", 96)))
+
+	for _, s := range summaries {
+		successStr := fmt.Sprintf("%.0f%%", s.SuccessRate)
+		durationStr := formatDurationMs(s.AvgDurationMs)
+		fmt.Fprintf(cmd.OutOrStdout(), "  %-14s %-16s %-24s %6d %8s %10d %12s\n",
+			s.Domain, s.Complexity, s.PipelineName,
+			s.Total, successStr, s.AvgTokens, durationStr)
+	}
+	fmt.Fprintln(cmd.OutOrStdout())
+	return nil
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -5177,6 +5177,11 @@ func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execu
 	if e.store != nil && childRunID != "" {
 		_ = e.store.SetParentRun(childRunID, pipelineID, step.ID)
 		_ = e.store.UpdateRunStatus(childRunID, "completed", "", childExecutor.GetTotalTokens())
+
+		// Propagate child's worktree branch to parent so the diff endpoint works
+		if childRun, err := e.store.GetRun(childRunID); err == nil && childRun.BranchName != "" {
+			_ = e.store.UpdateRunBranch(pipelineID, childRun.BranchName)
+		}
 	}
 
 	// Extract child artifacts and merge context variables

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -172,6 +172,7 @@ type StateStore interface {
 	RecordOrchestrationDecision(record *OrchestrationDecision) error
 	UpdateOrchestrationOutcome(runID string, outcome string, tokensUsed int, durationMs int64) error
 	GetOrchestrationStats(pipelineName string) (*OrchestrationStats, error)
+	ListOrchestrationDecisionSummary(limit int) ([]OrchestrationDecisionSummary, error)
 }
 
 // ListRetrosOptions specifies filters for listing retrospectives.
@@ -2919,6 +2920,42 @@ func (s *stateStore) UpdateOrchestrationOutcome(runID string, outcome string, to
 		outcome, tokensUsed, durationMs, time.Now().Unix(), runID,
 	)
 	return err
+}
+
+// ListOrchestrationDecisionSummary returns aggregated decision stats grouped by domain, complexity, pipeline.
+func (s *stateStore) ListOrchestrationDecisionSummary(limit int) ([]OrchestrationDecisionSummary, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(
+		`SELECT domain, complexity, pipeline_name,
+		        COUNT(*) as total,
+		        SUM(CASE WHEN outcome = 'completed' THEN 1 ELSE 0 END) as completed,
+		        SUM(CASE WHEN outcome = 'failed' THEN 1 ELSE 0 END) as failed,
+		        COALESCE(AVG(CASE WHEN tokens_used > 0 THEN tokens_used END), 0) as avg_tokens,
+		        COALESCE(AVG(CASE WHEN duration_ms > 0 THEN duration_ms END), 0) as avg_duration
+		 FROM orchestration_decision
+		 GROUP BY domain, complexity, pipeline_name
+		 ORDER BY total DESC
+		 LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []OrchestrationDecisionSummary
+	for rows.Next() {
+		var s OrchestrationDecisionSummary
+		if err := rows.Scan(&s.Domain, &s.Complexity, &s.PipelineName,
+			&s.Total, &s.Completed, &s.Failed, &s.AvgTokens, &s.AvgDurationMs); err != nil {
+			return nil, err
+		}
+		if s.Total > 0 {
+			s.SuccessRate = float64(s.Completed) / float64(s.Total) * 100
+		}
+		results = append(results, s)
+	}
+	return results, rows.Err()
 }
 
 // GetOrchestrationStats returns aggregate stats for a pipeline name.

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -315,3 +315,16 @@ type OrchestrationStats struct {
 	AvgTokens    int
 	AvgDurationMs int64
 }
+
+// OrchestrationDecisionSummary aggregates decisions grouped by domain+complexity+pipeline.
+type OrchestrationDecisionSummary struct {
+	Domain        string
+	Complexity    string
+	PipelineName  string
+	Total         int
+	Completed     int
+	Failed        int
+	SuccessRate   float64
+	AvgTokens     int
+	AvgDurationMs int64
+}

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -649,3 +649,6 @@ func (m *MockStateStore) UpdateOrchestrationOutcome(_, _ string, _ int, _ int64)
 func (m *MockStateStore) GetOrchestrationStats(_ string) (*state.OrchestrationStats, error) {
 	return nil, nil
 }
+func (m *MockStateStore) ListOrchestrationDecisionSummary(_ int) ([]state.OrchestrationDecisionSummary, error) {
+	return nil, nil
+}

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -175,6 +175,9 @@ func (b baseStateStore) UpdateOrchestrationOutcome(string, string, int, int64) e
 func (b baseStateStore) GetOrchestrationStats(string) (*state.OrchestrationStats, error) {
 	return nil, nil
 }
+func (b baseStateStore) ListOrchestrationDecisionSummary(int) ([]state.OrchestrationDecisionSummary, error) {
+	return nil, nil
+}
 
 // Compile-time check: baseStateStore must satisfy state.StateStore.
 var _ state.StateStore = baseStateStore{}


### PR DESCRIPTION
## Summary
- **P2a**: `wave analyze --decisions` — shows orchestration decision provenance as a formatted table (domain, complexity, pipeline, total, success%, avg tokens, avg duration). Empty state shows hint message.
- **P2b**: Fix sub-pipeline empty diff — after child sub-pipeline completes, propagate its `branch_name` to the parent run so the diff endpoint can find the worktree branch.

## Test plan
- [x] `go build ./...` clean, `go vet ./...` clean
- [x] `go test ./internal/state/...` — pass
- [x] `go test ./internal/pipeline/...` — pass
- [x] `go test ./cmd/wave/commands/...` — pass
- [x] `wave analyze --decisions` — renders empty state correctly
- [x] `wave analyze --decisions` — renders table with data (verified with test insert)

Closes partial #772