### PR TITLE
feat: #772 P3 — semantic convergence tracking for rework loops

### DIFF
--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -33,6 +33,10 @@ type ContractConfig struct {
 	Criteria  []string `json:"criteria,omitempty"`  // Evaluation criteria for LLM judge
 	Threshold float64  `json:"threshold,omitempty"` // Pass threshold (0.0-1.0), default 1.0
 
+	// Convergence tracking for rework loops
+	ConvergenceWindow         int     `json:"convergence_window,omitempty"`          // Number of rounds to compare for stall detection (default 3)
+	ConvergenceMinImprovement float64 `json:"convergence_min_improvement,omitempty"` // Minimum score improvement to consider progress (default 0.05 = 5%)
+
 	// Agent review settings
 	Persona      string                `json:"persona,omitempty"`      // Reviewer persona name
 	CriteriaPath string                `json:"criteriaPath,omitempty"` // Path to review criteria markdown

--- a/internal/pipeline/convergence.go
+++ b/internal/pipeline/convergence.go
@@ -1,0 +1,93 @@
+package pipeline
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// ConvergenceTracker monitors rework loop progress by tracking validation
+// scores across rounds. If scores plateau (no meaningful improvement over
+// a sliding window), the tracker signals a stall so the loop can bail early
+// instead of burning tokens on fruitless retries.
+type ConvergenceTracker struct {
+	scores         []float64
+	window         int
+	minImprovement float64
+}
+
+// NewConvergenceTracker creates a tracker with the given window size and
+// minimum improvement threshold. Window is the number of recent scores
+// to compare; minImprovement is the minimum score delta required to
+// consider the loop as making progress (e.g. 0.05 = 5%).
+func NewConvergenceTracker(window int, minImprovement float64) *ConvergenceTracker {
+	if window < 2 {
+		window = 2
+	}
+	if minImprovement <= 0 {
+		minImprovement = 0.05
+	}
+	return &ConvergenceTracker{
+		window:         window,
+		minImprovement: minImprovement,
+	}
+}
+
+// RecordScore appends a new score (0.0–1.0) to the history.
+func (ct *ConvergenceTracker) RecordScore(score float64) {
+	ct.scores = append(ct.scores, score)
+}
+
+// IsStalled returns true if the last `window` scores show no meaningful
+// improvement. Requires at least `window` scores recorded.
+func (ct *ConvergenceTracker) IsStalled() bool {
+	if len(ct.scores) < ct.window {
+		return false
+	}
+
+	recent := ct.scores[len(ct.scores)-ct.window:]
+	first := recent[0]
+	last := recent[len(recent)-1]
+
+	improvement := last - first
+	return improvement < ct.minImprovement
+}
+
+// LastScore returns the most recently recorded score, or 0 if none.
+func (ct *ConvergenceTracker) LastScore() float64 {
+	if len(ct.scores) == 0 {
+		return 0
+	}
+	return ct.scores[len(ct.scores)-1]
+}
+
+// Rounds returns the number of scores recorded.
+func (ct *ConvergenceTracker) Rounds() int {
+	return len(ct.scores)
+}
+
+// Summary returns a human-readable summary of convergence state.
+func (ct *ConvergenceTracker) Summary() string {
+	if len(ct.scores) == 0 {
+		return "no scores recorded"
+	}
+	return fmt.Sprintf("%.0f%% after %d round(s)", ct.LastScore()*100, len(ct.scores))
+}
+
+// scorePattern matches "Score: 75%" in ValidationError messages.
+var scorePattern = regexp.MustCompile(`Score:\s*(\d+)%`)
+
+// ExtractScoreFromError attempts to parse a score from a contract validation
+// error message (e.g. "Score: 75% (threshold: 100%)"). Returns 0 and false
+// if no score is found.
+func ExtractScoreFromError(errMsg string) (float64, bool) {
+	matches := scorePattern.FindStringSubmatch(errMsg)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	pct, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	return pct / 100.0, true
+}

--- a/internal/pipeline/convergence_test.go
+++ b/internal/pipeline/convergence_test.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import "testing"
+
+func TestConvergenceTracker_NotStalledWithFewScores(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.05)
+	ct.RecordScore(0.5)
+	if ct.IsStalled() {
+		t.Error("should not be stalled with only 1 score")
+	}
+	ct.RecordScore(0.5)
+	if ct.IsStalled() {
+		t.Error("should not be stalled with only 2 scores (window=3)")
+	}
+}
+
+func TestConvergenceTracker_StalledWhenFlat(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.05)
+	ct.RecordScore(0.5)
+	ct.RecordScore(0.5)
+	ct.RecordScore(0.51) // improvement < 0.05
+	if !ct.IsStalled() {
+		t.Error("should be stalled: 0.51 - 0.5 = 0.01 < 0.05")
+	}
+}
+
+func TestConvergenceTracker_NotStalledWhenImproving(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.05)
+	ct.RecordScore(0.5)
+	ct.RecordScore(0.55)
+	ct.RecordScore(0.6)
+	if ct.IsStalled() {
+		t.Error("should not be stalled: 0.6 - 0.5 = 0.1 >= 0.05")
+	}
+}
+
+func TestConvergenceTracker_StalledAfterPlateau(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.1)
+	// Initial improvement
+	ct.RecordScore(0.3)
+	ct.RecordScore(0.5)
+	ct.RecordScore(0.7)
+	if ct.IsStalled() {
+		t.Error("should not be stalled during improvement phase")
+	}
+	// Plateau
+	ct.RecordScore(0.71)
+	ct.RecordScore(0.72)
+	if !ct.IsStalled() {
+		t.Error("should be stalled: last 3 scores [0.7, 0.71, 0.72] delta = 0.02 < 0.1")
+	}
+}
+
+func TestConvergenceTracker_LastScore(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.05)
+	if ct.LastScore() != 0 {
+		t.Error("empty tracker should return 0")
+	}
+	ct.RecordScore(0.75)
+	if ct.LastScore() != 0.75 {
+		t.Errorf("LastScore() = %f, want 0.75", ct.LastScore())
+	}
+}
+
+func TestConvergenceTracker_Summary(t *testing.T) {
+	ct := NewConvergenceTracker(3, 0.05)
+	if ct.Summary() != "no scores recorded" {
+		t.Errorf("empty summary = %q", ct.Summary())
+	}
+	ct.RecordScore(0.75)
+	want := "75% after 1 round(s)"
+	if ct.Summary() != want {
+		t.Errorf("Summary() = %q, want %q", ct.Summary(), want)
+	}
+}
+
+func TestExtractScoreFromError(t *testing.T) {
+	tests := []struct {
+		msg       string
+		wantScore float64
+		wantOK    bool
+	}{
+		{"Score: 75% (threshold: 100%)", 0.75, true},
+		{"Score: 0% (threshold: 100%)", 0, true},
+		{"Score: 100% (threshold: 100%)", 1.0, true},
+		{"no score here", 0, false},
+		{"LLM judge score 50% is below threshold", 0, false}, // different format
+	}
+
+	for _, tt := range tests {
+		score, ok := ExtractScoreFromError(tt.msg)
+		if ok != tt.wantOK {
+			t.Errorf("ExtractScoreFromError(%q) ok = %v, want %v", tt.msg, ok, tt.wantOK)
+		}
+		if score != tt.wantScore {
+			t.Errorf("ExtractScoreFromError(%q) = %f, want %f", tt.msg, score, tt.wantScore)
+		}
+	}
+}
+
+func TestNewConvergenceTracker_Defaults(t *testing.T) {
+	ct := NewConvergenceTracker(0, 0)
+	if ct.window != 2 {
+		t.Errorf("window = %d, want 2 (minimum)", ct.window)
+	}
+	if ct.minImprovement != 0.05 {
+		t.Errorf("minImprovement = %f, want 0.05 (default)", ct.minImprovement)
+	}
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2116,9 +2116,22 @@ func (e *DefaultPipelineExecutor) validateStepContracts(
 	// maxRounds limits how many full contract-list re-runs can happen due to rework.
 	// We use the max max_retries across all contracts that have on_failure: rework.
 	maxRounds := 1
+	var convergenceTracker *ConvergenceTracker
 	for _, c := range contracts {
 		if c.OnFailure == OnFailureRework && c.MaxRetries > maxRounds {
 			maxRounds = c.MaxRetries
+		}
+		// Initialize convergence tracker from first rework contract with settings
+		if c.OnFailure == OnFailureRework && convergenceTracker == nil {
+			window := c.ConvergenceWindow
+			if window == 0 {
+				window = 3
+			}
+			minImprove := c.ConvergenceMinImprovement
+			if minImprove == 0 {
+				minImprove = 0.05
+			}
+			convergenceTracker = NewConvergenceTracker(window, minImprove)
 		}
 	}
 
@@ -2217,6 +2230,28 @@ func (e *DefaultPipelineExecutor) validateStepContracts(
 				)
 
 			case OnFailureRework:
+				// Track convergence: extract score from error and check for stall
+				if convergenceTracker != nil {
+					if score, ok := ExtractScoreFromError(cErr.Error()); ok {
+						convergenceTracker.RecordScore(score)
+						if convergenceTracker.IsStalled() {
+							e.emit(event.Event{
+								Timestamp:  time.Now(),
+								PipelineID: pipelineID,
+								StepID:     step.ID,
+								State:      "convergence_stalled",
+								Message:    fmt.Sprintf("rework loop stalled at %s — aborting to save tokens", convergenceTracker.Summary()),
+							})
+							e.recordDecision(pipelineID, step.ID, "contract",
+								fmt.Sprintf("convergence stalled for step %s", step.ID),
+								fmt.Sprintf("score plateaued at %s, no improvement over %d rounds", convergenceTracker.Summary(), convergenceTracker.Rounds()),
+								map[string]interface{}{"contract_type": c.Type, "scores": convergenceTracker.scores},
+							)
+							return fmt.Errorf("contract rework stalled (no convergence): %w", cErr)
+						}
+					}
+				}
+
 				if round >= maxRounds {
 					// Retries exhausted — fall back to fail
 					e.emit(event.Event{

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -459,6 +459,10 @@ type ContractConfig struct {
 	Criteria  []string `yaml:"criteria,omitempty"`  // Evaluation criteria for LLM judge
 	Threshold float64  `yaml:"threshold,omitempty"` // Pass threshold (0.0-1.0), default 1.0
 
+	// Convergence tracking for rework loops
+	ConvergenceWindow         int     `yaml:"convergence_window,omitempty"`          // Sliding window size for stall detection (default 3)
+	ConvergenceMinImprovement float64 `yaml:"convergence_min_improvement,omitempty"` // Min score improvement to continue rework (default 0.05)
+
 	// Agent review settings
 	Persona      string                `yaml:"persona,omitempty"`       // Reviewer persona name (must differ from step persona)
 	CriteriaPath string                `yaml:"criteria_path,omitempty"` // Path to review criteria markdown file


### PR DESCRIPTION
## Summary
- **ConvergenceTracker** (`internal/pipeline/convergence.go`): Tracks validation scores across rework rounds. Uses a sliding window to detect score plateaus — if improvement stalls, aborts early to save tokens.
- **Rework loop integration**: Before triggering rework, extracts score from LLM judge error ("Score: 75%"), feeds to tracker. Emits `convergence_stalled` event and records decision when detected.
- **YAML config**: `convergence_window` (default 3) and `convergence_min_improvement` (default 0.05) on contract config.

## Test plan
- [x] 7 unit tests: stall detection, improvement tracking, plateau after progress, score extraction, defaults
- [x] `go test ./internal/pipeline/...` — all pass (21s)
- [x] `go build ./...` clean, `go vet` clean
- [x] `wave run wave-smoke-contracts --adapter opencode` — passes (no regression)
- [x] Full smoke test suite: 7/9 pass, no regressions

Closes partial #772