### PR TITLE
feat: wire orchestration decision recording into wave do

### DIFF
--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -12,6 +12,7 @@ import (
 	"github.com/recinq/wave/internal/classify"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -157,6 +158,14 @@ func runDo(input string, opts DoOptions) error {
 		return nil
 	}
 
+	// Open state store for decision tracking and executor wiring
+	var store state.StateStore
+	if s, err := state.NewStateStore(".wave/state.db"); err == nil {
+		store = s
+		defer store.Close()
+	}
+
+
 	// Execute the pipeline
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -200,6 +209,9 @@ func runDo(input string, opts DoOptions) error {
 	if opts.Model != "" {
 		execOpts = append(execOpts, pipeline.WithModelOverride(opts.Model))
 	}
+	if store != nil {
+		execOpts = append(execOpts, pipeline.WithStateStore(store))
+	}
 
 	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)
 
@@ -210,12 +222,40 @@ func runDo(input string, opts DoOptions) error {
 	pipelineStart := time.Now()
 
 	if err := executor.Execute(execCtx, p, &m, input); err != nil {
+		if store != nil && useClassification {
+			elapsed := time.Since(pipelineStart)
+			recordOrchestrationDecision(store, executor.GetRunID(), input, profile, pipelineCfg, "failed", executor.GetTotalTokens(), elapsed.Milliseconds())
+		}
 		return NewCLIError(CodeInternalError, fmt.Sprintf("execution failed: %s", err), "Run 'wave logs' to inspect execution details").WithCause(err)
 	}
 
 	elapsed := time.Since(pipelineStart)
+	if store != nil && useClassification {
+		recordOrchestrationDecision(store, executor.GetRunID(), input, profile, pipelineCfg, "completed", executor.GetTotalTokens(), elapsed.Milliseconds())
+	}
 	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
 		fmt.Fprintf(os.Stderr, "\nTask completed (%.1fs)\n", elapsed.Seconds())
 	}
 	return nil
+}
+
+// recordOrchestrationDecision persists the classification → pipeline routing decision
+// so it appears in `wave analyze --decisions`.
+func recordOrchestrationDecision(store state.StateStore, runID, input string, profile classify.TaskProfile, cfg classify.PipelineConfig, outcome string, tokensUsed int, durationMs int64) {
+	if runID == "" {
+		return
+	}
+	_ = store.RecordOrchestrationDecision(&state.OrchestrationDecision{
+		RunID:        runID,
+		InputText:    input,
+		Domain:       string(profile.Domain),
+		Complexity:   string(profile.Complexity),
+		PipelineName: cfg.Name,
+		ModelTier:    string(cfg.ModelTier),
+		Reason:       cfg.Reason,
+		Outcome:      outcome,
+		TokensUsed:   tokensUsed,
+		DurationMs:   durationMs,
+		CreatedAt:    time.Now(),
+	})
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -4852,6 +4852,11 @@ func (e *DefaultPipelineExecutor) GetDeliverableTracker() *deliverable.Tracker {
 	return e.deliverableTracker
 }
 
+// GetRunID returns the run ID assigned to this executor (empty if not yet started).
+func (e *DefaultPipelineExecutor) GetRunID() string {
+	return e.runID
+}
+
 // GetTotalTokens returns the sum of tokens used across all completed steps.
 func (e *DefaultPipelineExecutor) GetTotalTokens() int {
 	e.mu.RLock()


### PR DESCRIPTION
## Summary
- Wire state store into `wave do` executor via `WithStateStore` — enables run tracking in dashboard
- Record orchestration decisions after pipeline execution completes (both success and failure paths)
- Add `GetRunID()` public getter to `DefaultPipelineExecutor`
- Decisions are recorded with domain, complexity, pipeline name, model tier, outcome, tokens, duration
- Feeds `wave analyze --decisions` provenance table with real data

## Known limitation
Decision recording requires the executor to create a `pipeline_run` record (FK constraint). Currently `wave do` ad-hoc pipelines may not always create one — this will be addressed in a follow-up that ensures all `wave do` runs appear in the dashboard.

## Test plan
- [x] `go test ./cmd/wave/commands/...` — pass
- [x] `go test ./internal/pipeline/...` — pass (24s)
- [x] `go build ./...` clean
- [x] `wave run wave-smoke-classify --auto-approve` — pass (includes lore tests)

Closes partial #772