### PR TITLE
fix(pipeline): widen unresolvedProjectVarRe to strip deep project vars

### DIFF
--- a/internal/pipeline/context.go
+++ b/internal/pipeline/context.go
@@ -18,7 +18,7 @@ import (
 // missing project config fields resolve to empty strings instead of leaking
 // literal mustache syntax into prompts and contract commands.
 var (
-	unresolvedProjectVarRe = regexp.MustCompile(`\{\{\s*(?:project|ontology)\.\w+(?:\.\w+)?\s*\}\}`)
+	unresolvedProjectVarRe = regexp.MustCompile(`\{\{\s*(?:project|ontology)\.\w+(?:\.\w+)*\s*\}\}`)
 	threeDigitPrefixRe     = regexp.MustCompile(`^(\d{3})-`)
 	numericPrefixRe        = regexp.MustCompile(`(\d+)[-_]`)
 	invalidPathCharRe      = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)

--- a/internal/pipeline/context_test.go
+++ b/internal/pipeline/context_test.go
@@ -92,6 +92,27 @@ func TestPipelineContext_ResolvePlaceholders(t *testing.T) {
 			template: "path/{{ custom_var }}/file.txt",
 			expected: "path/custom_value/file.txt",
 		},
+		// Unresolved {{ project.* }} placeholders are stripped — not leaked into prompts.
+		{
+			name:     "unresolved_project_var_1_segment",
+			template: "run {{ project.name }} now",
+			expected: "run  now",
+		},
+		{
+			name:     "unresolved_project_var_2_segments",
+			template: "cmd {{ project.build.tool }}",
+			expected: "cmd ",
+		},
+		{
+			name:     "unresolved_project_var_3_segments",
+			template: "path {{ project.services.api.path }}",
+			expected: "path ",
+		},
+		{
+			name:     "unresolved_ontology_var",
+			template: "ctx {{ ontology.bounded_context.name }}",
+			expected: "ctx ",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Correctness bug found by `audit-duplicates` pipeline.

The regex stripping unresolved `{{ project.* }}` placeholders used `(?:\.\w+)?` — matching only one optional extra dot-segment. Placeholders like `{{ project.services.api.path }}` (3 extra segments) were **not stripped** and leaked literally into prompts and contract commands when the project field was not configured.

**Fix:** `(?:\.\w+)?` → `(?:\.\w+)*` — matches any depth of dot-separated segments.

## Test plan
- [x] 4 new regression cases: 1-segment, 2-segment, 3-segment project vars, ontology var — all stripped correctly
- [x] All existing `TestPipelineContext_ResolvePlaceholders` cases still pass
- [x] `go test ./internal/pipeline/...` green