### PR TITLE
chore: remove dead code

### DIFF
--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -607,36 +607,8 @@ func WithSavePipelineState(fn func(id, status, input string) error) MockStateSto
 	return func(m *MockStateStore) { m.savePipelineState = fn }
 }
 
-func WithGetPipelineState(fn func(id string) (*state.PipelineStateRecord, error)) MockStateStoreOption {
-	return func(m *MockStateStore) { m.getPipelineState = fn }
-}
-
-func WithSaveStepState(fn func(pipelineID, stepID string, st state.StepState, errMsg string) error) MockStateStoreOption {
-	return func(m *MockStateStore) { m.saveStepState = fn }
-}
-
-func WithGetStepStates(fn func(pipelineID string) ([]state.StepStateRecord, error)) MockStateStoreOption {
-	return func(m *MockStateStore) { m.getStepStates = fn }
-}
-
-func WithRecordStepAttempt(fn func(record *state.StepAttemptRecord) error) MockStateStoreOption {
-	return func(m *MockStateStore) { m.recordStepAttempt = fn }
-}
-
-func WithGetStepAttempts(fn func(runID, stepID string) ([]state.StepAttemptRecord, error)) MockStateStoreOption {
-	return func(m *MockStateStore) { m.getStepAttempts = fn }
-}
-
 func WithCreateRun(fn func(pipelineName, input string) (string, error)) MockStateStoreOption {
 	return func(m *MockStateStore) { m.createRun = fn }
-}
-
-func WithUpdateRunStatus(fn func(runID, status, currentStep string, tokens int) error) MockStateStoreOption {
-	return func(m *MockStateStore) { m.updateRunStatus = fn }
-}
-
-func WithLogEvent(fn func(runID, stepID, st, persona, message string, tokens int, durationMs int64) error) MockStateStoreOption {
-	return func(m *MockStateStore) { m.logEvent = fn }
 }
 
 // Orchestration decision stubs


### PR DESCRIPTION
## Summary

Automated dead code removal based on static analysis scan (2026-04-13).

**7 items removed** across 1 file (`internal/testutil/statestore.go`), saving **28 lines**.

All removed items are exported `MockStateStoreOption` constructors in the `testutil` package that had **zero callers anywhere in the codebase** — not in production code, not in test files, not in any `_test.go` file. Confirmed by full-codebase grep across a clean worktree.

**Packages affected:** `github.com/recinq/wave/internal/testutil`

**4 items skipped** (medium-confidence findings): exported functions used exclusively by same-package test files. Removing them would break the test suite; they are correctly retained.

## Verification

**Verdict: CLEAN**

- `go build ./...` passes cleanly after all removals
- `go test ./...` passes with all 41 packages passing (no failures)
- Grep across clean worktree confirms zero callers remain for all 7 removed symbols
- Only `internal/testutil/statestore.go` was modified — no unrelated changes present
- All 4 medium-confidence items correctly skipped to preserve passing test suite
- No false positives detected

## Removed Items

| ID | Category | Symbol | Location |
|----|----------|--------|----------|
| DC-001 | Unused export (mock option constructor) | `WithGetPipelineState` | `internal/testutil/statestore.go:610` |
| DC-002 | Unused export (mock option constructor) | `WithSaveStepState` | `internal/testutil/statestore.go:614` |
| DC-003 | Unused export (mock option constructor) | `WithGetStepStates` | `internal/testutil/statestore.go:618` |
| DC-004 | Unused export (mock option constructor) | `WithRecordStepAttempt` | `internal/testutil/statestore.go:622` |
| DC-005 | Unused export (mock option constructor) | `WithGetStepAttempts` | `internal/testutil/statestore.go:626` |
| DC-006 | Unused export (mock option constructor) | `WithUpdateRunStatus` | `internal/testutil/statestore.go:634` |
| DC-007 | Unused export (mock option constructor) | `WithLogEvent` | `internal/testutil/statestore.go:638` |

All 7 are `MockStateStoreOption` functional-option constructors in the `testutil` package. Each was verified by grepping all `.go` files: exactly 1 result (the definition itself) — zero call sites.

## Skipped Items

| ID | Symbol | Location | Reason |
|----|--------|----------|--------|
| DC-008 | `NewConfigurationError` | `internal/security/errors.go:102` | Medium confidence — 3 call sites in `internal/security/errors_test.go`; removal would break test suite |
| DC-009 | `NewMalformedJSONError` | `internal/security/errors.go:78` | Medium confidence — 4 call sites in `internal/security/errors_test.go`; removal would break test suite |
| DC-010 | `RegisterLoreProvider` | `internal/classify/lore.go:64` | Medium confidence — 6 call sites in `internal/classify/lore_test.go`; removal would break test suite |
| DC-011 | `InjectCheckpointPrompt` | `internal/relay/checkpoint.go:78` | Medium confidence — 9 call sites across `relay_concurrency_test.go`, `checkpoint_test.go`, `relay_test.go`; removal would break test suite |

These 4 functions are exported but only exercised by same-package tests. They are not dead code in the traditional sense — they are test API surface for their respective packages. A follow-up decision to remove them would require also removing or rewriting the tests that use them.

## Test Plan

- Full test suite (`go test ./...`) passed after all incremental removals applied — 41/41 packages passing
- Build (`go build ./...`) verified clean after all removals applied
- Verification step confirmed no false positives via grep on clean worktree
- All checks passed: confidence threshold, build, tests, commit focus (single file, no unrelated changes), completeness