### PR TITLE
docs: add missing CLI commands + fix flag error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ personas:
       deny: ["Write(*)", "Edit(*)", "Bash(git commit*)", "Bash(git push*)"]
 ```
 
-**30 built-in personas** (plus `base-protocol.md` shared preamble) including `navigator`, `craftsman`, `auditor`, `philosopher`, `debugger`, and more.
+**31 built-in personas** (plus `base-protocol.md` shared preamble) including `navigator`, `craftsman`, `auditor`, `philosopher`, `debugger`, and more.
 
 > Explore all personas in [`.wave/personas/`](.wave/personas/)
 

--- a/cmd/wave/commands/list.go
+++ b/cmd/wave/commands/list.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -140,12 +141,21 @@ For 'list runs', additional flags are available:
   wave list skills`,
 		ValidArgs: []string{"adapters", "runs", "pipelines", "personas", "contracts", "skills", "compositions"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			filter := ""
 			if len(args) > 0 {
 				filter = args[0]
 			}
 			opts.Format = ResolveFormat(cmd, opts.Format)
-			return runList(opts, filter)
+			if err := runList(opts, filter); err != nil {
+				var cliErr *CLIError
+				if !errors.As(err, &cliErr) {
+					return NewCLIError(CodeInternalError, err.Error(), "").WithCause(err)
+				}
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/wave/commands/retro.go
+++ b/cmd/wave/commands/retro.go
@@ -26,6 +26,8 @@ Retrospectives combine quantitative metrics with optional LLM-powered
 narrative analysis to identify friction points and learnings.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			if len(args) == 0 {
 				return cmd.Help()
 			}
@@ -47,7 +49,8 @@ narrative analysis to identify friction points and learnings.`,
 func runRetroView(runID string, narrate bool, jsonOutput bool) error {
 	store, err := state.NewStateStore(".wave/state.db")
 	if err != nil {
-		return fmt.Errorf("failed to open state store: %w", err)
+		return NewCLIError(CodeStateDBError, "failed to open state store: "+err.Error(),
+			"Check that .wave/state.db exists and is not corrupted.").WithCause(err)
 	}
 	defer store.Close()
 
@@ -62,14 +65,16 @@ func runRetroView(runID string, narrate bool, jsonOutput bool) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 		if err := gen.GenerateNarrativeSync(ctx, runID); err != nil {
-			return fmt.Errorf("narrative generation failed: %w", err)
+			return NewCLIError(CodeInternalError, "narrative generation failed: "+err.Error(),
+				"Check adapter configuration and try again.").WithCause(err)
 		}
 		fmt.Fprintf(os.Stderr, "Narrative generated for run %s\n", runID)
 	}
 
 	r, err := storage.Load(runID)
 	if err != nil {
-		return fmt.Errorf("retrospective not found for run %s: %w", runID, err)
+		return NewCLIError(CodeRunNotFound, fmt.Sprintf("retrospective not found for run %s", runID),
+			"Run 'wave retro list' to see available retrospectives.").WithCause(err)
 	}
 
 	if jsonOutput {
@@ -155,6 +160,8 @@ func newRetroListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List retrospectives",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return runRetroList(pipelineFilter, since)
 		},
 	}
@@ -168,7 +175,8 @@ func newRetroListCmd() *cobra.Command {
 func runRetroList(pipelineFilter, since string) error {
 	store, err := state.NewStateStore(".wave/state.db")
 	if err != nil {
-		return fmt.Errorf("failed to open state store: %w", err)
+		return NewCLIError(CodeStateDBError, "failed to open state store: "+err.Error(),
+			"Check that .wave/state.db exists and is not corrupted.").WithCause(err)
 	}
 	defer store.Close()
 
@@ -178,14 +186,16 @@ func runRetroList(pipelineFilter, since string) error {
 	if since != "" {
 		d, err := parseSinceDuration(since)
 		if err != nil {
-			return fmt.Errorf("invalid --since value: %w", err)
+			return NewCLIError(CodeInvalidArgs, "invalid --since value: "+err.Error(),
+				"Use a duration like '7d', '24h', or '30m'.").WithCause(err)
 		}
 		sinceTime = time.Now().Add(-d)
 	}
 
 	records, err := storage.List(pipelineFilter, sinceTime, 50)
 	if err != nil {
-		return fmt.Errorf("failed to list retrospectives: %w", err)
+		return NewCLIError(CodeStateDBError, "failed to list retrospectives: "+err.Error(),
+			"Check that .wave/state.db is accessible.").WithCause(err)
 	}
 
 	if len(records) == 0 {
@@ -217,6 +227,8 @@ func newRetroStatsCmd() *cobra.Command {
 		Use:   "stats",
 		Short: "Show aggregate retrospective statistics",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return runRetroStats()
 		},
 	}
@@ -225,7 +237,8 @@ func newRetroStatsCmd() *cobra.Command {
 func runRetroStats() error {
 	store, err := state.NewStateStore(".wave/state.db")
 	if err != nil {
-		return fmt.Errorf("failed to open state store: %w", err)
+		return NewCLIError(CodeStateDBError, "failed to open state store: "+err.Error(),
+			"Check that .wave/state.db exists and is not corrupted.").WithCause(err)
 	}
 	defer store.Close()
 
@@ -233,7 +246,8 @@ func runRetroStats() error {
 
 	records, err := storage.List("", time.Time{}, 1000)
 	if err != nil {
-		return fmt.Errorf("failed to list retrospectives: %w", err)
+		return NewCLIError(CodeStateDBError, "failed to list retrospectives: "+err.Error(),
+			"Check that .wave/state.db is accessible.").WithCause(err)
 	}
 
 	if len(records) == 0 {

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -205,6 +205,16 @@ func shouldLaunchTUI(cmd *cobra.Command) bool {
 }
 
 func main() {
+	// Wrap cobra flag parse errors as CLIError so JSON mode renders them
+	// with code "invalid_args" instead of "internal_error", and suppresses
+	// the usage dump that cobra would otherwise print before returning.
+	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		return commands.NewCLIError(commands.CodeInvalidArgs, err.Error(),
+			fmt.Sprintf("Run 'wave %s --help' for usage.", cmd.Name()))
+	})
+
 	if err := rootCmd.Execute(); err != nil {
 		// Determine output mode from root flags for error rendering
 		debug, _ := rootCmd.PersistentFlags().GetBool("debug")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,8 +17,17 @@ Wave CLI commands for pipeline orchestration.
 | `wave list` | List adapters, runs, pipelines, personas, contracts |
 | `wave validate` | Validate configuration |
 | `wave clean` | Clean up workspaces |
+| `wave cleanup` | Remove orphaned worktrees from .wave/workspaces/ |
 | `wave compose` | Validate and execute pipeline sequences |
+| `wave decisions` | Show decision log for a pipeline run |
 | `wave doctor` | Diagnose project configuration and health |
+| `wave fork` | Fork a run from a checkpoint |
+| `wave merge` | Merge a pull request using forge CLI |
+| `wave persona` | Persona management (create, list) |
+| `wave pipeline` | Pipeline management (create, list) |
+| `wave retro` | View and manage run retrospectives |
+| `wave rewind` | Rewind a run to an earlier checkpoint |
+| `wave skill` | Manage skill templates and install from remote sources |
 | `wave suggest` | Suggest impactful pipeline runs |
 | `wave serve` | Start the web dashboard server |
 | `wave migrate` | Database migrations |
@@ -991,6 +1000,8 @@ wave bench run --dataset tasks.jsonl --pipeline bench-solve --results-path resul
 | `--label` | | Human-readable label for this run |
 | `--limit` | `0` | Maximum number of tasks to run (0 = all) |
 | `--timeout` | `0` | Per-task timeout in seconds (0 = no limit) |
+| `--concurrency` | `1` | Number of tasks to run in parallel |
+| `--offset` | `0` | Skip the first N tasks in the dataset |
 | `--results-path` | | Path to write JSON results file |
 | `--datasets-dir` | `.wave/bench/datasets` | Directory to search for dataset files |
 | `--keep-workspaces` | `false` | Preserve task worktrees after completion |
@@ -1026,6 +1037,242 @@ List available benchmark datasets in the datasets directory.
 wave bench list
 wave bench list --datasets-dir ./my-datasets
 ```
+
+---
+
+## wave cleanup
+
+Remove orphaned worktrees from `.wave/workspaces/` that have no corresponding running pipeline.
+
+```bash
+wave cleanup              # Remove orphaned worktrees (with confirmation)
+wave cleanup --dry-run    # Show what would be removed without deleting
+wave cleanup --force      # Skip confirmation prompt
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Show what would be removed without deleting anything |
+| `--force` | `false` | Skip confirmation prompt |
+
+---
+
+## wave decisions
+
+Show the structured decision log from pipeline runs. Decisions record model routing choices, retry attempts, contract validations, budget allocations, and composition selections.
+
+```bash
+wave decisions                          # Decisions from most recent run
+wave decisions impl-issue-20240315-abc  # Decisions for a specific run
+wave decisions --step plan              # Filter to a specific step
+wave decisions --category model_routing # Filter by category
+wave decisions --format json            # JSON output
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--step` | | Filter by step ID |
+| `--category` | | Filter by category: `model_routing`, `retry`, `contract`, `budget`, `composition` |
+| `--format` | `text` | Output format: `text`, `json` |
+| `--manifest` | `wave.yaml` | Path to manifest file |
+
+---
+
+## wave fork
+
+Create a new independent run branching from a specific step of an existing run. The forked run starts from the selected checkpoint with a fresh execution context.
+
+```bash
+wave fork impl-issue-20240315-abc123 --from-step plan
+wave fork impl-issue-20240315-abc123 --list       # List available fork points
+wave fork impl-issue-20240315-abc123 --from-step plan --input "updated input"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--from-step` | | Fork from after this step (required unless `--list`) |
+| `--list` | `false` | List available fork points |
+| `--allow-failed` | `false` | Allow forking non-completed (failed/cancelled) runs |
+| `--input` | | Override input for the forked run |
+| `--model` | | Override adapter model for the forked run |
+| `--manifest` | `wave.yaml` | Path to manifest file |
+
+---
+
+## wave merge
+
+Merge a pull request by number or URL. Detects the forge type (GitHub, GitLab, Gitea, Bitbucket) and uses the appropriate forge CLI with API fallback.
+
+```bash
+wave merge 123
+wave merge https://github.com/owner/repo/pull/123
+wave merge --all              # Merge all approved open PRs (oldest first)
+wave merge --all --yes        # Skip confirmation
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--all` | `false` | Merge all approved open PRs (oldest first) |
+| `--yes` | `false` | Skip confirmation prompt (use with `--all`) |
+
+---
+
+## wave persona
+
+Create and manage Wave personas.
+
+### persona create
+
+Scaffold a new persona from a built-in template.
+
+```bash
+wave persona create --name my-reviewer --template reviewer
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name` | | Name for the new persona (required) |
+| `--template` | | Built-in persona template to use (required) |
+
+### persona list
+
+List available persona templates.
+
+```bash
+wave persona list
+```
+
+---
+
+## wave pipeline
+
+Create and manage Wave pipelines.
+
+### pipeline create
+
+Scaffold a new pipeline YAML from a built-in template.
+
+```bash
+wave pipeline create --name my-pipeline --template impl-issue
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name` | | Name for the new pipeline (required) |
+| `--template` | | Built-in pipeline template to use (required) |
+
+### pipeline list
+
+List available pipelines (alias for `wave list pipelines`).
+
+```bash
+wave pipeline list
+```
+
+---
+
+## wave retro
+
+View, list, and generate retrospectives for pipeline runs.
+
+```bash
+wave retro                          # Retrospective for most recent run
+wave retro impl-issue-20240315-abc  # Retrospective for a specific run
+wave retro --narrate                # Generate LLM narrative
+wave retro --json                   # JSON output
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--narrate` | `false` | Generate or regenerate LLM narrative |
+| `--json` | `false` | Output in JSON format |
+
+### retro list
+
+List retrospectives across runs.
+
+```bash
+wave retro list
+wave retro list --pipeline impl-issue
+wave retro list --since 7d
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--pipeline` | | Filter by pipeline name |
+| `--since` | | Show retros since duration (e.g. `7d`, `24h`) |
+
+### retro stats
+
+Show aggregate retrospective statistics.
+
+```bash
+wave retro stats
+```
+
+---
+
+## wave rewind
+
+Reset a run's state to an earlier checkpoint (destructive). The run can be resumed from the rewound point.
+
+```bash
+wave rewind impl-issue-20240315-abc123 --to-step plan
+wave rewind impl-issue-20240315-abc123 --to-step plan --confirm
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--to-step` | | Rewind to after this step (required) |
+| `--confirm` | `false` | Skip confirmation prompt |
+| `--manifest` | `wave.yaml` | Path to manifest file |
+
+---
+
+## wave skill
+
+Manage skill templates shipped with Wave and install skills from remote sources. Skills are SKILL.md files that extend persona capabilities.
+
+### skill list
+
+List available and installed skill templates.
+
+```bash
+wave skill list
+wave skill list --format json
+wave skill list --remote          # Show available remote sources
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+| `--remote` | `false` | Show available remote sources |
+
+### skill install
+
+Install a skill from bundled templates, GitHub, Tessl, or URL.
+
+```bash
+wave skill install reviewer          # Bundled template
+wave skill install github:owner/repo # From GitHub
+wave skill install tessl:my-skill    # From Tessl registry
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skill check
+
+Run check commands for installed skills in `.wave/skills/`.
+
+```bash
+wave skill check
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
 
 ---
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -59,6 +59,19 @@ Wave automatically detects CI/CD environments by checking for these variables (r
 
 When a CI environment is detected, Wave adjusts display behavior (disables interactive TUI, uses plain text output).
 
+## Hook Environment Variables
+
+When a [lifecycle hook](/reference/hooks) executes, Wave injects these variables into the hook subprocess environment:
+
+| Variable | Description |
+|----------|-------------|
+| `WAVE_HOOK_EVENT` | The lifecycle event type (e.g., `pipeline.start`, `step.complete`, `pipeline.success`). |
+| `WAVE_HOOK_PIPELINE` | The pipeline ID for the current run. |
+| `WAVE_HOOK_STEP_ID` | The step ID that triggered the hook (empty for pipeline-level events). |
+| `WAVE_HOOK_WORKSPACE` | Absolute path to the workspace directory for the current run. |
+
+These variables are available inside hook scripts and HTTP hook payloads. Only these WAVE_HOOK_* variables and base system variables (HOME, PATH, TERM, TMPDIR) are injected — the full host environment is not passed.
+
 ## Credential Handling
 
 Wave enforces a strict credential model: **credentials never touch disk**.
@@ -155,6 +168,10 @@ Adapters may use additional environment variables for configuration:
 | `ANTHROPIC_API_KEY` | API key for Claude. |
 | `CLAUDE_CODE_MAX_TURNS` | Maximum agentic turns per invocation. |
 | `CLAUDE_CODE_MODEL` | Model override (e.g., `claude-sonnet-4-20250514`). Must be listed in `runtime.sandbox.env_passthrough` to reach adapter subprocesses. Wave's `--model` flag is the preferred mechanism for model selection. |
+| `DISABLE_TELEMETRY` | Set to `1` to disable Claude Code telemetry. Wave sets this automatically in adapter subprocesses. |
+| `DISABLE_ERROR_REPORTING` | Set to `1` to disable Claude Code error reporting. Wave sets this automatically. |
+| `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Set to `1` to suppress the feedback survey prompt. Wave sets this automatically. |
+| `DISABLE_BUG_COMMAND` | Set to `1` to disable the `/bug` command in Claude Code. Wave sets this automatically. |
 
 ### Custom Adapters
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -61,7 +61,7 @@ When a CI environment is detected, Wave adjusts display behavior (disables inter
 
 ## Hook Environment Variables
 
-When a [lifecycle hook](/reference/hooks) executes, Wave injects these variables into the hook subprocess environment:
+When a lifecycle hook executes, Wave injects these variables into the hook subprocess environment:
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
## Summary

- Adds 9 missing command sections to `docs/reference/cli.md` (cleanup, decisions, fork, merge, persona, pipeline, retro, rewind, skill) — closes DOC-002 through DOC-012
- Adds `--concurrency` and `--offset` flags to bench run docs — closes DOC-022
- Fixes persona count 30 → 31 in README — closes DOC-024
- Adds `WAVE_HOOK_*` env vars to environment.md — closes DOC-018
- Adds Claude Code telemetry suppression vars to environment.md — closes DOC-027
- `SetFlagErrorFunc` on root command: `--bad-flag` now returns `{"code":"invalid_args",...}` in JSON mode — closes #969
- Migrates `retro.go` to `CLIError` with appropriate codes
- Wraps `list.go` errors at the RunE boundary with `CLIError`

Closes #1029
Closes #969

## Test plan

- [ ] `go test ./cmd/wave/... ./internal/pipeline/...` — all pass
- [ ] `wave list --bad-flag` → `Error: unknown flag: --bad-flag\n  Suggestion: Run 'wave list --help' for usage.`
- [ ] `wave --output json list --bad-flag` → `{"error":"...","code":"invalid_args","suggestion":"..."}`
- [ ] CLI reference renders new command sections correctly