### PR TITLE
refactor: suppress issue URL warning, blockResult helper, CopyPath rename, remove trivial wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Use "wave [command] --help" for more information about a command.
 | `wave init` | Initialize project with personas and pipelines |
 | `wave run <pipeline>` | Execute a pipeline |
 | `wave resume <run-id>` | Resume a failed pipeline run |
+| `wave fork <run-id>` | Fork a run from a checkpoint |
+| `wave rewind <run-id>` | Rewind a run to an earlier checkpoint |
 | `wave do "<task>"` | Quick ad-hoc task (auto-generates 2-step pipeline) |
 | `wave meta "<task>"` | Generate and run a custom pipeline dynamically |
 | `wave compose <file>` | Validate and execute a pipeline sequence |
@@ -201,8 +203,17 @@ Use "wave [command] --help" for more information about a command.
 | `wave logs [run-id]` | View event logs (`--follow`, `--tail`, `--errors`) |
 | `wave artifacts [run-id]` | List and export pipeline artifacts |
 | `wave list [resource]` | List Wave configuration and resources |
+| `wave decisions [run-id]` | Show structured decision log for a run |
+| `wave retro [run-id]` | View and manage run retrospectives |
 | `wave chat [run-id]` | Open interactive analysis of a pipeline run |
 | `wave postmortem [run-id]` | Analyse a failed pipeline run and suggest recovery steps |
+| `wave analyze [run-id]` | Deep analysis of pipeline execution |
+
+### Forge & Collaboration
+
+| Command | Description |
+|---------|-------------|
+| `wave merge <PR>` | Merge a pull request using forge CLI with API fallback |
 
 ### Benchmarking
 
@@ -219,12 +230,21 @@ Use "wave [command] --help" for more information about a command.
 |---------|-------------|
 | `wave validate` | Validate Wave configuration |
 | `wave clean` | Clean up project artifacts (`--older-than`, `--status`) |
+| `wave cleanup` | Remove orphaned worktrees from `.wave/workspaces/` |
 | `wave doctor` | Check project health and environment setup |
 | `wave suggest` | Propose pipeline runs based on codebase state |
 | `wave serve` | Start the web dashboard server |
 | `wave migrate` | Database migration management |
-| `wave skills` | Skill lifecycle management |
+| `wave skills` | Skill lifecycle management (legacy) |
+| `wave skill` | Manage skill templates and install from remote sources |
 | `wave agent` | Persona-to-agent compiler utilities |
+
+### Configuration Management
+
+| Command | Description |
+|---------|-------------|
+| `wave persona` | Create and manage personas (`create`, `list`) |
+| `wave pipeline` | Create and manage pipelines (`create`, `list`) |
 
 ---
 

--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 )
 
-// CopyFile copies a file or directory from src to dest.
+// CopyPath copies a file or directory from src to dest.
 // Parent directories of dest are created automatically.
 // If src is a directory, it is copied recursively.
-func CopyFile(src, dest string) error {
+func CopyPath(src, dest string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func copyDir(src, dest string) error {
 				return err
 			}
 		} else {
-			if err := CopyFile(srcPath, destPath); err != nil {
+			if err := CopyPath(srcPath, destPath); err != nil {
 				return err
 			}
 		}

--- a/internal/hooks/http.go
+++ b/internal/hooks/http.go
@@ -23,43 +23,49 @@ type httpResponse struct {
 	Action string `json:"action,omitempty"`
 }
 
+// blockResult builds a blocking HookResult with a formatted reason and cause.
+func blockResult(hookName, reason string, err error) HookResult {
+	return HookResult{HookName: hookName, Decision: DecisionBlock, Reason: reason, Err: err}
+}
+
 func executeHTTP(ctx context.Context, hook *LifecycleHookDef, evt HookEvent) HookResult {
 	timeout := hook.GetTimeout()
 	body, err := json.Marshal(evt)
 	if err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("failed to marshal event: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("failed to marshal event: %v", err), err)
 	}
 	hookURL := os.ExpandEnv(hook.URL)
 	if err := urlValidator(hookURL); err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("blocked URL: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("blocked URL: %v", err), err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hookURL, bytes.NewReader(body))
 	if err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("failed to create request: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("failed to create request: %v", err), err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("HTTP request failed: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("HTTP request failed: %v", err), err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("HTTP hook returned status %d", resp.StatusCode), Err: fmt.Errorf("non-2xx status: %d", resp.StatusCode)}
+		statusErr := fmt.Errorf("non-2xx status: %d", resp.StatusCode)
+		return blockResult(hook.Name, fmt.Sprintf("HTTP hook returned status %d", resp.StatusCode), statusErr)
 	}
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("failed to read response: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("failed to read response: %v", err), err)
 	}
 	var hookResp httpResponse
 	if err := json.Unmarshal(respBody, &hookResp); err != nil {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: fmt.Sprintf("failed to parse response: %v", err), Err: err}
+		return blockResult(hook.Name, fmt.Sprintf("failed to parse response: %v", err), err)
 	}
 	if hookResp.Action == "skip" {
 		return HookResult{HookName: hook.Name, Decision: DecisionSkip, Reason: hookResp.Reason}
 	}
 	if !hookResp.OK {
-		return HookResult{HookName: hook.Name, Decision: DecisionBlock, Reason: hookResp.Reason}
+		return blockResult(hook.Name, hookResp.Reason, nil)
 	}
 	return HookResult{HookName: hook.Name, Decision: DecisionProceed}
 }

--- a/internal/pipeline/chatworkspace.go
+++ b/internal/pipeline/chatworkspace.go
@@ -511,7 +511,7 @@ func generatePostMortemQuestions(ctx *ChatContext) []string {
 	// Determine pipeline category from name
 	pipelineName := ""
 	if ctx.Pipeline != nil {
-		pipelineName = ctx.Pipeline.PipelineName()
+		pipelineName = ctx.Pipeline.Metadata.Name
 	}
 
 	switch {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1437,7 +1437,7 @@ func (e *DefaultPipelineExecutor) hasRequiredFailures(execution *PipelineExecuti
 	// Build a lookup of step optional status
 	stepOptional := make(map[string]bool, len(execution.Pipeline.Steps))
 	for i := range execution.Pipeline.Steps {
-		stepOptional[execution.Pipeline.Steps[i].ID] = execution.Pipeline.Steps[i].IsOptional()
+		stepOptional[execution.Pipeline.Steps[i].ID] = execution.Pipeline.Steps[i].Optional
 	}
 
 	execution.mu.Lock()
@@ -1738,7 +1738,7 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 			)
 			onFailure := step.Retry.OnFailure
 			if onFailure == "" {
-				if step.IsOptional() {
+				if step.Optional {
 					onFailure = OnFailureContinue
 				} else {
 					onFailure = OnFailureFail

--- a/internal/pipeline/fork.go
+++ b/internal/pipeline/fork.go
@@ -114,7 +114,7 @@ func (fm *ForkManager) copyArtifacts(checkpoint *state.CheckpointRecord, sourceR
 			dstPath = filepath.Join(".wave", "artifacts", newRunID, filepath.Base(srcPath))
 		}
 
-		if err := fileutil.CopyFile(srcPath, dstPath); err != nil {
+		if err := fileutil.CopyPath(srcPath, dstPath); err != nil {
 			return fmt.Errorf("failed to copy artifact %s: %w", srcPath, err)
 		}
 	}

--- a/internal/pipeline/matrix.go
+++ b/internal/pipeline/matrix.go
@@ -149,7 +149,7 @@ func (m *MatrixExecutor) Execute(ctx context.Context, execution *PipelineExecuti
 			PipelineID: pipelineID,
 			StepID:     step.ID,
 			State:      "matrix_child_pipeline_loaded",
-			Message:    fmt.Sprintf("Loaded child pipeline %q with %d steps", childPipeline.PipelineName(), len(childPipeline.Steps)),
+			Message:    fmt.Sprintf("Loaded child pipeline %q with %d steps", childPipeline.Metadata.Name, len(childPipeline.Steps)),
 		})
 		worker = m.childPipelineWorker(childPipeline)
 	}
@@ -1110,7 +1110,7 @@ func (m *MatrixExecutor) childPipelineWorker(childPipeline *Pipeline) matrixWork
 			PipelineID: pipelineID,
 			StepID:     step.ID,
 			State:      "matrix_child_pipeline_start",
-			Message:    fmt.Sprintf("Starting child pipeline %q for item %d", childPipeline.PipelineName(), itemIndex),
+			Message:    fmt.Sprintf("Starting child pipeline %q for item %d", childPipeline.Metadata.Name, itemIndex),
 		})
 
 		// Create child executor with independent state

--- a/internal/pipeline/subpipeline.go
+++ b/internal/pipeline/subpipeline.go
@@ -30,7 +30,7 @@ func injectSubPipelineArtifacts(cfg *SubPipelineConfig, parentCtx *PipelineConte
 		}
 
 		destPath := filepath.Join(destDir, name)
-		if err := fileutil.CopyFile(srcPath, destPath); err != nil {
+		if err := fileutil.CopyPath(srcPath, destPath); err != nil {
 			return fmt.Errorf("failed to inject artifact %q: %w", name, err)
 		}
 	}
@@ -65,7 +65,7 @@ func extractSubPipelineArtifacts(cfg *SubPipelineConfig, childCtx *PipelineConte
 		namespacedName := childPipelineName + "." + name
 		destPath := filepath.Join(destDir, namespacedName)
 
-		if err := fileutil.CopyFile(srcPath, destPath); err != nil {
+		if err := fileutil.CopyPath(srcPath, destPath); err != nil {
 			return fmt.Errorf("failed to extract artifact %q: %w", name, err)
 		}
 

--- a/internal/pipeline/subpipeline_test.go
+++ b/internal/pipeline/subpipeline_test.go
@@ -555,7 +555,7 @@ func TestAdapterOverride_NotPropagatedWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestCopyFile(t *testing.T) {
+func TestCopyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	src := filepath.Join(tmpDir, "source.txt")
@@ -564,8 +564,8 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	dest := filepath.Join(tmpDir, "subdir", "dest.txt")
-	if err := fileutil.CopyFile(src, dest); err != nil {
-		t.Fatalf("CopyFile() error: %v", err)
+	if err := fileutil.CopyPath(src, dest); err != nil {
+		t.Fatalf("CopyPath() error: %v", err)
 	}
 
 	got, err := os.ReadFile(dest)
@@ -573,7 +573,7 @@ func TestCopyFile(t *testing.T) {
 		t.Fatalf("failed to read dest: %v", err)
 	}
 	if string(got) != "hello" {
-		t.Errorf("CopyFile content = %q, want %q", string(got), "hello")
+		t.Errorf("CopyPath content = %q, want %q", string(got), "hello")
 	}
 }
 

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -98,11 +98,6 @@ func (r *Requires) SkillNames() []string {
 	return names
 }
 
-// PipelineName returns the logical pipeline name from metadata.
-func (p *Pipeline) PipelineName() string {
-	return p.Metadata.Name
-}
-
 // EffectiveMaxStepVisits returns the pipeline's max total visits, defaulting to 50.
 func (p *Pipeline) EffectiveMaxStepVisits() int {
 	if p.MaxStepVisits > 0 {
@@ -323,10 +318,6 @@ type Step struct {
 	Aggregate   *AggregateConfig   `yaml:"aggregate,omitempty"` // Output aggregation
 }
 
-// IsOptional returns whether this step is marked as optional.
-func (s *Step) IsOptional() bool {
-	return s.Optional
-}
 
 // EffectiveFidelity returns the fidelity level for this step.
 // Defaults to "full" when thread is set, "fresh" when no thread.

--- a/internal/pipeline/types_test.go
+++ b/internal/pipeline/types_test.go
@@ -608,8 +608,8 @@ func TestStep_Optional_YAMLParsing(t *testing.T) {
 				t.Errorf("Optional = %v, want %v", step.Optional, tt.wantOptional)
 			}
 
-			if step.IsOptional() != tt.wantOptional {
-				t.Errorf("IsOptional() = %v, want %v", step.IsOptional(), tt.wantOptional)
+			if step.Optional != tt.wantOptional {
+				t.Errorf("step.Optional = %v, want %v", step.Optional, tt.wantOptional)
 			}
 
 			// Round-trip: marshal and unmarshal

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -60,7 +60,7 @@ func (p *Provisioner) Provision(workspacePath string, skillNames []string) error
 			fileName := filepath.Base(src)
 			dst := filepath.Join(targetDir, fileName)
 
-			if err := fileutil.CopyFile(src, dst); err != nil {
+			if err := fileutil.CopyPath(src, dst); err != nil {
 				return fmt.Errorf("failed to copy skill command %q: %w", fileName, err)
 			}
 		}

--- a/internal/suggest/input.go
+++ b/internal/suggest/input.go
@@ -140,7 +140,8 @@ func CheckInputPipelineMismatch(input, pipelineName string) *InputMismatch {
 	// Only warn once per run for free text (not per step)
 	switch inputType {
 	case InputTypeIssueURL:
-		reason = "input looks like an issue URL — consider using: " + strings.Join(suggested, ", ")
+		// Suppress: issue URLs are commonly passed as context to any pipeline.
+		reason = ""
 	case InputTypePRURL:
 		reason = "input looks like a PR URL — consider using: " + strings.Join(suggested, ", ")
 	case InputTypeRepoRef:

--- a/internal/workspace/copy_edge_cases_test.go
+++ b/internal/workspace/copy_edge_cases_test.go
@@ -139,7 +139,7 @@ func TestCopyRecursive_BrokenSymlinkSkipped(t *testing.T) {
 	}
 }
 
-func TestCopyFile_SingleFile(t *testing.T) {
+func TestCopyPath_SingleFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	srcFile := filepath.Join(tmpDir, "source.txt")
@@ -149,7 +149,7 @@ func TestCopyFile_SingleFile(t *testing.T) {
 	}
 
 	dstFile := filepath.Join(tmpDir, "dest.txt")
-	if err := fileutil.CopyFile(srcFile, dstFile); err != nil {
+	if err := fileutil.CopyPath(srcFile, dstFile); err != nil {
 		t.Fatalf("copyFile failed: %v", err)
 	}
 
@@ -162,9 +162,9 @@ func TestCopyFile_SingleFile(t *testing.T) {
 	}
 }
 
-func TestCopyFile_SourceNotFound(t *testing.T) {
+func TestCopyPath_SourceNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
-	err := fileutil.CopyFile(filepath.Join(tmpDir, "nonexistent"), filepath.Join(tmpDir, "dest"))
+	err := fileutil.CopyPath(filepath.Join(tmpDir, "nonexistent"), filepath.Join(tmpDir, "dest"))
 	if err == nil {
 		t.Error("expected error for non-existent source file")
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -259,11 +259,11 @@ func copyRecursive(src, dst string) error {
 			if info.Size() > 10*1024*1024 {
 				return nil
 			}
-			return fileutil.CopyFile(path, targetPath)
+			return fileutil.CopyPath(path, targetPath)
 		})
 	}
 
-	return fileutil.CopyFile(src, dst)
+	return fileutil.CopyPath(src, dst)
 }
 
 func (wm *workspaceManager) CleanAll(root string) error {


### PR DESCRIPTION
## Summary

- **#774** — Suppress noisy `wave run` warning when input is a GitHub issue URL (users commonly pass issue URLs as context to any pipeline)
- **#967** — README command table now includes all registered commands (fork, rewind, decisions, retro, analyze, merge, cleanup, skill, persona, pipeline)
- **#1058** — Remove `PipelineName()` and `IsOptional()` trivial wrappers in `pipeline/types.go`; update all callers to direct field access
- **#1073** — Extract `blockResult()` helper in `hooks/http.go`; eliminates 7 repetitive `HookResult{Decision: DecisionBlock}` constructions
- **#1074** — Rename `fileutil.CopyFile` → `fileutil.CopyPath`; the function handles both files and directories

Closes #774
Closes #967
Closes #1058
Closes #1073
Closes #1074

## Test plan

- [ ] `go test ./internal/pipeline/... ./internal/hooks/... ./internal/suggest/... ./cmd/wave/...` — all pass
- [ ] `wave run impl-issue https://github.com/owner/repo/issues/42` — no warning printed
- [ ] `wave run doc-explain https://github.com/owner/repo/issues/42` — no warning printed