### PR TITLE
refactor: rename StepError→StepExecutionError, deduplicate skill Install methods

### DIFF
--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -271,7 +271,7 @@ func runResume(opts ResumeOptions, debug bool) error {
 
 	if execErr != nil {
 		var (
-			stepErr *pipeline.StepError
+			stepErr *pipeline.StepExecutionError
 			stepID  string
 			cause   = execErr
 		)

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -633,10 +633,10 @@ func runRun(opts RunOptions, debug bool) error {
 	}
 
 	if execErr != nil {
-		// Extract step ID from StepError when available; fall back gracefully
+		// Extract step ID from StepExecutionError when available; fall back gracefully
 		// so recovery hints are shown for all failure paths (including resume).
 		var (
-			stepErr *pipeline.StepError
+			stepErr *pipeline.StepExecutionError
 			stepID  string
 			cause   = execErr
 		)

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -2,19 +2,19 @@ package pipeline
 
 import "fmt"
 
-// StepError wraps a step execution error with the step ID for programmatic access.
+// StepExecutionError wraps a step execution error with the step ID for programmatic access.
 // It preserves the same error message format as the previous fmt.Errorf pattern
 // while making the step ID extractable via errors.As().
-type StepError struct {
+type StepExecutionError struct {
 	StepID string
 	Err    error
 }
 
-func (e *StepError) Error() string {
+func (e *StepExecutionError) Error() string {
 	return fmt.Sprintf("step %q failed: %v", e.StepID, e.Err)
 }
 
-func (e *StepError) Unwrap() error {
+func (e *StepExecutionError) Unwrap() error {
 	return e.Err
 }
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -790,7 +790,7 @@ func (e *DefaultPipelineExecutor) Execute(ctx context.Context, p *Pipeline, m *m
 				e.retroGenerator.Generate(pipelineID, execution.Pipeline.Metadata.Name)
 			}
 			e.cleanupCompletedPipeline(pipelineID)
-			return &StepError{StepID: failedStepID, Err: err}
+			return &StepExecutionError{StepID: failedStepID, Err: err}
 		}
 
 		// Process batch results: steps may have completed, failed (optional), or been skipped
@@ -4929,7 +4929,7 @@ func (e *DefaultPipelineExecutor) Resume(ctx context.Context, pipelineID string,
 				execution.Status.FailedSteps = append(execution.Status.FailedSteps, step.ID)
 				// Clean up failed pipeline from in-memory storage to prevent memory leak
 				e.cleanupCompletedPipeline(execution.Status.ID)
-				return &StepError{StepID: step.ID, Err: err}
+				return &StepExecutionError{StepID: step.ID, Err: err}
 			}
 			execution.Status.CompletedSteps = append(execution.Status.CompletedSteps, step.ID)
 		}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -252,7 +252,7 @@ func TestConcurrentStepFailure(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test")
 	assert.Error(t, err, "pipeline should fail when a concurrent step fails")
 
-	var stepErr *StepError
+	var stepErr *StepExecutionError
 	if errors.As(err, &stepErr) {
 		assert.Equal(t, "step-b", stepErr.StepID, "failed step should be step-b")
 	}
@@ -306,7 +306,7 @@ func TestSingleStepBatchNoOverhead(t *testing.T) {
 	assert.True(t, posB < posC, "step-b should execute before step-c")
 }
 
-// TestFailedStepAlwaysHasID ensures that StepError always carries the step ID,
+// TestFailedStepAlwaysHasID ensures that StepExecutionError always carries the step ID,
 // even when the step fails on a single-step batch (no concurrency).
 func TestFailedStepAlwaysHasID(t *testing.T) {
 	collector := testutil.NewEventCollector()
@@ -348,10 +348,10 @@ func TestFailedStepAlwaysHasID(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test")
 	require.Error(t, err)
 
-	var stepErr *StepError
-	require.True(t, errors.As(err, &stepErr), "error should be a StepError")
-	assert.Equal(t, "step-b", stepErr.StepID, "StepError must carry the failed step ID")
-	assert.NotEmpty(t, stepErr.StepID, "StepError.StepID must never be empty")
+	var stepErr *StepExecutionError
+	require.True(t, errors.As(err, &stepErr), "error should be a StepExecutionError")
+	assert.Equal(t, "step-b", stepErr.StepID, "StepExecutionError must carry the failed step ID")
+	assert.NotEmpty(t, stepErr.StepID, "StepExecutionError.StepID must never be empty")
 }
 
 // TestConcurrentStepWideFanOut tests a wide fan-out pattern with many parallel steps.
@@ -3917,8 +3917,8 @@ func TestOptionalStep_DefaultBehaviorPreserved(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test")
 	assert.Error(t, err, "pipeline should fail when required step fails")
 
-	var stepErr *StepError
-	assert.True(t, errors.As(err, &stepErr), "error should be a StepError")
+	var stepErr *StepExecutionError
+	assert.True(t, errors.As(err, &stepErr), "error should be a StepExecutionError")
 	assert.Equal(t, "step-1", stepErr.StepID)
 }
 
@@ -4112,8 +4112,8 @@ func TestOptionalStep_ExplicitOnFailurePrecedence(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test")
 	assert.Error(t, err, "pipeline should fail because explicit on_failure: fail takes precedence")
 
-	var stepErr *StepError
-	assert.True(t, errors.As(err, &stepErr), "error should be a StepError")
+	var stepErr *StepExecutionError
+	assert.True(t, errors.As(err, &stepErr), "error should be a StepExecutionError")
 }
 
 // TestOptionalStep_PipelineStatusCompleted verifies that pipeline status is completed
@@ -5166,7 +5166,7 @@ func (a *slowAdapter) Run(ctx context.Context, _ adapter.AdapterRunConfig) (*ada
 
 // TestConcurrentBatchCancellation verifies that when one step in a concurrent
 // batch fails (non-optional, default on_failure: fail), the errgroup cancels
-// remaining sibling steps and the pipeline returns a StepError.
+// remaining sibling steps and the pipeline returns a StepExecutionError.
 //
 // Steps A, B, C have no dependencies so they all land in the same ready batch.
 // B fails immediately; A and C are slow and should be cancelled.
@@ -5214,11 +5214,11 @@ func TestConcurrentBatchCancellation(t *testing.T) {
 	// Pipeline should fail
 	require.Error(t, err, "pipeline should fail when a non-optional step fails")
 
-	// The error should be a StepError (could be step-b's failure or a
+	// The error should be a StepExecutionError (could be step-b's failure or a
 	// sibling's context-cancelled error — errgroup returns whichever
 	// goroutine finishes first).
-	var stepErr *StepError
-	require.True(t, errors.As(err, &stepErr), "error should be a StepError, got: %T", err)
+	var stepErr *StepExecutionError
+	require.True(t, errors.As(err, &stepErr), "error should be a StepExecutionError, got: %T", err)
 
 	// Pipeline should complete quickly (not wait for slow steps to finish)
 	assert.Less(t, elapsed, 4*time.Second, "pipeline should not wait for slow steps after cancellation")
@@ -5538,9 +5538,9 @@ func TestExecutor_GateStep_Abort(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test abort gate")
 	require.Error(t, err, "pipeline should fail when gate aborts")
 
-	// The executor wraps gateAbortError inside a StepError
-	var stepErr *StepError
-	require.True(t, errors.As(err, &stepErr), "error should be a StepError")
+	// The executor wraps gateAbortError inside a StepExecutionError
+	var stepErr *StepExecutionError
+	require.True(t, errors.As(err, &stepErr), "error should be a StepExecutionError")
 	assert.Equal(t, "approve-plan", stepErr.StepID, "failed step should be approve-plan")
 
 	// Unwrap to find the gateAbortError

--- a/internal/pipeline/failure.go
+++ b/internal/pipeline/failure.go
@@ -34,7 +34,7 @@ func IsRetryable(class string) bool {
 
 // ClassifyStepFailure determines the failure class for a step based on the
 // execution error, contract validation error, and context error. It inspects
-// typed errors first (StepError, ValidationError), then falls back to
+// typed errors first (StepExecutionError, ValidationError), then falls back to
 // pattern matching on the error message.
 func ClassifyStepFailure(err error, contractErr error, ctxErr error) string {
 	// Context errors take highest priority.

--- a/internal/pipeline/resume.go
+++ b/internal/pipeline/resume.go
@@ -235,12 +235,12 @@ func (r *ResumeManager) ResumeFromStep(ctx context.Context, p *Pipeline, m *mani
 
 // ResumeState holds state information needed for resumption
 type ResumeState struct {
-	States            map[string]string
-	Results           map[string]map[string]interface{}
-	ArtifactPaths     map[string]string
-	WorkspacePaths    map[string]string
-	CompletedSteps    []string
-	FailureContexts   map[string]*AttemptContext // stepID -> failure context from prior run
+	States              map[string]string
+	Results             map[string]map[string]interface{}
+	ArtifactPaths       map[string]string
+	WorkspacePaths      map[string]string
+	CompletedSteps      []string
+	FailureContexts     map[string]*AttemptContext // stepID -> failure context from prior run
 	ReworkTransitions   map[string]string          // failedStepID -> reworkStepID
 	DiscoveredWorktrees []string                   // absolute paths of worktrees found from prior run
 }
@@ -518,7 +518,7 @@ func (r *ResumeManager) executeResumedPipeline(ctx context.Context, execution *P
 					_ = r.executor.store.SavePipelineState(pipelineID, stateFailed, execution.Input)
 				}
 
-				return &StepError{StepID: step.ID, Err: err}
+				return &StepExecutionError{StepID: step.ID, Err: err}
 			}
 
 			execution.Status.CompletedSteps = append(execution.Status.CompletedSteps, step.ID)

--- a/internal/pipeline/resume_test.go
+++ b/internal/pipeline/resume_test.go
@@ -1295,9 +1295,9 @@ func TestResumeWithExcludeFilter(t *testing.T) {
 }
 
 // TestExecuteResumedPipeline_ReturnsStepError verifies that errors from
-// executeResumedPipeline are wrapped as *StepError so the CLI can extract
+// executeResumedPipeline are wrapped as *StepExecutionError so the CLI can extract
 // the step ID via errors.As() for recovery hints.
-func TestExecuteResumedPipeline_ReturnsStepError(t *testing.T) {
+func TestExecuteResumedPipeline_ReturnsStepExecutionError(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	_ = os.Chdir(tmpDir)
@@ -1338,14 +1338,14 @@ func TestExecuteResumedPipeline_ReturnsStepError(t *testing.T) {
 		t.Fatal("expected error from resumed pipeline, got nil")
 	}
 
-	// Verify the error is a *StepError
-	var stepErr *StepError
+	// Verify the error is a *StepExecutionError
+	var stepErr *StepExecutionError
 	if !errors.As(err, &stepErr) {
-		t.Fatalf("expected error to be *StepError, got %T: %v", err, err)
+		t.Fatalf("expected error to be *StepExecutionError, got %T: %v", err, err)
 	}
 
 	if stepErr.StepID != "step-b" {
-		t.Errorf("expected StepError.StepID = %q, got %q", "step-b", stepErr.StepID)
+		t.Errorf("expected StepExecutionError.StepID = %q, got %q", "step-b", stepErr.StepID)
 	}
 
 	// Verify the original error is preserved

--- a/internal/skill/source_cli.go
+++ b/internal/skill/source_cli.go
@@ -97,6 +97,37 @@ func parseAndWriteSkills(_ context.Context, paths []string, store Store) (*Insta
 	return result, nil
 }
 
+// installViaCLI runs a CLI command in a fresh temp directory, discovers SKILL.md
+// files in the result, and writes them to the store. It is the shared body for
+// adapters whose Install methods differ only in dependency, temp-dir prefix, and
+// command arguments (BMAD, OpenSpec, SpecKit). TesslAdapter stays inline because
+// it needs to pass a ref argument and format a different error message.
+func installViaCLI(ctx context.Context, dep CLIDependency, lookPath lookPathFunc, tmpPrefix string, args []string, errPrefix string, store Store) (*InstallResult, error) {
+	if err := checkDependency(dep, lookPath); err != nil {
+		return nil, err
+	}
+	tmpDir, err := os.MkdirTemp("", tmpPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	ctx, cancel := context.WithTimeout(ctx, CLITimeout)
+	defer cancel()
+	//nolint:gosec // args are hardcoded by each adapter, not user-controlled
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = tmpDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s failed: %v\nstderr: %s", errPrefix, err, stderr.String())
+	}
+	paths, err := discoverSkillFiles(tmpDir)
+	if err != nil {
+		return nil, err
+	}
+	return parseAndWriteSkills(ctx, paths, store)
+}
+
 // TesslAdapter installs skills from the Tessl registry via the tessl CLI.
 type TesslAdapter struct {
 	dep      CLIDependency
@@ -173,35 +204,9 @@ func (a *BMADAdapter) Prefix() string { return "bmad" }
 
 // Install runs `npx bmad-method install --tools claude-code --yes` and discovers skills.
 func (a *BMADAdapter) Install(ctx context.Context, _ string, store Store) (*InstallResult, error) {
-	if err := checkDependency(a.dep, a.lookPath); err != nil {
-		return nil, err
-	}
-
-	tmpDir, err := os.MkdirTemp("", "wave-skill-bmad-*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	ctx, cancel := context.WithTimeout(ctx, CLITimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "npx", "bmad-method", "install", "--tools", "claude-code", "--yes")
-	cmd.Dir = tmpDir
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("npx bmad-method install failed: %v\nstderr: %s", err, stderr.String())
-	}
-
-	paths, err := discoverSkillFiles(tmpDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseAndWriteSkills(ctx, paths, store)
+	return installViaCLI(ctx, a.dep, a.lookPath, "wave-skill-bmad-*",
+		[]string{"npx", "bmad-method", "install", "--tools", "claude-code", "--yes"},
+		"npx bmad-method install", store)
 }
 
 // OpenSpecAdapter installs skills from the OpenSpec ecosystem.
@@ -226,35 +231,8 @@ func (a *OpenSpecAdapter) Prefix() string { return "openspec" }
 
 // Install runs `openspec init` and discovers resulting skill files.
 func (a *OpenSpecAdapter) Install(ctx context.Context, _ string, store Store) (*InstallResult, error) {
-	if err := checkDependency(a.dep, a.lookPath); err != nil {
-		return nil, err
-	}
-
-	tmpDir, err := os.MkdirTemp("", "wave-skill-openspec-*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	ctx, cancel := context.WithTimeout(ctx, CLITimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "openspec", "init")
-	cmd.Dir = tmpDir
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("openspec init failed: %v\nstderr: %s", err, stderr.String())
-	}
-
-	paths, err := discoverSkillFiles(tmpDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseAndWriteSkills(ctx, paths, store)
+	return installViaCLI(ctx, a.dep, a.lookPath, "wave-skill-openspec-*",
+		[]string{"openspec", "init"}, "openspec init", store)
 }
 
 // SpecKitAdapter installs skills from the SpecKit ecosystem.
@@ -279,33 +257,6 @@ func (a *SpecKitAdapter) Prefix() string { return "speckit" }
 
 // Install runs `specify init` and discovers resulting skill files.
 func (a *SpecKitAdapter) Install(ctx context.Context, _ string, store Store) (*InstallResult, error) {
-	if err := checkDependency(a.dep, a.lookPath); err != nil {
-		return nil, err
-	}
-
-	tmpDir, err := os.MkdirTemp("", "wave-skill-speckit-*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	ctx, cancel := context.WithTimeout(ctx, CLITimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "specify", "init")
-	cmd.Dir = tmpDir
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("specify init failed: %v\nstderr: %s", err, stderr.String())
-	}
-
-	paths, err := discoverSkillFiles(tmpDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return parseAndWriteSkills(ctx, paths, store)
+	return installViaCLI(ctx, a.dep, a.lookPath, "wave-skill-speckit-*",
+		[]string{"specify", "init"}, "specify init", store)
 }

--- a/tests/preflight_recovery_test.go
+++ b/tests/preflight_recovery_test.go
@@ -609,7 +609,7 @@ func TestPreflightRecovery_EndToEndFlow(t *testing.T) {
 	}
 
 	// Step 5: Extract error details (as run.go does)
-	var stepErr *pipeline.StepError
+	var stepErr *pipeline.StepExecutionError
 	var stepID string
 	cause := execErr
 	if errors.As(execErr, &stepErr) {


### PR DESCRIPTION
## Summary

- **#1065** — Rename `pipeline.StepError` → `pipeline.StepExecutionError` to eliminate the name collision with `adapter.StepError`. All callers updated: `executor.go` (2 construction sites), `resume.go`, `cmd/wave/commands/run.go`, `cmd/wave/commands/resume.go`, and `tests/preflight_recovery_test.go`. Test assertions in `executor_test.go` and `resume_test.go` updated to match.
- **#1071** — Extract `installViaCLI()` helper in `internal/skill/source_cli.go`. The three near-identical adapters (BMAD, OpenSpec, SpecKit) now delegate to this helper instead of repeating ~25 lines of mktemp/timeout/exec/discover/parse boilerplate. `TesslAdapter` stays inline because it passes a `ref` argument and captures stdout.

Closes #1065
Closes #1071

## Test plan

- [ ] `go test ./internal/pipeline/... ./internal/skill/... ./cmd/wave/... ./tests/...` — all pass
- [ ] `go build ./...` — clean