### PR TITLE
fix: suppress empty mismatch warning for issue URLs; split helpers.go

### DIFF
--- a/cmd/wave/commands/format_helpers.go
+++ b/cmd/wave/commands/format_helpers.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+)
+
+// formatSize formats bytes into human-readable format (KB, MB, etc.)
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+// formatTokens formats a token count with appropriate units.
+// Uses integer-based thousands suffix (e.g., "1k", "45k", "1M").
+func formatTokens(tokens int) string {
+	if tokens < 1000 {
+		return fmt.Sprintf("%d", tokens)
+	}
+	if tokens < 1000000 {
+		return fmt.Sprintf("%dk", tokens/1000)
+	}
+	return fmt.Sprintf("%dM", tokens/1000000)
+}
+
+// truncateString truncates a string to maxLen and adds "..." if needed.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// formatElapsed formats a duration as "1m23s" or "1h23m".
+func formatElapsed(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%dh%dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dm%ds", minutes, seconds)
+}

--- a/cmd/wave/commands/run_helpers.go
+++ b/cmd/wave/commands/run_helpers.go
@@ -10,20 +10,6 @@ import (
 	"github.com/recinq/wave/internal/onboarding"
 )
 
-// formatSize formats bytes into human-readable format (KB, MB, etc.)
-func formatSize(bytes int64) string {
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
-}
-
 // parseDuration parses duration strings like "7d", "24h", "1h30m".
 // Extends time.ParseDuration to support day suffix (d).
 func parseDuration(s string) (time.Duration, error) {
@@ -51,45 +37,6 @@ func parseDuration(s string) (time.Duration, error) {
 	}
 
 	return time.ParseDuration(s)
-}
-
-// formatTokens formats a token count with appropriate units.
-// Uses integer-based thousands suffix (e.g., "1k", "45k", "1M").
-func formatTokens(tokens int) string {
-	if tokens < 1000 {
-		return fmt.Sprintf("%d", tokens)
-	}
-	if tokens < 1000000 {
-		return fmt.Sprintf("%dk", tokens/1000)
-	}
-	return fmt.Sprintf("%dM", tokens/1000000)
-}
-
-// truncateString truncates a string to maxLen and adds "..." if needed.
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return s[:maxLen]
-	}
-	return s[:maxLen-3] + "..."
-}
-
-// formatElapsed formats a duration as "1m23s" or "1h23m".
-func formatElapsed(d time.Duration) string {
-	if d < 0 {
-		d = -d
-	}
-
-	hours := int(d.Hours())
-	minutes := int(d.Minutes()) % 60
-	seconds := int(d.Seconds()) % 60
-
-	if hours > 0 {
-		return fmt.Sprintf("%dh%dm", hours, minutes)
-	}
-	return fmt.Sprintf("%dm%ds", minutes, seconds)
 }
 
 // checkOnboarding verifies that onboarding has been completed.

--- a/internal/suggest/input.go
+++ b/internal/suggest/input.go
@@ -151,6 +151,11 @@ func CheckInputPipelineMismatch(input, pipelineName string) *InputMismatch {
 		reason = ""
 	}
 
+	// No message to show — caller suppressed this input type.
+	if reason == "" {
+		return nil
+	}
+
 	return &InputMismatch{
 		InputType:       inputType,
 		Pipeline:        pipelineName,

--- a/internal/suggest/input_test.go
+++ b/internal/suggest/input_test.go
@@ -257,10 +257,10 @@ func TestCheckInputPipelineMismatch(t *testing.T) {
 			wantNil:  true,
 		},
 		{
-			name:     "issue URL with ops-pr-review is mismatch",
+			name:     "issue URL with ops-pr-review returns nil (issue URLs never warn)",
 			input:    "https://github.com/owner/repo/issues/1",
 			pipeline: "ops-pr-review",
-			wantNil:  false,
+			wantNil:  true,
 		},
 		{
 			name:     "PR URL with ops-pr-review is fine",
@@ -281,16 +281,16 @@ func TestCheckInputPipelineMismatch(t *testing.T) {
 			wantNil:  true,
 		},
 		{
-			name:     "free text with impl-issue is mismatch",
+			name:     "free text with impl-issue returns nil (free text never warns)",
 			input:    "add auth support",
 			pipeline: "impl-issue",
-			wantNil:  false,
+			wantNil:  true,
 		},
 		{
-			name:     "empty input is always fine",
+			name:     "empty input returns nil (no warning)",
 			input:    "",
 			pipeline: "anything",
-			wantNil:  false, // empty classifies as free_text, "anything" not in suggestions
+			wantNil:  true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **#774 follow-up** — `CheckInputPipelineMismatch` was returning a non-nil `*InputMismatch` even when `SuggestedReason` is empty (issue URL and free text cases), causing `wave run` to print a bare `  warning: ` line with no message. Fix: return `nil` when the reason is empty — the caller only acts on non-nil mismatches.
- **#1075** — Split `cmd/wave/commands/helpers.go` grab-bag into focused files: `format_helpers.go` (output formatting) and `run_helpers.go` (duration parsing and onboarding check). Pure structural refactor, no behavior changes.

## Test plan

- [ ] `go test ./internal/suggest/... ./cmd/wave/...` — all pass
- [ ] `wave run doc-explain https://github.com/owner/repo/issues/42 --dry-run` — no warning printed
- [ ] `wave run impl-issue https://github.com/owner/repo/pull/42 --dry-run` — PR URL warning still shown