### PR TITLE
chore(adapter): remove ContractPrompt deprecated field from AdapterRunConfig

### DIFF
--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -73,11 +73,6 @@ type AdapterRunConfig struct {
 	// Built from manifest.Ontology.RenderMarkdown() by the executor.
 	OntologySection string
 
-	// ContractPrompt is deprecated — contract schemas are now appended directly to the
-	// user prompt by the executor. This field is retained for interface compatibility
-	// but is always empty at runtime. See executor.go buildContractPrompt().
-	ContractPrompt string
-
 	// OnStreamEvent is called for each real-time event during Claude Code execution.
 	// If nil, streaming events are silently ignored.
 	OnStreamEvent func(StreamEvent)

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -265,12 +265,9 @@ func (a *ClaudeAdapter) prepareWorkspace(workspacePath string, cfg AdapterRunCon
 		systemPrompt += skillSection
 	}
 
-	// 2. Contract compliance section (auto-generated from step contract)
+	// 2. Concurrency hint (when MaxConcurrentAgents > 1); contract schema is
+	// appended to the user prompt by the executor, not the agent file.
 	contractSection := ""
-	if cfg.ContractPrompt != "" {
-		contractSection = cfg.ContractPrompt
-	}
-
 	// 2.5. Concurrency hint (when MaxConcurrentAgents > 1)
 	if hint := buildConcurrencyHint(cfg.MaxConcurrentAgents); hint != "" {
 		contractSection += hint

--- a/internal/adapter/claude_test.go
+++ b/internal/adapter/claude_test.go
@@ -38,40 +38,6 @@ func setupBaseProtocol(t *testing.T) {
 	})
 }
 
-func TestContractPromptInAgentFile(t *testing.T) {
-	setupBaseProtocol(t)
-	adapter := NewClaudeAdapter()
-	tmpDir := t.TempDir()
-
-	cfg := AdapterRunConfig{
-		Persona:        "test",
-		WorkspacePath:  tmpDir,
-		Model:          "sonnet",
-		AllowedTools:   []string{"Read", "Bash"},
-		ContractPrompt: "## Contract Compliance\n\n- **Output file**: `artifact.json`\n- **Format**: Valid JSON only.\n",
-	}
-
-	if err := adapter.prepareWorkspace(tmpDir, cfg); err != nil {
-		t.Fatalf("prepareWorkspace failed: %v", err)
-	}
-
-	agentPath := filepath.Join(tmpDir, agentFilePath)
-	data, err := os.ReadFile(agentPath)
-	if err != nil {
-		t.Fatalf("failed to read agent file: %v", err)
-	}
-
-	content := string(data)
-	if !strings.Contains(content, "Contract Compliance") {
-		t.Error("agent file should contain 'Contract Compliance' section")
-	}
-	if !strings.Contains(content, "artifact.json") {
-		t.Error("agent file should contain the output file path")
-	}
-	if !strings.Contains(content, "Valid JSON only") {
-		t.Error("agent file should contain format instruction")
-	}
-}
 
 func TestNoSettingsJSONWhenSandboxDisabled(t *testing.T) {
 	setupBaseProtocol(t)
@@ -512,17 +478,15 @@ func TestConcurrencyHintInAgentFile(t *testing.T) {
 			},
 		},
 		{
-			name: "hint appears between contract and restrictions",
+			name: "hint appears before restrictions",
 			cfg: AdapterRunConfig{
 				Persona:             "test",
 				Model:               "sonnet",
 				SystemPrompt:        "# Test",
 				MaxConcurrentAgents: 4,
-				ContractPrompt:      "## Contract Compliance\n\nOutput JSON.",
 				AllowedTools:        []string{"Read", "Bash"},
 			},
 			wantContains: []string{
-				"Contract Compliance",
 				"Agent Concurrency",
 				"## Restrictions",
 			},
@@ -567,7 +531,6 @@ func TestConcurrencyHintOrdering(t *testing.T) {
 		Persona:             "test",
 		Model:               "sonnet",
 		SystemPrompt:        "# Test Persona",
-		ContractPrompt:      "## Contract\n\nProduce JSON output.",
 		MaxConcurrentAgents: 6,
 		AllowedTools:        []string{"Read", "Write"},
 		DenyTools:           []string{"Bash(rm *)"},
@@ -583,13 +546,9 @@ func TestConcurrencyHintOrdering(t *testing.T) {
 	}
 	content := string(data)
 
-	contractIdx := strings.Index(content, "## Contract")
 	concurrencyIdx := strings.Index(content, "## Agent Concurrency")
 	restrictionIdx := strings.Index(content, "## Restrictions")
 
-	if contractIdx == -1 {
-		t.Fatal("missing Contract section")
-	}
 	if concurrencyIdx == -1 {
 		t.Fatal("missing Agent Concurrency section")
 	}
@@ -597,9 +556,6 @@ func TestConcurrencyHintOrdering(t *testing.T) {
 		t.Fatal("missing Restrictions section")
 	}
 
-	if concurrencyIdx < contractIdx {
-		t.Errorf("Agent Concurrency (pos %d) should appear after Contract (pos %d)", concurrencyIdx, contractIdx)
-	}
 	if concurrencyIdx > restrictionIdx {
 		t.Errorf("Agent Concurrency (pos %d) should appear before Restrictions (pos %d)", concurrencyIdx, restrictionIdx)
 	}
@@ -1864,11 +1820,10 @@ func TestSkillSectionInAgentFile(t *testing.T) {
 		}
 	})
 
-	t.Run("skill section appears between persona and contract", func(t *testing.T) {
+	t.Run("skill section appears after persona", func(t *testing.T) {
 		cfg := AdapterRunConfig{
-			Persona:        "craftsman",
-			SystemPrompt:   "# Craftsman\n\nYou are a craftsman.",
-			ContractPrompt: "## Contract\n\nYour output must be valid JSON.",
+			Persona:      "craftsman",
+			SystemPrompt: "# Craftsman\n\nYou are a craftsman.",
 			ResolvedSkills: []SkillRef{
 				{Name: "golang", Description: "Go development"},
 			},
@@ -1886,15 +1841,14 @@ func TestSkillSectionInAgentFile(t *testing.T) {
 		content := string(data)
 
 		skillIdx := strings.Index(content, "## Available Skills")
-		contractIdx := strings.Index(content, "## Contract")
 		personaIdx := strings.Index(content, "# Craftsman")
 
-		if skillIdx == -1 || contractIdx == -1 || personaIdx == -1 {
-			t.Fatalf("missing sections: skill=%d contract=%d persona=%d", skillIdx, contractIdx, personaIdx)
+		if skillIdx == -1 || personaIdx == -1 {
+			t.Fatalf("missing sections: skill=%d persona=%d", skillIdx, personaIdx)
 		}
 
-		if personaIdx >= skillIdx || skillIdx >= contractIdx {
-			t.Errorf("wrong ordering: persona=%d < skill=%d < contract=%d", personaIdx, skillIdx, contractIdx)
+		if personaIdx >= skillIdx {
+			t.Errorf("wrong ordering: persona=%d should appear before skill=%d", personaIdx, skillIdx)
 		}
 	})
 }
@@ -2054,12 +2008,11 @@ func TestPrepareWorkspaceAgentMode(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(".wave") })
 
 	cfg := AdapterRunConfig{
-		Persona:        "navigator",
-		SystemPrompt:   "# Navigator\n\nYou explore codebases.",
-		ContractPrompt: "## Contract\n\nOutput JSON.",
-		AllowedTools:   []string{"Read", "Glob"},
-		DenyTools:      []string{"Edit(*)"},
-		Model:          "sonnet",
+		Persona:      "navigator",
+		SystemPrompt: "# Navigator\n\nYou explore codebases.",
+		AllowedTools: []string{"Read", "Glob"},
+		DenyTools:    []string{"Edit(*)"},
+		Model:        "sonnet",
 	}
 
 	if err := adapter.prepareWorkspace(tmpDir, cfg); err != nil {

--- a/internal/pipeline/contract_integration_test.go
+++ b/internal/pipeline/contract_integration_test.go
@@ -366,10 +366,6 @@ func TestContractIntegration_SchemaInjectedIntoPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "confidence", "Prompt should contain schema field 'confidence'")
 	assert.Contains(t, prompt, "CRITICAL", "Prompt should contain contract compliance warning")
 
-	// ContractPrompt on the adapter config should be empty (no longer injected into agent .md)
-	configs := capturingAdapter.GetCapturedConfigs()
-	require.Len(t, configs, 1)
-	assert.Empty(t, configs[0].ContractPrompt, "ContractPrompt should be empty — schema now in user prompt")
 }
 
 func TestContractIntegration_InlineSchemaInjectedIntoPrompt(t *testing.T) {
@@ -423,10 +419,6 @@ func TestContractIntegration_InlineSchemaInjectedIntoPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "status", "Prompt should contain inline schema field")
 	assert.Contains(t, prompt, "CRITICAL", "Prompt should contain contract compliance warning")
 
-	// ContractPrompt on the adapter config should be empty
-	configs := capturingAdapter.GetCapturedConfigs()
-	require.Len(t, configs, 1)
-	assert.Empty(t, configs[0].ContractPrompt, "ContractPrompt should be empty — schema now in user prompt")
 }
 
 // ============================================================================

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2991,7 +2991,6 @@ func (e *DefaultPipelineExecutor) runStepExecution(ctx context.Context, executio
 		SkillCommandsDir:    skillCommandsDir,
 		ResolvedSkills:      resolvedSkillRefs,
 		OntologySection:     ontologySection,
-		ContractPrompt:      "", // Contract now in user prompt, not system prompt
 		MaxConcurrentAgents: step.MaxConcurrentAgents,
 		OnStreamEvent: func(evt adapter.StreamEvent) {
 			if evt.Type == "tool_use" && evt.ToolName != "" {
@@ -3031,7 +3030,7 @@ func (e *DefaultPipelineExecutor) runStepExecution(ctx context.Context, executio
 	})
 
 	// Iron Rule: estimate prompt size and check against context window
-	promptBytes := len(cfg.Prompt) + len(cfg.OntologySection) + len(cfg.ContractPrompt)
+	promptBytes := len(cfg.Prompt) + len(cfg.OntologySection)
 	if promptBytes > 0 && resolvedModel != "" {
 		ironStatus, ironMsg := cost.CheckIronRule(resolvedModel, promptBytes)
 		switch ironStatus {

--- a/internal/pipeline/executor_schema_test.go
+++ b/internal/pipeline/executor_schema_test.go
@@ -466,14 +466,14 @@ func TestContractPrompt_EndToEndExecution(t *testing.T) {
 	err := executor.Execute(ctx, p, m, "test")
 	require.NoError(t, err)
 
-	// Schema injection is now in ContractPrompt (CLAUDE.md), NOT in the main prompt
+	// Schema injection is in the user prompt via buildContractPrompt(), NOT in the agent file.
 	prompts := mockAdapter.GetCapturedPrompts()
 	require.Len(t, prompts, 1)
 	capturedPrompt := prompts[0]
 
 	// Main prompt should NOT contain OUTPUT REQUIREMENTS (removed)
 	assert.NotContains(t, capturedPrompt, "OUTPUT REQUIREMENTS:",
-		"Main prompt should not contain schema injection — it's in ContractPrompt/CLAUDE.md")
+		"Main prompt should not contain schema injection")
 }
 
 // TestContractPrompt_RelativeSchemaPath tests handling of relative schema paths.
@@ -797,7 +797,7 @@ func TestContractPrompt_InjectArtifactsOnly(t *testing.T) {
 }
 
 // TestBuildStepPrompt_NoSchemaInjection verifies that buildStepPrompt no longer
-// injects schema content into the main prompt (schema is only in ContractPrompt).
+// injects schema content into the main prompt (schema is appended via buildContractPrompt).
 func TestBuildStepPrompt_NoSchemaInjection(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

**#1070** — `ContractPrompt` was a dead field in `AdapterRunConfig`: always set to `""` at runtime and the if-branch in `claude.go:270` was unreachable. Contract schemas are injected via `buildContractPrompt()` into the **user prompt**, not the agent file.

- `adapter.go` — remove field declaration
- `claude.go` — remove dead if-branch; `contractSection` still initialized to `""` and used for the concurrency hint
- `executor.go` — remove `ContractPrompt: ""` literal and `len(cfg.ContractPrompt)` from prompt-size estimate
- `claude_test.go` — remove `TestContractPromptInAgentFile` (tested removed behaviour), update concurrency ordering test and skill-section ordering test, drop `ContractPrompt` from remaining fixtures
- `contract_integration_test.go` — remove `assert.Empty(ContractPrompt)` checks
- `executor_schema_test.go` — update stale comments

Closes #1070

## Test plan

- [ ] `go test ./internal/adapter/... ./internal/pipeline/...` — all pass
- [ ] Contract schema still injected into user prompt in dry-run output (visible as `-p` arg content)