### PR TITLE
refactor: extract shared tool PATH-check logic to internal/tools

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/onboarding"
+	"github.com/recinq/wave/internal/tools"
 )
 
 // Status represents the severity of a check result.
@@ -347,8 +348,8 @@ func checkForge(opts *Options) (forge.ForgeInfo, []CheckResult) {
 }
 
 func checkRequiredTools(opts *Options) []CheckResult {
-	tools := collectRequiredTools(opts.PipelinesDir)
-	if len(tools) == 0 {
+	required := collectRequiredTools(opts.PipelinesDir)
+	if len(required) == 0 {
 		return []CheckResult{{
 			Name:     "Required Tools",
 			Category: "system",
@@ -357,23 +358,23 @@ func checkRequiredTools(opts *Options) []CheckResult {
 		}}
 	}
 
-	var results []CheckResult
-	for _, tool := range tools {
-		_, err := opts.lookPath(tool)
-		if err != nil {
+	checks := tools.CheckOnPath(opts.lookPath, required)
+	results := make([]CheckResult, 0, len(checks))
+	for _, c := range checks {
+		if c.Found {
 			results = append(results, CheckResult{
-				Name:     fmt.Sprintf("Tool: %s", tool),
+				Name:     fmt.Sprintf("Tool: %s", c.Name),
 				Category: "system",
-				Status:   StatusErr,
-				Message:  fmt.Sprintf("Required tool %q not found on PATH", tool),
-				Fix:      fmt.Sprintf("Install %s", tool),
+				Status:   StatusOK,
+				Message:  fmt.Sprintf("Tool %q available", c.Name),
 			})
 		} else {
 			results = append(results, CheckResult{
-				Name:     fmt.Sprintf("Tool: %s", tool),
+				Name:     fmt.Sprintf("Tool: %s", c.Name),
 				Category: "system",
-				Status:   StatusOK,
-				Message:  fmt.Sprintf("Tool %q available", tool),
+				Status:   StatusErr,
+				Message:  fmt.Sprintf("Required tool %q not found on PATH", c.Name),
+				Fix:      fmt.Sprintf("Install %s", c.Name),
 			})
 		}
 	}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/internal/skill"
+	"github.com/recinq/wave/internal/tools"
 )
 
 // SkillError represents a preflight failure due to missing skills.
@@ -98,37 +99,32 @@ func runCmdWithEnv(env []string, name string, args ...string) error {
 }
 
 // CheckTools verifies that all required CLI tools are available on PATH.
-func (c *Checker) CheckTools(tools []string) ([]Result, error) {
-	var results []Result
+func (c *Checker) CheckTools(toolNames []string) ([]Result, error) {
+	checks := tools.CheckOnPath(nil, toolNames)
+	results := make([]Result, 0, len(checks))
 	var missing []string
 
-	for _, tool := range tools {
-		if tool == "" {
-			continue // Skip empty strings from unresolved template variables
-		}
-		_, err := exec.LookPath(tool)
-		if err != nil {
+	for _, ch := range checks {
+		if ch.Found {
 			results = append(results, Result{
-				Name:    tool,
-				Kind:    "tool",
-				OK:      false,
-				Message: fmt.Sprintf("tool %q not found on PATH", tool),
-			})
-			missing = append(missing, tool)
-		} else {
-			results = append(results, Result{
-				Name:    tool,
+				Name:    ch.Name,
 				Kind:    "tool",
 				OK:      true,
-				Message: fmt.Sprintf("tool %q found", tool),
+				Message: fmt.Sprintf("tool %q found", ch.Name),
 			})
+		} else {
+			results = append(results, Result{
+				Name:    ch.Name,
+				Kind:    "tool",
+				OK:      false,
+				Message: fmt.Sprintf("tool %q not found on PATH", ch.Name),
+			})
+			missing = append(missing, ch.Name)
 		}
 	}
 
 	if len(missing) > 0 {
-		return results, &ToolError{
-			MissingTools: missing,
-		}
+		return results, &ToolError{MissingTools: missing}
 	}
 	return results, nil
 }

--- a/internal/tools/check.go
+++ b/internal/tools/check.go
@@ -1,0 +1,29 @@
+// Package tools provides shared utilities for checking CLI tool availability.
+package tools
+
+import "os/exec"
+
+// PathResult is the outcome of checking a single tool on PATH.
+type PathResult struct {
+	Name  string
+	Found bool
+}
+
+// CheckOnPath checks each tool name using lookPath and returns results in
+// input order. Empty tool names are skipped. If lookPath is nil, exec.LookPath
+// is used. This is the shared core for doctor's checkRequiredTools and
+// preflight's CheckTools — both packages build their own result types on top.
+func CheckOnPath(lookPath func(string) (string, error), tools []string) []PathResult {
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	results := make([]PathResult, 0, len(tools))
+	for _, t := range tools {
+		if t == "" {
+			continue
+		}
+		_, err := lookPath(t)
+		results = append(results, PathResult{Name: t, Found: err == nil})
+	}
+	return results
+}


### PR DESCRIPTION
## Summary

**#1063** — `doctor.checkRequiredTools` and `preflight.CheckTools` both implement the same `LookPath` loop: iterate tool names, call lookPath, partition into found/missing. The duplication was flagged by `audit-duplicates`.

Extracted to `tools.CheckOnPath(lookPath, tools)` in a new `internal/tools` package:
- `lookPath` is injectable (nil → `exec.LookPath`) — preserves doctor's testability
- Returns `[]PathResult` in input order; empty tool names skipped
- Both callers build their own result types (`[]CheckResult`, `[]Result`) on top

No behavior change — result order is preserved.

Closes #1063

## Test plan

- [ ] `go test ./internal/tools/... ./internal/doctor/... ./internal/preflight/...` — all pass
- [ ] `wave doctor` output unchanged