### PR TITLE
refactor: eliminate relay mirror types, use adapter.* directly (#1062)

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/timeouts"
 )
 
@@ -199,44 +200,12 @@ func (m *RelayMonitor) getTokenCount(chatHistory string) int {
 	return len(strings.Split(chatHistory, " "))
 }
 
-// AdapterRunnerWrapper wraps an adapter runner to implement CompactionAdapter.
+// AdapterRunnerWrapper wraps an adapter.AdapterRunner to implement CompactionAdapter.
 // This allows reusing the existing adapter infrastructure for compaction.
 type AdapterRunnerWrapper struct {
-	Runner      AdapterRunner
+	Runner      adapter.AdapterRunner
 	AdapterName string
 	PersonaName string
-}
-
-// AdapterRunner is a subset of adapter.AdapterRunner for compaction purposes.
-type AdapterRunner interface {
-	Run(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error)
-}
-
-// AdapterRunnerConfig mirrors the config needed for adapter runs.
-type AdapterRunnerConfig struct {
-	Adapter       string
-	Persona       string
-	WorkspacePath string
-	Prompt        string
-	SystemPrompt  string
-	Timeout       time.Duration
-	Temperature   float64
-	AllowedTools  []string
-	DenyTools     []string
-	OutputFormat  string
-}
-
-// AdapterResult mirrors the adapter result structure.
-type AdapterResult struct {
-	ExitCode   int
-	Stdout     StringReader
-	TokensUsed int
-	Artifacts  []string
-}
-
-// StringReader is a minimal interface for reading stdout.
-type StringReader interface {
-	Read(p []byte) (n int, err error)
 }
 
 // RunCompaction implements CompactionAdapter by running the adapter with a compaction prompt.
@@ -266,7 +235,7 @@ func (w *AdapterRunnerWrapper) RunCompaction(ctx context.Context, cfg Compaction
 	// Build the compaction prompt combining the chat history and compact instruction
 	prompt := fmt.Sprintf("%s\n\n---\n\nConversation history to summarize:\n%s", cfg.CompactPrompt, cfg.ChatHistory)
 
-	runCfg := AdapterRunnerConfig{
+	runCfg := adapter.AdapterRunConfig{
 		Adapter:       w.AdapterName,
 		Persona:       w.PersonaName,
 		WorkspacePath: cfg.WorkspacePath,

--- a/internal/relay/relay_benchmark_test.go
+++ b/internal/relay/relay_benchmark_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 )
 
 // =============================================================================
@@ -161,8 +163,8 @@ func Benchmark_validateConfig(b *testing.B) {
 
 func BenchmarkAdapterRunnerWrapper_RunCompaction(b *testing.B) {
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-			return &AdapterResult{
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("benchmark compaction result")},
 				TokensUsed: 100,

--- a/internal/relay/relay_concurrency_test.go
+++ b/internal/relay/relay_concurrency_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -126,10 +128,10 @@ func TestRelayMonitor_ConcurrentCompaction(t *testing.T) {
 
 func TestAdapterRunnerWrapper_ConcurrentRunCompaction(t *testing.T) {
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Simulate some processing time
 			time.Sleep(5 * time.Millisecond)
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("concurrent result")},
 				TokensUsed: 100,

--- a/internal/relay/relay_edge_cases_test.go
+++ b/internal/relay/relay_edge_cases_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -258,11 +260,11 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("empty adapter/persona names", func(t *testing.T) {
-		var receivedConfig AdapterRunnerConfig
+		var receivedConfig adapter.AdapterRunConfig
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				receivedConfig = cfg
-				return &AdapterResult{
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte("result")},
 				}, nil
@@ -293,11 +295,11 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 		longHistory := strings.Repeat("This is a very long conversation history. ", 10000)
 
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				if len(cfg.Prompt) < len(longHistory) {
 					t.Error("prompt should include the full chat history")
 				}
-				return &AdapterResult{
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte("summary of long history")},
 				}, nil
@@ -326,8 +328,8 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 
 	t.Run("adapter returns zero exit code but error", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{ExitCode: 0}, errors.New("runtime error")
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{ExitCode: 0}, errors.New("runtime error")
 			},
 		}
 

--- a/internal/relay/relay_stress_test.go
+++ b/internal/relay/relay_stress_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -208,10 +210,10 @@ func TestAdapterRunnerWrapper_LargePayloads(t *testing.T) {
 	largeOutput := strings.Repeat("This is a large compaction result with many details. ", 10000)
 
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Simulate processing time proportional to input size
 			time.Sleep(time.Duration(len(cfg.Prompt)/1000) * time.Microsecond)
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte(largeOutput)},
 				TokensUsed: len(cfg.Prompt) / 4, // Approximate token estimation
@@ -275,8 +277,8 @@ func TestAdapterRunnerWrapper_OutputSizeLimit(t *testing.T) {
 	}
 
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-			return &AdapterResult{
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: hugeMockOutput},
 				TokensUsed: 100000,

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -201,7 +203,7 @@ Decision 1
 func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 	// Create a mock adapter runner
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Verify the config was set correctly
 			if cfg.Temperature != 0.3 {
 				t.Errorf("expected temperature 0.3, got %f", cfg.Temperature)
@@ -209,7 +211,7 @@ func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 			if len(cfg.AllowedTools) != 3 {
 				t.Errorf("expected 3 allowed tools, got %d", len(cfg.AllowedTools))
 			}
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("summarized content")},
 				TokensUsed: 100,
@@ -241,14 +243,14 @@ func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 
 // mockAdapterRunner implements AdapterRunner for testing.
 type mockAdapterRunner struct {
-	runFunc func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error)
+	runFunc func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error)
 }
 
-func (m *mockAdapterRunner) Run(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+func (m *mockAdapterRunner) Run(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 	if m.runFunc != nil {
 		return m.runFunc(ctx, cfg)
 	}
-	return &AdapterResult{
+	return &adapter.AdapterResult{
 		ExitCode:   0,
 		Stdout:     &mockReader{data: []byte("default output")},
 		TokensUsed: 100,
@@ -670,7 +672,7 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 	t.Run("returns error from adapter", func(t *testing.T) {
 		expectedErr := errors.New("adapter failed")
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				return nil, expectedErr
 			},
 		}
@@ -697,8 +699,8 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles empty stdout", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte{}},
 				}, nil
@@ -726,8 +728,8 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles nil stdout", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   nil,
 				}, nil
@@ -755,7 +757,7 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles nil result", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				return nil, nil
 			},
 		}


### PR DESCRIPTION
## Summary

- Remove `relay.AdapterRunner` interface, `relay.AdapterRunnerConfig`, `relay.AdapterResult`, and `relay.StringReader` — all were manual subsets of types in `internal/adapter`
- `AdapterRunnerWrapper.Runner` is now `adapter.AdapterRunner` directly
- `RunCompaction` builds `adapter.AdapterRunConfig` instead of the now-deleted local mirror — manual field-mapping constructor removed
- Update all relay test files to import `adapter` and use `adapter.AdapterRunConfig` / `adapter.AdapterResult`

ADR-003 depguard allows `internal/relay` to import `internal/adapter` (only infrastructure packages like `state`, `workspace`, `forge` are blocked from importing domain packages).

Closes #1062

## Test plan

- [x] `go test ./internal/relay/...` passes
- [x] `go build ./...` clean