### PR TITLE
refactor: merge duplicate ContractConfig into contract package (#1061)

### DIFF
--- a/internal/contract/agent_review.go
+++ b/internal/contract/agent_review.go
@@ -16,10 +16,10 @@ import (
 
 // ReviewContextSource defines a context item provided to the reviewing agent.
 type ReviewContextSource struct {
-	Source   string `json:"source,omitempty"`   // "git_diff" or "artifact"
-	Artifact string `json:"artifact,omitempty"` // Artifact name when source is "artifact"
-	MaxSize  int    `json:"maxSize,omitempty"`  // Max bytes; 0 = default (50KB)
-	DiffBase string `json:"diffBase,omitempty"` // Git ref to diff against (e.g. "main"); auto-detected if empty
+	Source   string `json:"source,omitempty"   yaml:"source,omitempty"`    // "git_diff" or "artifact"
+	Artifact string `json:"artifact,omitempty" yaml:"artifact,omitempty"`  // Artifact name when source is "artifact"
+	MaxSize  int    `json:"maxSize,omitempty"  yaml:"max_size,omitempty"`   // Max bytes; 0 = default (50KB)
+	DiffBase string `json:"diffBase,omitempty" yaml:"diff_base,omitempty"` // Git ref to diff against (e.g. "main"); auto-detected if empty
 }
 
 // ReviewIssue is a single issue found during an agent review.

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -7,60 +7,63 @@ import (
 )
 
 // ContractConfig defines the configuration for contract validation.
+// It is the canonical type for contract configuration used by both the
+// pipeline (via YAML parsing) and the contract validation engine (via JSON/runtime).
 type ContractConfig struct {
-	Type        string   `json:"type"`
-	Source      string   `json:"source,omitempty"`
-	Schema      string   `json:"schema,omitempty"`
-	SchemaPath  string   `json:"schemaPath,omitempty"`
-	Command     string   `json:"command,omitempty"`
-	CommandArgs []string `json:"commandArgs,omitempty"`
-	Dir         string   `json:"dir,omitempty"`       // Working directory: "project_root", absolute path, or empty for workspace
-	MustPass    bool     `json:"must_pass,omitempty"` // Determines if validation failure blocks pipeline
-	MaxRetries  int      `json:"maxRetries,omitempty"`
+	Type        string   `json:"type"                    yaml:"type"`
+	Source      string   `json:"source,omitempty"        yaml:"source,omitempty"`
+	Schema      string   `json:"schema,omitempty"        yaml:"schema,omitempty"`
+	SchemaPath  string   `json:"schemaPath,omitempty"    yaml:"schema_path,omitempty"`
+	Validate    bool     `json:"validate,omitempty"      yaml:"validate,omitempty"`
+	Command     string   `json:"command,omitempty"       yaml:"command,omitempty"`
+	CommandArgs []string `json:"commandArgs,omitempty"   yaml:"command_args,omitempty"`
+	Dir         string   `json:"dir,omitempty"           yaml:"dir,omitempty"`        // Working directory: "project_root", absolute path, or empty for workspace
+	MustPass    bool     `json:"must_pass,omitempty"     yaml:"must_pass,omitempty"`  // Determines if validation failure blocks pipeline
+	MaxRetries  int      `json:"maxRetries,omitempty"    yaml:"max_retries,omitempty"`
 
 	// Progressive validation settings
-	ProgressiveValidation bool   `json:"progressive_validation,omitempty"` // Enable progressive validation with warnings
-	RecoveryLevel         string `json:"recovery_level,omitempty"`         // "conservative", "progressive", or "aggressive"
-	AllowRecovery         bool   `json:"allow_recovery,omitempty"`         // Enable automatic JSON recovery
-	WarnOnRecovery        bool   `json:"warn_on_recovery,omitempty"`       // Generate warnings instead of errors for recoverable issues
+	ProgressiveValidation bool   `json:"progressive_validation,omitempty" yaml:"progressive_validation,omitempty"` // Enable progressive validation with warnings
+	RecoveryLevel         string `json:"recovery_level,omitempty"         yaml:"recovery_level,omitempty"`         // "conservative", "progressive", or "aggressive"
+	AllowRecovery         bool   `json:"allow_recovery,omitempty"         yaml:"allow_recovery,omitempty"`         // Enable automatic JSON recovery
+	WarnOnRecovery        bool   `json:"warn_on_recovery,omitempty"       yaml:"warn_on_recovery,omitempty"`       // Generate warnings instead of errors for recoverable issues
 
 	// Wrapper detection settings
-	DisableWrapperDetection bool `json:"disable_wrapper_detection,omitempty"` // Disable error wrapper detection (default: false, detection enabled)
-	DebugMode               bool `json:"debug_mode,omitempty"`                // Enable debug logging for wrapper detection
+	DisableWrapperDetection bool `json:"disable_wrapper_detection,omitempty" yaml:"disable_wrapper_detection,omitempty"` // Disable error wrapper detection (default: false, detection enabled)
+	DebugMode               bool `json:"debug_mode,omitempty"                yaml:"debug_mode,omitempty"`                // Enable debug logging for wrapper detection
 
 	// LLM judge settings
-	Model     string   `json:"model,omitempty"`     // LLM model for judge evaluation; accepts tier names (cheapest, balanced, strongest) or literal model IDs
-	Criteria  []string `json:"criteria,omitempty"`  // Evaluation criteria for LLM judge
-	Threshold float64  `json:"threshold,omitempty"` // Pass threshold (0.0-1.0), default 1.0
+	Model     string   `json:"model,omitempty"     yaml:"model,omitempty"`     // LLM model for judge evaluation; accepts tier names (cheapest, balanced, strongest) or literal model IDs
+	Criteria  []string `json:"criteria,omitempty"  yaml:"criteria,omitempty"`  // Evaluation criteria for LLM judge
+	Threshold float64  `json:"threshold,omitempty" yaml:"threshold,omitempty"` // Pass threshold (0.0-1.0), default 1.0
 
 	// Convergence tracking for rework loops
-	ConvergenceWindow         int     `json:"convergence_window,omitempty"`          // Number of rounds to compare for stall detection (default 3)
-	ConvergenceMinImprovement float64 `json:"convergence_min_improvement,omitempty"` // Minimum score improvement to consider progress (default 0.05 = 5%)
+	ConvergenceWindow         int     `json:"convergence_window,omitempty"          yaml:"convergence_window,omitempty"`          // Number of rounds to compare for stall detection (default 3)
+	ConvergenceMinImprovement float64 `json:"convergence_min_improvement,omitempty" yaml:"convergence_min_improvement,omitempty"` // Minimum score improvement to consider progress (default 0.05 = 5%)
 
 	// Agent review settings
-	Persona      string                `json:"persona,omitempty"`      // Reviewer persona name
-	CriteriaPath string                `json:"criteriaPath,omitempty"` // Path to review criteria markdown
-	Context      []ReviewContextSource `json:"context,omitempty"`      // Context sources for the reviewer
-	TokenBudget  int                   `json:"tokenBudget,omitempty"`  // Max tokens for review agent
-	Timeout      string                `json:"timeout,omitempty"`      // Duration string for review timeout
-	ReworkStep   string                `json:"reworkStep,omitempty"`   // Step ID for on_failure: rework
-	OnFailure    string                `json:"onFailure,omitempty"`    // "fail", "skip", "continue", "rework"
+	Persona      string                `json:"persona,omitempty"      yaml:"persona,omitempty"`       // Reviewer persona name
+	CriteriaPath string                `json:"criteriaPath,omitempty" yaml:"criteria_path,omitempty"` // Path to review criteria markdown
+	Context      []ReviewContextSource `json:"context,omitempty"      yaml:"context,omitempty"`       // Context sources for the reviewer
+	TokenBudget  int                   `json:"tokenBudget,omitempty"  yaml:"token_budget,omitempty"`  // Max tokens for review agent
+	Timeout      string                `json:"timeout,omitempty"      yaml:"timeout,omitempty"`       // Duration string for review timeout
+	ReworkStep   string                `json:"reworkStep,omitempty"   yaml:"rework_step,omitempty"`   // Step ID for on_failure: rework
+	OnFailure    string                `json:"onFailure,omitempty"    yaml:"on_failure,omitempty"`    // "fail", "skip", "continue", "rework"
 	// ArtifactPaths provides artifact name→path mappings for artifact context sources.
 	// This is populated by the executor at validation time, not from YAML.
-	ArtifactPaths map[string]string `json:"artifactPaths,omitempty"`
+	ArtifactPaths map[string]string `json:"artifactPaths,omitempty" yaml:"-"`
 
 	// source_diff contract fields
-	Glob     string   `json:"glob,omitempty"`      // Glob pattern for qualifying source files
-	Exclude  []string `json:"exclude,omitempty"`   // Glob patterns for files to exclude
-	MinFiles int      `json:"min_files,omitempty"` // Minimum number of qualifying changed files required (default 1)
+	Glob     string   `json:"glob,omitempty"       yaml:"glob,omitempty"`      // Glob pattern for qualifying source files
+	Exclude  []string `json:"exclude,omitempty"    yaml:"exclude,omitempty"`   // Glob patterns for files to exclude
+	MinFiles int      `json:"min_files,omitempty"  yaml:"min_files,omitempty"` // Minimum number of qualifying changed files required (default 1)
 
 	// event_contains contract fields — validated by executor (needs event store access)
-	Events []EventPattern `json:"events,omitempty"` // Expected event patterns to match against the step's event log
+	Events []EventPattern `json:"events,omitempty" yaml:"events,omitempty"` // Expected event patterns to match against the step's event log
 
 	// spec_derived_test contract fields
-	SpecArtifact       string `json:"spec_artifact,omitempty"`       // Path to the specification artifact file
-	TestPersona        string `json:"test_persona,omitempty"`        // Persona that generates tests (must differ from implementer)
-	ImplementationStep string `json:"implementation_step,omitempty"` // Step ID of the implementation to validate
+	SpecArtifact       string `json:"spec_artifact,omitempty"        yaml:"spec_artifact,omitempty"`        // Path to the specification artifact file
+	TestPersona        string `json:"test_persona,omitempty"         yaml:"test_persona,omitempty"`         // Persona that generates tests (must differ from implementer)
+	ImplementationStep string `json:"implementation_step,omitempty"  yaml:"implementation_step,omitempty"` // Step ID of the implementation to validate
 }
 
 // ValidationError provides detailed information about contract validation failures.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2392,25 +2392,10 @@ func (e *DefaultPipelineExecutor) runSingleContract(
 	})
 	contractStart := time.Now()
 
-	contractCfg := contract.ContractConfig{
-		Type:          c.Type,
-		Source:        resolvedSource,
-		Schema:        c.Schema,
-		SchemaPath:    c.SchemaPath,
-		Command:       resolvedCommand,
-		Dir:           c.Dir,
-		MustPass:      c.MustPass,
-		MaxRetries:    c.MaxRetries,
-		Model:         c.Model,
-		Criteria:      c.Criteria,
-		Threshold:     c.Threshold,
-		Persona:       c.Persona,
-		CriteriaPath:  c.CriteriaPath,
-		Context:       convertReviewContextSources(c.Context),
-		TokenBudget:   c.TokenBudget,
-		Timeout:       c.Timeout,
-		ArtifactPaths: artifactPaths,
-	}
+	contractCfg := c
+	contractCfg.Source = resolvedSource
+	contractCfg.Command = resolvedCommand
+	contractCfg.ArtifactPaths = artifactPaths
 
 	var valErr error
 	switch c.Type {
@@ -2602,23 +2587,6 @@ func (e *DefaultPipelineExecutor) triggerContractRework(
 	execution.mu.Unlock()
 
 	return feedbackPath, nil
-}
-
-// convertReviewContextSources converts pipeline.ReviewContextSource to contract.ReviewContextSource.
-func convertReviewContextSources(sources []ReviewContextSource) []contract.ReviewContextSource {
-	if len(sources) == 0 {
-		return nil
-	}
-	out := make([]contract.ReviewContextSource, len(sources))
-	for i, s := range sources {
-		out[i] = contract.ReviewContextSource{
-			Source:   s.Source,
-			Artifact: s.Artifact,
-			MaxSize:  s.MaxSize,
-			DiffBase: s.DiffBase,
-		}
-	}
-	return out
 }
 
 // executeMatrixStep handles steps with matrix strategy using fan-out execution.

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/recinq/wave/internal/contract"
 	"github.com/recinq/wave/internal/hooks"
 	"github.com/recinq/wave/internal/skill"
 	"github.com/recinq/wave/internal/state"
@@ -412,64 +413,33 @@ func (a *ArtifactDef) GetEffectiveSource() string {
 }
 
 type HandoverConfig struct {
-	Contract     ContractConfig   `yaml:"contract,omitempty"`
-	Contracts    []ContractConfig `yaml:"contracts,omitempty"`
-	Compaction   CompactionConfig `yaml:"compaction,omitempty"`
-	OnReviewFail string           `yaml:"on_review_fail,omitempty"`
-	TargetStep   string           `yaml:"target_step,omitempty"`
+	Contract     contract.ContractConfig   `yaml:"contract,omitempty"`
+	Contracts    []contract.ContractConfig `yaml:"contracts,omitempty"`
+	Compaction   CompactionConfig          `yaml:"compaction,omitempty"`
+	OnReviewFail string                    `yaml:"on_review_fail,omitempty"`
+	TargetStep   string                    `yaml:"target_step,omitempty"`
 }
 
 // EffectiveContracts returns the ordered list of contracts to validate.
 // If Contracts (plural) is non-empty, it takes precedence.
 // If only the singular Contract is set, it is wrapped in a slice.
 // If neither is set, nil is returned.
-func (h *HandoverConfig) EffectiveContracts() []ContractConfig {
+func (h *HandoverConfig) EffectiveContracts() []contract.ContractConfig {
 	if len(h.Contracts) > 0 {
 		return h.Contracts
 	}
 	if h.Contract.Type != "" {
-		return []ContractConfig{h.Contract}
+		return []contract.ContractConfig{h.Contract}
 	}
 	return nil
 }
 
-type ContractConfig struct {
-	Type       string `yaml:"type,omitempty"`
-	Schema     string `yaml:"schema,omitempty"`
-	Source     string `yaml:"source,omitempty"`
-	SchemaPath string `yaml:"schema_path,omitempty"`
-	Validate   bool   `yaml:"validate,omitempty"`
-	Command    string `yaml:"command,omitempty"`
-	Dir        string `yaml:"dir,omitempty"` // Working directory: "project_root", absolute path, or empty for workspace
-	MustPass   bool   `yaml:"must_pass,omitempty"`
-	OnFailure  string `yaml:"on_failure,omitempty"`
-	MaxRetries int    `yaml:"max_retries,omitempty"`
+// ContractConfig is an alias for contract.ContractConfig for use in pipeline YAML files.
+// Pipelines should use this type directly; contract validation uses contract.ContractConfig.
+type ContractConfig = contract.ContractConfig
 
-	// LLM judge settings
-	Model     string   `yaml:"model,omitempty"`     // LLM model for judge evaluation
-	Criteria  []string `yaml:"criteria,omitempty"`  // Evaluation criteria for LLM judge
-	Threshold float64  `yaml:"threshold,omitempty"` // Pass threshold (0.0-1.0), default 1.0
-
-	// Convergence tracking for rework loops
-	ConvergenceWindow         int     `yaml:"convergence_window,omitempty"`          // Sliding window size for stall detection (default 3)
-	ConvergenceMinImprovement float64 `yaml:"convergence_min_improvement,omitempty"` // Min score improvement to continue rework (default 0.05)
-
-	// Agent review settings
-	Persona      string                `yaml:"persona,omitempty"`       // Reviewer persona name (must differ from step persona)
-	CriteriaPath string                `yaml:"criteria_path,omitempty"` // Path to review criteria markdown file
-	Context      []ReviewContextSource `yaml:"context,omitempty"`       // Context sources for the reviewer
-	TokenBudget  int                   `yaml:"token_budget,omitempty"`  // Max tokens for review agent (0 = unlimited)
-	Timeout      string                `yaml:"timeout,omitempty"`       // Duration string for review timeout (e.g. "60s")
-	ReworkStep   string                `yaml:"rework_step,omitempty"`   // Step ID to execute on review failure with on_failure: rework
-}
-
-// ReviewContextSource defines a single context item provided to the reviewing agent.
-type ReviewContextSource struct {
-	Source   string `yaml:"source,omitempty"`    // "git_diff" or "artifact"
-	Artifact string `yaml:"artifact,omitempty"`  // Artifact name when source is "artifact"
-	MaxSize  int    `yaml:"max_size,omitempty"`  // Max bytes for this source (0 = use default)
-	DiffBase string `yaml:"diff_base,omitempty"` // Git ref to diff against (e.g. "main"); auto-detected if empty
-}
+// ReviewContextSource is an alias for contract.ReviewContextSource.
+type ReviewContextSource = contract.ReviewContextSource
 
 type CompactionConfig struct {
 	Trigger string `yaml:"trigger,omitempty"`

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/timeouts"
 )
 
@@ -199,44 +200,12 @@ func (m *RelayMonitor) getTokenCount(chatHistory string) int {
 	return len(strings.Split(chatHistory, " "))
 }
 
-// AdapterRunnerWrapper wraps an adapter runner to implement CompactionAdapter.
+// AdapterRunnerWrapper wraps an adapter.AdapterRunner to implement CompactionAdapter.
 // This allows reusing the existing adapter infrastructure for compaction.
 type AdapterRunnerWrapper struct {
-	Runner      AdapterRunner
+	Runner      adapter.AdapterRunner
 	AdapterName string
 	PersonaName string
-}
-
-// AdapterRunner is a subset of adapter.AdapterRunner for compaction purposes.
-type AdapterRunner interface {
-	Run(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error)
-}
-
-// AdapterRunnerConfig mirrors the config needed for adapter runs.
-type AdapterRunnerConfig struct {
-	Adapter       string
-	Persona       string
-	WorkspacePath string
-	Prompt        string
-	SystemPrompt  string
-	Timeout       time.Duration
-	Temperature   float64
-	AllowedTools  []string
-	DenyTools     []string
-	OutputFormat  string
-}
-
-// AdapterResult mirrors the adapter result structure.
-type AdapterResult struct {
-	ExitCode   int
-	Stdout     StringReader
-	TokensUsed int
-	Artifacts  []string
-}
-
-// StringReader is a minimal interface for reading stdout.
-type StringReader interface {
-	Read(p []byte) (n int, err error)
 }
 
 // RunCompaction implements CompactionAdapter by running the adapter with a compaction prompt.
@@ -266,7 +235,7 @@ func (w *AdapterRunnerWrapper) RunCompaction(ctx context.Context, cfg Compaction
 	// Build the compaction prompt combining the chat history and compact instruction
 	prompt := fmt.Sprintf("%s\n\n---\n\nConversation history to summarize:\n%s", cfg.CompactPrompt, cfg.ChatHistory)
 
-	runCfg := AdapterRunnerConfig{
+	runCfg := adapter.AdapterRunConfig{
 		Adapter:       w.AdapterName,
 		Persona:       w.PersonaName,
 		WorkspacePath: cfg.WorkspacePath,

--- a/internal/relay/relay_benchmark_test.go
+++ b/internal/relay/relay_benchmark_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 )
 
 // =============================================================================
@@ -161,8 +163,8 @@ func Benchmark_validateConfig(b *testing.B) {
 
 func BenchmarkAdapterRunnerWrapper_RunCompaction(b *testing.B) {
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-			return &AdapterResult{
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("benchmark compaction result")},
 				TokensUsed: 100,

--- a/internal/relay/relay_concurrency_test.go
+++ b/internal/relay/relay_concurrency_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -126,10 +128,10 @@ func TestRelayMonitor_ConcurrentCompaction(t *testing.T) {
 
 func TestAdapterRunnerWrapper_ConcurrentRunCompaction(t *testing.T) {
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Simulate some processing time
 			time.Sleep(5 * time.Millisecond)
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("concurrent result")},
 				TokensUsed: 100,

--- a/internal/relay/relay_edge_cases_test.go
+++ b/internal/relay/relay_edge_cases_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -258,11 +260,11 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("empty adapter/persona names", func(t *testing.T) {
-		var receivedConfig AdapterRunnerConfig
+		var receivedConfig adapter.AdapterRunConfig
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				receivedConfig = cfg
-				return &AdapterResult{
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte("result")},
 				}, nil
@@ -293,11 +295,11 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 		longHistory := strings.Repeat("This is a very long conversation history. ", 10000)
 
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				if len(cfg.Prompt) < len(longHistory) {
 					t.Error("prompt should include the full chat history")
 				}
-				return &AdapterResult{
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte("summary of long history")},
 				}, nil
@@ -326,8 +328,8 @@ func TestAdapterRunnerWrapper_EdgeCases(t *testing.T) {
 
 	t.Run("adapter returns zero exit code but error", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{ExitCode: 0}, errors.New("runtime error")
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{ExitCode: 0}, errors.New("runtime error")
 			},
 		}
 

--- a/internal/relay/relay_stress_test.go
+++ b/internal/relay/relay_stress_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -208,10 +210,10 @@ func TestAdapterRunnerWrapper_LargePayloads(t *testing.T) {
 	largeOutput := strings.Repeat("This is a large compaction result with many details. ", 10000)
 
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Simulate processing time proportional to input size
 			time.Sleep(time.Duration(len(cfg.Prompt)/1000) * time.Microsecond)
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte(largeOutput)},
 				TokensUsed: len(cfg.Prompt) / 4, // Approximate token estimation
@@ -275,8 +277,8 @@ func TestAdapterRunnerWrapper_OutputSizeLimit(t *testing.T) {
 	}
 
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-			return &AdapterResult{
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: hugeMockOutput},
 				TokensUsed: 100000,

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
 	"time"
 )
 
@@ -201,7 +203,7 @@ Decision 1
 func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 	// Create a mock adapter runner
 	mockRunner := &mockAdapterRunner{
-		runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+		runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 			// Verify the config was set correctly
 			if cfg.Temperature != 0.3 {
 				t.Errorf("expected temperature 0.3, got %f", cfg.Temperature)
@@ -209,7 +211,7 @@ func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 			if len(cfg.AllowedTools) != 3 {
 				t.Errorf("expected 3 allowed tools, got %d", len(cfg.AllowedTools))
 			}
-			return &AdapterResult{
+			return &adapter.AdapterResult{
 				ExitCode:   0,
 				Stdout:     &mockReader{data: []byte("summarized content")},
 				TokensUsed: 100,
@@ -241,14 +243,14 @@ func TestAdapterRunnerWrapper_RunCompaction(t *testing.T) {
 
 // mockAdapterRunner implements AdapterRunner for testing.
 type mockAdapterRunner struct {
-	runFunc func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error)
+	runFunc func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error)
 }
 
-func (m *mockAdapterRunner) Run(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+func (m *mockAdapterRunner) Run(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 	if m.runFunc != nil {
 		return m.runFunc(ctx, cfg)
 	}
-	return &AdapterResult{
+	return &adapter.AdapterResult{
 		ExitCode:   0,
 		Stdout:     &mockReader{data: []byte("default output")},
 		TokensUsed: 100,
@@ -670,7 +672,7 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 	t.Run("returns error from adapter", func(t *testing.T) {
 		expectedErr := errors.New("adapter failed")
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				return nil, expectedErr
 			},
 		}
@@ -697,8 +699,8 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles empty stdout", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   &mockReader{data: []byte{}},
 				}, nil
@@ -726,8 +728,8 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles nil stdout", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
-				return &AdapterResult{
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+				return &adapter.AdapterResult{
 					ExitCode: 0,
 					Stdout:   nil,
 				}, nil
@@ -755,7 +757,7 @@ func TestAdapterRunnerWrapper_RunCompaction_ErrorHandling(t *testing.T) {
 
 	t.Run("handles nil result", func(t *testing.T) {
 		mockRunner := &mockAdapterRunner{
-			runFunc: func(ctx context.Context, cfg AdapterRunnerConfig) (*AdapterResult, error) {
+			runFunc: func(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 				return nil, nil
 			},
 		}


### PR DESCRIPTION
## Summary

- Adds dual YAML+JSON struct tags to `ContractConfig` in `internal/contract`, making it the single canonical definition
- Adds YAML tags to `ReviewContextSource` in `agent_review.go`
- Replaces `pipeline.ContractConfig` and `pipeline.ReviewContextSource` with Go type aliases (`=`) pointing to `contract.*` — zero impact on existing test files
- Simplifies `contractCfg` construction in `executor.go` from an 18-field struct literal to a 4-line copy+override pattern
- Removes the now-redundant `convertReviewContextSources` function

Closes #1061

## Test plan

- [ ] `go test ./internal/pipeline/... ./internal/contract/...` passes
- [ ] `go build ./...` clean
- [ ] CI green