### PR TITLE
fix: infinite scroll auto-fills viewport on large screens

### DIFF
--- a/internal/webui/templates/issues.html
+++ b/internal/webui/templates/issues.html
@@ -77,7 +77,9 @@ function filterItems(query) {
             var doc=new DOMParser().parseFromString(html,'text/html');
             doc.querySelectorAll('.wr-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
             var nl=doc.getElementById('wr-loader');
-            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');}
+            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');
+                if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
+            }
             else{loader.remove();}
         }).catch(function(){loader.classList.remove('active');loading=false;});
     }

--- a/internal/webui/templates/prs.html
+++ b/internal/webui/templates/prs.html
@@ -84,7 +84,9 @@ function filterItems(query) {
             var doc=new DOMParser().parseFromString(html,'text/html');
             doc.querySelectorAll('.wr-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
             var nl=doc.getElementById('wr-loader');
-            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');}
+            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');
+                if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
+            }
             else{loader.remove();}
         }).catch(function(){loader.classList.remove('active');loading=false;});
     }

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -207,6 +207,8 @@ function filterRuns(query) {
                 nextUrl=newLoader.dataset.next;
                 loading=false;
                 loader.classList.remove('active');
+                // Re-check: if viewport still not overflowing, load next batch
+                if(loader.getBoundingClientRect().top<window.innerHeight+300) loadMore();
             } else {
                 loader.remove();
             }


### PR DESCRIPTION
## Summary

- After each successful batch load in infinite scroll, re-check if the loader is still within the viewport
- If container doesn't overflow, immediately trigger next fetch — repeats until page scrolls or data exhausted
- Applied to runs, issues, and PRs overview pages

Closes #1042

## Test plan

- [x] `go test ./internal/webui/...` passes
- [x] Server renders all 3 pages with fix in JS output (verified via `curl`)
- [ ] Manual test on large screen: verify runs/issues/prs load beyond initial batch without scrolling