### PR TITLE
fix: enforce strict YAML parsing, fix schema drift (#1090)

### DIFF
--- a/.wave/pipelines/bench-solve.yaml
+++ b/.wave/pipelines/bench-solve.yaml
@@ -46,9 +46,10 @@ steps:
     persona: craftsman
     model: strongest
     workspace:
-      type: mount
-      source: ./
-      readonly: false
+      mount:
+        - source: ./
+          target: /project
+          mode: readwrite
     exec:
       type: prompt
       source_path: .wave/prompts/bench/solve.md

--- a/.wave/pipelines/full-impl-cycle.yaml
+++ b/.wave/pipelines/full-impl-cycle.yaml
@@ -169,7 +169,6 @@ steps:
   # ─── Phase 6: Rework Loop (conditional on gate fail) ───────────────────
   - id: rework-loop
     dependencies: [rework-gate]
-    condition: "{{ rework-gate.output.decision == 'fail' }}"
     loop:
       max_iterations: 3
       until: "{{ rework-loop.output.decision == 'pass' }}"
@@ -330,7 +329,6 @@ steps:
 
   - id: review-loop
     dependencies: [review]
-    condition: "{{ review.output.verdict != 'APPROVE' }}"
     loop:
       max_iterations: 3
       until: "{{ review-loop.output.verdict == 'APPROVE' }}"

--- a/.wave/pipelines/wave-validate.yaml
+++ b/.wave/pipelines/wave-validate.yaml
@@ -145,7 +145,6 @@ steps:
     retry:
       policy: patient
       max_attempts: 3
-      timeout: 300s
     handover:
       contract:
         type: json_schema

--- a/.wave/schemas/wave-pipeline.schema.json
+++ b/.wave/schemas/wave-pipeline.schema.json
@@ -362,7 +362,7 @@
         "adapt_prompt": {
           "type": "boolean",
           "default": false,
-          "description": "Inject prior failure context into retry prompt"
+          "description": "Deprecated: failure context is now always injected on retry. Kept for YAML backwards compatibility."
         },
         "on_failure": {
           "type": "string",
@@ -620,11 +620,12 @@
             "test_suite",
             "typescript_interface",
             "markdown_spec",
-            "template",
             "format",
             "non_empty_file",
             "llm_judge",
-            "agent_review"
+            "source_diff",
+            "agent_review",
+            "spec_derived_test"
           ],
           "description": "Contract validation type"
         },
@@ -737,6 +738,10 @@
           "type": "integer",
           "minimum": 0,
           "description": "Maximum bytes for this context source (0 = use default)"
+        },
+        "diff_base": {
+          "type": "string",
+          "description": "Git ref to diff against (e.g. 'main'); auto-detected if empty. Only used when source is 'git_diff'."
         }
       }
     },

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -940,12 +940,8 @@ func loadPipeline(name string, _ *manifest.Manifest) (*pipeline.Pipeline, error)
 		return nil, fmt.Errorf("failed to read pipeline file: %w", err)
 	}
 
-	var p pipeline.Pipeline
-	if err := yaml.Unmarshal(pipelineData, &p); err != nil {
-		return nil, fmt.Errorf("failed to parse pipeline: %w", err)
-	}
-
-	return &p, nil
+	loader := &pipeline.YAMLPipelineLoader{}
+	return loader.Unmarshal(pipelineData)
 }
 
 // isInteractive returns true when stdin is a TTY and interactive selection is possible.

--- a/cmd/wave/commands/validate.go
+++ b/cmd/wave/commands/validate.go
@@ -277,10 +277,12 @@ func validatePipelineFull(pipelineName string, m *manifest.Manifest, fi forge.Fo
 		return []string{fmt.Sprintf("cannot read pipeline file: %s", err)}
 	}
 
-	var p pipeline.Pipeline
-	if err := yaml.Unmarshal(pipelineData, &p); err != nil {
+	loader := &pipeline.YAMLPipelineLoader{}
+	pParsed, err := loader.Unmarshal(pipelineData)
+	if err != nil {
 		return []string{fmt.Sprintf("invalid YAML: %s", err)}
 	}
+	p := *pParsed
 
 	var errs []string
 

--- a/internal/defaults/pipelines/bench-solve.yaml
+++ b/internal/defaults/pipelines/bench-solve.yaml
@@ -46,9 +46,10 @@ steps:
     persona: craftsman
     model: strongest
     workspace:
-      type: mount
-      source: ./
-      readonly: false
+      mount:
+        - source: ./
+          target: /project
+          mode: readwrite
     exec:
       type: prompt
       source_path: .wave/prompts/bench/solve.md

--- a/internal/tui/pipelines.go
+++ b/internal/tui/pipelines.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 
 	"github.com/recinq/wave/internal/pipeline"
-	"gopkg.in/yaml.v3"
+
 )
 
 // PipelineInfo holds discoverable metadata about a pipeline.
@@ -59,8 +59,9 @@ func parsePipelineFile(path string) (PipelineInfo, error) {
 		return PipelineInfo{}, err
 	}
 
-	var p pipeline.Pipeline
-	if err := yaml.Unmarshal(data, &p); err != nil {
+	loader := &pipeline.YAMLPipelineLoader{}
+	p, err := loader.Unmarshal(data)
+	if err != nil {
 		return PipelineInfo{}, err
 	}
 
@@ -96,13 +97,14 @@ func LoadPipelineByName(dir, name string) (*pipeline.Pipeline, error) {
 			continue
 		}
 
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &p); err != nil {
+		loader := &pipeline.YAMLPipelineLoader{}
+		pParsed, err := loader.Unmarshal(data)
+		if err != nil {
 			continue
 		}
 
-		if p.Metadata.Name == name {
-			return &p, nil
+		if pParsed.Metadata.Name == name {
+			return pParsed, nil
 		}
 	}
 

--- a/internal/webui/handlers_compose_test.go
+++ b/internal/webui/handlers_compose_test.go
@@ -66,7 +66,7 @@ steps:
     iterate:
       over: items
       mode: parallel
-    sub_pipeline: sub-task
+    pipeline: sub-task
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "compose-render-test.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -152,12 +152,13 @@ steps:
       over: items
       mode: parallel
       max_concurrent: 3
-    sub_pipeline: worker
+    pipeline: worker
   - id: merge
     persona: navigator
-    depends_on: [fan-out]
+    dependencies: [fan-out]
     exec:
-      prompt: "merge results"
+      type: prompt
+      source: "merge results"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "compose-detail-test.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -235,7 +236,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "do something"
+      type: prompt
+      source: "do something"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "plain-only-pipeline.yaml"), []byte(plainYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -20,7 +20,7 @@ import (
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
-	"gopkg.in/yaml.v3"
+
 )
 
 // validPipelineName matches safe pipeline names: alphanumeric, hyphens, underscores, dots.
@@ -741,12 +741,8 @@ func loadPipelineYAML(name string) (*pipeline.Pipeline, error) {
 		return nil, fmt.Errorf("pipeline not found")
 	}
 
-	var p pipeline.Pipeline
-	if err := yaml.Unmarshal(data, &p); err != nil {
-		return nil, fmt.Errorf("invalid pipeline definition")
-	}
-
-	return &p, nil
+	loader := &pipeline.YAMLPipelineLoader{}
+	return loader.Unmarshal(data)
 }
 
 // handleGateApprove handles POST /api/runs/{id}/gates/{step}/approve

--- a/internal/webui/handlers_control_test.go
+++ b/internal/webui/handlers_control_test.go
@@ -294,7 +294,9 @@ metadata:
 steps:
   - id: step1
     persona: navigator
-    prompt: "do something"
+    exec:
+      type: prompt
+      source: "do something"
 `
 	if err := os.WriteFile(".wave/pipelines/test-pipeline.yaml", []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatal(err)
@@ -501,7 +503,7 @@ func setupPipelineDir(t *testing.T, pipelineName string, steps []string) { //nol
 
 	var stepYAML string
 	for _, s := range steps {
-		stepYAML += "  - id: " + s + "\n    persona: navigator\n    prompt: \"do\"\n"
+		stepYAML += "  - id: " + s + "\n    persona: navigator\n    exec:\n      type: prompt\n      source: \"do\"\n"
 	}
 
 	yaml := "kind: pipeline\nmetadata:\n  name: " + pipelineName + "\nsteps:\n" + stepYAML

--- a/internal/webui/handlers_pipelines_test.go
+++ b/internal/webui/handlers_pipelines_test.go
@@ -65,12 +65,14 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "plan"
+      type: prompt
+      source: "plan"
   - id: step2
     persona: craftsman
-    depends_on: [step1]
+    dependencies: [step1]
     exec:
-      prompt: "implement"
+      type: prompt
+      source: "implement"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "page-render-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -161,12 +163,14 @@ steps:
   - id: analyze
     persona: navigator
     exec:
-      prompt: "analyze"
+      type: prompt
+      source: "analyze"
   - id: build
     persona: craftsman
-    depends_on: [analyze]
+    dependencies: [analyze]
     exec:
-      prompt: "build"
+      type: prompt
+      source: "build"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "summary-fields-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -249,7 +253,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "work"
+      type: prompt
+      source: "work"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "info-metadata-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)

--- a/internal/webui/handlers_runs_test.go
+++ b/internal/webui/handlers_runs_test.go
@@ -282,12 +282,14 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "plan"
+      type: prompt
+      source: "plan"
   - id: step2
     persona: craftsman
-    depends_on: [step1]
+    dependencies: [step1]
     exec:
-      prompt: "implement"
+      type: prompt
+      source: "implement"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "test-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -471,12 +473,14 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "plan"
+      type: prompt
+      source: "plan"
   - id: step2
     persona: craftsman
-    depends_on: [step1]
+    dependencies: [step1]
     exec:
-      prompt: "implement"
+      type: prompt
+      source: "implement"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "test-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -804,9 +808,10 @@ steps:
           target: _fail
   - id: next-step
     persona: craftsman
-    depends_on: [review-gate]
+    dependencies: [review-gate]
     exec:
-      prompt: "implement"
+      type: prompt
+      source: "implement"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "gate-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)

--- a/internal/webui/handlers_skills_test.go
+++ b/internal/webui/handlers_skills_test.go
@@ -70,7 +70,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "work"
+      type: prompt
+      source: "work"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "skill-page-test-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -160,7 +161,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "work"
+      type: prompt
+      source: "work"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "skill-cmds-test.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -235,7 +237,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "work"
+      type: prompt
+      source: "work"
 `
 	pipeline2 := `kind: Pipeline
 metadata:
@@ -248,7 +251,8 @@ steps:
   - id: step1
     persona: craftsman
     exec:
-      prompt: "build"
+      type: prompt
+      source: "build"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "dedup-pipeline-a.yaml"), []byte(pipeline1), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -311,7 +315,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "work"
+      type: prompt
+      source: "work"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "no-skills-exclude-pipeline.yaml"), []byte(noSkillsYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -330,7 +330,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	pipelineDir := filepath.Join(tmpDir, ".wave", "pipelines")
 	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
@@ -429,7 +430,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	pipelineDir := filepath.Join(tmpDir, ".wave", "pipelines")
 	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
@@ -509,12 +511,14 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
   - id: step2
     persona: navigator
-    depends_on: [step1]
+    dependencies: [step1]
     exec:
-      prompt: "test2"
+      type: prompt
+      source: "test2"
 `
 	pipelineDir := filepath.Join(tmpDir, ".wave", "pipelines")
 	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
@@ -577,7 +581,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	pipelineDir := filepath.Join(tmpDir, ".wave", "pipelines")
 	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
@@ -982,7 +987,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "test-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -1087,7 +1093,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "simple-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -1140,7 +1147,8 @@ steps:
   - id: plan
     persona: navigator
     exec:
-      prompt: "plan"
+      type: prompt
+      source: "plan"
   - id: iterate-tasks
     pipeline: impl-issue
     iterate:
@@ -1264,11 +1272,13 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
   - id: step2
     persona: craftsman
     exec:
-      prompt: "build"
+      type: prompt
+      source: "build"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "test-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -1439,11 +1449,13 @@ steps:
   - id: fetch
     persona: navigator
     exec:
-      prompt: "fetch"
+      type: prompt
+      source: "fetch"
   - id: implement
     persona: craftsman
     exec:
-      prompt: "implement"
+      type: prompt
+      source: "implement"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "impl-issue.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -1581,7 +1593,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	if err := os.WriteFile(filepath.Join(pipelineDir, "my-pipeline.yaml"), []byte(pipelineYAML), 0o644); err != nil {
 		t.Fatalf("failed to write pipeline yaml: %v", err)
@@ -1682,7 +1695,8 @@ steps:
   - id: step1
     persona: navigator
     exec:
-      prompt: "test"
+      type: prompt
+      source: "test"
 `
 	pipelineDir := filepath.Join(tmpDir, ".wave", "pipelines")
 	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: `wave validate`, `wave run`, WebUI, and TUI all used `yaml.Unmarshal` (lenient) instead of `pipeline.YAMLPipelineLoader` (strict with `KnownFields(true)`). Invalid YAML fields were silently swallowed.
- All 4 callsites now use the strict loader — invalid pipeline YAML fields are rejected at parse time
- Fixed 3 pipeline YAML files with ghost/invalid fields (bench-solve, full-impl-cycle, wave-validate)
- Synced schema: added `diff_base`, `source_diff`, `spec_derived_test`; removed unused `template`; deprecated `adapt_prompt`
- Fixed 31 occurrences of invalid fields across 7 test fixture files

Closes #1090

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `wave validate --all` — all 47 pipelines pass with strict loader
- [x] `wave validate --pipeline bench-solve` — confirms fixed workspace config loads