### PR TITLE
fix: remove ghost params block from wave.yaml (#1089)

### DIFF
--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -110,7 +111,9 @@ func (l *yamlLoader) Load(path string) (*Manifest, error) {
 	}
 
 	var manifest Manifest
-	if err := yaml.Unmarshal(data, &manifest); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
 		// Try to extract line number from YAML error
 		return nil, parseYAMLError(path, err)
 	}

--- a/wave.yaml
+++ b/wave.yaml
@@ -655,13 +655,3 @@ runtime:
         warn_at: 25.0
     routing:
         auto_route: true
-params:
-    full_impl_cycle:
-        max_rework_iterations: 3
-        max_review_iterations: 3
-        audit_severity_threshold: "major"
-        enable_audit_security: true
-        enable_audit_correctness: true
-        enable_audit_architecture: true
-        enable_audit_tests: true
-        enable_audit_coverage: true


### PR DESCRIPTION
## Summary

- Removed unused `params` block from `wave.yaml` (lines 658-668) — not in Go Manifest struct, not in schema, not read by any code, silently dropped
- Switched manifest loader (`internal/manifest/parser.go`) to use `yaml.Decoder` with `KnownFields(true)` — unknown fields in wave.yaml are now rejected at parse time

Closes #1089

## Test plan

- [x] `go test ./...` — all 39 packages pass
- [x] `wave validate` — manifest loads correctly with strict parser
- [x] Unknown manifest fields now produce parse errors instead of silent drops