### PR TITLE
fix: migrate critical impl pipelines from readwrite mount to worktree

### DIFF
--- a/.wave/pipelines/impl-hotfix.yaml
+++ b/.wave/pipelines/impl-hotfix.yaml
@@ -155,10 +155,8 @@ steps:
           artifact: findings
           as: investigation
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "hotfix/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -270,10 +268,8 @@ steps:
     model: balanced
     rework_only: true
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "hotfix/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |

--- a/.wave/pipelines/impl-improve.yaml
+++ b/.wave/pipelines/impl-improve.yaml
@@ -178,10 +178,8 @@ steps:
           artifact: assessment
           as: findings
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "improve/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |

--- a/.wave/pipelines/impl-prototype.yaml
+++ b/.wave/pipelines/impl-prototype.yaml
@@ -131,10 +131,8 @@ steps:
         with implementation details.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: spec
@@ -253,10 +251,8 @@ steps:
         to stakeholders).
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: feature-docs
@@ -386,10 +382,8 @@ steps:
         specification — forcing rework in the implementation phase.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: prototype
@@ -525,10 +519,8 @@ steps:
         interfaces, skips tests, or implements behavior not described in the specification.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: implementation-plan
@@ -634,10 +626,8 @@ steps:
         body, or no testing instructions.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: pr-info
@@ -735,10 +725,8 @@ steps:
         categorizes blocking issues as suggestions, or provides no context for responses.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-respond
     persona: philosopher
@@ -820,10 +808,8 @@ steps:
         it"), or agree to every suggestion without evaluating impact.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-fix
     persona: craftsman
@@ -902,10 +888,8 @@ steps:
         PR scope beyond what was originally intended.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-merge
     persona: navigator
@@ -983,7 +967,5 @@ steps:
         or fails to handle merge conflicts gracefully.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"

--- a/.wave/pipelines/impl-refactor.yaml
+++ b/.wave/pipelines/impl-refactor.yaml
@@ -169,10 +169,8 @@ steps:
           artifact: analysis
           as: scope
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "refactor/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -291,10 +289,8 @@ steps:
           artifact: baseline
           as: tests
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "refactor/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/impl-hotfix.yaml
+++ b/internal/defaults/pipelines/impl-hotfix.yaml
@@ -155,10 +155,8 @@ steps:
           artifact: findings
           as: investigation
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "hotfix/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -270,10 +268,8 @@ steps:
     model: balanced
     rework_only: true
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "hotfix/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/impl-improve.yaml
+++ b/internal/defaults/pipelines/impl-improve.yaml
@@ -178,10 +178,8 @@ steps:
           artifact: assessment
           as: findings
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "improve/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/impl-prototype.yaml
+++ b/internal/defaults/pipelines/impl-prototype.yaml
@@ -131,10 +131,8 @@ steps:
         with implementation details.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: spec
@@ -253,10 +251,8 @@ steps:
         to stakeholders).
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: feature-docs
@@ -386,10 +382,8 @@ steps:
         specification — forcing rework in the implementation phase.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: prototype
@@ -525,10 +519,8 @@ steps:
         interfaces, skips tests, or implements behavior not described in the specification.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: implementation-plan
@@ -634,10 +626,8 @@ steps:
         body, or no testing instructions.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
     output_artifacts:
       - name: pr-info
@@ -735,10 +725,8 @@ steps:
         categorizes blocking issues as suggestions, or provides no context for responses.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-respond
     persona: philosopher
@@ -820,10 +808,8 @@ steps:
         it"), or agree to every suggestion without evaluating impact.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-fix
     persona: craftsman
@@ -902,10 +888,8 @@ steps:
         PR scope beyond what was originally intended.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"
 
   - id: pr-merge
     persona: navigator
@@ -983,7 +967,5 @@ steps:
         or fails to handle merge conflicts gracefully.
 
     workspace:
-      mount:
-        - source: .
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "proto/{{ pipeline_id }}"

--- a/internal/defaults/pipelines/impl-refactor.yaml
+++ b/internal/defaults/pipelines/impl-refactor.yaml
@@ -169,10 +169,8 @@ steps:
           artifact: analysis
           as: scope
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "refactor/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -291,10 +289,8 @@ steps:
           artifact: baseline
           as: tests
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "refactor/{{ pipeline_id }}"
     exec:
       type: prompt
       source: |


### PR DESCRIPTION
## Summary

- **impl-hotfix** (2 steps: fix, fix-retry) → worktree `hotfix/{{ pipeline_id }}`
- **impl-improve** (1 step: implement) → worktree `improve/{{ pipeline_id }}`
- **impl-prototype** (9 steps: spec through pr-merge) → worktree `proto/{{ pipeline_id }}`
- **impl-refactor** (2 steps: test-baseline, refactor) → worktree `refactor/{{ pipeline_id }}`

These pipelines were modifying the project root directly via readwrite mounts without git worktree isolation. Concurrent runs could conflict, and failures left the working directory dirty. Now matches the pattern used by impl-feature and impl-issue.

Closes #1086

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `wave validate --pipeline impl-hotfix` ✓
- [x] `wave validate --pipeline impl-improve` ✓
- [x] `wave validate --pipeline impl-prototype` ✓
- [x] `wave validate --pipeline impl-refactor` ✓
- [ ] Run each pipeline once to verify worktree creation and cleanup