### PR TITLE
feat: add completed_empty state for zero-diff worktree steps

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -858,7 +859,7 @@ func (e *DefaultPipelineExecutor) runSchedulingLoop(ctx context.Context, executi
 					execution.mu.Lock()
 					stepState := execution.States[step.ID]
 					execution.mu.Unlock()
-					if stepState == stateCompleted && !completed[step.ID] {
+					if (stepState == stateCompleted || stepState == stateCompletedEmpty) && !completed[step.ID] {
 						completed[step.ID] = true
 						completedCount++
 					}
@@ -927,7 +928,7 @@ func (e *DefaultPipelineExecutor) runSchedulingLoop(ctx context.Context, executi
 			execution.mu.Lock()
 			stepState := execution.States[step.ID]
 			execution.mu.Unlock()
-			if stepState == stateCompleted || stepState == stateFailed {
+			if stepState == stateCompleted || stepState == stateCompletedEmpty || stepState == stateFailed {
 				completed[step.ID] = true
 			}
 		}
@@ -971,9 +972,28 @@ func (e *DefaultPipelineExecutor) finalizePipelineExecution(_ context.Context, e
 			Input:      input,
 		})
 	} else {
-		execution.Status.State = stateCompleted
+		// If every step is either completed_empty or non-worktree, the pipeline
+		// itself is completed_empty — the run produced no code changes.
+		pipelineState := stateCompleted
+		execution.mu.Lock()
+		allEmpty := true
+		hasWorktreeStep := false
+		for _, st := range execution.States {
+			switch st {
+			case stateCompletedEmpty:
+				hasWorktreeStep = true
+			case stateCompleted:
+				allEmpty = false
+			}
+		}
+		execution.mu.Unlock()
+		if hasWorktreeStep && allEmpty {
+			pipelineState = stateCompletedEmpty
+		}
+
+		execution.Status.State = pipelineState
 		if e.store != nil {
-			_ = e.store.SavePipelineState(pipelineID, stateCompleted, input)
+			_ = e.store.SavePipelineState(pipelineID, pipelineState, input)
 		}
 		// Run run_completed hooks with detached context (non-blocking by default).
 		e.runTerminalHooks(hooks.HookEvent{
@@ -987,7 +1007,7 @@ func (e *DefaultPipelineExecutor) finalizePipelineExecution(_ context.Context, e
 	e.emit(event.Event{
 		Timestamp:  time.Now(),
 		PipelineID: pipelineID,
-		State:      stateCompleted,
+		State:      execution.Status.State,
 		DurationMs: elapsed,
 		Message:    fmt.Sprintf("%d steps completed", schedulableSteps),
 	})
@@ -3443,11 +3463,19 @@ func (e *DefaultPipelineExecutor) processAdapterResult(
 	}
 	e.fireWebhooks(ctx, stepCompletedEvt)
 
+	// Detect zero-diff worktree steps: step completed but produced no code changes.
+	// This gives the UI an honest signal — "completed_empty" with warning colors
+	// instead of a misleading green "completed" checkmark.
+	finalState := stateCompleted
+	if step.Workspace.Type == "worktree" && isWorktreeClean(res.workspacePath) {
+		finalState = stateCompletedEmpty
+	}
+
 	e.emit(event.Event{
 		Timestamp:  time.Now(),
 		PipelineID: pipelineID,
 		StepID:     step.ID,
-		State:      stateCompleted,
+		State:      finalState,
 		Persona:    res.resolvedPersona,
 		DurationMs: stepDuration,
 		TokensUsed: result.TokensUsed,
@@ -3457,7 +3485,7 @@ func (e *DefaultPipelineExecutor) processAdapterResult(
 	})
 
 	if e.logger != nil {
-		_ = e.logger.LogStepEnd(pipelineID, step.ID, "success", time.Since(stepStart), result.ExitCode, len(stdoutData), result.TokensUsed, "")
+		_ = e.logger.LogStepEnd(pipelineID, step.ID, finalState, time.Since(stepStart), result.ExitCode, len(stdoutData), result.TokensUsed, "")
 	}
 
 	// Record performance metric for TUI step breakdown
@@ -3478,6 +3506,35 @@ func (e *DefaultPipelineExecutor) processAdapterResult(
 	}
 
 	return nil
+}
+
+// isWorktreeClean checks whether a worktree workspace has uncommitted or
+// unstaged changes. Returns true when the worktree is identical to its HEAD
+// (zero diff) — meaning the agent produced no code changes.
+func isWorktreeClean(workspacePath string) bool {
+	// Find the worktree directory: it's typically a __wt_* subdirectory
+	entries, err := os.ReadDir(workspacePath)
+	if err != nil {
+		return false
+	}
+	wtDir := ""
+	for _, e := range entries {
+		if e.IsDir() && len(e.Name()) > 5 && e.Name()[:5] == "__wt_" {
+			wtDir = filepath.Join(workspacePath, e.Name())
+			break
+		}
+	}
+	if wtDir == "" {
+		return false // not a worktree workspace or can't find it
+	}
+
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = wtDir
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return len(bytes.TrimSpace(out)) == 0
 }
 
 // resolveModel applies model precedence:

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -14,13 +14,14 @@ import (
 
 // Step lifecycle state constants — canonical source: state.StepState.
 const (
-	statePending   = string(state.StatePending)
-	stateRunning   = string(state.StateRunning)
-	stateCompleted = string(state.StateCompleted)
-	stateFailed    = string(state.StateFailed)
-	stateRetrying  = string(state.StateRetrying)
-	stateSkipped   = string(state.StateSkipped)
-	stateReworking = string(state.StateReworking)
+	statePending        = string(state.StatePending)
+	stateRunning        = string(state.StateRunning)
+	stateCompleted      = string(state.StateCompleted)
+	stateCompletedEmpty = string(state.StateCompletedEmpty)
+	stateFailed         = string(state.StateFailed)
+	stateRetrying       = string(state.StateRetrying)
+	stateSkipped        = string(state.StateSkipped)
+	stateReworking      = string(state.StateReworking)
 )
 
 // OnFailure policy constants for contract and step failure handling.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -17,13 +17,14 @@ import (
 type StepState string
 
 const (
-	StatePending   StepState = "pending"
-	StateRunning   StepState = "running"
-	StateCompleted StepState = "completed"
-	StateFailed    StepState = "failed"
-	StateRetrying  StepState = "retrying"
-	StateSkipped   StepState = "skipped"
-	StateReworking StepState = "reworking"
+	StatePending        StepState = "pending"
+	StateRunning        StepState = "running"
+	StateCompleted      StepState = "completed"
+	StateCompletedEmpty StepState = "completed_empty" // Step completed but produced no meaningful changes (zero diff in worktree)
+	StateFailed         StepState = "failed"
+	StateRetrying       StepState = "retrying"
+	StateSkipped        StepState = "skipped"
+	StateReworking      StepState = "reworking"
 )
 
 // PipelineStateRecord holds persisted pipeline state.
@@ -378,7 +379,7 @@ func (s *stateStore) SaveStepState(pipelineID string, stepID string, state StepS
 	if state == StateRunning || state == StateRetrying {
 		startedAt = &now
 	}
-	if state == StateCompleted || state == StateFailed {
+	if state == StateCompleted || state == StateCompletedEmpty || state == StateFailed {
 		completedAt = &now
 	}
 

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -201,6 +201,8 @@ func statusClass(status string) string {
 	switch status {
 	case "completed":
 		return "status-completed"
+	case "completed_empty":
+		return "status-completed-empty"
 	case "running":
 		return "status-running"
 	case "failed":

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -31,6 +31,8 @@
     --color-cancelled-bg: rgba(139, 148, 158, 0.15);
     --color-pending: #d29922;
     --color-pending-bg: rgba(210, 153, 34, 0.15);
+    --color-completed-empty: #d29922;
+    --color-completed-empty-bg: rgba(210, 153, 34, 0.12);
     /* Model tier colors */
     --color-tier-strongest: #a78bfa;
     --color-tier-strongest-bg: rgba(139, 92, 246, 0.15);
@@ -85,6 +87,8 @@
     --color-failed-bg: rgba(220, 38, 38, 0.1);
     --color-cancelled: #64748b;
     --color-cancelled-bg: rgba(100, 116, 139, 0.1);
+    --color-completed-empty: #ca8a04;
+    --color-completed-empty-bg: rgba(202, 138, 4, 0.1);
     --color-pending: #ca8a04;
     --color-pending-bg: rgba(202, 138, 4, 0.1);
     /* Model tier colors (light) */
@@ -407,6 +411,7 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
 /* Status Badges */
 .badge { display: inline-block; padding: 0.15em 0.55em; font-size: 0.75rem; font-weight: 600; border-radius: 2em; text-transform: capitalize; line-height: 1.4; }
 .status-completed { background: var(--color-completed-bg); color: var(--color-completed); }
+.status-completed-empty { background: var(--color-completed-empty-bg); color: var(--color-completed-empty); }
 .badge.status-running, .status-running { background: var(--color-running-bg); color: var(--color-running) !important; }
 .status-failed { background: var(--color-failed-bg); color: var(--color-failed); }
 .status-cancelled { background: var(--color-cancelled-bg); color: var(--color-cancelled); }
@@ -658,6 +663,7 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
     font-size: 0.85rem; margin-right: 0.25rem; vertical-align: middle;
 }
 .status-icon-completed { color: var(--color-completed); }
+.status-icon-completed-empty { color: var(--color-completed-empty); }
 .status-icon-running { color: var(--color-running); animation: pulse 2s ease-in-out infinite; }
 .status-icon-failed { color: var(--color-failed); }
 .status-icon-cancelled { color: var(--color-cancelled); }
@@ -713,6 +719,7 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
 }
 .step-card.status-running { border-left-color: var(--color-running); }
 .step-card.status-completed { border-left-color: var(--color-completed); }
+.step-card.status-completed-empty { border-left-color: var(--color-completed-empty); }
 .step-card.status-failed { border-left-color: var(--color-failed); }
 .step-card.status-pending { border-left-color: var(--color-pending); }
 .step-card.status-cancelled { border-left-color: var(--color-cancelled); }

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -10,6 +10,7 @@
     <div class="wr-filters">
         <a href="/runs?status=all" class="wr-filter{{if eq .FilterStatus "all"}} active{{end}}">All</a>
         <a href="/runs?status=completed" class="wr-filter{{if eq .FilterStatus "completed"}} active{{end}}">Completed</a>
+        <a href="/runs?status=completed_empty" class="wr-filter{{if eq .FilterStatus "completed_empty"}} active{{end}}">No Changes</a>
         <a href="/runs?status=failed" class="wr-filter{{if eq .FilterStatus "failed"}} active{{end}}">Failed</a>
         <a href="/runs?status=cancelled" class="wr-filter{{if eq .FilterStatus "cancelled"}} active{{end}}">Cancelled</a>
     </div>


### PR DESCRIPTION
## Summary

Steps using worktree workspaces that complete with zero git diff now show as **completed_empty** (amber) instead of **completed** (green). This fixes a misleading UI signal where 70 out of 78 historical worktree runs showed green success despite producing no code changes.

- New `StateCompletedEmpty` in state store
- `isWorktreeClean()` detection after step contracts pass
- Scheduling loop treats `completed_empty` as terminal success (pipeline continues)
- Amber badge, step card border, and icon colors in both dark/light themes

## Test plan

- [x] `go test ./...` — all packages pass
- [x] CSS served correctly (7 `completed-empty` rules verified)
- [ ] Run impl-refactor with a no-op scope to verify amber badge renders
- [ ] Run impl-issue with a real issue to verify green badge still shows for real changes

## Historical data

From workspace analysis of 78 worktree runs:
- **70 zero-diff** (would now show amber `completed_empty`)
- **8 with changes** (would still show green `completed`)