### PR TITLE
fix: use strict manifest loader across all CLI commands (#1100)

### DIFF
--- a/cmd/wave/commands/agent.go
+++ b/cmd/wave/commands/agent.go
@@ -13,7 +13,6 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // AgentListItem represents one persona in the agent list output.
@@ -247,21 +246,7 @@ func runAgentExport(cmd *cobra.Command, name, outputPath string) error {
 // loadManifestForAgent loads the manifest and returns a CLIError if it is
 // missing or invalid.
 func loadManifestForAgent(manifestPath string) (*manifest.Manifest, error) {
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		return nil, NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", manifestPath),
-			"Run 'wave init' to create a manifest")
-	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(data, &m); err != nil {
-		return nil, NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml for syntax errors")
-	}
-
-	return &m, nil
+	return loadManifestStrict(manifestPath)
 }
 
 // compilePersonaToAgentMd resolves a persona by name and compiles it to agent

--- a/cmd/wave/commands/chat.go
+++ b/cmd/wave/commands/chat.go
@@ -8,11 +8,9 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // ChatOptions holds options for the chat command.
@@ -122,14 +120,11 @@ func runChat(opts ChatOptions) error {
 	}
 
 	// Load manifest
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing, fmt.Sprintf("failed to read manifest: %s", err), "Check that wave.yaml exists and is readable").WithCause(err)
+		return err
 	}
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid, fmt.Sprintf("failed to parse manifest: %s", err), "Check wave.yaml syntax -- run 'wave validate' to diagnose").WithCause(err)
-	}
+	m := *mp
 
 	// Load pipeline definition
 	p, err := loadPipeline(run.PipelineName, &m)

--- a/cmd/wave/commands/compose.go
+++ b/cmd/wave/commands/compose.go
@@ -11,13 +11,11 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // NewComposeCmd creates the compose command for validating and executing
@@ -269,19 +267,11 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 		cancel()
 	}()
 
-	manifestData, err := os.ReadFile(manifestPath)
+	mp, err := loadManifestStrict(manifestPath)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", manifestPath),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax — run 'wave validate' to diagnose")
-	}
+	m := *mp
 
 	var runner adapter.AdapterRunner
 	if mock {
@@ -393,19 +383,11 @@ func runCompose(seq tui.Sequence, input string, manifestPath string, mock bool, 
 		cancel()
 	}()
 
-	manifestData, err := os.ReadFile(manifestPath)
+	mp, err := loadManifestStrict(manifestPath)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", manifestPath),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax — run 'wave validate' to diagnose")
-	}
+	m := *mp
 
 	// Resolve adapter
 	var runner adapter.AdapterRunner

--- a/cmd/wave/commands/compose_test.go
+++ b/cmd/wave/commands/compose_test.go
@@ -35,7 +35,7 @@ func newComposeTestHelper(t *testing.T) *composeTestHelper {
 	}
 
 	// Create wave.yaml so checkOnboarding() grandfathers the project in.
-	h.writeFile("wave.yaml", "version: 1\n")
+	h.writeFile("wave.yaml", "apiVersion: v1\nkind: WaveManifest\nmetadata:\n  name: test\nruntime:\n  workspace_root: .wave/workspaces\n")
 
 	// Create the pipelines directory.
 	err = os.MkdirAll(filepath.Join(tmpDir, ".wave", "pipelines"), 0755)

--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -10,12 +10,10 @@ import (
 
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/classify"
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 type DoOptions struct {
@@ -74,18 +72,11 @@ func runDo(input string, opts DoOptions) error {
 		return err
 	}
 
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return NewCLIError(CodeManifestMissing, fmt.Sprintf("manifest file not found: %s", opts.Manifest), "Run 'wave init' to create a new Wave project or specify --manifest path")
-		}
-		return NewCLIError(CodeManifestMissing, fmt.Sprintf("failed to read manifest: %s", err), "Check file permissions and path").WithCause(err)
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid, fmt.Sprintf("failed to parse manifest %s: %s", opts.Manifest, err), "Ensure the file is valid YAML with correct indentation").WithCause(err)
-	}
+	m := *mp
 
 	// Classification: when not bypassed and no explicit persona, classify input
 	// to select the best pipeline from the manifest.

--- a/cmd/wave/commands/do_test.go
+++ b/cmd/wave/commands/do_test.go
@@ -229,7 +229,7 @@ metadata:
 	var cliErr *CLIError
 	require.ErrorAs(t, err, &cliErr)
 	assert.Equal(t, CodeManifestInvalid, cliErr.Code)
-	assert.Contains(t, cliErr.Suggestion, "valid YAML")
+	assert.Contains(t, cliErr.Suggestion, "wave validate")
 }
 
 // TestDoCommand_MissingPersonaError verifies that referencing a missing

--- a/cmd/wave/commands/errors.go
+++ b/cmd/wave/commands/errors.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/recinq/wave/internal/manifest"
 )
 
 // Error code constants for machine-parseable error classification.
@@ -117,4 +121,29 @@ func RenderTextError(w io.Writer, err error, debug bool) {
 	default:
 		fmt.Fprintf(w, "Error: %s\n", err.Error())
 	}
+}
+
+// loadManifestStrict loads a manifest using strict YAML parsing with
+// KnownFields(true) and sets RootDir for env file resolution.
+// Returns CLIError on failure for consistent error reporting across commands.
+func loadManifestStrict(path string) (*manifest.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, NewCLIError(CodeManifestMissing,
+				fmt.Sprintf("manifest file not found: %s", path),
+				"Run 'wave init' to create a manifest").WithCause(err)
+		}
+		return nil, NewCLIError(CodeManifestMissing,
+			fmt.Sprintf("failed to read manifest: %s", err),
+			"Check file permissions and path").WithCause(err)
+	}
+	m, err := manifest.UnmarshalStrict(data)
+	if err != nil {
+		return nil, NewCLIError(CodeManifestInvalid,
+			fmt.Sprintf("failed to parse manifest: %s", err),
+			"Check wave.yaml syntax — run 'wave validate' to diagnose").WithCause(err)
+	}
+	m.RootDir = filepath.Dir(path)
+	return m, nil
 }

--- a/cmd/wave/commands/fork.go
+++ b/cmd/wave/commands/fork.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // ForkOptions holds options for the fork command.
@@ -88,19 +86,11 @@ func runFork(opts ForkOptions) error {
 	}
 
 	// Load manifest for pipeline info
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", opts.Manifest),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax")
-	}
+	m := *mp
 
 	// Load pipeline
 	p, err := loadPipeline(run.PipelineName, &m)

--- a/cmd/wave/commands/meta.go
+++ b/cmd/wave/commands/meta.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/workspace"
-	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+	"github.com/spf13/cobra"
 )
 
 type MetaOptions struct {
@@ -67,18 +66,11 @@ Examples:
 }
 
 func runMeta(input string, opts MetaOptions) error {
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return NewCLIError(CodeManifestMissing, fmt.Sprintf("manifest file not found: %s", opts.Manifest), "Run 'wave init' to create a new Wave project or specify --manifest path")
-		}
-		return NewCLIError(CodeManifestMissing, fmt.Sprintf("failed to read manifest: %s", err), "Check file permissions and path").WithCause(err)
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid, fmt.Sprintf("failed to parse manifest %s: %s", opts.Manifest, err), "Ensure the file is valid YAML with correct indentation").WithCause(err)
-	}
+	m := *mp
 
 	// Set up context with signal handling
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/wave/commands/meta_test.go
+++ b/cmd/wave/commands/meta_test.go
@@ -102,7 +102,7 @@ metadata:
 	var cliErr2 *CLIError
 	require.ErrorAs(t, err, &cliErr2)
 	assert.Equal(t, CodeManifestInvalid, cliErr2.Code)
-	assert.Contains(t, cliErr2.Suggestion, "valid YAML")
+	assert.Contains(t, cliErr2.Suggestion, "wave validate")
 }
 
 // TestMetaCommand_MissingPhilosopher verifies that missing philosopher

--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -12,13 +12,11 @@ import (
 	"github.com/recinq/wave/internal/audit"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/recovery"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // ResumeOptions holds options for the resume command.
@@ -138,19 +136,11 @@ func runResume(opts ResumeOptions, debug bool) error {
 	}
 
 	// Load manifest.
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", opts.Manifest),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax — run 'wave validate' to diagnose")
-	}
+	m := *mp
 
 	// Load the pipeline that was used in the original run.
 	p, err := loadPipeline(run.PipelineName, &m)

--- a/cmd/wave/commands/retro.go
+++ b/cmd/wave/commands/retro.go
@@ -13,7 +13,6 @@ import (
 	"github.com/recinq/wave/internal/retro"
 	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // NewRetroCmd creates the wave retro command with subcommands.
@@ -326,14 +325,11 @@ func parseSinceDuration(s string) (time.Duration, error) {
 }
 
 func loadManifestAndRunner() (*manifest.Manifest, adapter.AdapterRunner, error) {
-	data, err := os.ReadFile("wave.yaml")
+	mp, err := loadManifestStrict("wave.yaml")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read wave.yaml: %w", err)
+		return nil, nil, err
 	}
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(data, &m); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse wave.yaml: %w", err)
-	}
+	m := *mp
 
 	var adapterName string
 	for name := range m.Adapters {

--- a/cmd/wave/commands/rewind.go
+++ b/cmd/wave/commands/rewind.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // RewindOptions holds options for the rewind command.
@@ -91,19 +89,11 @@ func runRewind(opts RewindOptions) error {
 	}
 
 	// Load manifest to get pipeline topology
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", opts.Manifest),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax")
-	}
+	m := *mp
 
 	p, err := loadPipeline(run.PipelineName, &m)
 	if err != nil {

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -30,7 +30,6 @@ import (
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 )
 
 type RunOptions struct {
@@ -265,19 +264,11 @@ func runRun(opts RunOptions, debug bool) error {
 		cancel()
 	}()
 
-	manifestData, err := os.ReadFile(opts.Manifest)
+	mp, err := loadManifestStrict(opts.Manifest)
 	if err != nil {
-		return NewCLIError(CodeManifestMissing,
-			fmt.Sprintf("manifest file not found: %s", opts.Manifest),
-			"Run 'wave init' to create a manifest")
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid,
-			fmt.Sprintf("failed to parse manifest: %s", err),
-			"Check wave.yaml syntax — run 'wave validate' to diagnose")
-	}
+	m := *mp
 
 	p, err := loadPipeline(opts.Pipeline, &m)
 	if err != nil {

--- a/cmd/wave/commands/validate.go
+++ b/cmd/wave/commands/validate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 type ValidateOptions struct {
@@ -47,18 +46,11 @@ func runValidate(opts ValidateOptions) error {
 		fmt.Printf("Validating manifest: %s\n", opts.ManifestPath)
 	}
 
-	manifestData, err := os.ReadFile(opts.ManifestPath)
+	mp, err := loadManifestStrict(opts.ManifestPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return NewCLIError(CodeManifestMissing, fmt.Sprintf("failed to read manifest: %s", err), "Run 'wave init' to create a new Wave project").WithCause(err)
-		}
-		return NewCLIError(CodeManifestMissing, fmt.Sprintf("failed to read manifest: %s", err), "Check file permissions and path").WithCause(err)
+		return err
 	}
-
-	var m manifest.Manifest
-	if err := yaml.Unmarshal(manifestData, &m); err != nil {
-		return NewCLIError(CodeManifestInvalid, fmt.Sprintf("failed to parse manifest YAML: %s", err), "Check for syntax errors like incorrect indentation or invalid characters").WithCause(err)
-	}
+	m := *mp
 
 	if opts.Verbose {
 		fmt.Printf("✓ Manifest syntax is valid\n")

--- a/cmd/wave/commands/validate_test.go
+++ b/cmd/wave/commands/validate_test.go
@@ -517,7 +517,7 @@ func TestValidateCmd_NonExistentManifest(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err, "validate should fail when manifest file doesn't exist")
-	assert.Contains(t, err.Error(), "failed to read manifest", "error should mention reading failure")
+	assert.Contains(t, err.Error(), "manifest file not found", "error should mention reading failure")
 }
 
 // Test validate with missing apiVersion

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -119,6 +119,7 @@ func (l *yamlLoader) Load(path string) (*Manifest, error) {
 	}
 
 	manifestPath := filepath.Dir(path)
+	manifest.RootDir = manifestPath
 	if errs := ValidateWithFile(&manifest, manifestPath, path); len(errs) > 0 {
 		return nil, errs[0]
 	}
@@ -436,6 +437,19 @@ func validateOntology(o *Ontology, filePath string) []error {
 
 func Load(path string) (*Manifest, error) {
 	return NewLoader().Load(path)
+}
+
+// UnmarshalStrict parses manifest YAML with KnownFields(true) to reject unknown
+// fields, but skips structural validation (workspace_root, adapter refs, etc.).
+// Use this when you need strict parsing + RootDir without full manifest validation.
+func UnmarshalStrict(data []byte) (*Manifest, error) {
+	var m Manifest
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&m); err != nil {
+		return nil, err
+	}
+	return &m, nil
 }
 
 // SkillStore is a minimal interface for skill existence checks during manifest validation.

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -57,6 +57,9 @@ type Manifest struct {
 	Skills     []string                 `yaml:"skills,omitempty"`
 	Hooks      []hooks.LifecycleHookDef `yaml:"hooks,omitempty"`
 	Runtime    Runtime                  `yaml:"runtime"`
+
+	// RootDir is the directory containing wave.yaml. Set by the loader.
+	RootDir string `yaml:"-"`
 }
 
 type Metadata struct {


### PR DESCRIPTION
## Summary

- All 11 CLI commands now use `loadManifestStrict()` instead of raw `yaml.Unmarshal`
- Strict parsing rejects unknown YAML fields (catches ghost config like the `params` block from #1089)
- Sets `Manifest.RootDir` — **required for env file support** (without this, `.env` file loading in adapter.go was dead code)
- Added `manifest.UnmarshalStrict()` — strict parsing without full structural validation

Commands fixed: run, do, chat, compose (2x), fork, resume, rewind, meta, retro, validate, agent

Closes #1100

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `wave validate` works with strict parsing
- [x] Test fixtures updated (error messages, minimal wave.yaml in compose test)