### PR TITLE
fix: allow null error in comment-result schema, fix speckit init args

### DIFF
--- a/.wave/contracts/comment-result.schema.json
+++ b/.wave/contracts/comment-result.schema.json
@@ -57,7 +57,7 @@
       "description": "Details of the posted comment (only present if success=true)"
     },
     "error": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "code": {
           "type": "string",

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -14,7 +14,7 @@ requires:
     speckit:
       check: specify check
       install: uv tool install --force specify-cli --from git+https://github.com/github/spec-kit.git
-      init: specify init
+      init: specify init --here --force
   tools:
     - git
     - gh


### PR DESCRIPTION
## Summary
- `comment-result.schema.json`: `error` field type changed from `"object"` to `["object", "null"]` — LLMs correctly set `error: null` on success, but the schema rejected it
- `impl-speckit.yaml`: `specify init` → `specify init --here --force` — the init command needs `--here` to initialize in the worktree directory and `--force` to skip interactive confirmation

## Context
- `plan-research` pipeline posted its comment successfully but failed contract validation on the `error: null` field
- `impl-speckit` pipeline failed at workspace creation because `specify init` without args requires a project name or `--here` flag

## Test plan
- [x] `go vet ./...` clean
- [x] `internal/defaults` tests pass
- [x] Verified `specify init --here --force` works in a temp directory