### PR TITLE
fix(webui): force dark headings in run-detail prompt view

### DIFF
--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -2955,6 +2955,12 @@ details[open] > .section-toggle::before { transform: rotate(90deg); }
 .ws-tabcontent[hidden] { display: none !important; }
 .ws-tabcontent .av-smart { padding: 0.5rem var(--ws-pad-x); color: #c9d1d9; }
 .ws-tabcontent .markdown-body { font-size: 0.82rem; line-height: 1.6; color: #c9d1d9; background: transparent; border: none; }
+.ws-tabcontent .markdown-body h1,
+.ws-tabcontent .markdown-body h2,
+.ws-tabcontent .markdown-body h3,
+.ws-tabcontent .markdown-body h4,
+.ws-tabcontent .markdown-body h5,
+.ws-tabcontent .markdown-body h6 { color: #e6edf3; }
 .ws-tabcontent .markdown-body h1 { font-size: 1.2rem; margin: 0.5rem 0 0.3rem; border-bottom: 1px solid #30363d; padding-bottom: 0.2rem; }
 .ws-tabcontent .markdown-body h2 { font-size: 1rem; margin: 0.4rem 0 0.2rem; }
 .ws-tabcontent .markdown-body h3 { font-size: 0.9rem; margin: 0.3rem 0 0.15rem; }


### PR DESCRIPTION
## Summary

- Override h1-h6 color in \`.ws-tabcontent .markdown-body\` to \`#e6edf3\`
- Fixes unreadable headings in the step prompt view when the page theme is light

## Why

The prompt view panel has a hardcoded dark background (\`#161b22\` at \`run_detail.html:374\`) by design — that's intentional and the user wants it to stay. But headings inherited \`color: var(--color-text)\` from the generic \`.markdown-body\` rule, which is near-black in light mode → invisible dark-on-dark. The \`strong\` rule already used \`#e6edf3\` and looked right, so headings now match.

## Test plan

- [ ] Open a run detail page in light mode, click IN on any step, verify Objective/Context/etc. headings are visible
- [ ] Switch to dark mode, verify no regression (color is the same in both themes since it's hardcoded to match the panel)