### PR TITLE
fix(webui): render each IN artifact as an individually clickable chip

### DIFF
--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -314,22 +314,26 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	// Enrich step I/O descriptions from pipeline definition
 	if p, loadErr := loadPipelineYAML(run.PipelineName); loadErr == nil {
 		type stepRef struct {
-			deps    []string
-			injects []string
+			deps       []string
+			injects    []string
+			injectRefs []InputArtifactRef
 		}
 		stepRefs := make(map[string]stepRef)
 		for _, ps := range p.Steps {
 			var injects []string
+			var injectRefs []InputArtifactRef
 			for _, ia := range ps.Memory.InjectArtifacts {
 				injects = append(injects, ia.Step+"/"+ia.Artifact)
+				injectRefs = append(injectRefs, InputArtifactRef{Step: ia.Step, Name: ia.Artifact})
 			}
-			stepRefs[ps.ID] = stepRef{deps: ps.Dependencies, injects: injects}
+			stepRefs[ps.ID] = stepRef{deps: ps.Dependencies, injects: injects, injectRefs: injectRefs}
 		}
 		for i, sd := range stepDetails {
 			if ref, ok := stepRefs[sd.StepID]; ok {
 				if len(ref.injects) > 0 {
 					// Show artifact names: "spec/analysis, docs/feature-docs"
 					stepDetails[i].Action = strings.Join(ref.injects, ", ")
+					stepDetails[i].InputArtifacts = ref.injectRefs
 				} else if len(ref.deps) > 0 {
 					stepDetails[i].Action = strings.Join(ref.deps, " + ")
 				}

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -311,36 +311,6 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 
 	stepDetails := s.buildStepDetails(runID, run.PipelineName, run.Status)
 
-	// Enrich step I/O descriptions from pipeline definition
-	if p, loadErr := loadPipelineYAML(run.PipelineName); loadErr == nil {
-		type stepRef struct {
-			deps       []string
-			injects    []string
-			injectRefs []InputArtifactRef
-		}
-		stepRefs := make(map[string]stepRef)
-		for _, ps := range p.Steps {
-			var injects []string
-			var injectRefs []InputArtifactRef
-			for _, ia := range ps.Memory.InjectArtifacts {
-				injects = append(injects, ia.Step+"/"+ia.Artifact)
-				injectRefs = append(injectRefs, InputArtifactRef{Step: ia.Step, Name: ia.Artifact})
-			}
-			stepRefs[ps.ID] = stepRef{deps: ps.Dependencies, injects: injects, injectRefs: injectRefs}
-		}
-		for i, sd := range stepDetails {
-			if ref, ok := stepRefs[sd.StepID]; ok {
-				if len(ref.injects) > 0 {
-					// Show artifact names: "spec/analysis, docs/feature-docs"
-					stepDetails[i].Action = strings.Join(ref.injects, ", ")
-					stepDetails[i].InputArtifacts = ref.injectRefs
-				} else if len(ref.deps) > 0 {
-					stepDetails[i].Action = strings.Join(ref.deps, " + ")
-				}
-			}
-		}
-	}
-
 	stepStatusMap := make(map[string]string)
 	stepDetailMap := make(map[string]StepDetail)
 	for _, sd := range stepDetails {
@@ -842,6 +812,20 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 				names = append(names, a.Name)
 			}
 			sd.Output = strings.Join(names, ", ")
+		}
+
+		// Populate injected input artifacts for IN display (clickable chips)
+		if len(step.Memory.InjectArtifacts) > 0 {
+			injectRefs := make([]InputArtifactRef, 0, len(step.Memory.InjectArtifacts))
+			pairs := make([]string, 0, len(step.Memory.InjectArtifacts))
+			for _, ia := range step.Memory.InjectArtifacts {
+				injectRefs = append(injectRefs, InputArtifactRef{Step: ia.Step, Name: ia.Artifact})
+				pairs = append(pairs, ia.Step+"/"+ia.Artifact)
+			}
+			sd.InputArtifacts = injectRefs
+			sd.Action = strings.Join(pairs, ", ")
+		} else if len(step.Dependencies) > 0 {
+			sd.Action = strings.Join(step.Dependencies, " + ")
 		}
 
 		// Populate structured gate data for interactive UI

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -190,8 +190,8 @@
 
             <!-- Row 2: I/O + tabs -->
             <div class="ws-io">
-                <span class="ws-io-lbl">IN</span>
-                <span class="ws-io-val ws-io-click" onclick="toggleIn(this)" title="Show prompt">{{if and $step.Action (not (hasPrefix $step.Action "{{"))}}{{if gt (len $step.Action) 80}}{{slice $step.Action 0 80}}…{{else}}{{$step.Action}}{{end}}{{else if eq $i 0}}pipeline input{{else if $step.Dependencies}}{{joinStrings $step.Dependencies " + "}}{{else}}prev step{{end}}</span>
+                <span class="ws-io-lbl ws-io-click" onclick="toggleIn(this)" title="Show prompt">IN</span>
+                {{if $step.InputArtifacts}}{{range $ia := $step.InputArtifacts}}<a href="#" class="w-tab" data-run-id="{{$step.RunID}}" data-step-id="{{$ia.Step}}" data-artifact-name="{{$ia.Name}}" onclick="toggleArt(this);return false;" title="Show injected artifact content">{{$ia.Step}}/{{$ia.Name}}</a>{{end}}{{else}}<span class="ws-io-val ws-io-click" onclick="toggleIn(this)" title="Show prompt">{{if and $step.Action (not (hasPrefix $step.Action "{{"))}}{{if gt (len $step.Action) 80}}{{slice $step.Action 0 80}}…{{else}}{{$step.Action}}{{end}}{{else if eq $i 0}}pipeline input{{else if $step.Dependencies}}{{joinStrings $step.Dependencies " + "}}{{else}}prev step{{end}}</span>{{end}}
                 {{if $step.ReviewVerdict}}<span class="w-ctr {{if eq $step.ReviewVerdict "pass"}}w-ctr-pass{{else}}w-ctr-fail{{end}}">{{$step.ReviewVerdict}}</span>{{end}}
                 <span class="ws-io-sep"></span>
                 <span class="ws-io-lbl">OUT</span>

--- a/internal/webui/types.go
+++ b/internal/webui/types.go
@@ -80,6 +80,7 @@ type StepDetail struct {
 	ConfiguredModel    string                `json:"configured_model,omitempty"`     // Tier from pipeline config (e.g., "cheapest")
 	Adapter            string                `json:"adapter,omitempty"`              // Adapter used for this step
 	Dependencies       []string              `json:"dependencies,omitempty"`         // Step dependencies (step IDs)
+	InputArtifacts     []InputArtifactRef    `json:"input_artifacts,omitempty"`      // Injected artifacts from upstream steps (source-step/name)
 	VisitCount         int                   `json:"visit_count,omitempty"`          // Current visit count for graph loop steps
 	MaxVisits          int                   `json:"max_visits,omitempty"`           // Max visit limit for graph loop steps
 	GanttLeft          float64               `json:"gantt_left,omitempty"`           // Gantt bar left offset (percentage)
@@ -90,6 +91,14 @@ type StepDetail struct {
 	ReviewerPersona    string                `json:"reviewer_persona,omitempty"`     // Persona used for review step
 	ReviewTokens       int                   `json:"review_tokens,omitempty"`        // Tokens used in review step
 	ReviewIssueCount   int                   `json:"review_issue_count,omitempty"`   // Number of review issues found
+}
+
+// InputArtifactRef identifies an artifact injected from an upstream step.
+// Used to render each IN artifact as an individually clickable chip on the
+// run detail page (same URL shape as OUT: source step + artifact name).
+type InputArtifactRef struct {
+	Step string `json:"step"` // Source step ID (where the artifact was produced)
+	Name string `json:"name"` // Artifact name
 }
 
 // EventSummary holds summary information about a pipeline event.


### PR DESCRIPTION
## Summary

- Add \`InputArtifactRef{Step, Name}\` type and \`StepDetail.InputArtifacts\` field
- Populate \`InputArtifacts\` from \`pipeline.Memory.InjectArtifacts\` in the run handler
- Render each injected artifact as a \`w-tab\` chip that reuses the existing \`toggleArt\` handler, pointing \`data-step-id\` at the source step (where the artifact was produced)
- The IN label itself stays clickable for the prompt view

## Why

The IN area was a single \`<span>\` with one \`toggleIn\` click that opened a bundled prompt view. Steps with multiple injected artifacts — e.g. \`triage\` receives \`review-findings\` AND \`triage-verdict\` — had no way to open each artifact's content separately: one click fit all. Artifacts inside the prompt view were non-interactive \`<code>\` badges.

This mirrors what OUT already does — each output artifact is its own clickable tab. Input artifacts use the same \`/api/runs/{id}/artifacts/{step}/{name}\` endpoint (the artifact lives in the source step's outputs), so no backend work beyond surfacing the step/name pairs.

## Test plan

- [ ] Run a pipeline with a step that injects multiple artifacts (e.g. \`ops-pr-fix-review\` apply-fixes step)
- [ ] Open the run detail page, verify each IN chip is individually clickable and shows the correct artifact content
- [ ] Verify IN label click still opens the prompt view
- [ ] Verify steps with no injected artifacts still show the fallback IN text (action/deps/\"pipeline input\")