### PR TITLE
docs: resolve 7 consistency findings from #1127

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ Use "wave [command] --help" for more information about a command.
 | `wave suggest` | Propose pipeline runs based on codebase state |
 | `wave serve` | Start the web dashboard server |
 | `wave migrate` | Database migration management |
-| `wave skills` | Skill lifecycle management (legacy) |
-| `wave skill` | Manage skill templates and install from remote sources |
+| `wave skills` | Project skill lifecycle (install, remove, search, sync, audit, publish, verify) |
+| `wave skill` | Manage bundled skill templates (list, install, check) |
 | `wave agent` | Persona-to-agent compiler utilities |
 
 ### Configuration Management

--- a/docs/guide/skill-ecosystems.md
+++ b/docs/guide/skill-ecosystems.md
@@ -102,7 +102,7 @@ github:<owner>/<repo>[/<path>]
 ### Install
 
 ```bash
-wave skills install github:re-cinq/wave-skills/golang
+wave skills install github:your-org/your-skills-repo/golang
 wave skills install github:user/repo
 ```
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -38,7 +38,7 @@ description: Expert Go language development including idiomatic patterns and con
 license: MIT
 compatibility: Claude 4.x
 metadata:
-  author: re-cinq
+  author: your-org
   version: "1.0"
 allowed-tools: "Read Write Edit Bash Grep Glob"
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,7 +27,8 @@ Wave CLI commands for pipeline orchestration.
 | `wave pipeline` | Pipeline management (create, list) |
 | `wave retro` | View and manage run retrospectives |
 | `wave rewind` | Rewind a run to an earlier checkpoint |
-| `wave skill` | Manage skill templates and install from remote sources |
+| `wave skill` | Manage bundled skill templates (list, install, check) |
+| `wave skills` | Project skill lifecycle (install, remove, search, sync, audit, publish, verify) |
 | `wave suggest` | Suggest impactful pipeline runs |
 | `wave serve` | Start the web dashboard server |
 | `wave migrate` | Database migrations |
@@ -1250,12 +1251,17 @@ wave skill list --remote          # Show available remote sources
 
 ### skill install
 
-Install a skill from bundled templates, GitHub, Tessl, or URL.
+Install a skill from bundled templates or any supported remote source. The installer inspects the argument for a recognized prefix; bare names resolve against bundled templates.
 
 ```bash
-wave skill install reviewer          # Bundled template
-wave skill install github:owner/repo # From GitHub
-wave skill install tessl:my-skill    # From Tessl registry
+wave skill install docker                                # Bundled template (bare name)
+wave skill install github:owner/repo                     # From a GitHub repository
+wave skill install tessl:spec-kit                        # From the Tessl registry
+wave skill install bmad:install                          # Run the BMAD installer
+wave skill install openspec:init                         # Run the OpenSpec installer
+wave skill install speckit:init                          # Run the SpecKit installer
+wave skill install file:./path/to/skill                  # From a local filesystem path
+wave skill install https://example.com/skills.tar.gz     # From a direct URL (archive)
 ```
 
 | Flag | Default | Description |
@@ -1268,6 +1274,145 @@ Run check commands for installed skills in `.wave/skills/`.
 
 ```bash
 wave skill check
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+---
+
+## wave skills
+
+Project skill lifecycle management. Unlike `wave skill` (which manages Wave's bundled templates), `wave skills` operates on the skills actually installed in your project (`.wave/skills/`) and user (`~/.claude/skills/`) directories. Use it to install from any supported source, remove installed skills, and interact with the Tessl registry.
+
+### skills list
+
+List installed skills discovered in project and user directories.
+
+```bash
+wave skills list
+wave skills list --format json
+wave skills list --ontology            # Filter to ontology context skills (wave-ctx-*)
+```
+
+The `--format json` output has the shape:
+
+```json
+{
+  "skills": [
+    { "name": "docker", "description": "…", "source": ".wave/skills/docker" }
+  ],
+  "warnings": []
+}
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+| `--ontology` | `false` | Show only ontology context skills (`wave-ctx-*`) |
+
+### skills install
+
+Install a skill from any supported source. Accepts the same prefixes as `wave skill install`.
+
+```bash
+wave skills install tessl:github/golang
+wave skills install bmad:install
+wave skills install openspec:init
+wave skills install speckit:init
+wave skills install github:<owner>/<repo>[/<path>]
+wave skills install file:./path/to/skill
+wave skills install https://example.com/skills/skill.tar.gz
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skills remove
+
+Remove an installed skill from the project skill store.
+
+```bash
+wave skills remove docker
+wave skills remove docker --yes        # Skip confirmation prompt
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+| `--yes` | `false` | Skip confirmation prompt |
+
+### skills search
+
+Search the Tessl registry for publicly available skills. Requires `@tessl/cli` to be installed (`npm i -g @tessl/cli`).
+
+```bash
+wave skills search golang
+wave skills search --format json spec-kit
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skills sync
+
+Sync project skill dependencies declared in `wave.yaml` against the Tessl registry.
+
+```bash
+wave skills sync
+wave skills sync --format json
+```
+
+The `--format json` output has the shape:
+
+```json
+{
+  "synced_skills": ["golang", "spec-kit"],
+  "warnings": [],
+  "status": "ok"
+}
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skills audit
+
+Audit installed skills and classify each as standalone, Wave-specific, or both (based on `wave/`-namespaced references in its content).
+
+```bash
+wave skills audit
+wave skills audit --format json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skills publish
+
+Publish skills to a registry (requires publishing credentials and a configured registry).
+
+```bash
+wave skills publish
+wave skills publish --format json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `table` | Output format: `table`, `json` |
+
+### skills verify
+
+Verify that installed skills match their published digest (detects local modification or drift).
+
+```bash
+wave skills verify
+wave skills verify --format json
 ```
 
 | Flag | Default | Description |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1301,7 +1301,7 @@ The `--format json` output has the shape:
 ```json
 {
   "skills": [
-    { "name": "docker", "description": "…", "source": ".wave/skills/docker" }
+    { "name": "docker", "description": "...", "source": ".wave/skills/docker" }
   ],
   "warnings": []
 }
@@ -1399,11 +1399,18 @@ Publish skills to a registry (requires publishing credentials and a configured r
 
 ```bash
 wave skills publish
-wave skills publish --format json
+wave skills publish --all
+wave skills publish --dry-run
+wave skills publish --force
+wave skills publish --registry tessl --format json
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--all` | `false` | Publish all standalone-eligible skills |
+| `--dry-run` | `false` | Validate and compute digest without publishing |
+| `--force` | `false` | Force publish wave-specific skills |
+| `--registry` | `tessl` | Target registry name |
 | `--format` | `table` | Output format: `table`, `json` |
 
 ### skills verify


### PR DESCRIPTION
## Summary

Resolves all 7 DOC-* items from the consistency report in #1127. Note that 2 findings proposed blanket replacements (`wave skills` -> `wave skill`) that would have broken documentation, and 1 claim did not reproduce against the actual CLI — these required reinterpretation or skipping.

The key correction: `wave skill` (singular, 3 subcommands: list/install/check) and `wave skills` (plural, 8 subcommands: list/install/remove/search/sync/audit/publish/verify) are distinct commands with non-overlapping feature sets. The issue's `README.md:238 (legacy)` label was also misleading — both commands are current.

## Item-by-item handling

**Fixed (4):**
- **DOC-004** (`wave skills search` missing from CLI reference): added full `## wave skills` section to `docs/reference/cli.md` covering all 8 subcommands.
- **DOC-005** (`wave skills sync` missing from CLI reference): included in the new `## wave skills` section with `SyncOutput` JSON shape.
- **DOC-006** (`wave skill install` missing 5 source prefixes): extended examples to cover `github:`, `tessl:`, `bmad:`, `openspec:`, `speckit:`, `file:`, `https://` — verified against `cmd/wave/commands/skill.go:182`.
- **DOC-007** (`re-cinq/wave-skills` repo doesn't exist): verified via `gh repo view` (404). Replaced with `your-org/your-skills-repo` and `author: your-org` placeholders.

**Reinterpreted (2):**
- **DOC-001** (blanket `wave skills` -> `wave skill` in skills.md): the proposed fix would have pointed users to a command that doesn't implement `search`, `sync`, `remove`, `audit`, `publish`, or `verify`. Kept `wave skills` references and instead clarified the README command table to describe each command's actual subcommand set.
- **DOC-002** (same replacement for ecosystems.md): same reason — guide legitimately uses `wave skills install/search/sync/remove` functionality. Only changed the `github:` example target per DOC-007.

**Skipped (1):**
- **DOC-003** (`.skills[]` jq example wrong): did not reproduce. 

Closes #1127