### PR TITLE
fix(smoke): adapter-portable wave-smoke-skills-* contracts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
           bubblewrap
           nodejs_22  # Claude Code requires Node.js
           uv         # Python package manager for skill installation
+          codex      # OpenAI Codex CLI (adapter target)
+          gemini-cli # Google Gemini CLI (adapter target)
         ];
 
         claudeYoloScript = pkgs.writeShellScriptBin "claude-yolo" ''

--- a/internal/defaults/pipelines/wave-smoke-skills-claude.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-claude.yaml
@@ -39,15 +39,16 @@ steps:
       type: prompt
       source: |
         Activate the `wave-smoke-test` skill via your native Skill tool.
-        Read its SKILL.md, then emit the sentinel string defined in the
-        activation contract on a line by itself. Do nothing else.
+        Read its SKILL.md to find the activation sentinel, then write
+        EXACTLY that sentinel string (and nothing else) to a file named
+        `smoke-result` in the current working directory. Then stop.
     output_artifacts:
       - name: smoke-result
-        source: stdout
+        path: smoke-result
         type: text
     handover:
       contract:
-        type: non_empty_file
-        source: smoke-result
+        type: test_suite
+        command: "grep -q SMOKE_TEST_OK_4f7a2b1c smoke-result"
         must_pass: true
         on_failure: fail

--- a/internal/defaults/pipelines/wave-smoke-skills-codex.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-codex.yaml
@@ -30,15 +30,16 @@ steps:
       type: prompt
       source: |
         Activate the `wave-smoke-test` skill via the `/skills` command.
-        Read its SKILL.md, then emit the sentinel string defined in the
-        activation contract on a line by itself. Do nothing else.
+        Read its SKILL.md to find the activation sentinel, then write
+        EXACTLY that sentinel string (and nothing else) to a file named
+        `smoke-result` in the current working directory. Then stop.
     output_artifacts:
       - name: smoke-result
-        source: stdout
+        path: smoke-result
         type: text
     handover:
       contract:
-        type: non_empty_file
-        source: smoke-result
+        type: test_suite
+        command: "grep -q SMOKE_TEST_OK_4f7a2b1c smoke-result"
         must_pass: true
         on_failure: fail

--- a/internal/defaults/pipelines/wave-smoke-skills-gemini.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-gemini.yaml
@@ -30,15 +30,16 @@ steps:
       type: prompt
       source: |
         Activate the `wave-smoke-test` skill via the `activate_skill` tool.
-        Read its SKILL.md, then emit the sentinel string defined in the
-        activation contract on a line by itself. Do nothing else.
+        Read its SKILL.md to find the activation sentinel, then write
+        EXACTLY that sentinel string (and nothing else) to a file named
+        `smoke-result` in the current working directory. Then stop.
     output_artifacts:
       - name: smoke-result
-        source: stdout
+        path: smoke-result
         type: text
     handover:
       contract:
-        type: non_empty_file
-        source: smoke-result
+        type: test_suite
+        command: "grep -q SMOKE_TEST_OK_4f7a2b1c smoke-result"
         must_pass: true
         on_failure: fail

--- a/internal/defaults/pipelines/wave-smoke-skills-opencode.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-opencode.yaml
@@ -30,15 +30,16 @@ steps:
       type: prompt
       source: |
         Activate the `wave-smoke-test` skill via your native skill tool.
-        Read its SKILL.md, then emit the sentinel string defined in the
-        activation contract on a line by itself. Do nothing else.
+        Read its SKILL.md to find the activation sentinel, then write
+        EXACTLY that sentinel string (and nothing else) to a file named
+        `smoke-result` in the current working directory. Then stop.
     output_artifacts:
       - name: smoke-result
-        source: stdout
+        path: smoke-result
         type: text
     handover:
       contract:
-        type: non_empty_file
-        source: smoke-result
+        type: test_suite
+        command: "grep -q SMOKE_TEST_OK_4f7a2b1c smoke-result"
         must_pass: true
         on_failure: fail


### PR DESCRIPTION
## Summary

The wave-smoke-skills-* pipelines shipped in #1136 relied on `output_artifact source: stdout` which only works for adapters that fill `ResultContent` via their stream. opencode runs cleanly, the skill is correctly provisioned, the agent emits the sentinel — but the executor never writes the artifact file, so the `non_empty_file` contract fails on every run.

Also adds codex + gemini-cli to the nix flake so `nix develop` provisions all four adapter CLIs.

## Fix

Per pipeline, two changes:

1. Prompt the agent to write the sentinel to a `smoke-result` file in CWD using its own Write tool. Portable across every adapter that supports tool use; no dependency on stdout capture.
2. Replace `non_empty_file` with `test_suite` running `grep -q SMOKE_TEST_OK_4f7a2b1c smoke-result`. Validates actual content match, not just file existence.

## Flake change

`pkgs.codex` (0.118.0) and `pkgs.gemini-cli` (0.38.1) added to commonPackages. Both first-class nixpkgs entries — no overlay or npm fallback.

## Test plan

Verified end-to-end against real adapters (not mocks):

- [x] `wave run wave-smoke-skills-claude --adapter claude --model cheapest` → ✓ 56s, sentinel matched
- [x] `wave run wave-smoke-skills-opencode --adapter opencode` → ✓ 51s, sentinel matched
- [x] `wave run wave-smoke-skills-gemini --adapter opencode` → ✓ 1026s, sentinel matched (pipeline structurally correct; gemini adapter native path untested — requires `gemini login`)
- [x] `wave run wave-smoke-skills-codex --adapter opencode` → ✓ 76s, sentinel matched (codex adapter native path untested — requires `codex login`)
- [x] `go test ./...` green
- [x] codex + gemini-cli binaries provisioned via `nix develop`