### PR TITLE
fix: replace leftover .wave/ references with .agents/

### DIFF
--- a/.agents/contracts/impl-review-criteria.md
+++ b/.agents/contracts/impl-review-criteria.md
@@ -10,8 +10,8 @@ You are reviewing an implementation step's output. Evaluate whether the implemen
 
 3. **No leaked files**: The implementation does not commit Wave-internal files that should not be in PRs:
    - `.claude/settings.json` or other `.claude/` files
-   - `.wave/artifacts/` files
-   - `.wave/output/` files
+   - `.agents/artifacts/` files
+   - `.agents/output/` files
    - `CLAUDE.md` (unless specifically modifying Wave's CLAUDE.md)
 
 ## Code Quality

--- a/.agents/pipelines/audit-architecture.yaml
+++ b/.agents/pipelines/audit-architecture.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] architecture audit started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] architecture audit started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-findings
     event: step_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -56,10 +56,10 @@ steps:
           mode: readonly
     exec:
       type: prompt
-      source_path: .wave/prompts/audit/architecture-scan.md
+      source_path: .agents/prompts/audit/architecture-scan.md
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -67,8 +67,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: report
@@ -81,7 +81,7 @@ steps:
         - step: scan
           artifact: findings
           as: scan_findings
-          schema_path: .wave/contracts/shared-findings.schema.json
+          schema_path: .agents/contracts/shared-findings.schema.json
     exec:
       type: prompt
       source: |
@@ -114,7 +114,7 @@ steps:
         bullet lists for scannability.
     output_artifacts:
       - name: report
-        path: .wave/output/architecture-report.md
+        path: .agents/output/architecture-report.md
         type: markdown
     retry:
       policy: standard
@@ -123,8 +123,8 @@ steps:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/architecture-report.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/architecture-report.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/audit-closed.yaml
+++ b/.agents/pipelines/audit-closed.yaml
@@ -38,12 +38,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -151,7 +151,7 @@ steps:
 
     output_artifacts:
       - name: inventory
-        path: .wave/artifacts/inventory.json
+        path: .agents/artifacts/inventory.json
         type: json
     retry:
       policy: patient
@@ -159,8 +159,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/artifacts/inventory.json
-        schema_path: .wave/contracts/audit-inventory.schema.json
+        source: .agents/artifacts/inventory.json
+        schema_path: .agents/contracts/audit-inventory.schema.json
         on_failure: retry
 
   - id: audit
@@ -252,7 +252,7 @@ steps:
 
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -260,8 +260,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: triage
@@ -360,9 +360,9 @@ steps:
 
     output_artifacts:
       - name: triage-report
-        path: .wave/artifacts/triage-report.md
+        path: .agents/artifacts/triage-report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/artifacts/triage-report.md
+        source: .agents/artifacts/triage-report.md

--- a/.agents/pipelines/audit-consolidate.yaml
+++ b/.agents/pipelines/audit-consolidate.yaml
@@ -34,12 +34,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -112,7 +112,7 @@ steps:
         A good scan reads source code from both sides of each reported redundancy, explains the specific behavioral or structural overlap, and proposes a concrete consolidation path with realistic effort estimates. A bad scan reports surface-level name similarities without reading the code, flags intentional design patterns as redundancy, or provides vague recommendations like "these should be consolidated" without explaining how.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -120,6 +120,6 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-correctness.yaml
+++ b/.agents/pipelines/audit-correctness.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] correctness audit started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] correctness audit started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-findings
     event: step_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -56,10 +56,10 @@ steps:
           mode: readonly
     exec:
       type: prompt
-      source_path: .wave/prompts/audit/correctness-scan.md
+      source_path: .agents/prompts/audit/correctness-scan.md
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -67,8 +67,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: report
@@ -81,7 +81,7 @@ steps:
         - step: scan
           artifact: findings
           as: scan_findings
-          schema_path: .wave/contracts/shared-findings.schema.json
+          schema_path: .agents/contracts/shared-findings.schema.json
     exec:
       type: prompt
       source: |
@@ -113,7 +113,7 @@ steps:
         bullet lists for scannability.
     output_artifacts:
       - name: report
-        path: .wave/output/correctness-report.md
+        path: .agents/output/correctness-report.md
         type: markdown
     retry:
       policy: standard
@@ -122,8 +122,8 @@ steps:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/correctness-report.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/correctness-report.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/audit-coverage.yaml
+++ b/.agents/pipelines/audit-coverage.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] coverage audit started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] coverage audit started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-findings
     event: step_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -56,10 +56,10 @@ steps:
           mode: readonly
     exec:
       type: prompt
-      source_path: .wave/prompts/audit/coverage-scan.md
+      source_path: .agents/prompts/audit/coverage-scan.md
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -67,8 +67,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: report
@@ -113,7 +113,7 @@ steps:
         bullet lists for scannability.
     output_artifacts:
       - name: report
-        path: .wave/output/coverage-report.md
+        path: .agents/output/coverage-report.md
         type: markdown
     retry:
       policy: standard
@@ -122,8 +122,8 @@ steps:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/coverage-report.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/coverage-report.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/audit-dead-code-issue.yaml
+++ b/.agents/pipelines/audit-dead-code-issue.yaml
@@ -37,12 +37,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -121,7 +121,7 @@ steps:
         A good scan produces a task list where a developer can confidently act on HIGH-confidence, safe_to_remove=true items without further research, and knows exactly what additional investigation is needed for MEDIUM-confidence items. Each finding includes the specific Grep pattern used and its output (or absence thereof). A bad scan reports items without verification, mixes low-confidence guesses with confirmed findings, or provides descriptions too vague to act on.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -129,8 +129,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: compose-report
@@ -142,7 +142,7 @@ steps:
         - step: scan
           artifact: findings
           as: findings
-          schema_path: .wave/contracts/shared-findings.schema.json
+          schema_path: .agents/contracts/shared-findings.schema.json
     exec:
       type: prompt
       source: |
@@ -211,12 +211,12 @@ steps:
         A good report allows a developer to open the GitHub issue, scan the summary tables to understand the scope, then work through the task list top-to-bottom, checking off items as they are addressed. Each item has enough context (file:line, action, safety assessment) to act immediately. A bad report buries findings in prose paragraphs, omits file locations, or uses a format that does not render as interactive checkboxes in GitHub.
     output_artifacts:
       - name: report
-        path: .wave/output/report.md
+        path: .agents/output/report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/report.md
+        source: .agents/output/report.md
 
   - id: create-issue
     persona: craftsman
@@ -227,7 +227,7 @@ steps:
         - step: scan
           artifact: findings
           as: findings
-          schema_path: .wave/contracts/shared-findings.schema.json
+          schema_path: .agents/contracts/shared-findings.schema.json
         - step: compose-report
           artifact: report
           as: report
@@ -266,7 +266,7 @@ steps:
         ```bash
         {{ forge.cli_tool }} issue create \
           --title "chore: dead code report (N findings)" \
-          --body-file .wave/artifacts/report \
+          --body-file .agents/artifacts/report \
           --label "code-quality"
         ```
 
@@ -276,7 +276,7 @@ steps:
         ```bash
         {{ forge.cli_tool }} issue create \
           --title "chore: dead code report (N findings)" \
-          --body-file .wave/artifacts/report
+          --body-file .agents/artifacts/report
         ```
 
         If the forge CLI command fails for any other reason (network error, authentication issue), log the error and report it in the result JSON. Do not retry indefinitely.
@@ -309,7 +309,7 @@ steps:
         A good issue creation step produces an issue with a clear, count-inclusive title that communicates the scope at a glance, the full report as the body with interactive checkboxes, and a result JSON that downstream steps or outcomes can extract the issue URL from. A bad issue creation step creates an issue with a generic title, loses the report formatting, or fails silently without recording the failure in the result JSON.
     output_artifacts:
       - name: issue-result
-        path: .wave/output/issue-result.json
+        path: .agents/output/issue-result.json
         type: json
     retry:
       policy: aggressive
@@ -317,12 +317,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/issue-result.json
-        schema_path: .wave/contracts/dead-code-issue-result.schema.json
+        source: .agents/output/issue-result.json
+        schema_path: .agents/contracts/dead-code-issue-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: issue
-        extract_from: .wave/output/issue-result.json
+        extract_from: .agents/output/issue-result.json
         json_path: .issue.url
         label: "Dead Code Issue"

--- a/.agents/pipelines/audit-dead-code-review.yaml
+++ b/.agents/pipelines/audit-dead-code-review.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -131,7 +131,7 @@ steps:
         A good PR-scoped scan focuses tightly on the PR's changes, catches dead code the PR introduces (not pre-existing issues), and produces findings that the PR author can address with a follow-up commit. A bad scan reports pre-existing dead code in untouched files, flags symbols that are used in files not modified by the PR, or produces so many findings that the PR review comment becomes noise.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -139,8 +139,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: compose
@@ -218,12 +218,12 @@ steps:
         A good review comment is scannable in under 30 seconds, gives the PR author clear action items for each finding, and includes file:line references for direct navigation. A bad review comment is longer than the PR diff itself, buries findings in prose, or omits locations that would help the author find the code.
     output_artifacts:
       - name: review_comment
-        path: .wave/output/review-comment.md
+        path: .agents/output/review-comment.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/review-comment.md
+        source: .agents/output/review-comment.md
 
   - id: publish
     persona: "{{ forge.type }}-commenter"
@@ -306,7 +306,7 @@ steps:
 
     output_artifacts:
       - name: publish-result
-        path: .wave/output/publish-result.json
+        path: .agents/output/publish-result.json
         type: json
     retry:
       policy: aggressive
@@ -314,12 +314,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/publish-result.json
-        schema_path: .wave/contracts/gh-pr-comment-result.schema.json
+        source: .agents/output/publish-result.json
+        schema_path: .agents/contracts/gh-pr-comment-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: url
-        extract_from: .wave/output/publish-result.json
+        extract_from: .agents/output/publish-result.json
         json_path: .comment_url
         label: "Dead Code Review Comment"

--- a/.agents/pipelines/audit-dead-code-scan.yaml
+++ b/.agents/pipelines/audit-dead-code-scan.yaml
@@ -29,12 +29,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -105,11 +105,11 @@ steps:
         A good scan produces findings where every reported symbol has been verified with at least one cross-reference search covering /project/internal/ and /project/cmd/. Each finding includes the specific Grep pattern used and the absence of matches as evidence. A bad scan reports symbols without verification, includes obvious false positives like interface implementations or init() functions, or provides vague descriptions like "might be unused" without concrete evidence.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-dead-code.yaml
+++ b/.agents/pipelines/audit-dead-code.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -129,7 +129,7 @@ steps:
         A good scan produces findings where every reported item has been verified with cross-codebase Grep searches and the evidence section documents exactly what was searched. The clean step should be able to act on each finding without additional investigation. A bad scan reports symbols without verification, includes interface implementations as dead code, or uses vague confidence assessments without documenting the search methodology.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -137,8 +137,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: clean
@@ -319,7 +319,7 @@ steps:
         A good verification catches subtle issues like a removed function that is referenced via reflect, a test that passes only because the tested function was also removed, or an unrelated formatting change that slipped into the commit. A bad verification rubber-stamps the changes by checking only that the build passes without examining what was actually removed.
     output_artifacts:
       - name: verification
-        path: .wave/output/verification.json
+        path: .agents/output/verification.json
         type: json
     retry:
       policy: standard
@@ -327,8 +327,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/verification.json
-        schema_path: .wave/contracts/dead-code-verification.schema.json
+        source: .agents/output/verification.json
+        schema_path: .agents/contracts/dead-code-verification.schema.json
         on_failure: retry
 
   - id: create-pr
@@ -444,7 +444,7 @@ steps:
 
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -452,12 +452,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/audit-doc-scan.yaml
+++ b/.agents/pipelines/audit-doc-scan.yaml
@@ -29,12 +29,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -119,11 +119,11 @@ steps:
         A good scan verifies at least 3 specific claims per documentation file audited, provides concrete evidence for each finding (not just "this looks outdated"), and correctly distinguishes between critical inaccuracies and minor staleness. A bad scan makes vague assertions like "README might be outdated" without checking specific claims, reports formatting issues as findings, or fails to cross-reference documentation statements against the actual code.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-doc.yaml
+++ b/.agents/pipelines/audit-doc.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -125,7 +125,7 @@ steps:
         A good scan captures every documentation file in the project with accurate summaries, correctly categorizes all changed files, and handles edge cases (no changes found, full mode, custom ref). A bad scan misses documentation directories, miscategorizes test files as source code, or produces summaries too vague to be useful for cross-referencing.
     output_artifacts:
       - name: scan-results
-        path: .wave/output/scan-results.json
+        path: .agents/output/scan-results.json
         type: json
     retry:
       policy: patient
@@ -133,8 +133,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/scan-results.json
-        schema_path: .wave/contracts/doc-scan-results.schema.json
+        source: .agents/output/scan-results.json
+        schema_path: .agents/contracts/doc-scan-results.schema.json
         on_failure: retry
 
   - id: analyze-consistency
@@ -146,7 +146,7 @@ steps:
         - step: scan-changes
           artifact: scan-results
           as: scan
-          schema_path: .wave/contracts/doc-scan-results.schema.json
+          schema_path: .agents/contracts/doc-scan-results.schema.json
     workspace:
       type: worktree
       branch: "{{ pipeline_id }}"
@@ -227,7 +227,7 @@ steps:
         A good consistency analysis finds the non-obvious inconsistencies: a flag renamed in code but not in docs, a new environment variable with no documentation, an ADR decision that was reversed in code. Each finding cites both the documentation passage and the code location. A bad analysis only catches the obvious (deleted files still mentioned in README) while missing subtle drift, or reports style issues as consistency findings.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -235,8 +235,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: compose-report
@@ -324,12 +324,12 @@ steps:
         A good report allows a developer to open the issue and work through findings top-to-bottom, fixing documentation files based on the task descriptions and code references provided. Each item has enough context to make the edit without consulting the original analysis artifacts. A bad report uses vague descriptions ("some docs are outdated"), omits code references, or formats the task list in a way that does not render as interactive checkboxes.
     output_artifacts:
       - name: report
-        path: .wave/output/report.md
+        path: .agents/output/report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/report.md
+        source: .agents/output/report.md
 
   - id: publish
     persona: craftsman
@@ -378,7 +378,7 @@ steps:
         ```bash
         {{ forge.cli_tool }} issue create \
           --title "docs: documentation consistency report (N inconsistencies)" \
-          --body-file .wave/artifacts/report \
+          --body-file .agents/artifacts/report \
           --label "documentation"
         ```
 
@@ -388,7 +388,7 @@ steps:
         ```bash
         {{ forge.cli_tool }} issue create \
           --title "docs: documentation consistency report (N inconsistencies)" \
-          --body-file .wave/artifacts/report
+          --body-file .agents/artifacts/report
         ```
 
         If the forge CLI command fails for any other reason, log the error and record it in the result JSON.
@@ -421,7 +421,7 @@ steps:
         A good issue creation produces an issue with a count-inclusive title, the full formatted report with interactive checkboxes as the body, and a result JSON capturing the issue URL. A bad issue creation uses a generic title without the count, fails silently without recording the error, or creates an issue even when the report says clean.
     output_artifacts:
       - name: issue-result
-        path: .wave/output/issue-result.json
+        path: .agents/output/issue-result.json
         type: json
     retry:
       policy: aggressive
@@ -429,12 +429,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/issue-result.json
-        schema_path: .wave/contracts/doc-issue-result.schema.json
+        source: .agents/output/issue-result.json
+        schema_path: .agents/contracts/doc-issue-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: issue
-        extract_from: .wave/output/issue-result.json
+        extract_from: .agents/output/issue-result.json
         json_path: .issue_url
         label: "Documentation Issue"

--- a/.agents/pipelines/audit-dual.yaml
+++ b/.agents/pipelines/audit-dual.yaml
@@ -47,12 +47,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -118,13 +118,13 @@ steps:
         A good quality scan reads the actual source code for each finding, provides specific file:line references, and distinguishes between high-impact issues (behavioral duplication, complex critical-path functions) and low-impact ones (minor style preferences). A bad scan lists generic categories without examining actual code or reports every function over 20 lines as "complex."
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: quality-detail
@@ -148,7 +148,7 @@ steps:
       source: |
         Deepen the code quality analysis from the scan results.
 
-        For each finding in .wave/artifacts/scan_results:
+        For each finding in .agents/artifacts/scan_results:
         1. Verify the finding by reading the source code
         2. Assess severity and impact on maintainability
         3. Suggest specific refactoring with code examples
@@ -157,12 +157,12 @@ steps:
         Produce a markdown report with prioritized recommendations.
     output_artifacts:
       - name: quality_report
-        path: .wave/output/quality-detail.md
+        path: .agents/output/quality-detail.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/quality-detail.md
+        source: .agents/output/quality-detail.md
 
   # ── Track B: Security ──────────────────────────────────────────────
   - id: security-scan
@@ -189,7 +189,7 @@ steps:
         Output a structured JSON report matching the contract schema.
     output_artifacts:
       - name: security_scan
-        path: .wave/output/security-scan.json
+        path: .agents/output/security-scan.json
         type: json
 
   - id: security-detail
@@ -213,7 +213,7 @@ steps:
       source: |
         Deepen the security analysis from the scan results.
 
-        For each finding in .wave/artifacts/scan_results:
+        For each finding in .agents/artifacts/scan_results:
         1. Verify by reading the actual source code
         2. Trace data flow from entry point to sink
         3. Assess exploitability and real-world impact
@@ -222,12 +222,12 @@ steps:
         Produce a markdown report with severity-ordered findings.
     output_artifacts:
       - name: security_report
-        path: .wave/output/security-detail.md
+        path: .agents/output/security-detail.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/security-detail.md
+        source: .agents/output/security-detail.md
 
   # ── Merge: Converge both tracks ────────────────────────────────────
   - id: merge
@@ -250,8 +250,8 @@ steps:
         unified assessment.
 
         Read both reports:
-        - .wave/artifacts/quality_findings (code quality)
-        - .wave/artifacts/security_findings (security)
+        - .agents/artifacts/quality_findings (code quality)
+        - .agents/artifacts/security_findings (security)
 
         Produce a final report with:
         1. Executive summary with overall health rating
@@ -260,9 +260,9 @@ steps:
         4. Positive observations and strengths
     output_artifacts:
       - name: report
-        path: .wave/output/dual-analysis-report.md
+        path: .agents/output/dual-analysis-report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/dual-analysis-report.md
+        source: .agents/output/dual-analysis-report.md

--- a/.agents/pipelines/audit-duplicates.yaml
+++ b/.agents/pipelines/audit-duplicates.yaml
@@ -30,12 +30,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -114,11 +114,11 @@ steps:
         A good scan reads actual source code from both sides of each comparison, identifies specific functions or types that overlap, and provides a concrete consolidation strategy. A bad scan reports package-level suspicions ("these two packages might overlap") without examining the code, or treats intentional interface polymorphism as accidental duplication.
     output_artifacts:
       - name: findings
-        path: .wave/output/duplicate-findings.json
+        path: .agents/output/duplicate-findings.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/duplicate-findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/duplicate-findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-dx.yaml
+++ b/.agents/pipelines/audit-dx.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -171,14 +171,14 @@ steps:
         praise or ungrounded criticism fails the quality bar.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
       - name: report
-        path: .wave/output/findings.md
+        path: .agents/output/findings.md
         type: markdown
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-junk-code.yaml
+++ b/.agents/pipelines/audit-junk-code.yaml
@@ -34,12 +34,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -107,7 +107,7 @@ steps:
         A good junk code audit distinguishes between code that is complex-because-the-domain-is-complex and code that is complex-because-it-was-written-hastily. Each finding includes a concrete "before and after" vision: what the code does now, what it should look like after remediation, and why the change matters. A bad audit flags every function over 30 lines as a complexity hotspot or reports stylistic preferences as structural debt.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -115,6 +115,6 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-quality-loop.yaml
+++ b/.agents/pipelines/audit-quality-loop.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:

--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -33,12 +33,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] security audit started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] security audit started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-findings
     event: step_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -145,7 +145,7 @@ steps:
 
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -153,8 +153,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: deep-dive
@@ -262,7 +262,7 @@ steps:
         confirmations fail the quality bar.
     output_artifacts:
       - name: deep_dive
-        path: .wave/output/security-deep-dive.md
+        path: .agents/output/security-deep-dive.md
         type: markdown
 
   - id: report
@@ -359,7 +359,7 @@ steps:
         a wall of text or inflates risk to seem thorough fails the quality bar.
     output_artifacts:
       - name: report
-        path: .wave/output/security-report.md
+        path: .agents/output/security-report.md
         type: markdown
     retry:
       policy: standard
@@ -368,8 +368,8 @@ steps:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/security-report.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/security-report.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/audit-tests.yaml
+++ b/.agents/pipelines/audit-tests.yaml
@@ -30,12 +30,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] test audit started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] test audit started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-findings
     event: step_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -55,10 +55,10 @@ steps:
           mode: readonly
     exec:
       type: prompt
-      source_path: .wave/prompts/audit/tests-scan.md
+      source_path: .agents/prompts/audit/tests-scan.md
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -66,8 +66,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip
 
   - id: report
@@ -80,7 +80,7 @@ steps:
         - step: scan
           artifact: findings
           as: scan_findings
-          schema_path: .wave/contracts/shared-findings.schema.json
+          schema_path: .agents/contracts/shared-findings.schema.json
     exec:
       type: prompt
       source: |
@@ -114,7 +114,7 @@ steps:
         bullet lists for scannability.
     output_artifacts:
       - name: report
-        path: .wave/output/tests-report.md
+        path: .agents/output/tests-report.md
         type: markdown
     retry:
       policy: standard
@@ -123,8 +123,8 @@ steps:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/tests-report.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/tests-report.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/audit-unwired.yaml
+++ b/.agents/pipelines/audit-unwired.yaml
@@ -29,12 +29,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -118,11 +118,11 @@ steps:
         A good scan traces from concrete entry points inward and reports only symbols where the search for callers was thorough (covering cmd/, internal/, and YAML references). Each finding names the specific entry points checked and explains why no path was found. A bad scan simply lists exported symbols without verifying whether they are actually called, or reports interface methods and standard patterns as unwired.
     output_artifacts:
       - name: findings
-        path: .wave/output/unwired-findings.json
+        path: .agents/output/unwired-findings.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/unwired-findings.json
-        schema_path: .wave/contracts/shared-findings.schema.json
+        source: .agents/output/unwired-findings.json
+        schema_path: .agents/contracts/shared-findings.schema.json
         on_failure: skip

--- a/.agents/pipelines/audit-ux.yaml
+++ b/.agents/pipelines/audit-ux.yaml
@@ -34,12 +34,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -119,9 +119,9 @@ steps:
         A good UX audit simulates the user's journey through specific tasks and identifies concrete friction points with reproduction steps ("running `wave run` with no arguments produces an unhelpful error on line 47 of run.go"). A bad audit lists generic UX principles without checking whether they apply, or focuses on cosmetic issues while ignoring blocking usability problems.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.md
+        path: .agents/output/findings.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/findings.md
+        source: .agents/output/findings.md

--- a/.agents/pipelines/bench-solve.yaml
+++ b/.agents/pipelines/bench-solve.yaml
@@ -33,12 +33,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -52,7 +52,7 @@ steps:
           mode: readwrite
     exec:
       type: prompt
-      source_path: .wave/prompts/bench/solve.md
+      source_path: .agents/prompts/bench/solve.md
     retry:
       policy: standard
       max_attempts: 2

--- a/.agents/pipelines/doc-changelog.yaml
+++ b/.agents/pipelines/doc-changelog.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -141,7 +141,7 @@ steps:
         A good commit analysis correctly parses every conventional commit prefix and scope, identifies all breaking changes (including those marked only in the body), and captures the full commit body for context. A bad analysis misparses scopes, misses breaking changes that use the body marker instead of the `!` suffix, or truncates commit bodies.
     output_artifacts:
       - name: commits
-        path: .wave/output/commit-analysis.json
+        path: .agents/output/commit-analysis.json
         type: json
     retry:
       policy: patient
@@ -149,8 +149,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/commit-analysis.json
-        schema_path: .wave/contracts/commit-analysis.schema.json
+        source: .agents/output/commit-analysis.json
+        schema_path: .agents/contracts/commit-analysis.schema.json
         on_failure: retry
 
   - id: categorize
@@ -244,7 +244,7 @@ steps:
         A good categorization transforms "fix(webui): nil pointer in handler" into "Fix crash when loading pipeline detail pages with missing step data" -- user-visible impact, not implementation detail. Breaking changes include specific migration instructions. A bad categorization copies commit messages verbatim, fails to deduplicate a commit and its follow-up lint fix, or describes breaking changes without migration guidance.
     output_artifacts:
       - name: categorized
-        path: .wave/output/categorized-changes.json
+        path: .agents/output/categorized-changes.json
         type: json
     retry:
       policy: standard
@@ -252,8 +252,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/categorized-changes.json
-        schema_path: .wave/contracts/categorized-changes.schema.json
+        source: .agents/output/categorized-changes.json
+        schema_path: .agents/contracts/categorized-changes.schema.json
         on_failure: retry
 
   - id: format
@@ -373,9 +373,9 @@ steps:
         A good changelog is scannable in 30 seconds, communicates the most important changes in the first 3 entries, includes migration instructions for every breaking change, and reads naturally to someone who uses the product but does not contribute to it. A bad changelog is a reformatted git log, includes internal implementation details, omits migration guidance for breaking changes, or includes empty sections.
     output_artifacts:
       - name: changelog
-        path: .wave/output/CHANGELOG.md
+        path: .agents/output/CHANGELOG.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/CHANGELOG.md
+        source: .agents/output/CHANGELOG.md

--- a/.agents/pipelines/doc-explain.yaml
+++ b/.agents/pipelines/doc-explain.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -73,7 +73,7 @@ steps:
         1. **Find all relevant files**: Use Glob to find files by name pattern and Grep to find files by content. Cast a wide net:
            - Search for the topic's key terms in file names and file contents
            - Include implementation files, test files, configuration files, and documentation
-           - Check multiple directories: internal/, cmd/, docs/, configs/, .wave/
+           - Check multiple directories: internal/, cmd/, docs/, configs/, .agents/
            - Look for related files that might not use the exact term (e.g., if exploring "pipeline execution," also search for "step," "executor," "scheduler")
            Record every relevant file path with a brief note on what it contains.
 
@@ -130,7 +130,7 @@ steps:
 
     output_artifacts:
       - name: exploration
-        path: .wave/output/exploration.json
+        path: .agents/output/exploration.json
         type: json
     retry:
       policy: patient
@@ -138,8 +138,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/exploration.json
-        schema_path: .wave/contracts/explain-exploration.schema.json
+        source: .agents/output/exploration.json
+        schema_path: .agents/contracts/explain-exploration.schema.json
         on_failure: retry
 
   - id: analyze
@@ -229,7 +229,7 @@ steps:
         A good analysis reveals the "why" behind the "what" -- explaining not just that a factory pattern is used, but why it is necessary for this specific component (e.g., "because sandbox backends need runtime selection based on configuration"). Each design decision includes the trade-off. A bad analysis describes code structure without explaining architectural intent, or lists patterns without connecting them to the problems they solve.
     output_artifacts:
       - name: analysis
-        path: .wave/output/analysis.json
+        path: .agents/output/analysis.json
         type: json
     retry:
       policy: patient
@@ -237,8 +237,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/analysis.json
-        schema_path: .wave/contracts/explain-analysis.schema.json
+        source: .agents/output/analysis.json
+        schema_path: .agents/contracts/explain-analysis.schema.json
         on_failure: retry
 
   - id: document
@@ -333,9 +333,9 @@ steps:
         A good explanation document enables a new team member to become productive in this area of the codebase within one day of reading it. The architecture diagram is accurate enough to navigate the code. The execution flow walkthrough matches what actually happens when you trace through the code. File:line references are correct. A bad explanation is a surface-level overview that could describe any project, uses generic descriptions instead of real code references, or skips the "why" in favor of only the "what."
     output_artifacts:
       - name: explanation
-        path: .wave/output/explanation.md
+        path: .agents/output/explanation.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/explanation.md
+        source: .agents/output/explanation.md

--- a/.agents/pipelines/doc-fix.yaml
+++ b/.agents/pipelines/doc-fix.yaml
@@ -32,12 +32,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -79,7 +79,7 @@ steps:
         - Architecture Decision Records (docs/adrs/)
         - Inline documentation: godoc comments on exported types and functions in key packages
         - Configuration documentation: comments in config schemas, YAML files, or dedicated config docs
-        - Pipeline documentation: YAML file descriptions and prompt content in .wave/pipelines/
+        - Pipeline documentation: YAML file descriptions and prompt content in .agents/pipelines/
 
         Build a list of all documentation files with their paths.
 
@@ -91,7 +91,7 @@ steps:
         - Configuration options (search for config struct definitions, environment variable access, flag definitions)
         - Environment variables (search for os.Getenv, os.LookupEnv patterns)
         - API endpoints (search for HTTP handler registrations)
-        - Pipeline names and descriptions (search .wave/pipelines/ for metadata.name fields)
+        - Pipeline names and descriptions (search .agents/pipelines/ for metadata.name fields)
 
         ### 3. Cross-Reference
 
@@ -143,7 +143,7 @@ steps:
         A good scan cross-references every documented feature against the code and every code feature against the documentation, catching both stale docs and missing docs. Each finding includes a concrete suggested fix that the fix-docs step can implement. A bad scan only checks whether files exist without reading their content, misses environment variables and config options, or provides vague descriptions like "docs might be outdated."
     output_artifacts:
       - name: scan_results
-        path: .wave/output/doc-scan.json
+        path: .agents/output/doc-scan.json
         type: json
     retry:
       policy: patient
@@ -151,8 +151,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/doc-scan.json
-        schema_path: .wave/contracts/doc-fix-scan.schema.json
+        source: .agents/output/doc-scan.json
+        schema_path: .agents/contracts/doc-fix-scan.schema.json
         on_failure: retry
 
   - id: analyze
@@ -249,14 +249,14 @@ steps:
         A good fix plan is specific enough that the fix-docs step can apply each change without re-reading the codebase. Each fix identifies the exact text to change and where to find the correct value. A bad fix plan says "update README" without specifying what to change, includes fixes that require code modifications, or fails to verify findings against the actual code.
     output_artifacts:
       - name: fix_plan
-        path: .wave/output/fix-plan.md
+        path: .agents/output/fix-plan.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/plan-review-criteria.md
-        source: .wave/output/fix-plan.md
+        criteria_path: .agents/contracts/plan-review-criteria.md
+        source: .agents/output/fix-plan.md
         model: cheapest
         token_budget: 8000
         timeout: 90s
@@ -375,7 +375,7 @@ steps:
         on_failure: retry
     output_artifacts:
       - name: result
-        path: .wave/output/result.md
+        path: .agents/output/result.md
         type: markdown
 
   - id: create-pr
@@ -489,7 +489,7 @@ steps:
 
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -497,12 +497,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/doc-onboard.yaml
+++ b/.agents/pipelines/doc-onboard.yaml
@@ -32,12 +32,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -156,7 +156,7 @@ steps:
         A good survey captures the exact commands to build, test, and run the project, identifies every configuration surface, and provides specific file paths for everything. A developer reading the survey should be able to reconstruct the project's setup from scratch. A bad survey provides generic descriptions ("there is a Makefile") without reading the actual content, or misses key directories and configuration.
     output_artifacts:
       - name: survey
-        path: .wave/output/project-survey.json
+        path: .agents/output/project-survey.json
         type: json
     retry:
       policy: patient
@@ -164,8 +164,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/project-survey.json
-        schema_path: .wave/contracts/project-survey.schema.json
+        source: .agents/output/project-survey.json
+        schema_path: .agents/contracts/project-survey.schema.json
         on_failure: retry
 
   - id: guide
@@ -214,7 +214,7 @@ steps:
 
         A structured map of the project layout:
         - What each top-level directory contains (one line per directory)
-        - Where to find specific things: "tests are alongside source files", "configuration schemas are in .wave/contracts/", "pipeline definitions are in .wave/pipelines/"
+        - Where to find specific things: "tests are alongside source files", "configuration schemas are in .agents/contracts/", "pipeline definitions are in .agents/pipelines/"
         - Which directories a new contributor will work in most often
         - Which directories they can safely ignore initially
 
@@ -269,9 +269,9 @@ steps:
         A good onboarding guide passes the "first day" test: a developer who reads it on Monday morning can submit their first PR by Monday afternoon. Every command works when copy-pasted. The architecture diagram matches the actual code. The common tasks section provides step-by-step instructions, not vague pointers. A bad guide reads like a generic "how to contribute to open source" article, uses placeholder text, or provides instructions that do not work because the project has diverged from the documented setup.
     output_artifacts:
       - name: guide
-        path: .wave/output/onboarding-guide.md
+        path: .agents/output/onboarding-guide.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/onboarding-guide.md
+        source: .agents/output/onboarding-guide.md

--- a/.agents/pipelines/full-impl-cycle.yaml
+++ b/.agents/pipelines/full-impl-cycle.yaml
@@ -49,12 +49,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] full impl cycle started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] full impl cycle started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -124,10 +124,10 @@ steps:
           as: coverage_findings
     exec:
       type: prompt
-      source_path: .wave/prompts/full-impl-cycle/audit-aggregate.md
+      source_path: .agents/prompts/full-impl-cycle/audit-aggregate.md
     output_artifacts:
       - name: aggregated-findings
-        path: .wave/output/aggregated-findings.json
+        path: .agents/output/aggregated-findings.json
         type: json
     retry:
       policy: standard
@@ -135,8 +135,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/aggregated-findings.json
-        schema_path: .wave/contracts/aggregated-findings.schema.json
+        source: .agents/output/aggregated-findings.json
+        schema_path: .agents/contracts/aggregated-findings.schema.json
         on_failure: skip
 
   # ─── Phase 5: Rework Gate ──────────────────────────────────────────────
@@ -151,10 +151,10 @@ steps:
           as: aggregated_findings
     exec:
       type: prompt
-      source_path: .wave/prompts/full-impl-cycle/rework-gate.md
+      source_path: .agents/prompts/full-impl-cycle/rework-gate.md
     output_artifacts:
       - name: rework-verdict
-        path: .wave/output/rework-gate-verdict.json
+        path: .agents/output/rework-gate-verdict.json
         type: json
     retry:
       policy: standard
@@ -162,8 +162,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/rework-gate-verdict.json
-        schema_path: .wave/contracts/rework-gate-verdict.schema.json
+        source: .agents/output/rework-gate-verdict.json
+        schema_path: .agents/contracts/rework-gate-verdict.schema.json
         on_failure: skip
 
   # ─── Phase 6: Rework Loop (conditional on gate fail) ───────────────────
@@ -280,16 +280,16 @@ steps:
                 as: coverage_findings
           exec:
             type: prompt
-            source_path: .wave/prompts/full-impl-cycle/audit-aggregate.md
+            source_path: .agents/prompts/full-impl-cycle/audit-aggregate.md
           output_artifacts:
             - name: aggregated-findings
-              path: .wave/output/aggregated-findings.json
+              path: .agents/output/aggregated-findings.json
               type: json
           handover:
             contract:
               type: json_schema
-              source: .wave/output/aggregated-findings.json
-              schema_path: .wave/contracts/aggregated-findings.schema.json
+              source: .agents/output/aggregated-findings.json
+              schema_path: .agents/contracts/aggregated-findings.schema.json
               on_failure: skip
 
         - id: re-gate
@@ -303,16 +303,16 @@ steps:
                 as: aggregated_findings
           exec:
             type: prompt
-            source_path: .wave/prompts/full-impl-cycle/rework-gate.md
+            source_path: .agents/prompts/full-impl-cycle/rework-gate.md
           output_artifacts:
             - name: rework-verdict
-              path: .wave/output/rework-gate-verdict.json
+              path: .agents/output/rework-gate-verdict.json
               type: json
           handover:
             contract:
               type: json_schema
-              source: .wave/output/rework-gate-verdict.json
-              schema_path: .wave/contracts/rework-gate-verdict.schema.json
+              source: .agents/output/rework-gate-verdict.json
+              schema_path: .agents/contracts/rework-gate-verdict.schema.json
               on_failure: skip
 
   # ─── Phase 7: PR Creation ──────────────────────────────────────────────

--- a/.agents/pipelines/impl-feature.yaml
+++ b/.agents/pipelines/impl-feature.yaml
@@ -33,12 +33,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[impl-feature] started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-feature] started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[impl-feature] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-feature] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -146,7 +146,7 @@ steps:
         dependencies, or violate conventions — causing rework in later steps.
     output_artifacts:
       - name: exploration
-        path: .wave/output/exploration.json
+        path: .agents/output/exploration.json
         type: json
     retry:
       policy: patient
@@ -154,8 +154,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/exploration.json
-        schema_path: .wave/contracts/feature-exploration.schema.json
+        source: .agents/output/exploration.json
+        schema_path: .agents/contracts/feature-exploration.schema.json
         on_failure: retry
 
   - id: plan
@@ -262,7 +262,7 @@ steps:
         cases, and failed contracts.
     output_artifacts:
       - name: plan
-        path: .wave/output/plan.json
+        path: .agents/output/plan.json
         type: json
     retry:
       policy: standard
@@ -270,8 +270,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/plan.json
-        schema_path: .wave/contracts/feature-plan.schema.json
+        source: .agents/output/plan.json
+        schema_path: .agents/contracts/feature-plan.schema.json
         on_failure: retry
 
   - id: implement
@@ -411,7 +411,7 @@ steps:
         persona: summarizer
     output_artifacts:
       - name: result
-        path: .wave/output/result.md
+        path: .agents/output/result.md
         type: markdown
 
   - id: fix-implement
@@ -500,7 +500,7 @@ steps:
         on_failure: retry
     output_artifacts:
       - name: result
-        path: .wave/output/result.md
+        path: .agents/output/result.md
         type: markdown
 
   # ── Publish ─────────────────────────────────────────────────────────
@@ -562,7 +562,7 @@ steps:
         3. **Create the pull request**: Use the forge CLI to open the PR with the
            implementation result as the body:
            ```bash
-           {{ forge.cli_tool }} {{ forge.pr_command }} create --title "$(cat /tmp/wave-pr-title.txt)" --body-file .wave/artifacts/result
+           {{ forge.cli_tool }} {{ forge.pr_command }} create --title "$(cat /tmp/wave-pr-title.txt)" --body-file .agents/artifacts/result
            ```
 
         4. **Capture the PR result**: After creating the PR, produce a JSON result
@@ -595,7 +595,7 @@ steps:
         files", or leaves the result artifact empty or malformed.
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -603,12 +603,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/impl-hotfix.yaml
+++ b/.agents/pipelines/impl-hotfix.yaml
@@ -29,12 +29,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[impl-hotfix] started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-hotfix] started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[impl-hotfix] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-hotfix] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -131,7 +131,7 @@ steps:
         that forces the fixer to re-investigate from scratch.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -139,8 +139,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/bug-investigation.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/bug-investigation.schema.json
         on_failure: retry
 
   - id: fix
@@ -457,14 +457,14 @@ steps:
         that do not affect correctness or safety.
     output_artifacts:
       - name: verdict
-        path: .wave/output/verdict.md
+        path: .agents/output/verdict.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/verification-criteria.md
-        source: .wave/output/verdict.md
+        criteria_path: .agents/contracts/verification-criteria.md
+        source: .agents/output/verdict.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/impl-improve.yaml
+++ b/.agents/pipelines/impl-improve.yaml
@@ -32,12 +32,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[impl-improve] started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-improve] started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[impl-improve] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-improve] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -155,7 +155,7 @@ steps:
         needed for the implementer to act on the findings.
     output_artifacts:
       - name: assessment
-        path: .wave/output/assessment.json
+        path: .agents/output/assessment.json
         type: json
     retry:
       policy: patient
@@ -163,8 +163,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/assessment.json
-        schema_path: .wave/contracts/improvement-assessment.schema.json
+        source: .agents/output/assessment.json
+        schema_path: .agents/contracts/improvement-assessment.schema.json
         on_failure: retry
 
   - id: implement
@@ -380,14 +380,14 @@ steps:
         checking or rejects valid improvements based on subjective style preferences.
     output_artifacts:
       - name: verification
-        path: .wave/output/verification.md
+        path: .agents/output/verification.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/verification-criteria.md
-        source: .wave/output/verification.md
+        criteria_path: .agents/contracts/verification-criteria.md
+        source: .agents/output/verification.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/impl-issue-core.yaml
+++ b/.agents/pipelines/impl-issue-core.yaml
@@ -23,12 +23,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -65,10 +65,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/fetch-assess.md
+      source_path: .agents/prompts/implement/fetch-assess.md
     output_artifacts:
       - name: assessment
-        path: .wave/output/issue-assessment.json
+        path: .agents/output/issue-assessment.json
         type: json
     retry:
       policy: patient
@@ -76,8 +76,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/issue-assessment.json
-        schema_path: .wave/contracts/issue-assessment.schema.json
+        source: .agents/output/issue-assessment.json
+        schema_path: .agents/contracts/issue-assessment.schema.json
         must_pass: true
         on_failure: retry
 
@@ -96,10 +96,10 @@ steps:
       base: main
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/plan.md
+      source_path: .agents/prompts/implement/plan.md
     output_artifacts:
       - name: impl-plan
-        path: .wave/output/impl-plan.json
+        path: .agents/output/impl-plan.json
         type: json
     retry:
       policy: standard
@@ -107,8 +107,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/impl-plan.json
-        schema_path: .wave/contracts/issue-impl-plan.schema.json
+        source: .agents/output/impl-plan.json
+        schema_path: .agents/contracts/issue-impl-plan.schema.json
         must_pass: true
         on_failure: retry
 
@@ -131,7 +131,7 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/implement.md
+      source_path: .agents/prompts/implement/implement.md
     retry:
       policy: aggressive
       max_attempts: 3

--- a/.agents/pipelines/impl-issue.yaml
+++ b/.agents/pipelines/impl-issue.yaml
@@ -43,12 +43,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -66,10 +66,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/fetch-assess.md
+      source_path: .agents/prompts/implement/fetch-assess.md
     output_artifacts:
       - name: assessment
-        path: .wave/output/issue-assessment.json
+        path: .agents/output/issue-assessment.json
         type: json
     retry:
       policy: patient
@@ -77,8 +77,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/issue-assessment.json
-        schema_path: .wave/contracts/issue-assessment.schema.json
+        source: .agents/output/issue-assessment.json
+        schema_path: .agents/contracts/issue-assessment.schema.json
         must_pass: true
         on_failure: retry
 
@@ -100,10 +100,10 @@ steps:
       base: main
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/plan.md
+      source_path: .agents/prompts/implement/plan.md
     output_artifacts:
       - name: impl-plan
-        path: .wave/output/impl-plan.json
+        path: .agents/output/impl-plan.json
         type: json
     retry:
       policy: standard
@@ -111,8 +111,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/impl-plan.json
-        schema_path: .wave/contracts/issue-impl-plan.schema.json
+        source: .agents/output/impl-plan.json
+        schema_path: .agents/contracts/issue-impl-plan.schema.json
         must_pass: true
         on_failure: retry
 
@@ -135,7 +135,7 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/implement.md
+      source_path: .agents/prompts/implement/implement.md
     retry:
       policy: aggressive
       max_attempts: 2
@@ -242,7 +242,7 @@ steps:
           on_failure: fail
         - type: agent_review
           persona: navigator
-          criteria_path: .wave/contracts/impl-review-criteria.md
+          criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
           token_budget: 8000
           timeout: 90s
@@ -265,10 +265,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/implement/create-pr.md
+      source_path: .agents/prompts/implement/create-pr.md
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: standard
@@ -276,12 +276,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/impl-prototype.yaml
+++ b/.agents/pipelines/impl-prototype.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -142,7 +142,7 @@ steps:
         path: requirements.md
         type: markdown
       - name: contract_data
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
 
     retry:
@@ -151,7 +151,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/spec-phase.schema.json
+        schema_path: .agents/contracts/spec-phase.schema.json
         must_pass: true
         on_failure: retry
 
@@ -262,7 +262,7 @@ steps:
         path: stakeholder-summary.md
         type: markdown
       - name: contract_data
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
 
     retry:
@@ -271,7 +271,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/docs-phase.schema.json
+        schema_path: .agents/contracts/docs-phase.schema.json
         must_pass: true
         on_failure: retry
 
@@ -393,7 +393,7 @@ steps:
         path: interfaces.md
         type: markdown
       - name: contract_data
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
 
     retry:
@@ -402,7 +402,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/dummy-phase.schema.json
+        schema_path: .agents/contracts/dummy-phase.schema.json
         must_pass: true
         on_failure: retry
 
@@ -530,7 +530,7 @@ steps:
         path: implementation-checklist.md
         type: markdown
       - name: contract_data
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
 
     retry:
@@ -539,7 +539,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/implement-phase.schema.json
+        schema_path: .agents/contracts/implement-phase.schema.json
         must_pass: true
         on_failure: retry
 
@@ -645,7 +645,7 @@ steps:
       contract:
         type: json_schema
         source: pr-info.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
 

--- a/.agents/pipelines/impl-recinq.yaml
+++ b/.agents/pipelines/impl-recinq.yaml
@@ -34,12 +34,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 # Pipeline structure implements the Double Diamond:
@@ -142,7 +142,7 @@ steps:
         produces a vague focus hint that does not help narrow the search.
     output_artifacts:
       - name: context
-        path: .wave/output/context.json
+        path: .agents/output/context.json
         type: json
     retry:
       policy: patient
@@ -150,8 +150,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/context.json
-        schema_path: .wave/contracts/recinq-context.schema.json
+        source: .agents/output/context.json
+        schema_path: .agents/contracts/recinq-context.schema.json
         must_pass: true
         on_failure: retry
 
@@ -242,7 +242,7 @@ steps:
         that appear in multiple findings.
     output_artifacts:
       - name: findings
-        path: .wave/output/divergent-findings.json
+        path: .agents/output/divergent-findings.json
         type: json
     retry:
       policy: patient
@@ -250,8 +250,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/divergent-findings.json
-        schema_path: .wave/contracts/divergent-findings.schema.json
+        source: .agents/output/divergent-findings.json
+        schema_path: .agents/contracts/divergent-findings.schema.json
         must_pass: true
         on_failure: retry
 
@@ -357,7 +357,7 @@ steps:
         investigation.
     output_artifacts:
       - name: validated_findings
-        path: .wave/output/validated-findings.json
+        path: .agents/output/validated-findings.json
         type: json
     retry:
       policy: patient
@@ -365,8 +365,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/validated-findings.json
-        schema_path: .wave/contracts/validated-findings.schema.json
+        source: .agents/output/validated-findings.json
+        schema_path: .agents/contracts/validated-findings.schema.json
         must_pass: true
         on_failure: retry
 
@@ -479,7 +479,7 @@ steps:
         discovering anything new.
     output_artifacts:
       - name: probed_findings
-        path: .wave/output/probed-findings.json
+        path: .agents/output/probed-findings.json
         type: json
     retry:
       policy: patient
@@ -487,8 +487,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/probed-findings.json
-        schema_path: .wave/contracts/probed-findings.schema.json
+        source: .agents/output/probed-findings.json
+        schema_path: .agents/contracts/probed-findings.schema.json
         must_pass: true
         on_failure: retry
 
@@ -613,7 +613,7 @@ steps:
         to redundant or conflicting changes in the simplify step.
     output_artifacts:
       - name: proposals
-        path: .wave/output/convergent-proposals.json
+        path: .agents/output/convergent-proposals.json
         type: json
     retry:
       policy: standard
@@ -621,8 +621,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/convergent-proposals.json
-        schema_path: .wave/contracts/convergent-proposals.schema.json
+        source: .agents/output/convergent-proposals.json
+        schema_path: .agents/contracts/convergent-proposals.schema.json
         must_pass: true
         on_failure: retry
 
@@ -763,7 +763,7 @@ steps:
         persona: summarizer
     output_artifacts:
       - name: result
-        path: .wave/output/result.md
+        path: .agents/output/result.md
         type: markdown
 
   # ── Reporting ────────────────────────────────────────────────────────
@@ -874,12 +874,12 @@ steps:
         of summarizing).
     output_artifacts:
       - name: report
-        path: .wave/output/report.md
+        path: .agents/output/report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/report.md
+        source: .agents/output/report.md
 
   # ── Publish ─────────────────────────────────────────────────────────
   - id: publish
@@ -943,7 +943,7 @@ steps:
         3. **Create the pull request**: Use the forge CLI to open the PR with the report
            as the body:
            ```bash
-           {{ forge.cli_tool }} {{ forge.pr_command }} create --title "$(cat /tmp/wave-pr-title.txt)" --body-file .wave/artifacts/report
+           {{ forge.cli_tool }} {{ forge.pr_command }} create --title "$(cat /tmp/wave-pr-title.txt)" --body-file .agents/artifacts/report
            ```
            Capture the PR URL from the command output.
 
@@ -990,7 +990,7 @@ steps:
         silently, creates PRs with empty bodies, or does not link back to the source.
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -998,12 +998,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/impl-refactor.yaml
+++ b/.agents/pipelines/impl-refactor.yaml
@@ -33,12 +33,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -147,7 +147,7 @@ steps:
         confuses test existence with test adequacy.
     output_artifacts:
       - name: analysis
-        path: .wave/output/refactor-analysis.json
+        path: .agents/output/refactor-analysis.json
         type: json
     retry:
       policy: patient
@@ -155,8 +155,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/refactor-analysis.json
-        schema_path: .wave/contracts/refactor-analysis.schema.json
+        source: .agents/output/refactor-analysis.json
+        schema_path: .agents/contracts/refactor-analysis.schema.json
         on_failure: retry
 
   - id: test-baseline
@@ -273,7 +273,7 @@ steps:
         on_failure: retry
     output_artifacts:
       - name: baseline
-        path: .wave/output/test-baseline.md
+        path: .agents/output/test-baseline.md
         type: markdown
   - id: refactor
     persona: craftsman
@@ -494,14 +494,14 @@ steps:
         objective behavior preservation.
     output_artifacts:
       - name: verification
-        path: .wave/output/verification.md
+        path: .agents/output/verification.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/verification-criteria.md
-        source: .wave/output/verification.md
+        criteria_path: .agents/contracts/verification-criteria.md
+        source: .agents/output/verification.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/impl-research.yaml
+++ b/.agents/pipelines/impl-research.yaml
@@ -39,12 +39,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[impl-research] started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-research] started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[impl-research] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[impl-research] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:

--- a/.agents/pipelines/impl-review-loop.yaml
+++ b/.agents/pipelines/impl-review-loop.yaml
@@ -30,12 +30,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 skills:

--- a/.agents/pipelines/impl-smart-route.yaml
+++ b/.agents/pipelines/impl-smart-route.yaml
@@ -34,12 +34,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -144,7 +144,7 @@ steps:
         classifies complex multi-package changes as simple because the issue title is short.
     output_artifacts:
       - name: assessment
-        path: .wave/output/complexity.json
+        path: .agents/output/complexity.json
         type: json
     retry:
       policy: patient
@@ -152,8 +152,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/complexity.json
-        schema_path: .wave/contracts/issue-assessment.schema.json
+        source: .agents/output/complexity.json
+        schema_path: .agents/contracts/issue-assessment.schema.json
         on_failure: retry
 
   - id: route

--- a/.agents/pipelines/impl-speckit.yaml
+++ b/.agents/pipelines/impl-speckit.yaml
@@ -14,7 +14,7 @@ requires:
     speckit:
       check: specify check
       install: uv tool install --force specify-cli --from git+https://github.com/github/spec-kit.git
-      init: specify init --here --force --ai generic --ai-commands-dir .wave/commands --no-git
+      init: specify init --here --force --ai generic --ai-commands-dir .agents/commands --no-git
       optional: true
   tools:
     - git
@@ -44,7 +44,7 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -63,10 +63,10 @@ steps:
       base: main
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/specify.md
+      source_path: .agents/prompts/speckit-flow/specify.md
     output_artifacts:
       - name: spec-status
-        path: .wave/output/specify-status.json
+        path: .agents/output/specify-status.json
         type: json
     retry:
       policy: standard
@@ -74,8 +74,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/specify-status.json
-        schema_path: .wave/contracts/specify-status.schema.json
+        source: .agents/output/specify-status.json
+        schema_path: .agents/contracts/specify-status.schema.json
         must_pass: true
         on_failure: retry
 
@@ -94,10 +94,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/clarify.md
+      source_path: .agents/prompts/speckit-flow/clarify.md
     output_artifacts:
       - name: clarify-status
-        path: .wave/output/clarify-status.json
+        path: .agents/output/clarify-status.json
         type: json
     retry:
       policy: standard
@@ -105,8 +105,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/clarify-status.json
-        schema_path: .wave/contracts/clarify-status.schema.json
+        source: .agents/output/clarify-status.json
+        schema_path: .agents/contracts/clarify-status.schema.json
         must_pass: true
         on_failure: retry
 
@@ -125,10 +125,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/plan.md
+      source_path: .agents/prompts/speckit-flow/plan.md
     output_artifacts:
       - name: plan-status
-        path: .wave/output/plan-status.json
+        path: .agents/output/plan-status.json
         type: json
     retry:
       policy: standard
@@ -136,8 +136,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/plan-status.json
-        schema_path: .wave/contracts/plan-status.schema.json
+        source: .agents/output/plan-status.json
+        schema_path: .agents/contracts/plan-status.schema.json
         must_pass: true
         on_failure: retry
 
@@ -156,10 +156,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/tasks.md
+      source_path: .agents/prompts/speckit-flow/tasks.md
     output_artifacts:
       - name: tasks-status
-        path: .wave/output/tasks-status.json
+        path: .agents/output/tasks-status.json
         type: json
     retry:
       policy: standard
@@ -167,8 +167,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/tasks-status.json
-        schema_path: .wave/contracts/tasks-status.schema.json
+        source: .agents/output/tasks-status.json
+        schema_path: .agents/contracts/tasks-status.schema.json
         must_pass: true
         on_failure: retry
 
@@ -187,10 +187,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/checklist.md
+      source_path: .agents/prompts/speckit-flow/checklist.md
     output_artifacts:
       - name: checklist-status
-        path: .wave/output/checklist-status.json
+        path: .agents/output/checklist-status.json
         type: json
     retry:
       policy: standard
@@ -198,8 +198,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/checklist-status.json
-        schema_path: .wave/contracts/checklist-status.schema.json
+        source: .agents/output/checklist-status.json
+        schema_path: .agents/contracts/checklist-status.schema.json
         must_pass: true
         on_failure: retry
 
@@ -218,10 +218,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/analyze.md
+      source_path: .agents/prompts/speckit-flow/analyze.md
     output_artifacts:
       - name: analysis-report
-        path: .wave/output/analysis-report.json
+        path: .agents/output/analysis-report.json
         type: json
     retry:
       policy: patient
@@ -229,8 +229,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/analysis-report.json
-        schema_path: .wave/contracts/analysis-report.schema.json
+        source: .agents/output/analysis-report.json
+        schema_path: .agents/contracts/analysis-report.schema.json
         must_pass: true
         on_failure: retry
 
@@ -249,7 +249,7 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/implement.md
+      source_path: .agents/prompts/speckit-flow/implement.md
     retry:
       policy: standard
       max_attempts: 2
@@ -261,7 +261,7 @@ steps:
           on_failure: retry
         - type: agent_review
           persona: navigator
-          criteria_path: .wave/contracts/impl-review-criteria.md
+          criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
           token_budget: 8000
           timeout: 5m
@@ -287,10 +287,10 @@ steps:
       branch: "{{ pipeline_id }}"
     exec:
       type: prompt
-      source_path: .wave/prompts/speckit-flow/create-pr.md
+      source_path: .agents/prompts/speckit-flow/create-pr.md
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -298,12 +298,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/ops-bootstrap.yaml
+++ b/.agents/pipelines/ops-bootstrap.yaml
@@ -36,12 +36,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -128,7 +128,7 @@ steps:
         in a non-buildable state.
     output_artifacts:
       - name: assessment
-        path: .wave/output/bootstrap-assessment.json
+        path: .agents/output/bootstrap-assessment.json
         type: json
     retry:
       policy: patient
@@ -136,8 +136,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/bootstrap-assessment.json
-        schema_path: .wave/contracts/bootstrap-assessment.schema.json
+        source: .agents/output/bootstrap-assessment.json
+        schema_path: .agents/contracts/bootstrap-assessment.schema.json
         must_pass: true
         on_failure: retry
 
@@ -335,7 +335,7 @@ steps:
 
         3. Stage each project file individually by explicit path. For every file shown by
            `git status`, run `git add <filepath>` — but NEVER stage any of these paths:
-           - `.wave/` (pipeline-internal files)
+           - `.agents/` (pipeline-internal files)
            - `.claude/` (Claude Code configuration)
            - `CLAUDE.md` (Claude Code instructions)
            You may stage files using a single `git add` command with multiple paths, but
@@ -368,7 +368,7 @@ steps:
           never be committed.
         - Do NOT include Co-Authored-By, Signed-off-by, or any AI attribution lines in
           the commit message.
-        - Do NOT commit `.wave/`, `.claude/`, or `CLAUDE.md`.
+        - Do NOT commit `.agents/`, `.claude/`, or `CLAUDE.md`.
         - Do NOT amend, rebase, or force-push. Create exactly one new commit.
         - Do NOT create the commit if `git status` shows no changes to stage. Report
           that the scaffold step produced no files and exit cleanly.

--- a/.agents/pipelines/ops-debug.yaml
+++ b/.agents/pipelines/ops-debug.yaml
@@ -36,12 +36,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -131,7 +131,7 @@ steps:
         documenting symptoms.
     output_artifacts:
       - name: reproduction
-        path: .wave/output/reproduction.json
+        path: .agents/output/reproduction.json
         type: json
     retry:
       policy: patient
@@ -139,8 +139,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/reproduction.json
-        schema_path: .wave/contracts/debug-reproduction.schema.json
+        source: .agents/output/reproduction.json
+        schema_path: .agents/contracts/debug-reproduction.schema.json
         on_failure: retry
     edges:
       - target: hypothesize
@@ -239,7 +239,7 @@ steps:
         on the first plausible explanation.
     output_artifacts:
       - name: hypotheses
-        path: .wave/output/hypotheses.json
+        path: .agents/output/hypotheses.json
         type: json
     retry:
       policy: patient
@@ -247,8 +247,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/hypotheses.json
-        schema_path: .wave/contracts/debug-hypotheses.schema.json
+        source: .agents/output/hypotheses.json
+        schema_path: .agents/contracts/debug-hypotheses.schema.json
         on_failure: retry
 
   - id: investigate
@@ -373,12 +373,12 @@ steps:
         could lead the fix step in multiple directions.
     output_artifacts:
       - name: findings
-        path: .wave/output/investigation.md
+        path: .agents/output/investigation.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/investigation.md
+        source: .agents/output/investigation.md
 
   - id: fix
     persona: craftsman
@@ -487,7 +487,7 @@ steps:
       max_attempts: 3
     output_artifacts:
       - name: fix
-        path: .wave/output/fix-summary.md
+        path: .agents/output/fix-summary.md
         type: markdown
 
   - id: run-tests

--- a/.agents/pipelines/ops-epic-runner.yaml
+++ b/.agents/pipelines/ops-epic-runner.yaml
@@ -37,12 +37,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:

--- a/.agents/pipelines/ops-hello-world.yaml
+++ b/.agents/pipelines/ops-hello-world.yaml
@@ -63,7 +63,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/smoke-review.schema.json
+        schema_path: .agents/contracts/smoke-review.schema.json
         on_failure: fail
     retry:
       policy: standard

--- a/.agents/pipelines/ops-implement-epic.yaml
+++ b/.agents/pipelines/ops-implement-epic.yaml
@@ -50,12 +50,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -160,7 +160,7 @@ steps:
         order in a way that creates dependency conflicts during sequential implementation.
     output_artifacts:
       - name: children
-        path: .wave/output/epic-children.json
+        path: .agents/output/epic-children.json
         type: json
         required: true
     retry:
@@ -169,8 +169,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/epic-children.json
-        schema_path: .wave/contracts/epic-children.schema.json
+        source: .agents/output/epic-children.json
+        schema_path: .agents/contracts/epic-children.schema.json
         must_pass: true
         on_failure: retry
 
@@ -308,11 +308,11 @@ steps:
         leaves the reviewer guessing about whether all children were actually handled.
     output_artifacts:
       - name: epic-summary
-        path: .wave/output/epic-summary.json
+        path: .agents/output/epic-summary.json
         type: json
     outcomes:
       - type: url
-        extract_from: .wave/output/epic-summary.json
+        extract_from: .agents/output/epic-summary.json
         json_path: .comment_url
         label: "Epic Summary Comment"
     retry:

--- a/.agents/pipelines/ops-issue-quality.yaml
+++ b/.agents/pipelines/ops-issue-quality.yaml
@@ -39,12 +39,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -173,7 +173,7 @@ steps:
         includes issues above the threshold in the poor-quality list.
     output_artifacts:
       - name: quality-report
-        path: .wave/artifacts/quality-report.json
+        path: .agents/artifacts/quality-report.json
         type: json
         required: true
     retry:
@@ -182,8 +182,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/artifacts/quality-report.json
-        schema_path: .wave/contracts/github-issue-analysis.schema.json
+        source: .agents/artifacts/quality-report.json
+        schema_path: .agents/contracts/github-issue-analysis.schema.json
         on_failure: retry
 
   - id: enhance
@@ -340,7 +340,7 @@ steps:
         quick snapshot of issue health across the repository.
     output_artifacts:
       - name: enhancement-summary
-        path: .wave/artifacts/enhancement-summary.md
+        path: .agents/artifacts/enhancement-summary.md
         type: markdown
         required: true
     retry:
@@ -349,4 +349,4 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .wave/artifacts/enhancement-summary.md
+        source: .agents/artifacts/enhancement-summary.md

--- a/.agents/pipelines/ops-parallel-audit.yaml
+++ b/.agents/pipelines/ops-parallel-audit.yaml
@@ -50,12 +50,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -84,7 +84,7 @@ steps:
     dependencies: [run-audits]
     aggregate:
       from: "{{ run-audits.output }}"
-      into: .wave/output/merged-findings.json
+      into: .agents/output/merged-findings.json
       strategy: merge_arrays
 
   # ── Step 3: synthesise a unified markdown report ──────────────────────────
@@ -219,9 +219,9 @@ steps:
         recommendations that do not reference specific code.
     output_artifacts:
       - name: audit-report
-        path: .wave/output/parallel-audit-report.md
+        path: .agents/output/parallel-audit-report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/parallel-audit-report.md
+        source: .agents/output/parallel-audit-report.md

--- a/.agents/pipelines/ops-pr-fix-review.yaml
+++ b/.agents/pipelines/ops-pr-fix-review.yaml
@@ -27,12 +27,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 skills:
@@ -190,7 +190,7 @@ steps:
         impossible), or silently filters out findings it deems unimportant.
     output_artifacts:
       - name: review-findings
-        path: .wave/output/review-findings.json
+        path: .agents/output/review-findings.json
         type: json
     retry:
       policy: patient
@@ -198,8 +198,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/review-findings.json
-        schema_path: .wave/contracts/review-findings.schema.json
+        source: .agents/output/review-findings.json
+        schema_path: .agents/contracts/review-findings.schema.json
         on_failure: retry
 
   - id: triage
@@ -212,7 +212,7 @@ steps:
         - step: fetch-review
           artifact: review-findings
           as: raw_findings
-          schema_path: .wave/contracts/review-findings.schema.json
+          schema_path: .agents/contracts/review-findings.schema.json
     workspace:
       mount:
         - source: ./
@@ -248,7 +248,7 @@ steps:
         ### Step 1: Checkout the PR Branch
 
         ```bash
-        HEAD_BRANCH=$(cat .wave/artifacts/raw_findings | jq -r '.head_branch')  # reads the injected artifact
+        HEAD_BRANCH=$(cat .agents/artifacts/raw_findings | jq -r '.head_branch')  # reads the injected artifact
         git fetch origin "$HEAD_BRANCH"
         git checkout "$HEAD_BRANCH"
         ```
@@ -341,7 +341,7 @@ steps:
         areas.
     output_artifacts:
       - name: triage-verdict
-        path: .wave/output/triage-verdict.json
+        path: .agents/output/triage-verdict.json
         type: json
     retry:
       policy: patient
@@ -349,8 +349,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/triage-verdict.json
-        schema_path: .wave/contracts/triage-verdict.schema.json
+        source: .agents/output/triage-verdict.json
+        schema_path: .agents/contracts/triage-verdict.schema.json
         on_failure: retry
 
   - id: apply-fixes
@@ -401,7 +401,7 @@ steps:
         ### Step 1: Checkout the PR Branch
 
         ```bash
-        HEAD_BRANCH=$(cat .wave/artifacts/triage | jq -r '.head_branch')  # reads the injected artifact
+        HEAD_BRANCH=$(cat .agents/artifacts/triage | jq -r '.head_branch')  # reads the injected artifact
         git fetch origin "$HEAD_BRANCH"
         git checkout "$HEAD_BRANCH"
         ```
@@ -461,14 +461,14 @@ steps:
         ### Step 6: Commit and Push
 
         ```bash
-        # Stage only files you modified — NEVER .wave/, .claude/, or CLAUDE.md
+        # Stage only files you modified — NEVER .agents/, .claude/, or CLAUDE.md
         git diff --name-only
         git add $(git diff --name-only)
         git diff --cached --stat
 
         git commit -m "fix: address review findings
 
-        $(cat .wave/artifacts/triage | jq -r '.fixes[] | "- [\(.severity)] \(.summary)"' | head -10)"  # reads the injected artifact
+        $(cat .agents/artifacts/triage | jq -r '.fixes[] | "- [\(.severity)] \(.summary)"' | head -10)"  # reads the injected artifact
 
         git push origin "$HEAD_BRANCH"
         ```
@@ -485,7 +485,7 @@ steps:
           other issues, ignore them — they are out of scope.
         - Do NOT `git add -A`, `git add .`, or `git add --all`. Stage files by explicit
           path only.
-        - Do NOT stage Wave-internal directories (`.wave/`, `.claude/`) or `CLAUDE.md`.
+        - Do NOT stage Wave-internal directories (`.agents/`, `.claude/`) or `CLAUDE.md`.
         - Do NOT refactor, rename, or "improve" surrounding code. Minimal fixes only.
         - Do NOT apply rejected, deferred, or skipped findings. Only the `fixes` array.
         - If a fix has `confidence: "low"`, proceed with extra caution — double-check the
@@ -578,7 +578,7 @@ steps:
         - Do NOT use `git add -A`, `git add .`, or `git add --all`. Stage files by
           explicit path to avoid committing Wave-internal files.
         - Do NOT force push or rebase the branch. Add a new commit.
-        - Do NOT stage Wave-internal directories (`.wave/`, `.claude/`) or `CLAUDE.md`.
+        - Do NOT stage Wave-internal directories (`.agents/`, `.claude/`) or `CLAUDE.md`.
         - Do NOT introduce new features, refactors, or improvements. This is a pure
           correction step.
         - If the test failure appears unrelated to the previous fix (a flaky test or
@@ -661,8 +661,8 @@ steps:
         ### Step 1: Extract PR Metadata
 
         ```bash
-        PR_NUMBER=$(cat .wave/artifacts/raw_findings | jq -r '.pr_number')  # reads the injected artifact
-        REPO=$(cat .wave/artifacts/raw_findings | jq -r '.repo')
+        PR_NUMBER=$(cat .agents/artifacts/raw_findings | jq -r '.pr_number')  # reads the injected artifact
+        REPO=$(cat .agents/artifacts/raw_findings | jq -r '.repo')
         echo "PR: $REPO#$PR_NUMBER"
         ```
 
@@ -777,11 +777,11 @@ steps:
         post a wall of text that obscures the actual decisions made.
     output_artifacts:
       - name: resolution-summary
-        path: .wave/output/resolution-summary.json
+        path: .agents/output/resolution-summary.json
         type: json
     outcomes:
       - type: url
-        extract_from: .wave/output/resolution-summary.json
+        extract_from: .agents/output/resolution-summary.json
         json_path: .comment_url
         label: "Review Comment"
     retry:

--- a/.agents/pipelines/ops-pr-review-core.yaml
+++ b/.agents/pipelines/ops-pr-review-core.yaml
@@ -41,12 +41,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -144,7 +144,7 @@ steps:
         flat list without classification or misses test coverage gaps.
     output_artifacts:
       - name: diff
-        path: .wave/output/diff-analysis.json
+        path: .agents/output/diff-analysis.json
         type: json
     retry:
       policy: patient
@@ -152,8 +152,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/diff-analysis.json
-        schema_path: .wave/contracts/diff-analysis.schema.json
+        source: .agents/output/diff-analysis.json
+        schema_path: .agents/contracts/diff-analysis.schema.json
         on_failure: retry
 
   - id: security-review
@@ -260,12 +260,12 @@ steps:
         like hardcoded tokens in test fixtures.
     output_artifacts:
       - name: security
-        path: .wave/output/security-review.md
+        path: .agents/output/security-review.md
         type: markdown
     handover:
       contract:
         type: llm_judge
-        source: .wave/output/security-review.md
+        source: .agents/output/security-review.md
         model: cheapest
         criteria:
           - "Identifies injection vulnerabilities (SQL, command, XSS) if present in the diff"
@@ -379,14 +379,14 @@ steps:
         gap, or misses genuine error handling problems while fixating on variable naming.
     output_artifacts:
       - name: quality
-        path: .wave/output/quality-review.md
+        path: .agents/output/quality-review.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/quality-review-criteria.md
-        source: .wave/output/quality-review.md
+        criteria_path: .agents/contracts/quality-review-criteria.md
+        source: .agents/output/quality-review.md
         model: cheapest
         token_budget: 8000
         timeout: 90s
@@ -495,12 +495,12 @@ steps:
         understanding the project's development stage and conventions.
     output_artifacts:
       - name: slop
-        path: .wave/output/slop-review.md
+        path: .agents/output/slop-review.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/slop-review.md
+        source: .agents/output/slop-review.md
 
   - id: summary
     persona: summarizer
@@ -609,11 +609,11 @@ steps:
         to any PR.
     output_artifacts:
       - name: verdict
-        path: .wave/output/review-verdict.json
+        path: .agents/output/review-verdict.json
         type: json
     handover:
       contract:
         type: json_schema
-        source: .wave/output/review-verdict.json
-        schema_path: .wave/contracts/shared-review-verdict.schema.json
+        source: .agents/output/review-verdict.json
+        schema_path: .agents/contracts/shared-review-verdict.schema.json
         on_failure: skip

--- a/.agents/pipelines/ops-pr-review.yaml
+++ b/.agents/pipelines/ops-pr-review.yaml
@@ -43,12 +43,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -87,10 +87,10 @@ steps:
 
         The core-review step (ops-pr-review-core sub-pipeline) has completed and written
         two output files you must read:
-        - `.wave/output/review-verdict.json`: The structured review verdict JSON
+        - `.agents/output/review-verdict.json`: The structured review verdict JSON
           containing the overall verdict (APPROVE/REQUEST_CHANGES/COMMENT/REJECT),
           finding arrays by severity, and positive notes.
-        - `.wave/output/diff-analysis.json`: The diff analysis JSON containing PR
+        - `.agents/output/diff-analysis.json`: The diff analysis JSON containing PR
           metadata — especially the PR number needed for the comment command.
 
         Read BOTH files before composing the comment.
@@ -99,7 +99,7 @@ steps:
 
         ### Step 1: Extract PR Number
 
-        Read `.wave/output/diff-analysis.json` and extract the PR number from
+        Read `.agents/output/diff-analysis.json` and extract the PR number from
         `pr_metadata.number`. Parse the repository owner/name if needed for the
         comment command.
 
@@ -182,7 +182,7 @@ steps:
         includes raw JSON, or uses a hostile tone that discourages the author.
     output_artifacts:
       - name: publish-result
-        path: .wave/output/publish-result.json
+        path: .agents/output/publish-result.json
         type: json
     retry:
       policy: aggressive
@@ -190,12 +190,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/publish-result.json
-        schema_path: .wave/contracts/gh-pr-comment-result.schema.json
+        source: .agents/output/publish-result.json
+        schema_path: .agents/contracts/gh-pr-comment-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: url
-        extract_from: .wave/output/publish-result.json
+        extract_from: .agents/output/publish-result.json
         json_path: .comment_url
         label: "Review Comment"

--- a/.agents/pipelines/ops-refresh.yaml
+++ b/.agents/pipelines/ops-refresh.yaml
@@ -39,12 +39,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -174,7 +174,7 @@ steps:
         the input.
     output_artifacts:
       - name: issue_context
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     retry:
@@ -183,7 +183,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/issue-update-context.schema.json
+        schema_path: .agents/contracts/issue-update-context.schema.json
         validate: true
         must_pass: true
         on_failure: retry
@@ -308,7 +308,7 @@ steps:
         or leaves stale file references because it did not check the missing files list.
     output_artifacts:
       - name: update_draft
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     retry:
@@ -317,7 +317,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/issue-update-draft.schema.json
+        schema_path: .agents/contracts/issue-update-draft.schema.json
         validate: true
         must_pass: true
         on_failure: retry
@@ -443,12 +443,12 @@ steps:
         and reports success without confirming.
     output_artifacts:
       - name: update_result
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     outcomes:
       - type: issue
-        extract_from: .wave/artifact.json
+        extract_from: .agents/artifact.json
         json_path: .url
         label: "Updated Issue"
     retry:
@@ -457,7 +457,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/issue-update-result.schema.json
+        schema_path: .agents/contracts/issue-update-result.schema.json
         validate: true
         must_pass: true
         on_failure: retry

--- a/.agents/pipelines/ops-release-harden.yaml
+++ b/.agents/pipelines/ops-release-harden.yaml
@@ -37,12 +37,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:

--- a/.agents/pipelines/ops-rewrite.yaml
+++ b/.agents/pipelines/ops-rewrite.yaml
@@ -38,12 +38,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -191,7 +191,7 @@ steps:
         that are shorter than the originals.
     output_artifacts:
       - name: enhancement_plan
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     retry:
@@ -200,7 +200,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/enhancement-plan.schema.json
+        schema_path: .agents/contracts/enhancement-plan.schema.json
         validate: true
         must_pass: true
         on_failure: retry
@@ -325,12 +325,12 @@ steps:
         was actually truncated or corrupted.
     output_artifacts:
       - name: enhancement_results
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     outcomes:
       - type: issue
-        extract_from: .wave/artifact.json
+        extract_from: .agents/artifact.json
         json_path: .enhanced_issues[*].url
         label: "Enhanced Issue"
     retry:
@@ -339,7 +339,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/enhancement-results.schema.json
+        schema_path: .agents/contracts/enhancement-results.schema.json
         validate: true
         must_pass: true
         on_failure: retry

--- a/.agents/pipelines/ops-supervise.yaml
+++ b/.agents/pipelines/ops-supervise.yaml
@@ -30,12 +30,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -81,8 +81,8 @@ steps:
         Determine what to inspect based on the input format:
 
         - **Empty or "last pipeline run"**: Find the most recent pipeline run by scanning
-          `.wave/workspaces/` directory timestamps and recent git activity. Use
-          `ls -lt .wave/workspaces/` to find the latest run.
+          `.agents/workspaces/` directory timestamps and recent git activity. Use
+          `ls -lt .agents/workspaces/` to find the latest run.
         - **"current pr" or "PR #N"**: Inspect the current or specified pull request. Use
           `git log` and `{{ forge.cli_tool }} {{ forge.pr_command }} view` to get PR
           details, commits, and review state.
@@ -128,9 +128,9 @@ steps:
 
         ### Step 4: Collect Pipeline Artifacts
 
-        Scan `.wave/workspaces/` for the relevant pipeline run directory:
+        Scan `.agents/workspaces/` for the relevant pipeline run directory:
         ```bash
-        ls -la .wave/workspaces/
+        ls -la .agents/workspaces/
         ```
 
         For the relevant run, list all output artifacts and read their contents:
@@ -188,7 +188,7 @@ steps:
         output, or collects evidence from the wrong scope.
     output_artifacts:
       - name: evidence
-        path: .wave/output/supervision-evidence.json
+        path: .agents/output/supervision-evidence.json
         type: json
     retry:
       policy: patient
@@ -196,8 +196,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/supervision-evidence.json
-        schema_path: .wave/contracts/supervision-evidence.schema.json
+        source: .agents/output/supervision-evidence.json
+        schema_path: .agents/contracts/supervision-evidence.schema.json
         on_failure: retry
 
   - id: evaluate
@@ -352,7 +352,7 @@ steps:
         fine"), or rates process quality without transcript data.
     output_artifacts:
       - name: evaluation
-        path: .wave/output/supervision-evaluation.json
+        path: .agents/output/supervision-evaluation.json
         type: json
     retry:
       policy: patient
@@ -360,8 +360,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/supervision-evaluation.json
-        schema_path: .wave/contracts/supervision-evaluation.schema.json
+        source: .agents/output/supervision-evaluation.json
+        schema_path: .agents/contracts/supervision-evaluation.schema.json
         on_failure: retry
 
   - id: verdict
@@ -544,9 +544,9 @@ steps:
         rubber-stamps the evaluation.
     output_artifacts:
       - name: verdict
-        path: .wave/output/supervision-verdict.md
+        path: .agents/output/supervision-verdict.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/supervision-verdict.md
+        source: .agents/output/supervision-verdict.md

--- a/.agents/pipelines/plan-adr.yaml
+++ b/.agents/pipelines/plan-adr.yaml
@@ -32,12 +32,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -125,7 +125,7 @@ steps:
         or fabricates constraints not grounded in the codebase.
     output_artifacts:
       - name: context
-        path: .wave/output/adr-context.json
+        path: .agents/output/adr-context.json
         type: json
     retry:
       policy: patient
@@ -133,8 +133,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/adr-context.json
-        schema_path: .wave/contracts/adr-context.schema.json
+        source: .agents/output/adr-context.json
+        schema_path: .agents/contracts/adr-context.schema.json
         on_failure: retry
 
   - id: analyze-options
@@ -233,7 +233,7 @@ steps:
         a recommendation without addressing why alternatives were rejected.
     output_artifacts:
       - name: options
-        path: .wave/output/adr-options.json
+        path: .agents/output/adr-options.json
         type: json
     retry:
       policy: patient
@@ -241,8 +241,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/adr-options.json
-        schema_path: .wave/contracts/adr-options.schema.json
+        source: .agents/output/adr-options.json
+        schema_path: .agents/contracts/adr-options.schema.json
         on_failure: retry
 
   - id: draft-record
@@ -363,12 +363,12 @@ steps:
         pitch for the chosen option rather than a balanced evaluation.
     output_artifacts:
       - name: adr
-        path: .wave/output/adr.md
+        path: .agents/output/adr.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/adr.md
+        source: .agents/output/adr.md
 
   - id: publish
     persona: craftsman
@@ -419,7 +419,7 @@ steps:
            git push -u origin HEAD
            {{ forge.cli_tool }} {{ forge.pr_command }} create \
              --title "docs: ADR -- <decision topic>" \
-             --body-file .wave/artifacts/adr
+             --body-file .agents/artifacts/adr
            ```
         6. Capture the PR URL from the creation output.
         7. Produce the result JSON with fields:
@@ -451,7 +451,7 @@ steps:
         publish step has wrong numbering, missing PR, or commits extraneous files.
     output_artifacts:
       - name: pr-result
-        path: .wave/output/pr-result.json
+        path: .agents/output/pr-result.json
         type: json
     retry:
       policy: aggressive
@@ -459,12 +459,12 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/pr-result.json
-        schema_path: .wave/contracts/pr-result.schema.json
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
         must_pass: true
         on_failure: retry
     outcomes:
       - type: pr
-        extract_from: .wave/output/pr-result.json
+        extract_from: .agents/output/pr-result.json
         json_path: .pr_url
         label: "Pull Request"

--- a/.agents/pipelines/plan-approve-implement.yaml
+++ b/.agents/pipelines/plan-approve-implement.yaml
@@ -36,12 +36,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -121,7 +121,7 @@ steps:
         that a different engineer (not the plan author) could implement it faithfully.
     output_artifacts:
       - name: plan
-        path: .wave/output/plan.md
+        path: .agents/output/plan.md
         type: markdown
 
   - id: approve-plan

--- a/.agents/pipelines/plan-research.yaml
+++ b/.agents/pipelines/plan-research.yaml
@@ -40,12 +40,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -123,7 +123,7 @@ steps:
         or fabricates data that causes the research to address the wrong questions.
     output_artifacts:
       - name: issue-content
-        path: .wave/output/issue-content.json
+        path: .agents/output/issue-content.json
         type: json
     retry:
       policy: aggressive
@@ -131,8 +131,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/issue-content.json
-        schema_path: .wave/contracts/issue-content.schema.json
+        source: .agents/output/issue-content.json
+        schema_path: .agents/contracts/issue-content.schema.json
         on_failure: retry
 
   - id: analyze-topics
@@ -219,7 +219,7 @@ steps:
         redundant, or address questions already answered in the issue body.
     output_artifacts:
       - name: topics
-        path: .wave/output/research-topics.json
+        path: .agents/output/research-topics.json
         type: json
     retry:
       policy: patient
@@ -227,8 +227,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/research-topics.json
-        schema_path: .wave/contracts/research-topics.schema.json
+        source: .agents/output/research-topics.json
+        schema_path: .agents/contracts/research-topics.schema.json
         on_failure: retry
 
   - id: research-topics
@@ -325,7 +325,7 @@ steps:
         "inconclusive" without evidence of genuine search effort.
     output_artifacts:
       - name: findings
-        path: .wave/output/research-findings.json
+        path: .agents/output/research-findings.json
         type: json
     retry:
       policy: patient
@@ -333,8 +333,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/research-findings.json
-        schema_path: .wave/contracts/research-findings.schema.json
+        source: .agents/output/research-findings.json
+        schema_path: .agents/contracts/research-findings.schema.json
         on_failure: retry
 
   - id: synthesize-report
@@ -427,7 +427,7 @@ steps:
         without synthesis, makes unsupported recommendations, or is too long to read.
     output_artifacts:
       - name: report
-        path: .wave/output/research-report.json
+        path: .agents/output/research-report.json
         type: json
     retry:
       policy: standard
@@ -435,8 +435,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/research-report.json
-        schema_path: .wave/contracts/research-report.schema.json
+        source: .agents/output/research-report.json
+        schema_path: .agents/contracts/research-report.schema.json
         on_failure: retry
 
   - id: post-comment
@@ -528,11 +528,11 @@ steps:
         without recording the error.
     output_artifacts:
       - name: comment-result
-        path: .wave/output/comment-result.json
+        path: .agents/output/comment-result.json
         type: json
     outcomes:
       - type: url
-        extract_from: .wave/output/comment-result.json
+        extract_from: .agents/output/comment-result.json
         json_path: .comment.url
         label: "Research Comment"
     retry:
@@ -541,6 +541,6 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/comment-result.json
-        schema_path: .wave/contracts/comment-result.schema.json
+        source: .agents/output/comment-result.json
+        schema_path: .agents/contracts/comment-result.schema.json
         on_failure: retry

--- a/.agents/pipelines/plan-scope.yaml
+++ b/.agents/pipelines/plan-scope.yaml
@@ -39,12 +39,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -116,7 +116,7 @@ steps:
           be split into multiple epics first.
 
         OUTPUT FORMAT:
-        Write the assessment as structured JSON to .wave/artifact.json matching the
+        Write the assessment as structured JSON to .agents/artifact.json matching the
         epic-assessment schema. Include: epic (number, title, url, body_summary),
         is_epic (boolean), themes (array), planned_sub_issues (array with tentative
         titles, complexity, dependencies, overlap), existing_issues (array of potentially
@@ -131,7 +131,7 @@ steps:
         themes, or ignores existing issues that cover the same ground.
     output_artifacts:
       - name: epic_assessment
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     retry:
@@ -140,7 +140,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/epic-assessment.schema.json
+        schema_path: .agents/contracts/epic-assessment.schema.json
         validate: true
         must_pass: true
         on_failure: retry
@@ -225,7 +225,7 @@ steps:
           continue with remaining issues. Do not abort the entire step.
 
         OUTPUT FORMAT:
-        Write the results as structured JSON to .wave/artifact.json with:
+        Write the results as structured JSON to .agents/artifact.json with:
         - parent_issue: object with number, url, and repository
         - created_issues: array of objects, each with number, title, url, labels (array),
           success (boolean), complexity (S/M/L), dependencies (array of issue numbers)
@@ -244,12 +244,12 @@ steps:
         scope creep.
     output_artifacts:
       - name: scope_plan
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     outcomes:
       - type: issue
-        extract_from: .wave/artifact.json
+        extract_from: .agents/artifact.json
         json_path: .created_issues[*].url
         label: "First Sub-Issue"
     retry:
@@ -258,7 +258,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/scope-plan.schema.json
+        schema_path: .agents/contracts/scope-plan.schema.json
         validate: true
         must_pass: true
         on_failure: retry
@@ -335,7 +335,7 @@ steps:
         - Do NOT modify the markdown_summary to hide failures. Report accurately.
 
         OUTPUT FORMAT:
-        Write the verification report as structured JSON to .wave/artifact.json with:
+        Write the verification report as structured JSON to .agents/artifact.json with:
         - parent_issue: object with number (integer) and url (string)
         - verified_issues: array of objects, each with:
           - number: integer
@@ -360,7 +360,7 @@ steps:
         summary that does not match the actual verification results.
     output_artifacts:
       - name: scope_report
-        path: .wave/artifact.json
+        path: .agents/artifact.json
         type: json
         required: true
     retry:
@@ -369,7 +369,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        schema_path: .wave/contracts/scope-report.schema.json
+        schema_path: .agents/contracts/scope-report.schema.json
         validate: true
         must_pass: true
         on_failure: retry

--- a/.agents/pipelines/plan-task.yaml
+++ b/.agents/pipelines/plan-task.yaml
@@ -32,12 +32,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -134,7 +134,7 @@ steps:
         fabricates file paths the planner will reference in tasks that turn out to be wrong.
     output_artifacts:
       - name: exploration
-        path: .wave/output/exploration.json
+        path: .agents/output/exploration.json
         type: json
     retry:
       policy: patient
@@ -142,8 +142,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/exploration.json
-        schema_path: .wave/contracts/plan-exploration.schema.json
+        source: .agents/output/exploration.json
+        schema_path: .agents/contracts/plan-exploration.schema.json
         on_failure: retry
 
   - id: breakdown
@@ -244,7 +244,7 @@ steps:
         parallel execution was possible.
     output_artifacts:
       - name: tasks
-        path: .wave/output/tasks.json
+        path: .agents/output/tasks.json
         type: json
     retry:
       policy: standard
@@ -252,8 +252,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/tasks.json
-        schema_path: .wave/contracts/plan-tasks.schema.json
+        source: .agents/output/tasks.json
+        schema_path: .agents/contracts/plan-tasks.schema.json
         on_failure: retry
 
   - id: review
@@ -373,7 +373,7 @@ steps:
         everything or nitpicks trivially while missing structural problems.
     output_artifacts:
       - name: review
-        path: .wave/output/plan-review.json
+        path: .agents/output/plan-review.json
         type: json
     retry:
       policy: standard
@@ -381,6 +381,6 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/plan-review.json
-        schema_path: .wave/contracts/plan-review.schema.json
+        source: .agents/output/plan-review.json
+        schema_path: .agents/contracts/plan-review.schema.json
         on_failure: retry

--- a/.agents/pipelines/test-gen.yaml
+++ b/.agents/pipelines/test-gen.yaml
@@ -30,12 +30,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -138,7 +138,7 @@ steps:
         A good coverage analysis identifies specific functions and specific branches that need testing, maps the dependencies that must be mocked, and suggests concrete test cases for each gap. A developer receiving this analysis should know exactly what tests to write. A bad analysis reports only package-level percentages without identifying which functions need tests, or suggests vague "add more tests" without specifying what to test.
     output_artifacts:
       - name: coverage
-        path: .wave/output/coverage-analysis.json
+        path: .agents/output/coverage-analysis.json
         type: json
     retry:
       policy: patient
@@ -146,8 +146,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/coverage-analysis.json
-        schema_path: .wave/contracts/coverage-analysis.schema.json
+        source: .agents/output/coverage-analysis.json
+        schema_path: .agents/contracts/coverage-analysis.schema.json
         on_failure: retry
 
   - id: generate-tests
@@ -283,7 +283,7 @@ steps:
         on_failure: retry
     output_artifacts:
       - name: tests
-        path: .wave/output/generated-tests.md
+        path: .agents/output/generated-tests.md
         type: markdown
 
   - id: run-tests
@@ -390,9 +390,9 @@ steps:
         A good verification report honestly assesses whether the generated tests add real value. It distinguishes between coverage improvement (more lines executed) and quality improvement (more bugs would be caught). It identifies tests that should be strengthened and gaps that remain. A bad verification report treats any coverage increase as success without examining whether the tests actually verify behavior.
     output_artifacts:
       - name: verification
-        path: .wave/output/coverage-verification.md
+        path: .agents/output/coverage-verification.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/coverage-verification.md
+        source: .agents/output/coverage-verification.md

--- a/.agents/pipelines/wave-audit.yaml
+++ b/.agents/pipelines/wave-audit.yaml
@@ -41,12 +41,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -153,7 +153,7 @@ steps:
         criteria extraction.
     output_artifacts:
       - name: inventory
-        path: .wave/output/inventory.json
+        path: .agents/output/inventory.json
         type: json
     retry:
       policy: patient
@@ -161,8 +161,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/inventory.json
-        schema_path: .wave/contracts/audit-inventory.schema.json
+        source: .agents/output/inventory.json
+        schema_path: .agents/contracts/audit-inventory.schema.json
         on_failure: retry
 
   - id: audit-items
@@ -271,7 +271,7 @@ steps:
         gut feeling without reading code or checking git history.
     output_artifacts:
       - name: findings
-        path: .wave/output/audit-findings.json
+        path: .agents/output/audit-findings.json
         type: json
     retry:
       policy: patient
@@ -279,8 +279,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/audit-findings.json
-        schema_path: .wave/contracts/audit-findings.schema.json
+        source: .agents/output/audit-findings.json
+        schema_path: .agents/contracts/audit-findings.schema.json
         on_failure: retry
 
   - id: compose-triage
@@ -377,7 +377,7 @@ steps:
         grouping, or creates actions for items that need no remediation.
     output_artifacts:
       - name: triage-report
-        path: .wave/output/triage-report.json
+        path: .agents/output/triage-report.json
         type: json
     retry:
       policy: standard
@@ -385,8 +385,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/triage-report.json
-        schema_path: .wave/contracts/audit-triage-report.schema.json
+        source: .agents/output/triage-report.json
+        schema_path: .agents/contracts/audit-triage-report.schema.json
         on_failure: retry
 
   - id: publish
@@ -501,7 +501,7 @@ steps:
         errors.
     output_artifacts:
       - name: publish-result
-        path: .wave/output/publish-result.json
+        path: .agents/output/publish-result.json
         type: json
     retry:
       policy: aggressive
@@ -509,11 +509,11 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/publish-result.json
-        schema_path: .wave/contracts/audit-publish-result.schema.json
+        source: .agents/output/publish-result.json
+        schema_path: .agents/contracts/audit-publish-result.schema.json
         on_failure: retry
     outcomes:
       - type: issue
-        extract_from: .wave/output/publish-result.json
+        extract_from: .agents/output/publish-result.json
         json_path: .issues_created[].url
         label: "Audit Remediation Issue"

--- a/.agents/pipelines/wave-bugfix.yaml
+++ b/.agents/pipelines/wave-bugfix.yaml
@@ -32,7 +32,7 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -113,7 +113,7 @@ steps:
 
         OUTPUT FORMAT:
         Write the findings as structured JSON conforming to
-        .wave/contracts/bug-investigation.schema.json. Required fields: root_cause,
+        .agents/contracts/bug-investigation.schema.json. Required fields: root_cause,
         affected_files, fix_approach. Include these additional fields for richer
         analysis: bug_summary (string), root_cause as object (with file, function,
         line_range, condition, and explanation), execution_path (array of function
@@ -131,7 +131,7 @@ steps:
         similar patterns that need the same fix.
     output_artifacts:
       - name: findings
-        path: .wave/output/findings.json
+        path: .agents/output/findings.json
         type: json
     retry:
       policy: patient
@@ -139,8 +139,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/findings.json
-        schema_path: .wave/contracts/bug-investigation.schema.json
+        source: .agents/output/findings.json
+        schema_path: .agents/contracts/bug-investigation.schema.json
         on_failure: retry
 
   - id: fix

--- a/.agents/pipelines/wave-evolve.yaml
+++ b/.agents/pipelines/wave-evolve.yaml
@@ -37,12 +37,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -73,11 +73,11 @@ steps:
         CONTEXT:
         You are the first step in a three-step self-evolution pipeline (analyze, evolve,
         verify). Your analysis will be consumed by a craftsman persona who will apply
-        the highest-impact improvements. Only .wave/ files will be modified -- Go source
+        the highest-impact improvements. Only .agents/ files will be modified -- Go source
         code is out of scope. You have read-only access to the full project.
 
         REQUIREMENTS:
-        1. Analyze pipeline YAML files (`.wave/pipelines/`):
+        1. Analyze pipeline YAML files (`.agents/pipelines/`):
            - Read each pipeline file. For each step with a prompt, evaluate:
              - Clarity: Is the prompt unambiguous? Could an LLM misinterpret any instruction?
              - Structure: Does the prompt follow the Objective/Context/Requirements/
@@ -91,24 +91,24 @@ steps:
              for implementation)
            - Check artifact handoffs: does every step that consumes an artifact have it
              properly declared in memory.inject_artifacts?
-        2. Analyze persona definitions (`.wave/personas/`):
+        2. Analyze persona definitions (`.agents/personas/`):
            - Read each persona file. Evaluate:
              - Role clarity: Is the role description specific enough to guide behavior?
              - Permission scope: Do deny/allow rules match the persona's actual needs?
                (e.g., a navigator should not have Bash write permissions)
              - Constraints: Are behavioral constraints specific enough to prevent drift
                into other personas' responsibilities?
-        3. Analyze prompt templates (`.wave/prompts/` if present):
+        3. Analyze prompt templates (`.agents/prompts/` if present):
            - Are instructions structured for LLM comprehension (numbered lists, clear
              sections, explicit constraints)?
            - Do templates include concrete examples where helpful?
            - Are output format requirements explicit (field names, types, structure)?
-        4. Analyze contract schemas (`.wave/contracts/`):
+        4. Analyze contract schemas (`.agents/contracts/`):
            - For each schema, check: do required fields match what the step prompt asks
              the agent to produce? Are there required fields that agents consistently
              struggle to populate? Are there optional fields that should be required?
            - Cross-reference with actual step prompts to find mismatches.
-        5. Analyze execution patterns if traces are available (`.wave/traces/`):
+        5. Analyze execution patterns if traces are available (`.agents/traces/`):
            - Which steps retry most often? What causes the retries (contract failure,
              timeout, error)?
            - Which contracts fail most? Is it a schema mismatch or agent output quality?
@@ -122,7 +122,7 @@ steps:
              improvements first)
 
         CONSTRAINTS AND ANTI-PATTERNS:
-        - Do NOT suggest changes to Go source code. This pipeline modifies only .wave/ files.
+        - Do NOT suggest changes to Go source code. This pipeline modifies only .agents/ files.
         - Do NOT suggest changes you cannot verify. Every finding must reference a specific
           file path and the specific issue observed.
         - Do NOT produce generic improvement advice ("improve prompts"). Every improvement
@@ -146,7 +146,7 @@ steps:
         high-risk changes to working pipelines.
     output_artifacts:
       - name: evolution-analysis
-        path: .wave/output/evolution-analysis.json
+        path: .agents/output/evolution-analysis.json
         type: json
     retry:
       policy: patient
@@ -154,8 +154,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/evolution-analysis.json
-        schema_path: .wave/contracts/improvement-assessment.schema.json
+        source: .agents/output/evolution-analysis.json
+        schema_path: .agents/contracts/improvement-assessment.schema.json
         on_failure: retry
 
   - id: evolve
@@ -178,7 +178,7 @@ steps:
         OBJECTIVE:
         Apply the highest-impact improvements identified in the analysis to Wave's pipeline
         infrastructure files. Each change must be validated before proceeding to the next.
-        Only .wave/ files are in scope.
+        Only .agents/ files are in scope.
 
         CONTEXT:
         You are the second step in the self-evolution pipeline. The analysis artifact
@@ -214,8 +214,8 @@ steps:
            runs.
 
         CONSTRAINTS AND ANTI-PATTERNS:
-        - IMPORTANT: Only modify files under `.wave/` -- pipelines, personas, prompts, and
-          contracts. Do NOT modify Go source code, test files, or any file outside .wave/.
+        - IMPORTANT: Only modify files under `.agents/` -- pipelines, personas, prompts, and
+          contracts. Do NOT modify Go source code, test files, or any file outside .agents/.
         - Do NOT apply high-risk improvements regardless of their impact. The verify step
           cannot catch all regressions from risky changes.
         - Do NOT batch changes. Apply one, validate, then proceed to the next.
@@ -227,7 +227,7 @@ steps:
           revert and skip that improvement.
 
         OUTPUT FORMAT:
-        The output is the modified .wave/ files. The handover contract validates by running
+        The output is the modified .agents/ files. The handover contract validates by running
         `wave validate`. No explicit artifact is produced beyond the file changes and the
         validation passing.
 
@@ -239,7 +239,7 @@ steps:
         Go source code outside the scope.
     output_artifacts:
       - name: evolution-log
-        path: .wave/output/evolution-log.json
+        path: .agents/output/evolution-log.json
         type: json
     retry:
       policy: standard
@@ -275,7 +275,7 @@ steps:
         You are the third and final step in the self-evolution pipeline. The analysis
         artifact (injected as "original_findings") contains the prioritized list of
         improvements that the evolve step was instructed to apply. The evolve step has
-        already modified .wave/ files. Your job is to verify correctness, not to make
+        already modified .agents/ files. Your job is to verify correctness, not to make
         additional changes. You have read-only access to the codebase.
 
         REQUIREMENTS:
@@ -287,7 +287,7 @@ steps:
            c. Record status: applied (change matches), skipped (file unchanged, which
               is expected for high-risk items), or divergent (change was made but does
               not match the described improvement)
-        3. Validate all modified .wave/ files:
+        3. Validate all modified .agents/ files:
            a. YAML files: verify they parse as valid YAML. Check that template variables
               are properly formatted ({{ variable }} with spaces inside braces).
            b. JSON schema files: verify they parse as valid JSON. Check that required
@@ -295,14 +295,14 @@ steps:
            c. Persona files: verify role, description, and permission fields are present.
         4. Check for unintended modifications:
            a. Run `git diff --name-only` to see all changed files
-           b. Confirm ALL changed files are under .wave/. If any Go source files, test
-              files, or files outside .wave/ were modified, flag this as a critical issue.
+           b. Confirm ALL changed files are under .agents/. If any Go source files, test
+              files, or files outside .agents/ were modified, flag this as a critical issue.
         5. Run `wave validate` to verify the overall configuration integrity.
         6. Produce the verification report as markdown with:
            - Summary: how many improvements applied, skipped, divergent
            - Per-improvement details: status, target file, what was verified
            - Validation results: YAML parsing, JSON parsing, wave validate output
-           - Unintended changes: any files modified outside .wave/ (should be none)
+           - Unintended changes: any files modified outside .agents/ (should be none)
            - Overall verdict: PASS (all validations succeed, no unintended changes) or
              FAIL (any validation failure or unintended change)
 
@@ -327,14 +327,14 @@ steps:
         for out-of-scope modifications.
     output_artifacts:
       - name: verification
-        path: .wave/output/verification.md
+        path: .agents/output/verification.md
         type: markdown
     handover:
       contract:
         type: agent_review
         persona: navigator
-        criteria_path: .wave/contracts/verification-criteria.md
-        source: .wave/output/verification.md
+        criteria_path: .agents/contracts/verification-criteria.md
+        source: .agents/output/verification.md
         model: cheapest
         token_budget: 8000
         timeout: 90s

--- a/.agents/pipelines/wave-land.yaml
+++ b/.agents/pipelines/wave-land.yaml
@@ -38,12 +38,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -118,8 +118,8 @@ steps:
         - NEVER use `git add -A` or `git add .`. Stage specific files only.
         - NEVER include Co-Authored-By lines in commit messages.
         - NEVER include AI attribution in commit messages.
-        - NEVER stage .wave/ or .claude/ directories.
-          Run `git reset HEAD -- .wave/ .claude/` if any
+        - NEVER stage .agents/ or .claude/ directories.
+          Run `git reset HEAD -- .agents/ .claude/` if any
           are accidentally staged.
         - Do NOT create more than 5 commits for a single feature. If changes are
           numerous, group more aggressively rather than creating a long commit chain.
@@ -144,7 +144,7 @@ steps:
       ref: commit
     output_artifacts:
       - name: ship-result
-        path: .wave/output/ship-result.json
+        path: .agents/output/ship-result.json
         type: json
     exec:
       type: prompt
@@ -218,7 +218,7 @@ steps:
           needed for diagnosing the failure.
 
         OUTPUT FORMAT:
-        After creating the PR, write a JSON file to .wave/output/ship-result.json with
+        After creating the PR, write a JSON file to .agents/output/ship-result.json with
         the PR URL and number:
         ```json
         { "pr_url": "<full PR URL>", "pr_number": <number>, "merged": true }

--- a/.agents/pipelines/wave-orchestrate.yaml
+++ b/.agents/pipelines/wave-orchestrate.yaml
@@ -30,31 +30,31 @@ hooks:
   - name: log-orchestration
     event: run_start
     type: command
-    command: "echo '[wave-orchestrate] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[wave-orchestrate] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
   - id: discover
     type: command
     script: |
-      mkdir -p .wave/output
-      echo "# Available Pipelines" > .wave/output/pipeline-catalog.md
-      echo "" >> .wave/output/pipeline-catalog.md
-      for f in .wave/pipelines/*.yaml; do
+      mkdir -p .agents/output
+      echo "# Available Pipelines" > .agents/output/pipeline-catalog.md
+      echo "" >> .agents/output/pipeline-catalog.md
+      for f in .agents/pipelines/*.yaml; do
         name=$(basename "$f" .yaml)
         # Skip smoke tests, validation, and stress test pipelines
         case "$name" in wave-smoke-*|wave-test-*|wave-validate*|wave-stress*|wave-ontology*) continue;; esac
         desc=$(grep -A3 'description:' "$f" 2>/dev/null | head -4 | sed 's/.*description: *>-\?//' | sed 's/^ *//' | tr '\n' ' ' | head -c 120)
-        echo "- **$name**: $desc" >> .wave/output/pipeline-catalog.md
+        echo "- **$name**: $desc" >> .agents/output/pipeline-catalog.md
       done
     output_artifacts:
       - name: catalog
-        path: .wave/output/pipeline-catalog.md
+        path: .agents/output/pipeline-catalog.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/pipeline-catalog.md
+        source: .agents/output/pipeline-catalog.md
         on_failure: fail
 
   - id: classify
@@ -79,7 +79,7 @@ steps:
 
         ## Available Pipelines
 
-        Read the pipeline catalog at `project/.wave/output/pipeline-catalog.md` to see
+        Read the pipeline catalog at `project/.agents/output/pipeline-catalog.md` to see
         all available pipelines with their descriptions. Pick the one that best matches
         the input task.
 
@@ -100,7 +100,7 @@ steps:
            (e.g. "audit-dead-code-scan", NOT "Code Audit Pipeline"). Copy the bold
            name from the catalog exactly as written. Any other value will fail.
 
-        5. Write ONLY valid JSON to `.wave/output/classification.json`:
+        5. Write ONLY valid JSON to `.agents/output/classification.json`:
            ```json
            {
              "domain": "<domain>",
@@ -119,7 +119,7 @@ steps:
         - The pipeline field MUST exactly match a name from the catalog.
     output_artifacts:
       - name: classification
-        path: .wave/output/classification.json
+        path: .agents/output/classification.json
         type: json
     retry:
       policy: patient
@@ -127,7 +127,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/classification.json
+        source: .agents/output/classification.json
         schema: |
           {
             "type": "object",
@@ -149,9 +149,9 @@ steps:
       # Find the classification artifact — check workspace artifact path, then project root
       CLASS_FILE=""
       for candidate in \
-        .wave/workspaces/{{ pipeline_id }}/classify/.wave/output/classification.json \
-        .wave/workspaces/{{ pipeline_id }}/classify/.wave/artifacts/classify/classification.json \
-        .wave/output/classification.json; do
+        .agents/workspaces/{{ pipeline_id }}/classify/.agents/output/classification.json \
+        .agents/workspaces/{{ pipeline_id }}/classify/.agents/artifacts/classify/classification.json \
+        .agents/output/classification.json; do
         if [ -f "$candidate" ]; then
           CLASS_FILE="$candidate"
           break
@@ -169,10 +169,10 @@ steps:
         exit 1
       fi
       # Validate pipeline exists on disk
-      if [ ! -f ".wave/pipelines/${PIPELINE}.yaml" ]; then
+      if [ ! -f ".agents/pipelines/${PIPELINE}.yaml" ]; then
         echo "ERROR: classified pipeline '$PIPELINE' not found"
         echo "Available pipelines:"
-        ls .wave/pipelines/*.yaml | sed 's|.wave/pipelines/||;s|\.yaml||' | head -20
+        ls .agents/pipelines/*.yaml | sed 's|.agents/pipelines/||;s|\.yaml||' | head -20
         exit 1
       fi
       echo "Orchestrating: pipeline=$PIPELINE"

--- a/.agents/pipelines/wave-review.yaml
+++ b/.agents/pipelines/wave-review.yaml
@@ -39,12 +39,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -163,7 +163,7 @@ steps:
         misses the actual issues.
     output_artifacts:
       - name: review
-        path: .wave/output/review.md
+        path: .agents/output/review.md
         type: markdown
     retry:
       policy: standard
@@ -171,5 +171,5 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/review.md
+        source: .agents/output/review.md
         on_failure: retry

--- a/.agents/pipelines/wave-scope-audit.yaml
+++ b/.agents/pipelines/wave-scope-audit.yaml
@@ -55,12 +55,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[wave-scope-audit] started run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[wave-scope-audit] started run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-step
     event: step_completed
     type: command
-    command: "echo '[wave-scope-audit] step=$WAVE_HOOK_STEP_ID completed' >> .wave/output/hook-log.txt"
+    command: "echo '[wave-scope-audit] step=$WAVE_HOOK_STEP_ID completed' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -83,7 +83,7 @@ steps:
     dependencies: [run-audits]
     aggregate:
       from: "{{ run-audits.output }}"
-      into: .wave/output/merged-findings.json
+      into: .agents/output/merged-findings.json
       strategy: merge_arrays
 
   # ── Phase 3: Synthesize unified report + scope document ─────────────────
@@ -136,10 +136,10 @@ steps:
            - Package health matrix: for every package under internal/, classify as:
              active (used, tested, maintained), dead (no references, should be removed),
              or partial (partially used or poorly tested).
-           - Pipeline fleet assessment: for every pipeline in .wave/pipelines/, classify as:
+           - Pipeline fleet assessment: for every pipeline in .agents/pipelines/, classify as:
              core (essential for daily use), useful (valuable but not critical), or
              remove (dead, redundant, or broken).
-           - Persona fleet assessment: for every persona in .wave/personas/, classify as:
+           - Persona fleet assessment: for every persona in .agents/personas/, classify as:
              essential (used by core pipelines), specialized (used by specific workflows),
              or remove (unused or redundant).
            - Recommended consolidation actions: ordered list of specific actions to reduce
@@ -185,10 +185,10 @@ steps:
         Run-ID: {{ run.id }}
     output_artifacts:
       - name: audit-report
-        path: .wave/output/audit-synthesis.md
+        path: .agents/output/audit-synthesis.md
         type: markdown
       - name: wave-scope
-        path: .wave/output/wave-scope.md
+        path: .agents/output/wave-scope.md
         type: markdown
     retry:
       policy: patient
@@ -196,7 +196,7 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/wave-scope.md
+        source: .agents/output/wave-scope.md
         on_failure: retry
 
   # ── Phase 4: Human gate — approve scope before issue creation ───────────
@@ -316,10 +316,10 @@ steps:
         duplicates existing issues from previous runs.
     output_artifacts:
       - name: created-issues
-        path: .wave/output/created-issues.md
+        path: .agents/output/created-issues.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/created-issues.md
+        source: .agents/output/created-issues.md
         on_failure: skip

--- a/.agents/pipelines/wave-security-audit.yaml
+++ b/.agents/pipelines/wave-security-audit.yaml
@@ -37,12 +37,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -153,7 +153,7 @@ steps:
         categories without mapping them to actual code paths in the project.
     output_artifacts:
       - name: threat-model
-        path: .wave/output/threat-model.json
+        path: .agents/output/threat-model.json
         type: json
     retry:
       policy: patient
@@ -161,8 +161,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/threat-model.json
-        schema_path: .wave/contracts/security-scan.schema.json
+        source: .agents/output/threat-model.json
+        schema_path: .agents/contracts/security-scan.schema.json
         on_failure: retry
 
   - id: verify
@@ -269,9 +269,9 @@ steps:
         dismisses threats without reading the actual code paths.
     output_artifacts:
       - name: security-report
-        path: .wave/output/security-report.md
+        path: .agents/output/security-report.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/security-report.md
+        source: .agents/output/security-report.md

--- a/.agents/pipelines/wave-smoke-classify.yaml
+++ b/.agents/pipelines/wave-smoke-classify.yaml
@@ -20,37 +20,37 @@ steps:
   - id: classify
     type: command
     script: |
-      mkdir -p .wave/output
-      go test ./internal/classify/... -v -count=1 > .wave/output/classify-results.txt 2>&1
-      echo "exit_code=$?" >> .wave/output/classify-results.txt
+      mkdir -p .agents/output
+      go test ./internal/classify/... -v -count=1 > .agents/output/classify-results.txt 2>&1
+      echo "exit_code=$?" >> .agents/output/classify-results.txt
     output_artifacts:
       - name: classify-results
-        path: .wave/output/classify-results.txt
+        path: .agents/output/classify-results.txt
         type: text
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/classify-results.txt
+        source: .agents/output/classify-results.txt
         on_failure: fail
 
   - id: verify
     type: command
     dependencies: [classify]
     script: |
-      mkdir -p .wave/output
-      if grep -q "FAIL" .wave/output/classify-results.txt; then
-        echo '{"status":"fail","reason":"FAIL found in test output"}' > .wave/output/verify.json
-      elif grep -q "PASS" .wave/output/classify-results.txt; then
-        echo '{"status":"pass","reason":"All tests passed"}' > .wave/output/verify.json
+      mkdir -p .agents/output
+      if grep -q "FAIL" .agents/output/classify-results.txt; then
+        echo '{"status":"fail","reason":"FAIL found in test output"}' > .agents/output/verify.json
+      elif grep -q "PASS" .agents/output/classify-results.txt; then
+        echo '{"status":"pass","reason":"All tests passed"}' > .agents/output/verify.json
       else
-        echo '{"status":"fail","reason":"No PASS found in test output"}' > .wave/output/verify.json
+        echo '{"status":"fail","reason":"No PASS found in test output"}' > .agents/output/verify.json
       fi
     output_artifacts:
       - name: verify
-        path: .wave/output/verify.json
+        path: .agents/output/verify.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/verify.json
+        source: .agents/output/verify.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-contracts.yaml
+++ b/.agents/pipelines/wave-smoke-contracts.yaml
@@ -20,17 +20,17 @@ steps:
   - id: setup
     type: command
     script: |
-      mkdir -p .wave/output
-      echo '{"valid": true}' > .wave/output/test-data.json
-      echo '{"type":"object","properties":{"valid":{"type":"boolean"}},"required":["valid"]}' > .wave/output/test-schema.json
+      mkdir -p .agents/output
+      echo '{"valid": true}' > .agents/output/test-data.json
+      echo '{"type":"object","properties":{"valid":{"type":"boolean"}},"required":["valid"]}' > .agents/output/test-schema.json
     output_artifacts:
       - name: test-data
-        path: .wave/output/test-data.json
+        path: .agents/output/test-data.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/test-data.json
+        source: .agents/output/test-data.json
         on_failure: fail
 
   - id: validate
@@ -40,16 +40,16 @@ steps:
     exec:
       type: prompt
       source: |
-        Read `.wave/output/test-data.json` and `.wave/output/test-schema.json`.
+        Read `.agents/output/test-data.json` and `.agents/output/test-schema.json`.
         Verify both exist and contain valid JSON. Write confirmation to
-        `.wave/output/contract-check.json`:
+        `.agents/output/contract-check.json`:
         {"data_valid": true, "schema_valid": true, "checked_at": "<timestamp>"}
     output_artifacts:
       - name: contract-check
-        path: .wave/output/contract-check.json
+        path: .agents/output/contract-check.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/contract-check.json
+        source: .agents/output/contract-check.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-gates.yaml
+++ b/.agents/pipelines/wave-smoke-gates.yaml
@@ -15,18 +15,18 @@ steps:
   - id: prepare
     type: command
     script: |
-      mkdir -p .wave/output
+      mkdir -p .agents/output
       echo '{"gate_test": "pending", "created_at": "'$(date -Iseconds)'"}' \
-        > .wave/output/gate-marker.json
+        > .agents/output/gate-marker.json
       echo "Gate marker written"
     output_artifacts:
       - name: gate-marker
-        path: .wave/output/gate-marker.json
+        path: .agents/output/gate-marker.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/gate-marker.json
+        source: .agents/output/gate-marker.json
         on_failure: fail
 
   - id: approval-gate
@@ -40,19 +40,19 @@ steps:
     type: command
     dependencies: [approval-gate]
     script: |
-      if [ ! -f .wave/output/gate-marker.json ]; then
+      if [ ! -f .agents/output/gate-marker.json ]; then
         echo "FAIL: gate-marker.json missing"
         exit 1
       fi
       echo '{"gate_test": "passed", "verified_at": "'$(date -Iseconds)'"}' \
-        > .wave/output/gate-result.json
+        > .agents/output/gate-result.json
       echo "Gate smoke test passed"
     output_artifacts:
       - name: gate-result
-        path: .wave/output/gate-result.json
+        path: .agents/output/gate-result.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/gate-result.json
+        source: .agents/output/gate-result.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-git-forensics.yaml
+++ b/.agents/pipelines/wave-smoke-git-forensics.yaml
@@ -19,49 +19,49 @@ steps:
   - id: forensics
     type: command
     script: |
-      mkdir -p .wave/output
-      echo "=== CHURN ===" > .wave/output/forensics.txt
-      git log --format=format: --name-only --since="1 year ago" | sort | uniq -c | sort -nr | head -10 >> .wave/output/forensics.txt 2>&1
-      echo "" >> .wave/output/forensics.txt
-      echo "=== BUG HOTSPOTS ===" >> .wave/output/forensics.txt
-      git log -i -E --grep="fix|bug|broken" --name-only --format='' | sort | uniq -c | sort -nr | head -10 >> .wave/output/forensics.txt 2>&1
-      echo "" >> .wave/output/forensics.txt
-      echo "=== BUS FACTOR ===" >> .wave/output/forensics.txt
-      git shortlog -sn --no-merges | head -10 >> .wave/output/forensics.txt 2>&1
-      echo "" >> .wave/output/forensics.txt
-      echo "=== MOMENTUM ===" >> .wave/output/forensics.txt
-      git log --format='%ad' --date=format:'%Y-%m' | sort | uniq -c | tail -6 >> .wave/output/forensics.txt 2>&1
-      echo "" >> .wave/output/forensics.txt
-      echo "=== FIREFIGHTING ===" >> .wave/output/forensics.txt
-      git log --oneline --since="1 year ago" | grep -iE 'revert|hotfix|emergency|rollback' | head -10 >> .wave/output/forensics.txt 2>&1 || echo "none found" >> .wave/output/forensics.txt
+      mkdir -p .agents/output
+      echo "=== CHURN ===" > .agents/output/forensics.txt
+      git log --format=format: --name-only --since="1 year ago" | sort | uniq -c | sort -nr | head -10 >> .agents/output/forensics.txt 2>&1
+      echo "" >> .agents/output/forensics.txt
+      echo "=== BUG HOTSPOTS ===" >> .agents/output/forensics.txt
+      git log -i -E --grep="fix|bug|broken" --name-only --format='' | sort | uniq -c | sort -nr | head -10 >> .agents/output/forensics.txt 2>&1
+      echo "" >> .agents/output/forensics.txt
+      echo "=== BUS FACTOR ===" >> .agents/output/forensics.txt
+      git shortlog -sn --no-merges | head -10 >> .agents/output/forensics.txt 2>&1
+      echo "" >> .agents/output/forensics.txt
+      echo "=== MOMENTUM ===" >> .agents/output/forensics.txt
+      git log --format='%ad' --date=format:'%Y-%m' | sort | uniq -c | tail -6 >> .agents/output/forensics.txt 2>&1
+      echo "" >> .agents/output/forensics.txt
+      echo "=== FIREFIGHTING ===" >> .agents/output/forensics.txt
+      git log --oneline --since="1 year ago" | grep -iE 'revert|hotfix|emergency|rollback' | head -10 >> .agents/output/forensics.txt 2>&1 || echo "none found" >> .agents/output/forensics.txt
     output_artifacts:
       - name: forensics
-        path: .wave/output/forensics.txt
+        path: .agents/output/forensics.txt
         type: text
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/forensics.txt
+        source: .agents/output/forensics.txt
         on_failure: fail
 
   - id: verify
     type: command
     dependencies: [forensics]
     script: |
-      mkdir -p .wave/output
-      SECTIONS=$(grep -c "^===" .wave/output/forensics.txt)
-      LINES=$(wc -l < .wave/output/forensics.txt)
+      mkdir -p .agents/output
+      SECTIONS=$(grep -c "^===" .agents/output/forensics.txt)
+      LINES=$(wc -l < .agents/output/forensics.txt)
       if [ "$SECTIONS" -ge 5 ] && [ "$LINES" -gt 10 ]; then
-        echo "{\"status\":\"pass\",\"sections\":$SECTIONS,\"lines\":$LINES}" > .wave/output/forensics-verify.json
+        echo "{\"status\":\"pass\",\"sections\":$SECTIONS,\"lines\":$LINES}" > .agents/output/forensics-verify.json
       else
-        echo "{\"status\":\"fail\",\"sections\":$SECTIONS,\"lines\":$LINES}" > .wave/output/forensics-verify.json
+        echo "{\"status\":\"fail\",\"sections\":$SECTIONS,\"lines\":$LINES}" > .agents/output/forensics-verify.json
       fi
     output_artifacts:
       - name: verify
-        path: .wave/output/forensics-verify.json
+        path: .agents/output/forensics-verify.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/forensics-verify.json
+        source: .agents/output/forensics-verify.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-hooks.yaml
+++ b/.agents/pipelines/wave-smoke-hooks.yaml
@@ -19,46 +19,46 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "mkdir -p .wave/output && echo 'HOOK_START' >> .wave/output/hook-log.txt"
+    command: "mkdir -p .agents/output && echo 'HOOK_START' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo 'HOOK_COMPLETE' >> .wave/output/hook-log.txt"
+    command: "echo 'HOOK_COMPLETE' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
   - id: work
     type: command
     script: |
-      mkdir -p .wave/output
-      echo '{"step":"work","status":"done"}' > .wave/output/work.json
+      mkdir -p .agents/output
+      echo '{"step":"work","status":"done"}' > .agents/output/work.json
     output_artifacts:
       - name: work
-        path: .wave/output/work.json
+        path: .agents/output/work.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/work.json
+        source: .agents/output/work.json
         on_failure: fail
 
   - id: verify-hooks
     type: command
     dependencies: [work]
     script: |
-      mkdir -p .wave/output
-      if grep -q "HOOK_START" .wave/output/hook-log.txt 2>/dev/null; then
-        echo '{"status":"pass","hook_start":true}' > .wave/output/hooks-verify.json
+      mkdir -p .agents/output
+      if grep -q "HOOK_START" .agents/output/hook-log.txt 2>/dev/null; then
+        echo '{"status":"pass","hook_start":true}' > .agents/output/hooks-verify.json
       else
-        echo '{"status":"fail","error":"HOOK_START not found"}' > .wave/output/hooks-verify.json
+        echo '{"status":"fail","error":"HOOK_START not found"}' > .agents/output/hooks-verify.json
       fi
     output_artifacts:
       - name: hooks-verify
-        path: .wave/output/hooks-verify.json
+        path: .agents/output/hooks-verify.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/hooks-verify.json
+        source: .agents/output/hooks-verify.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-llm-judge.yaml
+++ b/.agents/pipelines/wave-smoke-llm-judge.yaml
@@ -22,8 +22,8 @@ steps:
   - id: create-artifact
     type: command
     script: |
-      mkdir -p .wave/output
-      cat > .wave/output/sample-code.md << 'CONTENT'
+      mkdir -p .agents/output
+      cat > .agents/output/sample-code.md << 'CONTENT'
       # Authentication Module — auth.go
 
       ```go
@@ -60,12 +60,12 @@ steps:
       CONTENT
     output_artifacts:
       - name: sample-code
-        path: .wave/output/sample-code.md
+        path: .agents/output/sample-code.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/sample-code.md
+        source: .agents/output/sample-code.md
         on_failure: fail
 
   - id: review
@@ -80,9 +80,9 @@ steps:
     exec:
       type: prompt
       source: |
-        Read the code sample at `project/.wave/output/sample-code.md`.
+        Read the code sample at `project/.agents/output/sample-code.md`.
 
-        Write a structured security review to `.wave/output/judge-output.md` with:
+        Write a structured security review to `.agents/output/judge-output.md` with:
         1. A **Summary** section (2-3 sentences)
         2. A **Findings** section with numbered items, each having severity (Critical/High/Medium/Low/Info)
         3. A **Recommendations** section with actionable fixes
@@ -90,12 +90,12 @@ steps:
         Focus on: authentication flaws, token handling, rate limiting gaps.
     output_artifacts:
       - name: judge-output
-        path: .wave/output/judge-output.md
+        path: .agents/output/judge-output.md
         type: markdown
     handover:
       contract:
         type: llm_judge
-        source: .wave/output/judge-output.md
+        source: .agents/output/judge-output.md
         model: cheapest
         criteria:
           - "Output contains a structured security review with clearly labeled findings"

--- a/.agents/pipelines/wave-smoke-mount.yaml
+++ b/.agents/pipelines/wave-smoke-mount.yaml
@@ -30,14 +30,14 @@ steps:
         Check if the directory `project/` exists and contains files.
         Run: ls project/ | head -10
         Verify AGENTS.md and wave.yaml are present.
-        Write result to `.wave/output/mount-check.json`:
+        Write result to `.agents/output/mount-check.json`:
         {"status":"pass","agents_md":true,"wave_yaml":true,"file_count":N}
     output_artifacts:
       - name: mount-check
-        path: .wave/output/mount-check.json
+        path: .agents/output/mount-check.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/mount-check.json
+        source: .agents/output/mount-check.json
         on_failure: fail

--- a/.agents/pipelines/wave-smoke-test.yaml
+++ b/.agents/pipelines/wave-smoke-test.yaml
@@ -28,12 +28,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -97,7 +97,7 @@ steps:
         - Do NOT exceed 20 findings. This is a smoke test, not an exhaustive audit.
 
         OUTPUT FORMAT:
-        Write your JSON output to the artifact path `.wave/output/analysis.json`.
+        Write your JSON output to the artifact path `.agents/output/analysis.json`.
         Produce the JSON report as a single valid JSON object (not an array, not wrapped
         in anything). It will be validated against the wave-smoke-test contract schema.
 
@@ -108,7 +108,7 @@ steps:
         array that would not exercise the summarize step meaningfully.
     output_artifacts:
       - name: analysis
-        path: .wave/output/analysis.json
+        path: .agents/output/analysis.json
         type: json
     retry:
       policy: patient
@@ -116,8 +116,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/analysis.json
-        schema_path: .wave/contracts/wave-smoke-test.schema.json
+        source: .agents/output/analysis.json
+        schema_path: .agents/contracts/wave-smoke-test.schema.json
         on_failure: retry
 
   - id: summarize
@@ -185,10 +185,10 @@ steps:
         written without reading the artifact at all.
     output_artifacts:
       - name: summary
-        path: .wave/output/summary.md
+        path: .agents/output/summary.md
         type: markdown
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/summary.md
+        source: .agents/output/summary.md
         on_failure: retry

--- a/.agents/pipelines/wave-smoke-watchdog.yaml
+++ b/.agents/pipelines/wave-smoke-watchdog.yaml
@@ -20,37 +20,37 @@ steps:
   - id: test-watchdog
     type: command
     script: |
-      mkdir -p .wave/output
-      go test ./internal/pipeline/ -v -run "Stall|Watchdog|Progress" > .wave/output/watchdog-results.txt 2>&1
-      echo "exit_code=$?" >> .wave/output/watchdog-results.txt
+      mkdir -p .agents/output
+      go test ./internal/pipeline/ -v -run "Stall|Watchdog|Progress" > .agents/output/watchdog-results.txt 2>&1
+      echo "exit_code=$?" >> .agents/output/watchdog-results.txt
     output_artifacts:
       - name: watchdog-results
-        path: .wave/output/watchdog-results.txt
+        path: .agents/output/watchdog-results.txt
         type: text
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/watchdog-results.txt
+        source: .agents/output/watchdog-results.txt
         on_failure: fail
 
   - id: verify
     type: command
     dependencies: [test-watchdog]
     script: |
-      mkdir -p .wave/output
-      if grep -q "FAIL" .wave/output/watchdog-results.txt; then
-        echo '{"status":"fail","reason":"FAIL found in watchdog test output"}' > .wave/output/watchdog-verify.json
-      elif grep -q "PASS" .wave/output/watchdog-results.txt; then
-        echo '{"status":"pass","reason":"All watchdog tests passed"}' > .wave/output/watchdog-verify.json
+      mkdir -p .agents/output
+      if grep -q "FAIL" .agents/output/watchdog-results.txt; then
+        echo '{"status":"fail","reason":"FAIL found in watchdog test output"}' > .agents/output/watchdog-verify.json
+      elif grep -q "PASS" .agents/output/watchdog-results.txt; then
+        echo '{"status":"pass","reason":"All watchdog tests passed"}' > .agents/output/watchdog-verify.json
       else
-        echo '{"status":"fail","reason":"No PASS found in watchdog test output"}' > .wave/output/watchdog-verify.json
+        echo '{"status":"fail","reason":"No PASS found in watchdog test output"}' > .agents/output/watchdog-verify.json
       fi
     output_artifacts:
       - name: verify
-        path: .wave/output/watchdog-verify.json
+        path: .agents/output/watchdog-verify.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/watchdog-verify.json
+        source: .agents/output/watchdog-verify.json
         on_failure: fail

--- a/.agents/pipelines/wave-stress-test.yaml
+++ b/.agents/pipelines/wave-stress-test.yaml
@@ -29,21 +29,21 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
   - id: succeed
     type: command
-    script: "echo 'hello' > .wave/output/hello.txt && echo 'Step succeeded'"
+    script: "echo 'hello' > .agents/output/hello.txt && echo 'Step succeeded'"
     output_artifacts:
       - name: hello
-        path: .wave/output/hello.txt
+        path: .agents/output/hello.txt
         type: text
     edges:
       - target: deliberate-fail

--- a/.agents/pipelines/wave-test-forge.yaml
+++ b/.agents/pipelines/wave-test-forge.yaml
@@ -31,12 +31,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[wave-test-forge] started run={{ pipeline_id }} forge={{ forge.type }}' >> .wave/output/hook-log.txt"
+    command: "echo '[wave-test-forge] started run={{ pipeline_id }} forge={{ forge.type }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-step
     event: step_completed
     type: command
-    command: "echo '[wave-test-forge] step=$WAVE_HOOK_STEP_ID completed' >> .wave/output/hook-log.txt"
+    command: "echo '[wave-test-forge] step=$WAVE_HOOK_STEP_ID completed' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -128,12 +128,12 @@ steps:
         detected forge type and actual remote URL.
     output_artifacts:
       - name: forge-detect
-        path: .wave/output/forge-detect.json
+        path: .agents/output/forge-detect.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/forge-detect.json
+        source: .agents/output/forge-detect.json
         on_failure: retry
     edges:
       - target: verify-cli
@@ -144,25 +144,25 @@ steps:
     script: |
       CLI="{{ forge.cli_tool }}"
       if [ -z "$CLI" ]; then
-        echo '{"cli":"none","status":"skipped","reason":"no forge CLI (local mode)"}' > .wave/output/cli-check.json
+        echo '{"cli":"none","status":"skipped","reason":"no forge CLI (local mode)"}' > .agents/output/cli-check.json
         exit 0
       fi
       if command -v "$CLI" > /dev/null 2>&1; then
         VERSION=$($CLI --version 2>&1 | head -1)
-        echo "{\"cli\":\"$CLI\",\"status\":\"found\",\"version\":\"$VERSION\"}" > .wave/output/cli-check.json
+        echo "{\"cli\":\"$CLI\",\"status\":\"found\",\"version\":\"$VERSION\"}" > .agents/output/cli-check.json
       else
-        echo "{\"cli\":\"$CLI\",\"status\":\"not_found\",\"error\":\"$CLI binary not in PATH\"}" > .wave/output/cli-check.json
+        echo "{\"cli\":\"$CLI\",\"status\":\"not_found\",\"error\":\"$CLI binary not in PATH\"}" > .agents/output/cli-check.json
         exit 1
       fi
     dependencies: [detect-forge]
     output_artifacts:
       - name: cli-check
-        path: .wave/output/cli-check.json
+        path: .agents/output/cli-check.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/cli-check.json
+        source: .agents/output/cli-check.json
         on_failure: skip
     edges:
       - target: verify-auth
@@ -175,55 +175,55 @@ steps:
       case "$FORGE" in
         github)
           if gh auth status 2>&1 | grep -q "Logged in"; then
-            echo '{"forge":"github","auth":"ok"}' > .wave/output/auth-check.json
+            echo '{"forge":"github","auth":"ok"}' > .agents/output/auth-check.json
           else
-            echo '{"forge":"github","auth":"failed","error":"gh auth status failed"}' > .wave/output/auth-check.json
+            echo '{"forge":"github","auth":"failed","error":"gh auth status failed"}' > .agents/output/auth-check.json
           fi
           ;;
         gitlab)
           if [ -n "$GITLAB_TOKEN" ]; then
-            echo '{"forge":"gitlab","auth":"ok","method":"env_token"}' > .wave/output/auth-check.json
+            echo '{"forge":"gitlab","auth":"ok","method":"env_token"}' > .agents/output/auth-check.json
           else
-            echo '{"forge":"gitlab","auth":"failed","error":"GITLAB_TOKEN not set"}' > .wave/output/auth-check.json
+            echo '{"forge":"gitlab","auth":"failed","error":"GITLAB_TOKEN not set"}' > .agents/output/auth-check.json
           fi
           ;;
         gitea|forgejo)
           if [ -n "$GITEA_TOKEN" ]; then
-            echo '{"forge":"gitea","auth":"ok","method":"env_token"}' > .wave/output/auth-check.json
+            echo '{"forge":"gitea","auth":"ok","method":"env_token"}' > .agents/output/auth-check.json
           else
-            echo '{"forge":"gitea","auth":"failed","error":"GITEA_TOKEN not set"}' > .wave/output/auth-check.json
+            echo '{"forge":"gitea","auth":"failed","error":"GITEA_TOKEN not set"}' > .agents/output/auth-check.json
           fi
           ;;
         codeberg)
           if [ -n "$CODEBERG_TOKEN" ] || [ -n "$GITEA_TOKEN" ]; then
-            echo '{"forge":"codeberg","auth":"ok","method":"env_token"}' > .wave/output/auth-check.json
+            echo '{"forge":"codeberg","auth":"ok","method":"env_token"}' > .agents/output/auth-check.json
           else
-            echo '{"forge":"codeberg","auth":"failed","error":"CODEBERG_TOKEN not set"}' > .wave/output/auth-check.json
+            echo '{"forge":"codeberg","auth":"failed","error":"CODEBERG_TOKEN not set"}' > .agents/output/auth-check.json
           fi
           ;;
         bitbucket)
           if [ -n "$BITBUCKET_TOKEN" ]; then
-            echo '{"forge":"bitbucket","auth":"ok","method":"env_token"}' > .wave/output/auth-check.json
+            echo '{"forge":"bitbucket","auth":"ok","method":"env_token"}' > .agents/output/auth-check.json
           else
-            echo '{"forge":"bitbucket","auth":"failed","error":"BITBUCKET_TOKEN not set"}' > .wave/output/auth-check.json
+            echo '{"forge":"bitbucket","auth":"failed","error":"BITBUCKET_TOKEN not set"}' > .agents/output/auth-check.json
           fi
           ;;
         local)
-          echo '{"forge":"local","auth":"skipped","reason":"no forge in local mode"}' > .wave/output/auth-check.json
+          echo '{"forge":"local","auth":"skipped","reason":"no forge in local mode"}' > .agents/output/auth-check.json
           ;;
         *)
-          echo "{\"forge\":\"$FORGE\",\"auth\":\"unknown\"}" > .wave/output/auth-check.json
+          echo "{\"forge\":\"$FORGE\",\"auth\":\"unknown\"}" > .agents/output/auth-check.json
           ;;
       esac
     dependencies: [verify-cli]
     output_artifacts:
       - name: auth-check
-        path: .wave/output/auth-check.json
+        path: .agents/output/auth-check.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/auth-check.json
+        source: .agents/output/auth-check.json
         on_failure: skip
     edges:
       - target: test-api
@@ -238,7 +238,7 @@ steps:
       CLI="{{ forge.cli_tool }}"
       FORGE="{{ forge.type }}"
       if [ -z "$CLI" ] || [ "$FORGE" = "local" ]; then
-        echo '{"api":"skipped","reason":"no forge CLI"}' > .wave/output/api-check.json
+        echo '{"api":"skipped","reason":"no forge CLI"}' > .agents/output/api-check.json
         exit 0
       fi
 
@@ -256,15 +256,15 @@ steps:
           ISSUES="bitbucket-cli-not-standard" && STATUS="skipped"
           ;;
       esac
-      echo "{\"forge\":\"$FORGE\",\"api\":\"$STATUS\",\"sample\":\"$(echo $ISSUES | head -c 200)\"}" > .wave/output/api-check.json
+      echo "{\"forge\":\"$FORGE\",\"api\":\"$STATUS\",\"sample\":\"$(echo $ISSUES | head -c 200)\"}" > .agents/output/api-check.json
     output_artifacts:
       - name: api-check
-        path: .wave/output/api-check.json
+        path: .agents/output/api-check.json
         type: json
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/api-check.json
+        source: .agents/output/api-check.json
         on_failure: skip
 
   # Step 5: Synthesize results — LLM reviews all checks
@@ -360,10 +360,10 @@ steps:
         reports FAIL when checks were legitimately skipped.
     output_artifacts:
       - name: forge-report
-        path: .wave/output/forge-report.md
+        path: .agents/output/forge-report.md
         type: markdown
       - name: forge-report-json
-        path: .wave/output/forge-report.json
+        path: .agents/output/forge-report.json
         type: json
     retry:
       policy: standard
@@ -371,5 +371,5 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/forge-report.json
+        source: .agents/output/forge-report.json
         on_failure: retry

--- a/.agents/pipelines/wave-test-hardening.yaml
+++ b/.agents/pipelines/wave-test-hardening.yaml
@@ -35,12 +35,12 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] started run={{ pipeline_id }} input={{ input }}' >> .agents/output/hook-log.txt"
     blocking: false
   - name: log-complete
     event: run_completed
     type: command
-    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .wave/output/hook-log.txt"
+    command: "echo '[{{ pipeline_name }}] completed run={{ pipeline_id }}' >> .agents/output/hook-log.txt"
     blocking: false
 
 steps:
@@ -146,7 +146,7 @@ steps:
         while missing critical gaps in the pipeline executor.
     output_artifacts:
       - name: coverage-analysis
-        path: .wave/output/coverage-analysis.json
+        path: .agents/output/coverage-analysis.json
         type: json
     retry:
       policy: patient
@@ -154,8 +154,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/coverage-analysis.json
-        schema_path: .wave/contracts/improvement-assessment.schema.json
+        source: .agents/output/coverage-analysis.json
+        schema_path: .agents/contracts/improvement-assessment.schema.json
         on_failure: retry
 
   - id: harden

--- a/.agents/pipelines/wave-validate.yaml
+++ b/.agents/pipelines/wave-validate.yaml
@@ -31,13 +31,13 @@ hooks:
   - name: log-start
     event: run_start
     type: command
-    command: "echo 'wave-validate started at $(date)' >> .wave/output/hook-log.txt"
+    command: "echo 'wave-validate started at $(date)' >> .agents/output/hook-log.txt"
     blocking: false
 
   - name: log-step
     event: step_completed
     type: command
-    command: "echo 'step completed: $WAVE_HOOK_STEP_ID' >> .wave/output/hook-log.txt"
+    command: "echo 'step completed: $WAVE_HOOK_STEP_ID' >> .agents/output/hook-log.txt"
     blocking: false
 
 pipeline_outputs:
@@ -85,12 +85,12 @@ steps:
            - Verify at least one adapter is configured
            - Record: adapter_count (integer), adapter_names (array of strings)
         3. Check persona definitions:
-           - Look for persona files in .wave/personas/ directory
+           - Look for persona files in .agents/personas/ directory
            - Verify at least one persona is defined
            - For each persona, check that it has required fields (role, description)
            - Record: persona_count (integer), persona_names (array of strings)
         4. Check pipeline files:
-           - List all .yaml files in .wave/pipelines/
+           - List all .yaml files in .agents/pipelines/
            - Verify at least one pipeline file exists
            - For a sample of pipeline files (first 5), verify they parse as valid YAML
              and contain required fields (kind, metadata.name, steps)
@@ -140,7 +140,7 @@ steps:
         parse correctly.
     output_artifacts:
       - name: config-check
-        path: .wave/output/config-check.json
+        path: .agents/output/config-check.json
         type: json
     retry:
       policy: patient
@@ -148,8 +148,8 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .wave/output/config-check.json
-        schema_path: .wave/contracts/config-check.schema.json
+        source: .agents/output/config-check.json
+        schema_path: .agents/contracts/config-check.schema.json
         on_failure: retry
     edges:
       - target: sub-pipeline-test
@@ -234,7 +234,7 @@ steps:
         A bad diagnosis says "something went wrong" without specifics.
     output_artifacts:
       - name: diagnosis
-        path: .wave/output/diagnosis.md
+        path: .agents/output/diagnosis.md
         type: markdown
     retry:
       policy: patient
@@ -242,7 +242,7 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .wave/output/diagnosis.md
+        source: .agents/output/diagnosis.md
         on_failure: retry
     edges:
       - target: approval-gate
@@ -370,12 +370,12 @@ steps:
         | Feature | Status | Evidence | Notes |
         |---------|--------|----------|-------|
         | Model routing | VERIFIED | This step executing proves cheapest model routing works | — |
-        | Sub-pipeline composition | VERIFIED | ops-hello-world artifacts present in .wave/output/ | — |
+        | Sub-pipeline composition | VERIFIED | ops-hello-world artifacts present in .agents/output/ | — |
         | Command steps | VERIFIED | run-tests step completed, pipeline reached this step | — |
         | Conditional edges | VERIFIED | test-gate routed to approval-gate (success path) | — |
         | Thread continuity | UNTESTED | Failure path not taken, diagnose-failure did not execute | Expected when tests pass |
         | Retry policies | VERIFIED | check-config used patient policy, completed without retry | — |
-        | Lifecycle hooks | VERIFIED | .wave/output/hook-log.txt exists with entries | — |
+        | Lifecycle hooks | VERIFIED | .agents/output/hook-log.txt exists with entries | — |
         | LLM-as-judge | VERIFIED | This report is being evaluated by llm_judge contract | — |
 
         ## Recommendations
@@ -383,7 +383,7 @@ steps:
         ```
     output_artifacts:
       - name: report
-        path: .wave/output/validation-report.md
+        path: .agents/output/validation-report.md
         type: markdown
     retry:
       policy: standard
@@ -391,7 +391,7 @@ steps:
     handover:
       contract:
         type: llm_judge
-        source: .wave/output/validation-report.md
+        source: .agents/output/validation-report.md
         model: cheapest
         criteria:
           - "Report covers all 8 feature categories"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1292,7 +1292,7 @@ wave skills add ./my-skill --project
 
 ### skills doctor
 
-Diagnose discovery issues: duplicate names across roots, malformed frontmatter, deprecated `.wave/skills/` references.
+Diagnose discovery issues: duplicate names across roots, malformed frontmatter, deprecated `.agents/skills/` references.
 
 ```bash
 wave skills doctor


### PR DESCRIPTION
## Problem

PR #1136 renamed the project config dir \`.wave/\` → \`.agents/\` but missed inline path strings inside pipeline YAML (\`schema_path\`, \`path:\`, hook commands, embedded bash heredocs), contract criteria, a docs example, and the \`schema_path\` field on contract blocks across ~80 files.

User-visible symptom: ops-hello-world (and every pipeline with json_schema contracts) failed:

\`\`\`
contract validation failed [json_schema]: failed to read schema file: .wave/contracts/smoke-review.schema.json
  open .wave/contracts/smoke-review.schema.json: no such file or directory
\`\`\`

## Fix

Bulk \`sed\` replacement of \`.wave/\` → \`.agents/\` across \`*.yaml\`, \`*.yml\`, \`*.json\`, \`*.go\`, \`*.md\` under:
- \`.agents/pipelines/\`
- \`.agents/contracts/\`
- \`internal/\`
- \`cmd/\`
- \`docs/\`

Excluded \`.agents/output/\` (historical artifacts/logs, not re-read).

Preserved two intentional \`.wave/\` mentions in \`cmd/wave/commands/skills.go\` — \`wave skills doctor\` detects a leftover \`.wave/skills/\` dir and reports a migration hint. Tests updated accordingly.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] Preserved doctor-deprecated-detection behavior (TestSkillsDoctorDeprecated passes with \`.wave/skills/\` fixture)