### PR TITLE
docs: ADR -- unified in-memory caching layer

### DIFF
--- a/.agents/pipelines/audit-architecture.yaml
+++ b/.agents/pipelines/audit-architecture.yaml
@@ -13,6 +13,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the architecture of the pipeline package"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-closed.yaml
+++ b/.agents/pipelines/audit-closed.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "last 30 days -- audit recent closed work"
   schema:
     type: string
@@ -38,6 +39,7 @@ pipeline_outputs:
   report:
     step: triage
     artifact: triage-report
+    type: findings_report
 
 steps:
   - id: inventory

--- a/.agents/pipelines/audit-consolidate.yaml
+++ b/.agents/pipelines/audit-consolidate.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline — check for redundant patterns"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-correctness.yaml
+++ b/.agents/pipelines/audit-correctness.yaml
@@ -13,6 +13,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit correctness of the authentication module implementation"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-coverage.yaml
+++ b/.agents/pipelines/audit-coverage.yaml
@@ -13,6 +13,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit requirements coverage for the authentication feature"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-dead-code-issue.yaml
+++ b/.agents/pipelines/audit-dead-code-issue.yaml
@@ -19,6 +19,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "scan all packages for dead code and report findings"
 
 chat_context:
@@ -37,6 +38,7 @@ pipeline_outputs:
   findings:
     step: create-issue
     artifact: issue-result
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-dead-code-review.yaml
+++ b/.agents/pipelines/audit-dead-code-review.yaml
@@ -17,6 +17,7 @@ skills:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/re-cinq/wave/pull/42"
 
 chat_context:
@@ -35,6 +36,7 @@ pipeline_outputs:
   report:
     step: publish
     artifact: publish-result
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-dead-code-scan.yaml
+++ b/.agents/pipelines/audit-dead-code-scan.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "internal/"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-dead-code.yaml
+++ b/.agents/pipelines/audit-dead-code.yaml
@@ -16,6 +16,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "find and remove dead code in internal/pipeline"
 
 chat_context:
@@ -35,9 +36,11 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: findings_report
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-doc-scan.yaml
+++ b/.agents/pipelines/audit-doc-scan.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "docs/"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-doc.yaml
+++ b/.agents/pipelines/audit-doc.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "full -- scan all documentation for inconsistencies with the codebase"
   schema:
     type: string
@@ -35,6 +36,7 @@ pipeline_outputs:
   findings:
     step: publish
     artifact: issue-result
+    type: findings_report
 
 steps:
   - id: scan-changes

--- a/.agents/pipelines/audit-dual.yaml
+++ b/.agents/pipelines/audit-dual.yaml
@@ -30,6 +30,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "analyze the authentication module"
 
 chat_context:
@@ -47,6 +48,7 @@ pipeline_outputs:
   report:
     step: merge
     artifact: report
+    type: findings_report
 
 steps:
   # ── Track A: Code Quality ──────────────────────────────────────────

--- a/.agents/pipelines/audit-duplicates.yaml
+++ b/.agents/pipelines/audit-duplicates.yaml
@@ -13,6 +13,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "internal/"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-dx.yaml
+++ b/.agents/pipelines/audit-dx.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the contributor onboarding experience"
   schema:
     type: string
@@ -35,9 +36,11 @@ pipeline_outputs:
   findings:
     step: audit
     artifact: findings
+    type: findings_report
   report:
     step: audit
     artifact: report
+    type: findings_report
 
 steps:
   - id: audit

--- a/.agents/pipelines/audit-junk-code.yaml
+++ b/.agents/pipelines/audit-junk-code.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/ — find accidental complexity and dead weight"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-quality-loop.yaml
+++ b/.agents/pipelines/audit-quality-loop.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "last pipeline run"
   schema:
     type: string

--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the authentication module for vulnerabilities"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-tests.yaml
+++ b/.agents/pipelines/audit-tests.yaml
@@ -12,6 +12,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit test quality for the pipeline package"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-unwired.yaml
+++ b/.agents/pipelines/audit-unwired.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "internal/"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/audit-ux.yaml
+++ b/.agents/pipelines/audit-ux.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the CLI onboarding flow for new users"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: audit
     artifact: findings
+    type: findings_report
 
 steps:
   - id: audit

--- a/.agents/pipelines/bench-solve.yaml
+++ b/.agents/pipelines/bench-solve.yaml
@@ -10,6 +10,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   schema:
     type: string
     description: "Problem statement describing the bug or feature to implement"
@@ -28,6 +29,7 @@ pipeline_outputs:
   solution:
     step: solve
     artifact: solve
+    type: findings_report
 
 steps:
   - id: solve

--- a/.agents/pipelines/doc-changelog.yaml
+++ b/.agents/pipelines/doc-changelog.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "generate changelog from v0.1.0 to HEAD"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   changelog:
     step: format
     artifact: changelog
+    type: findings_report
 
 steps:
   - id: analyze-commits

--- a/.agents/pipelines/doc-explain.yaml
+++ b/.agents/pipelines/doc-explain.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "explain the pipeline execution system and how steps are scheduled"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   explanation:
     step: document
     artifact: explanation
+    type: findings_report
 
 steps:
   - id: explore

--- a/.agents/pipelines/doc-fix.yaml
+++ b/.agents/pipelines/doc-fix.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "sync docs with current implementation"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: findings_report
 
 steps:
   - id: scan-changes

--- a/.agents/pipelines/doc-onboard.yaml
+++ b/.agents/pipelines/doc-onboard.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "create an onboarding guide for this project"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   guide:
     step: guide
     artifact: guide
+    type: findings_report
 
 steps:
   - id: survey

--- a/.agents/pipelines/full-impl-cycle.yaml
+++ b/.agents/pipelines/full-impl-cycle.yaml
@@ -22,6 +22,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   schema:
     type: string
     description: "GitHub repository and issue number"
@@ -49,6 +50,7 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: pr_ref
 
 steps:
   # ─── Phase 1: Implementation ───────────────────────────────────────────

--- a/.agents/pipelines/impl-feature.yaml
+++ b/.agents/pipelines/impl-feature.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "add a --dry-run flag to the run command"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: explore

--- a/.agents/pipelines/impl-hotfix.yaml
+++ b/.agents/pipelines/impl-hotfix.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "fix panic in pipeline executor when step has nil context"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   verdict:
     step: verify
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: investigate

--- a/.agents/pipelines/impl-improve.yaml
+++ b/.agents/pipelines/impl-improve.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "improve error handling in internal/pipeline"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   result:
     step: verify
     artifact: verification
+    type: findings_report
 
 steps:
   - id: assess

--- a/.agents/pipelines/impl-issue-core.yaml
+++ b/.agents/pipelines/impl-issue-core.yaml
@@ -23,9 +23,11 @@ pipeline_outputs:
   assessment:
     step: fetch-assess
     artifact: assessment
+    type: findings_report
   plan:
     step: plan
     artifact: impl-plan
+    type: pr_ref
 
 skills:
   - "{{ project.skill }}"
@@ -38,6 +40,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   schema:
     type: string
     description: "GitHub repository and issue number"

--- a/.agents/pipelines/impl-issue.yaml
+++ b/.agents/pipelines/impl-issue.yaml
@@ -34,15 +34,17 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   schema:
     type: string
-    description: "GitHub repository and issue number"
+    description: "GitHub repository and issue number (accepts typed issue_ref or 'owner/repo number' text)"
   example: "re-cinq/wave 42"
 
 pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: fetch-assess

--- a/.agents/pipelines/impl-prototype.yaml
+++ b/.agents/pipelines/impl-prototype.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "build a REST API for user management with CRUD operations"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   pr:
     step: pr-create
     artifact: pr-info
+    type: pr_ref
 
 steps:
   # Phase 1: Spec - Requirements capture with speckit integration

--- a/.agents/pipelines/impl-recinq.yaml
+++ b/.agents/pipelines/impl-recinq.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline"
 
 chat_context:
@@ -42,6 +43,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: gather

--- a/.agents/pipelines/impl-refactor.yaml
+++ b/.agents/pipelines/impl-refactor.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "extract workspace manager from executor into its own package"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   result:
     step: verify
     artifact: verification
+    type: findings_report
 
 steps:
   - id: analyze

--- a/.agents/pipelines/impl-research.yaml
+++ b/.agents/pipelines/impl-research.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   verdict:
     step: review
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: research

--- a/.agents/pipelines/impl-review-loop.yaml
+++ b/.agents/pipelines/impl-review-loop.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/owner/repo/issues/42"
 
 chat_context:

--- a/.agents/pipelines/impl-smart-route.yaml
+++ b/.agents/pipelines/impl-smart-route.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/owner/repo/issues/42"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   assessment:
     step: assess
     artifact: assessment
+    type: findings_report
 
 steps:
   - id: assess

--- a/.agents/pipelines/impl-speckit.yaml
+++ b/.agents/pipelines/impl-speckit.yaml
@@ -44,6 +44,7 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: specify

--- a/.agents/pipelines/impl-speckit.yaml
+++ b/.agents/pipelines/impl-speckit.yaml
@@ -22,6 +22,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "add user authentication with JWT tokens"
   schema:
     type: string

--- a/.agents/pipelines/ops-bootstrap.yaml
+++ b/.agents/pipelines/ops-bootstrap.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   schema:
     type: string
     description: "Project description and intent (e.g. 'Rust CLI tool for processing CSV files')"
@@ -31,6 +32,7 @@ pipeline_outputs:
   assessment:
     step: assess
     artifact: assessment
+    type: workspace_ref
 
 steps:
   - id: assess

--- a/.agents/pipelines/ops-debug.yaml
+++ b/.agents/pipelines/ops-debug.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "TestPipelineExecutor fails with nil pointer on resume"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   fix:
     step: fix
     artifact: fix
+    type: findings_report
 
 steps:
   - id: reproduce

--- a/.agents/pipelines/ops-epic-runner.yaml
+++ b/.agents/pipelines/ops-epic-runner.yaml
@@ -12,10 +12,11 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave 42"
   schema:
     type: string
-    description: "GitHub epic reference (owner/repo number)"
+    description: "GitHub epic reference (owner/repo number). Parsed by the scope sub-pipeline."
 
 chat_context:
   artifact_summaries:
@@ -36,12 +37,17 @@ pipeline_outputs:
 steps:
   - id: scope
     pipeline: plan-scope
+    # Legacy string input is fine: plan-scope declares input.type: string.
     input: "{{input}}"
 
   - id: implement-all
     dependencies: [scope]
-    pipeline: impl-speckit
-    input: "{{item.url}} — child of {{input}}, see parent for full context"
+    pipeline: impl-issue
+    # Typed wiring: input_ref.from resolves against scope's scope_result output.
+    # The iterate primitive binds the current element as {{item}}; impl-issue's
+    # declared input.type is issue_ref which matches the element schema of
+    # scope_result.child_issues. See docs/adr/010-pipeline-io-protocol.md.
     iterate:
       over: "{{scope.output.child_issues}}"
       mode: sequential
+    input: "{{item.owner}}/{{item.repo}} {{item.number}}"

--- a/.agents/pipelines/ops-epic-runner.yaml
+++ b/.agents/pipelines/ops-epic-runner.yaml
@@ -33,6 +33,7 @@ pipeline_outputs:
   scope:
     step: scope
     artifact: scope
+    type: scope_result
 
 steps:
   - id: scope

--- a/.agents/pipelines/ops-hello-world.yaml
+++ b/.agents/pipelines/ops-hello-world.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "testing Wave"
 
 steps:

--- a/.agents/pipelines/ops-implement-epic.yaml
+++ b/.agents/pipelines/ops-implement-epic.yaml
@@ -29,6 +29,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/re-cinq/wave/issues/184"
   schema:
     type: string
@@ -50,6 +51,7 @@ pipeline_outputs:
   summary:
     step: summarise
     artifact: epic-summary
+    type: findings_report
 
 steps:
   # ── Step 1: fetch parent issue, emit child issue URLs ─────────────────────

--- a/.agents/pipelines/ops-issue-quality.yaml
+++ b/.agents/pipelines/ops-issue-quality.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave"
   schema:
     type: string
@@ -39,6 +40,7 @@ pipeline_outputs:
   report:
     step: enhance
     artifact: enhancement-summary
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/ops-parallel-audit.yaml
+++ b/.agents/pipelines/ops-parallel-audit.yaml
@@ -30,6 +30,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline"
   schema:
     type: string
@@ -50,6 +51,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: audit-report
+    type: findings_report
 
 steps:
   # ── Step 1: fan out over the three audit types in parallel ────────────────

--- a/.agents/pipelines/ops-pr-fix-review.yaml
+++ b/.agents/pipelines/ops-pr-fix-review.yaml
@@ -34,6 +34,7 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   schema:
     type: string
     description: "Pull request URL"
@@ -43,6 +44,7 @@ pipeline_outputs:
   result:
     step: reply-comments
     artifact: resolution-summary
+    type: findings_report
 
 steps:
   - id: fetch-review

--- a/.agents/pipelines/ops-pr-review-core.yaml
+++ b/.agents/pipelines/ops-pr-review-core.yaml
@@ -35,15 +35,18 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/owner/repo/pull/42"
 
 pipeline_outputs:
   verdict:
     step: summary
     artifact: verdict
+    type: findings_report
   diff:
     step: diff-analysis
     artifact: diff
+    type: findings_report
 
 steps:
   - id: diff-analysis

--- a/.agents/pipelines/ops-pr-review.yaml
+++ b/.agents/pipelines/ops-pr-review.yaml
@@ -37,12 +37,14 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/owner/repo/pull/42"
 
 pipeline_outputs:
   verdict:
     step: publish
     artifact: publish-result
+    type: findings_report
 
 steps:
   # ─── Phase 1: Core review (diff, security, quality, slop, verdict) ──────

--- a/.agents/pipelines/ops-refresh.yaml
+++ b/.agents/pipelines/ops-refresh.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 45 -- acceptance criteria are outdated after the worktree refactor"
   schema:
     type: string
@@ -39,6 +40,7 @@ pipeline_outputs:
   result:
     step: apply-update
     artifact: update_result
+    type: issue_ref
 
 steps:
   - id: gather-context

--- a/.agents/pipelines/ops-release-harden.yaml
+++ b/.agents/pipelines/ops-release-harden.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "v1.0.0"
   schema:
     type: string
@@ -32,6 +33,7 @@ pipeline_outputs:
   scan:
     step: scan
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/.agents/pipelines/ops-rewrite.yaml
+++ b/.agents/pipelines/ops-rewrite.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42 or https://github.com/re-cinq/wave/issues/42"
   schema:
     type: string
@@ -38,6 +39,7 @@ pipeline_outputs:
   result:
     step: apply-enhancements
     artifact: enhancement_results
+    type: findings_report
 
 steps:
   - id: scan-and-score

--- a/.agents/pipelines/ops-supervise.yaml
+++ b/.agents/pipelines/ops-supervise.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "review the last pipeline run for quality and process issues"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   verdict:
     step: verdict
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: gather

--- a/.agents/pipelines/plan-adr.yaml
+++ b/.agents/pipelines/plan-adr.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "ADR: should we use SQLite or PostgreSQL for pipeline state?"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: plan_ref
 
 steps:
   - id: explore-context

--- a/.agents/pipelines/plan-approve-implement.yaml
+++ b/.agents/pipelines/plan-approve-implement.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: argument
+  type: string
   schema:
     type: string
     description: "Description of the feature or change to implement"
@@ -31,6 +32,7 @@ pipeline_outputs:
   plan:
     step: plan
     artifact: plan
+    type: plan_ref
 
 steps:
   - id: plan

--- a/.agents/pipelines/plan-research.yaml
+++ b/.agents/pipelines/plan-research.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42"
   schema:
     type: string
@@ -40,6 +41,7 @@ pipeline_outputs:
   result:
     step: post-comment
     artifact: comment-result
+    type: plan_ref
 
 steps:
   - id: fetch-issue

--- a/.agents/pipelines/plan-scope.yaml
+++ b/.agents/pipelines/plan-scope.yaml
@@ -19,10 +19,11 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave 184"
   schema:
     type: string
-    description: "GitHub repository with epic issue number (e.g. 'owner/repo 42')"
+    description: "GitHub repository with epic issue number (e.g. 'owner/repo 42'). Accepts free-text; the fetch-epic step parses it into an issue_ref."
 
 chat_context:
   artifact_summaries:
@@ -39,6 +40,10 @@ pipeline_outputs:
   report:
     step: verify-report
     artifact: scope_report
+  scope:
+    step: scope-and-create
+    artifact: scope_plan
+    type: scope_result
 
 steps:
   - id: fetch-epic

--- a/.agents/pipelines/plan-scope.yaml
+++ b/.agents/pipelines/plan-scope.yaml
@@ -40,6 +40,7 @@ pipeline_outputs:
   report:
     step: verify-report
     artifact: scope_report
+    type: string
   scope:
     step: scope-and-create
     artifact: scope_plan

--- a/.agents/pipelines/plan-task.yaml
+++ b/.agents/pipelines/plan-task.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "add webhook support for pipeline completion events"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   review:
     step: review
     artifact: review
+    type: plan_ref
 
 steps:
   - id: explore

--- a/.agents/pipelines/test-gen.yaml
+++ b/.agents/pipelines/test-gen.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "generate tests for internal/pipeline to improve coverage"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   result:
     step: verify-coverage
     artifact: verification
+    type: findings_report
 
 steps:
   - id: analyze-coverage

--- a/.agents/pipelines/wave-audit.yaml
+++ b/.agents/pipelines/wave-audit.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "last 30 days -- audit only recent work"
   schema:
     type: string
@@ -41,6 +42,7 @@ pipeline_outputs:
   report:
     step: publish
     artifact: publish-result
+    type: findings_report
 
 steps:
   - id: collect-inventory

--- a/.agents/pipelines/wave-bugfix.yaml
+++ b/.agents/pipelines/wave-bugfix.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "pipeline executor panics when step has nil workspace config"
   schema:
     type: string

--- a/.agents/pipelines/wave-evolve.yaml
+++ b/.agents/pipelines/wave-evolve.yaml
@@ -16,6 +16,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "analyze last 5 pipeline runs and improve prompts that had retries"
   schema:
     type: string
@@ -37,6 +38,7 @@ pipeline_outputs:
   result:
     step: verify
     artifact: verification
+    type: findings_report
 
 steps:
   - id: analyze

--- a/.agents/pipelines/wave-land.yaml
+++ b/.agents/pipelines/wave-land.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "fix onboarding wizard bugs — personas missing from manifest, model at wrong level"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   pr:
     step: ship
     artifact: ship-result
+    type: pr_ref
 
 steps:
   - id: commit

--- a/.agents/pipelines/wave-ontology-empty.yaml
+++ b/.agents/pipelines/wave-ontology-empty.yaml
@@ -21,6 +21,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology empty contexts"
 
 steps:

--- a/.agents/pipelines/wave-ontology-inherit.yaml
+++ b/.agents/pipelines/wave-ontology-inherit.yaml
@@ -22,6 +22,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology inherit-all"
 
 steps:

--- a/.agents/pipelines/wave-ontology-warn.yaml
+++ b/.agents/pipelines/wave-ontology-warn.yaml
@@ -24,6 +24,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology warnings"
 
 steps:

--- a/.agents/pipelines/wave-orchestrate.yaml
+++ b/.agents/pipelines/wave-orchestrate.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/re-cinq/wave/issues/123"
 
 chat_context:
@@ -25,6 +26,7 @@ pipeline_outputs:
   classification:
     step: classify
     artifact: classification
+    type: findings_report
 
 steps:
   - id: discover

--- a/.agents/pipelines/wave-review.yaml
+++ b/.agents/pipelines/wave-review.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "#42 — review the PR for the new contract validator"
   schema:
     type: string
@@ -39,6 +40,7 @@ pipeline_outputs:
   review:
     step: review
     artifact: review
+    type: findings_report
 
 steps:
   - id: review

--- a/.agents/pipelines/wave-scope-audit.yaml
+++ b/.agents/pipelines/wave-scope-audit.yaml
@@ -36,6 +36,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/re-cinq/wave/issues/655"
 
 chat_context:
@@ -55,6 +56,7 @@ pipeline_outputs:
   issues:
     step: create-issues
     artifact: created-issues
+    type: findings_report
 
 steps:
   # ── Phase 1: Fan out 6 audit pipelines in parallel ──────────────────────

--- a/.agents/pipelines/wave-security-audit.yaml
+++ b/.agents/pipelines/wave-security-audit.yaml
@@ -16,6 +16,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit persona permission enforcement and sandbox isolation"
   schema:
     type: string
@@ -37,6 +38,7 @@ pipeline_outputs:
   report:
     step: verify
     artifact: security-report
+    type: findings_report
 
 steps:
   - id: threat-model

--- a/.agents/pipelines/wave-smoke-classify.yaml
+++ b/.agents/pipelines/wave-smoke-classify.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify classify package tests pass"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-contracts.yaml
+++ b/.agents/pipelines/wave-smoke-contracts.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify contract validation works"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-gates.yaml
+++ b/.agents/pipelines/wave-smoke-gates.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify gate steps work"
 
 steps:

--- a/.agents/pipelines/wave-smoke-git-forensics.yaml
+++ b/.agents/pipelines/wave-smoke-git-forensics.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify git forensics commands work"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-hooks.yaml
+++ b/.agents/pipelines/wave-smoke-hooks.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify hooks fire correctly"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-llm-judge.yaml
+++ b/.agents/pipelines/wave-smoke-llm-judge.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify llm judge contract works"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-mount.yaml
+++ b/.agents/pipelines/wave-smoke-mount.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify workspace mount works"
 
 chat_context:

--- a/.agents/pipelines/wave-smoke-test.yaml
+++ b/.agents/pipelines/wave-smoke-test.yaml
@@ -10,6 +10,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify contract validation works"
 
 chat_context:
@@ -28,6 +29,7 @@ pipeline_outputs:
   summary:
     step: summarize
     artifact: summary
+    type: findings_report
 
 steps:
   - id: analyze

--- a/.agents/pipelines/wave-smoke-watchdog.yaml
+++ b/.agents/pipelines/wave-smoke-watchdog.yaml
@@ -9,6 +9,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify watchdog tests pass"
 
 chat_context:

--- a/.agents/pipelines/wave-stress-test.yaml
+++ b/.agents/pipelines/wave-stress-test.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "test failure handling"
 
 chat_context:

--- a/.agents/pipelines/wave-test-forge.yaml
+++ b/.agents/pipelines/wave-test-forge.yaml
@@ -13,6 +13,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "full forge validation"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   report:
     step: synthesize
     artifact: forge-report
+    type: findings_report
 
 steps:
   # Step 1: Detect forge and verify template variables resolve

--- a/.agents/pipelines/wave-test-hardening.yaml
+++ b/.agents/pipelines/wave-test-hardening.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "harden tests in internal/pipeline and internal/contract"
   schema:
     type: string

--- a/.agents/pipelines/wave-validate.yaml
+++ b/.agents/pipelines/wave-validate.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "full validation run"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   report:
     step: generate-report
     artifact: report
+    type: findings_report
 
 steps:
   # Step 1: Model routing — uses cheapest tier for cost-efficient analysis

--- a/docs/adr/010-pipeline-io-protocol.md
+++ b/docs/adr/010-pipeline-io-protocol.md
@@ -1,0 +1,244 @@
+# ADR-010: Pipeline I/O Protocol
+
+## Status
+Accepted
+
+## Date
+2026-04-20
+
+## Context
+
+Wave ships 57 pipelines. A pre-1.0 audit revealed three symptoms of the
+same underlying problem:
+
+1. **Inputs are universally free-text.** Every pipeline accepts a
+   `string` input, regardless of whether the semantic intent is a URL,
+   an issue reference, a spec path, or an arbitrary prompt. This pushes
+   the cost of parsing into each pipeline's first step and makes typos
+   survive until runtime.
+2. **Output shapes diverge.** `pipeline_outputs` is uniform in
+   structure (`{ name: { step, artifact } }`), but the contents differ
+   dramatically. There are 7 different shapes for "PR result" and 11 for
+   "findings," none of which share a schema. Pipelines that want to
+   consume another pipeline's output must know the producer's private
+   schema by convention.
+3. **Composition is brittle.** Only 3 of 57 pipelines compose today.
+   Sub-pipelines exchange data via `SubPipelineConfig.Inject` /
+   `Extract` — manual artifact-name gymnastics that break silently when
+   a producer renames an artifact or changes a field name. The handover
+   is text-shaped and unverified.
+
+Together these make Wave pipelines individually useful but collectively
+incapable of being treated as Lego blocks. The goal of this ADR is a
+typed I/O protocol that lets a user write `A → B` and have Wave reject
+the pipeline at load time if B cannot consume what A produces.
+
+Relevant code and files:
+- `internal/pipeline/types.go` — `Pipeline`, `Step`, `PipelineOutput`,
+  `InputConfig`
+- `internal/pipeline/composition.go` — iterate / branch / loop / aggregate
+- `internal/pipeline/subpipeline.go` — inject / extract (legacy path)
+- `internal/pipeline/dag.go` — `YAMLPipelineLoader`
+- `.agents/pipelines/*.yaml` — pipeline definitions
+- `internal/contract/` — JSON-schema, TypeScript, test-suite validators
+
+## Decision
+
+Introduce a **typed I/O protocol** with four pieces:
+
+1. **Shared schema registry.** A fixed set of canonical types lives in
+   `internal/contract/schemas/shared/*.json`, embedded into the Wave
+   binary via `go:embed`. Each file's basename is the type name
+   (`issue_ref`, `pr_ref`, `branch_ref`, `spec_ref`, `findings_report`,
+   `plan_ref`, `workspace_ref`, `scope_result`). A pipeline's type
+   annotation must resolve against this registry or the sentinel
+   `string`.
+
+2. **Typed inputs and outputs at the pipeline level.**
+
+   ```yaml
+   input:
+     source: cli
+     type: issue_ref            # or "string"
+     example: "re-cinq/wave 42"
+
+   pipeline_outputs:
+     pr:
+       step: create-pr
+       artifact: pr-result
+       type: pr_ref             # or "string"
+   ```
+
+   Both fields are optional; an absent `type` is treated as `string`,
+   which lets the 50+ free-text pipelines keep working unchanged.
+
+3. **Typed handover at composition boundaries.** Composition steps
+   (`pipeline:`, `iterate:`, `branch:`) gain an optional `input_ref`
+   block that replaces today's ad-hoc string template:
+
+   ```yaml
+   - id: implement-all
+     pipeline: impl-issue
+     iterate:
+       over: "{{ scope.output.child_issues }}"
+       mode: sequential
+     input_ref:
+       from: scope.scope        # parent_step.output_name
+       # literal: "..."          # alternative: static value
+   ```
+
+   Exactly one of `from` or `literal` is set. `from` references a
+   pipeline output of a prior step; at validation time, the declared
+   output type must match the child pipeline's declared input type.
+
+4. **Load-time type-checking.** `YAMLPipelineLoader.Unmarshal` calls
+   `ValidatePipelineIOTypes` immediately after defaulting. Unknown type
+   names, malformed `input_ref` blocks, and outputs pointing at
+   non-existent steps all fail there, before any step has run.
+   Cross-pipeline wiring (producer output type must match consumer
+   input type) is enforced by `TypedWiringCheck`, which is invoked
+   alongside `detectSubPipelineCycles` when the composition runtime
+   resolves sub-pipeline references.
+
+## Options Considered
+
+### Option 1: Per-pipeline inline schemas (status quo + more JSON)
+
+Let each pipeline keep defining its own bespoke schema in
+`.agents/contracts/` and push harder on documentation conventions.
+
+**Pros:**
+- Zero code changes.
+- Full flexibility for pipeline authors.
+
+**Cons:**
+- Does not solve the composition problem — two pipelines that both
+  produce "a PR result" still have incompatible schemas.
+- Documentation drift is inevitable and has already happened.
+- Catches nothing at load time.
+
+### Option 2: Content-addressable artifact store (phase 2)
+
+Store every artifact by content hash, with the type name as metadata.
+Composition wires `from: <hash>` and validates by schema on read.
+
+**Pros:**
+- Perfect traceability.
+- Enables cache-style reuse of prior step outputs.
+
+**Cons:**
+- Substantial state-store changes.
+- Breaks intuitive `step.output` references.
+- Overkill for phase 1. Keep as a follow-up.
+
+### Option 3: Shared registry + declared types (**chosen**)
+
+Canonical shared schemas embedded in the binary, declared type names
+on input/output, load-time validation.
+
+**Pros:**
+- Minimal surface area: two optional YAML fields, one Go package.
+- Fails fast on typos and mis-wired compositions.
+- Leaves free-text pipelines alone.
+- Sets the stage for content-addressable storage later without
+  constraining it.
+
+**Cons:**
+- Introduces a second schema location (shared vs per-pipeline). This
+  is acceptable because the shared set is small and stable by design.
+- Pipelines that want richer types than the canonical set still need
+  per-pipeline schemas; shared types are the interoperable core, not
+  an exhaustive catalog.
+
+## Consequences
+
+### Positive
+- Pipeline authors declare semantic intent once; Wave enforces it.
+- New pipelines compose by default — the loader tells you at parse
+  time whether A → B is valid.
+- Seven of the most common "shape churns" (PR, issue, branch, spec,
+  plan, workspace, findings, scope) now have a single reference shape.
+- Existing untyped pipelines continue to run without edit.
+
+### Negative
+- Shared-schema evolution must be handled with care. Any breaking
+  change to a shared schema invalidates every pipeline that uses it.
+  Before 1.0 this is fine (no external users); after 1.0, changes
+  require a major-version bump per project policy.
+- Two flavors of input wiring coexist temporarily: the legacy
+  `input: "<string template>"` and the new `input_ref`. The legacy
+  form remains valid for `string`-typed children indefinitely.
+
+### Neutral
+- `ArtifactRef.Type` (a pre-existing field on step-level
+  `inject_artifacts`) is not affected — it remains a documentation
+  hint for now; extending it to use the shared registry is a
+  follow-up.
+- No DB schema changes.
+- No changes to sandbox, adapter, webui, audit, ontology.
+
+## Implementation Notes
+
+Files created:
+- `internal/contract/schemas/shared/*.json` (8 canonical schemas)
+- `internal/contract/schemas/shared/registry.go` (+ test)
+- `internal/pipeline/iotypes.go` (+ test)
+- `docs/adr/010-pipeline-io-protocol.md` (this file)
+
+Files modified:
+- `internal/pipeline/types.go` — added `InputConfig.Type`,
+  `PipelineOutput.Type`, `StepInput`, `Step.InputRef`.
+- `internal/pipeline/dag.go` — invoke `ValidatePipelineIOTypes` from
+  `YAMLPipelineLoader.Unmarshal`.
+- `internal/pipeline/composition.go` — `resolveStepInput` honors
+  `InputRef.From` / `InputRef.Literal` ahead of the legacy `SubInput`.
+- Reference pipelines migrated:
+  - `.agents/pipelines/impl-issue.yaml` +
+    `internal/defaults/pipelines/impl-issue.yaml`
+    — input `issue_ref`, output `pr_ref`.
+  - `.agents/pipelines/impl-speckit.yaml` +
+    `internal/defaults/pipelines/impl-speckit.yaml`
+    — input `string` (free-text is the right model for natural-language
+    feature descriptions), output `pr_ref`.
+  - `.agents/pipelines/plan-scope.yaml` +
+    `internal/defaults/pipelines/plan-scope.yaml`
+    — input `string`; added typed `scope` output (`scope_result`).
+  - `.agents/pipelines/ops-epic-runner.yaml` +
+    `internal/defaults/pipelines/ops-epic-runner.yaml`
+    — shows scope → iterate over child_issues → impl-issue wiring.
+
+### Phase 2 migration TODO
+
+The following pipelines have obvious typed-I/O candidates and should
+be migrated in a follow-up PR. None of them block this ADR.
+
+| Pipeline | Suggested input | Suggested outputs |
+|---|---|---|
+| `impl-issue-core` | `issue_ref` | `pr_ref` |
+| `impl-research` | `issue_ref` | `pr_ref` |
+| `impl-hotfix`, `impl-feature`, `impl-improve`, `impl-refactor`, `impl-recinq`, `impl-prototype` | `issue_ref` or `string` | `pr_ref` |
+| `ops-pr-review`, `ops-pr-review-core`, `ops-pr-fix-review` | `pr_ref` | `findings_report` |
+| `ops-refresh` | `issue_ref` | `issue_ref` |
+| `plan-research`, `plan-adr`, `plan-task`, `plan-approve-implement` | `string` or `issue_ref` | `plan_ref` |
+| `audit-*` (14 pipelines) | `string` (scope hint) | `findings_report` |
+| `audit-dead-code-issue`, `audit-dead-code-review` | `issue_ref` / `pr_ref` | `findings_report` |
+| `doc-fix`, `doc-scan`, `doc-onboard` | `string` | `findings_report` |
+| `test-gen` | `string` (target package/path) | `findings_report` |
+| `bench-solve` | `string` (task id) | custom (keep per-pipeline) |
+| `wave-bugfix`, `wave-evolve`, `wave-review`, `wave-audit`, `wave-security-audit`, `wave-test-hardening` | `string` | `findings_report` |
+| `ops-implement-epic`, `ops-epic-runner` (partial) | `string` | aggregate |
+| `ops-bootstrap` | `string` | `workspace_ref` |
+
+The `wave-smoke-*` and `wave-ontology-*` test pipelines stay untyped
+by design — they exercise specific executor paths and need free shape.
+
+### Non-goals for phase 1
+
+- No content-addressable artifact store (ADR candidate for phase 2).
+- No automatic runtime schema-validation of produced outputs against
+  declared types. Today's `json_schema` contract handles output
+  validation per-step; the shared registry is for **load-time**
+  compatibility, not runtime enforcement. A follow-up ADR should
+  decide whether to wire shared types into the runtime contract path.
+- No deep `field`-extraction on `pipeline_outputs` with type
+  narrowing. The existing `field:` hint stays as-is.

--- a/docs/adr/011-unified-in-memory-caching-layer.md
+++ b/docs/adr/011-unified-in-memory-caching-layer.md
@@ -1,0 +1,114 @@
+# ADR-011: Introduce a Unified In-Memory Caching Layer
+
+## Status
+Proposed
+
+## Date
+2026-04-20
+
+## Context
+Wave is a Go 1.25+ multi-agent pipeline orchestrator that wraps Claude Code and other LLM CLIs via subprocess execution. It ships as a single static binary with `modernc.org/sqlite` persistence and ephemeral, run-scoped workspaces. Today the codebase contains three unrelated ad-hoc caches: a TTL-based in-memory map in `internal/webui/cache.go` (RWMutex, prefix invalidation, `POST /api/cache/refresh` endpoint), prompt-cache token accounting in `internal/adapter/claude.go` (tracks `cache_read_input_tokens` and `cache_creation_input_tokens` for cost calculation), and memoized TypeScript schema parsing in `internal/contract/typescript.go`. There is no shared abstraction, no configurable cache block in `wave.yaml`, no persistent backend, and no consistent key/invalidation discipline across packages.
+
+The cost of this fragmentation is rising. Several expensive hotspots are entirely uncached: Claude subprocess calls (5–120 s latency, $0.01–$1+ per call), relay context compaction/summarization, manifest/persona/pipeline parsing on every CLI invocation, the skill directory walk, artifact injection file I/O, and the TUI list providers (`internal/tui/contract_provider.go`, `health_provider.go`, `pipeline_detail_provider.go`). Each new hotspot currently acquires its own local memoization, diverging invalidation rules, and no visibility into hit/miss rates.
+
+Several recently-proposed ADRs make this decision time-sensitive but also constrained. ADR-006 (cost-infrastructure) defers dynamic routing, the decision log, and Iron Rule enforcement pending real cost data — data that cache hit/miss counters would produce. ADR-007 (StateStore consolidation) mandates that any new SQLite access go through the single StateStore handle, so a persistent cache cannot simply open its own database. ADR-002 targets a 40–50% complexity reduction in `internal/pipeline/executor.go` (6 469 lines); threading caching through the executor before the StepExecutor extraction would enlarge that refactor. ADR-005 replaces `TopologicalSort` with a graph `NextSteps` model, meaning any invalidation strategy tied to step ordering must be graph-aware.
+
+A decision is needed now to stop further divergence (every new hotspot ships its own cache), to unblock ADR-006 observability with a concrete hit/miss signal, and to pick an approach that does not pre-empt ADR-007, ADR-002, or ADR-005 sequencing.
+
+## Decision
+Adopt a unified in-memory cache package at `internal/cache`, extracted from the proven `internal/webui/cache.go` pattern. The package exposes typed `Get`/`Set`/`Invalidate` operations with per-tier TTL, prefix invalidation, `singleflight` deduplication of concurrent identical lookups, and hit/miss counters wired to the cost ledger. Configuration lives in a new `runtime.cache` block in `wave.yaml` (enable flags and TTLs per tier, mirroring the existing `runtime.timeouts` and `runtime.pricing` patterns). The existing webui and TypeScript caches migrate onto it; `internal/adapter`, `internal/relay`, `internal/manifest`, `internal/skill`, and the TUI providers opt in incrementally.
+
+This option wins on risk/value against the current ADR queue. It uses only Go stdlib plus `golang.org/x/sync` (already in `go.mod`), preserves the single-binary deployment model, and introduces no SQLite schema — so it does not couple to ADR-007 StateStore sequencing or to the ADR-002 executor extraction. `singleflight` alone delivers a measurable win for parallel pipeline steps that issue identical Claude prompts within a run. Exposing hit/miss metrics is the concrete feed ADR-006 needs to decide whether a persistent backend is worth the correctness cost later. Persistence is deliberately out of scope: LLM cache-key correctness (prompt + context + model hash invalidating on codebase/manifest change) and Claude SDK prompt-cache coordination (avoiding double-count in `internal/cost`) are hard problems that should wait for real cost data from ADR-006 before being tackled.
+
+## Options Considered
+
+### Option 1: Status quo — keep ad-hoc per-package caches
+Retain the three existing caches and let any new hotspot add its own local memoization, as `internal/contract/typescript.go` already does.
+
+Pros: zero new code; no coupling to ADR-002/005/007; no interaction with the Claude SDK prompt cache, so no double-count risk in `internal/cost`; respects ADR-006's deferral of speculative optimization.
+
+Cons: expensive hotspots stay uncached (Claude subprocess calls, relay compaction, manifest and skill parsing, artifact I/O); no persistence, so manifest parse and skill walk are cold on every CLI run; ADR-006 gets no hit/miss signal and cannot measure savings; invalidation discipline continues to diverge with every new local cache.
+
+Effort: trivial. Reversibility: easy — this is the current state.
+
+### Option 2: Unified in-memory cache package (`internal/cache`) — recommended
+Extract the `internal/webui/cache.go` pattern into a reusable package with typed API, per-tier TTL, prefix invalidation, `singleflight`, and cost-ledger hooks. Add `runtime.cache` in `wave.yaml`. Migrate webui and TypeScript memoization; expose opt-in hooks for adapter, relay, manifest, and skill. No persistent backend.
+
+Pros: single static binary preserved (stdlib + `golang.org/x/sync` only); leverages an already-accepted pattern, minimising novelty risk; `singleflight` collapses concurrent identical LLM prompts across parallel steps within a run; hit/miss counters feed ADR-006 directly; fits ADR-003 layering as a low-level utility package; touches no SQLite schema, so independent of ADR-007.
+
+Cons: no cross-invocation persistence — manifest parse and skill walk are still cold on every `wave` CLI run; LLM response cache has limited value for one-shot CLI runs because the process exits immediately; the long-lived webui process needs a bounded eviction policy beyond TTL to avoid memory growth; integration in `internal/adapter/claude.go` must carefully separate SDK `cache_read` tokens from app-layer hits so `internal/cost` does not double-count.
+
+Effort: medium. Reversibility: moderate — callers depend on the package, but the implementation can be swapped or disabled via `runtime.cache.enabled`.
+
+### Option 3: Persistent SQLite-backed cache via StateStore
+Add a `cache_entries` table behind `internal/state.StateStore` (per ADR-007) with key, BLOB value, tier tag, `created_at`, `expires_at`, `hit_count`. Build `internal/cache` with in-memory L1 and SQLite L2. Key schema hashes prompt+context+model for LLM entries, path+mtime for files, and config-hash for manifest. Database lives at a stable path (XDG cache or `.agents/cache.db`), not in an ephemeral workspace.
+
+Pros: survives CLI invocations, so manifest parse, skill walk, and TypeScript schema warm on the second run — a real user-visible latency win; LLM response cache becomes genuinely useful for repeated dev loops that reissue the same prompt and context; routes through StateStore as ADR-007 mandates; hit/miss ledger joins trivially with the cost ledger in the same SQLite file; stable-path placement respects the ephemeral-workspace constraint.
+
+Cons: couples directly to ADR-007 sequencing, which is still Proposed — this option either blocks or duplicates integration work; LLM cache-key correctness is semantically hard, and false hits produce stale replies (a correctness bug, not a performance bug); must coordinate with SDK prompt-cache tokens at `internal/adapter/claude.go:434-610` to avoid cost double-count; SQLite writes on every subprocess call add I/O to the hot path and need benchmarking; cache schema becomes part of StateStore migrations, which is effectively irreversible once users have populated caches; scope creep risk into `internal/pipeline/executor.go` that ADR-002 wants to extract first.
+
+Effort: large. Reversibility: difficult.
+
+### Option 4: Filesystem-keyed content-addressed cache (no DB)
+Back `internal/cache` with content-addressed files under `XDG_CACHE_HOME/wave/` (`sha256(key)` → file) plus an in-memory L1 for hot keys. No SQLite dependency and no StateStore coupling. Pruning via LRU mtime sweep on startup. Configure via `runtime.cache.dir` and `max_size_mb`.
+
+Pros: persistent without ADR-007 coupling, so ships independently; single binary preserved (only `os`, `path/filepath`, `crypto/sha256` from stdlib); content-addressing sidesteps invalidation for immutable inputs (file bytes, schemas keyed by content hash); natural fit for large LLM response blobs without bloating SQLite's page cache; `rm -rf` on the cache directory is a full reset.
+
+Cons: two persistence mechanisms (SQLite for state, filesystem for cache) violate the ADR-007 consolidation spirit; no transactional guarantees — partial writes possible on crash, requiring tmp+rename discipline; LRU pruning is custom code, easy to get wrong and risking unbounded growth; no query surface, so the cost ledger cannot join hit statistics against run rows without bespoke indexing; per-entry metadata (hit counts, TTL) needs sidecar files or a JSON index, re-implementing what SQLite gives for free.
+
+Effort: medium. Reversibility: easy.
+
+### Option 5: Expand SDK-level prompt caching only (adapter-scoped)
+Do not build a general cache. Instead, deepen use of the Claude SDK's native prompt caching in `internal/adapter/claude.go`: mark stable prefixes (system prompt, manifest digest, persona) with `cache_control`, let Anthropic's API handle TTL and invalidation, and surface `cache_read_input_tokens` savings in the ADR-006 cost ledger. Leave the webui and TypeScript caches untouched.
+
+Pros: zero app-layer cache-correctness burden — Anthropic owns TTL and invalidation; infrastructure is already half-built, since `cache_read`/`cache_creation` token accounting exists at `claude.go:434-610`; immediate cost reduction on the most expensive hotspot (LLM calls) without introducing any new package; no coupling to ADR-002, ADR-005, or ADR-007; produces real cached-token telemetry for ADR-006.
+
+Cons: does nothing for non-LLM hotspots (manifest parse, skill walk, artifact I/O, TUI providers stay cold); only applies to the Claude adapter — other LLM CLIs added per `docs/guides/adapter-development.md` gain nothing; Anthropic's server-side cache TTL (~5 minutes) limits cross-run benefit; does not address the underlying fragmentation of ad-hoc caches.
+
+Effort: small. Reversibility: easy.
+
+## Consequences
+
+### Positive
+- Ends cache fragmentation: `internal/webui/cache.go`, the `internal/contract/typescript.go` memoization, and future hotspots share one typed API, one invalidation model, and one TTL policy source.
+- `singleflight` deduplication eliminates redundant concurrent Claude subprocess calls within a single pipeline run; parallel steps that compute the same prompt collapse to one 5–120 s invocation instead of N.
+- Cache hit/miss counters flow into `internal/cost`, giving ADR-006 the concrete data it is waiting on to decide on dynamic routing and Iron Rule enforcement.
+- TUI list providers (persona, pipeline, skill, contract) gain a process-scoped cache, cutting repeat-navigation latency inside a single TUI session to near-zero.
+- No new runtime dependency, no SQLite schema change — the single static binary and existing `go.mod` stand unchanged.
+
+### Negative
+- No cross-invocation persistence: every `wave` CLI run re-parses `wave.yaml`, re-walks the skill directory, and re-parses TypeScript schemas. Mitigation: measure the aggregate cold-start cost; if it exceeds 50 ms per run, revisit option 3 once ADR-007 lands.
+- LLM response caching in a one-shot CLI process has limited benefit (cache dies at exit). Mitigation: scope LLM caching to the webui and to long-running pipeline runs where `singleflight` within-run dedup is the primary win.
+- Long-lived webui process memory grows with unique cache keys over time; TTL alone is insufficient. Mitigation: add a bounded max-entries policy with LRU eviction in the initial implementation; emit a cache-size metric.
+- Integration in `internal/adapter/claude.go` must carefully separate SDK `cache_read_input_tokens` from app-layer hits to avoid double-counting cost. Mitigation: dedicated unit test covering a synthetic response with both `cache_read` tokens and an app-layer hit; assert `internal/cost` records each exactly once.
+
+### Neutral
+- `wave.yaml` gains a new top-level `runtime.cache` block (enable flag, per-tier TTL, max size); existing configs without it must default to current behavior.
+- `POST /api/cache/refresh` endpoint moves from `internal/webui` to the shared package but keeps its URL and semantics.
+- New package `internal/cache` enters the layered architecture below domain packages (consistent with ADR-003).
+- An opt-in migration path for adapter/relay/manifest/skill means the ADR does not dictate ordering; those packages adopt the cache as their maintainers judge.
+
+## Implementation Notes
+
+Execution order:
+1. Create `internal/cache` package. Lift the TTL map, RWMutex, prefix invalidation, and lazy expiration from `internal/webui/cache.go`. Add a typed generic API (`Get[T]`, `Set[T]`), `singleflight.Group` for dedup, bounded LRU eviction, and atomic hit/miss counters.
+2. Add `runtime.cache` block to `wave.yaml` (fields: `enabled`, per-tier `ttl`, `max_entries`). Wire into `internal/manifest` config loading. Default `enabled: true` with conservative TTLs.
+3. Migrate `internal/webui/cache.go` and `internal/webui/handlers_cache.go` to consume `internal/cache`. Preserve `POST /api/cache/refresh` semantics and route registration in `internal/webui/routes.go`.
+4. Migrate `internal/contract/typescript.go` memoization to `internal/cache` with a `contract:` key prefix.
+5. Wire hit/miss counters into `internal/cost`. Add a `cost.RecordCacheEvent` (or equivalent) and ensure it records separately from SDK `cache_read_input_tokens` already tracked in `internal/adapter/claude.go:434-610`.
+6. Opt-in adopt in `internal/manifest` (parsed `wave.yaml`, persona, pipeline keyed by file hash), `internal/skill/store.go` (directory walk result keyed by dir mtime), and TUI providers (`internal/tui/contract_provider.go`, `health_provider.go`, `pipeline_detail_provider.go`).
+7. Defer `internal/adapter/claude.go`, `internal/relay/relay.go`, and `internal/pipeline/executor.go` adoption. Relay and executor should wait on ADR-002's StepExecutor extraction to avoid enlarging that refactor.
+
+Files changed or added:
+- new: `internal/cache/cache.go`, `internal/cache/cache_test.go`, `internal/cache/singleflight.go`
+- modified: `internal/webui/cache.go`, `internal/webui/handlers_cache.go`, `internal/webui/routes.go`, `internal/contract/typescript.go`, `internal/manifest/*`, `internal/skill/store.go`, `internal/tui/contract_provider.go`, `internal/tui/health_provider.go`, `internal/tui/pipeline_detail_provider.go`, `internal/cost/*`, `wave.yaml`, `docs/guides/adapter-development.md` (note for future adapter authors)
+- not yet touched: `internal/adapter/claude.go`, `internal/relay/relay.go`, `internal/pipeline/executor.go`
+
+Migration: callers of the old webui cache move to the new package in a single commit alongside the package creation; the public HTTP surface is preserved. No data migration needed (no persistence). If `runtime.cache.enabled: false`, all operations degrade to direct computation, giving a safe off-switch.
+
+Testing:
+- Unit tests in `internal/cache` for TTL expiry, prefix invalidation, `singleflight` dedup under concurrent callers, LRU eviction at `max_entries`, and nil-safe receiver.
+- Regression test preserving existing `POST /api/cache/refresh` behavior.
+- Cost double-count test: simulate a Claude response carrying `cache_read_input_tokens` and an `internal/cache` hit on the same call, assert `internal/cost` records each event exactly once.
+- Benchmark: cold vs warm manifest parse and skill walk; record aggregate per-run cold-start cost as the signal for whether ADR-007-based persistence (option 3) is justified later.
+- Race detector (`go test -race`) on concurrent `Get`/`Set`/`Invalidate` paths.

--- a/internal/contract/schemas/shared/branch_ref.json
+++ b/internal/contract/schemas/shared/branch_ref.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/branch_ref",
+  "title": "BranchRef",
+  "description": "Reference to a git branch.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Branch name."
+    },
+    "base": {
+      "type": "string",
+      "description": "Base branch the head diverged from (optional)."
+    },
+    "head_sha": {
+      "type": "string",
+      "description": "Commit SHA at the head of the branch (optional)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/contract/schemas/shared/findings_report.json
+++ b/internal/contract/schemas/shared/findings_report.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/findings_report",
+  "title": "FindingsReport",
+  "description": "Canonical shape for audit-style findings. Replaces the 11+ divergent schemas currently in use across audit-* pipelines.",
+  "type": "object",
+  "required": ["items"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "message"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["info", "low", "medium", "high", "critical"]
+          },
+          "file": {
+            "type": "string",
+            "description": "Repo-relative path to the file where the finding was observed."
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fix_suggestion": {
+            "type": "string",
+            "description": "Optional human-readable suggested fix."
+          },
+          "category": {
+            "type": "string",
+            "description": "Optional category tag (e.g. security, dx, dead-code)."
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Optional free-text summary."
+    }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/schemas/shared/issue_ref.json
+++ b/internal/contract/schemas/shared/issue_ref.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/issue_ref",
+  "title": "IssueRef",
+  "description": "Canonical reference to an issue on a git forge. Used as the lingua franca between pipelines that fetch, decompose, implement, or verify issues.",
+  "type": "object",
+  "required": ["forge", "owner", "repo", "number"],
+  "properties": {
+    "forge": {
+      "type": "string",
+      "description": "Forge type: github, gitlab, gitea, forgejo, bitbucket, local",
+      "enum": ["github", "gitlab", "gitea", "forgejo", "bitbucket", "local"]
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Owner (user or organization)."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository name."
+    },
+    "number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Issue number."
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Full URL to the issue (optional convenience field)."
+    },
+    "title": {
+      "type": "string",
+      "description": "Issue title (optional)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/contract/schemas/shared/plan_ref.json
+++ b/internal/contract/schemas/shared/plan_ref.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/plan_ref",
+  "title": "PlanRef",
+  "description": "Implementation plan produced by planning steps and consumed by implementers.",
+  "type": "object",
+  "required": ["tasks"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Optional repo-relative path to the plan document."
+    },
+    "complexity": {
+      "type": "string",
+      "enum": ["trivial", "simple", "medium", "complex"],
+      "description": "Overall plan complexity."
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "depends_on": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/schemas/shared/pr_ref.json
+++ b/internal/contract/schemas/shared/pr_ref.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/pr_ref",
+  "title": "PRRef",
+  "description": "Canonical reference to a pull/merge request on a git forge. Produced by pipelines that create a PR and consumed by review / merge pipelines.",
+  "type": "object",
+  "required": ["forge", "owner", "repo", "number", "branch"],
+  "properties": {
+    "forge": {
+      "type": "string",
+      "enum": ["github", "gitlab", "gitea", "forgejo", "bitbucket", "local"],
+      "description": "Forge type."
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Full URL to the pull/merge request."
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Head branch name."
+    },
+    "head_sha": {
+      "type": "string",
+      "description": "Commit SHA at the head of the branch (optional)."
+    },
+    "title": {
+      "type": "string"
+    },
+    "issue_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional linked issue number."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/contract/schemas/shared/registry.go
+++ b/internal/contract/schemas/shared/registry.go
@@ -1,0 +1,78 @@
+// Package shared provides canonical artifact schemas used by the Wave
+// pipeline I/O protocol. Each schema is identified by a short type name
+// (e.g. "issue_ref", "pr_ref") and is embedded into the binary so the
+// manifest loader can resolve and validate typed inputs and outputs
+// without touching the filesystem.
+//
+// See docs/adr/010-pipeline-io-protocol.md for the protocol design.
+package shared
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed *.json
+var schemasFS embed.FS
+
+// TypeString is the sentinel type name for free-text (unstructured) I/O.
+// Pipelines with no typed schema default to "string".
+const TypeString = "string"
+
+// registry is populated at init time from the embedded *.json files.
+// Keys are the filename sans extension (e.g. "issue_ref").
+var registry = func() map[string][]byte {
+	out := make(map[string][]byte)
+	entries, err := fs.ReadDir(schemasFS, ".")
+	if err != nil {
+		panic(fmt.Sprintf("shared schemas: failed to read embedded FS: %v", err))
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := schemasFS.ReadFile(e.Name())
+		if err != nil {
+			panic(fmt.Sprintf("shared schemas: failed to read %s: %v", e.Name(), err))
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		out[name] = data
+	}
+	return out
+}()
+
+// Lookup returns the raw JSON schema bytes for a named type.
+// The special name "string" resolves to (nil, true) — callers treat it as
+// free-text with no schema validation.
+// Returns (nil, false) if the type is unknown.
+func Lookup(name string) ([]byte, bool) {
+	if name == "" || name == TypeString {
+		return nil, true
+	}
+	data, ok := registry[name]
+	return data, ok
+}
+
+// Exists reports whether the given type name is registered (or is the
+// "string" sentinel).
+func Exists(name string) bool {
+	if name == "" || name == TypeString {
+		return true
+	}
+	_, ok := registry[name]
+	return ok
+}
+
+// Names returns the sorted list of registered typed schema names.
+// The "string" sentinel is not included.
+func Names() []string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/contract/schemas/shared/registry_test.go
+++ b/internal/contract/schemas/shared/registry_test.go
@@ -1,0 +1,80 @@
+package shared
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegistryContainsCanonicalTypes(t *testing.T) {
+	expected := []string{
+		"issue_ref",
+		"pr_ref",
+		"branch_ref",
+		"spec_ref",
+		"findings_report",
+		"plan_ref",
+		"workspace_ref",
+	}
+	for _, name := range expected {
+		data, ok := Lookup(name)
+		if !ok {
+			t.Errorf("Lookup(%q) = !ok, want ok", name)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("Lookup(%q): empty schema bytes", name)
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(data, &obj); err != nil {
+			t.Errorf("schema %q is not valid JSON: %v", name, err)
+		}
+		if !Exists(name) {
+			t.Errorf("Exists(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestStringSentinel(t *testing.T) {
+	if !Exists("string") {
+		t.Error("Exists(\"string\") = false, want true")
+	}
+	if !Exists("") {
+		t.Error("Exists(\"\") = false, want true (empty treated as string)")
+	}
+	data, ok := Lookup("string")
+	if !ok {
+		t.Error("Lookup(\"string\"): ok = false")
+	}
+	if data != nil {
+		t.Error("Lookup(\"string\"): expected nil bytes for string sentinel")
+	}
+}
+
+func TestUnknownType(t *testing.T) {
+	if Exists("not_a_real_type_xyz") {
+		t.Error("Exists(unknown) = true, want false")
+	}
+	_, ok := Lookup("not_a_real_type_xyz")
+	if ok {
+		t.Error("Lookup(unknown): ok = true, want false")
+	}
+}
+
+func TestNamesSorted(t *testing.T) {
+	names := Names()
+	if len(names) < 7 {
+		t.Errorf("Names() returned %d entries, want at least 7", len(names))
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] >= names[i] {
+			t.Errorf("Names() not sorted: %q >= %q", names[i-1], names[i])
+		}
+	}
+	// string sentinel must not leak into Names()
+	for _, n := range names {
+		if n == "string" {
+			t.Error("Names() must not include \"string\" sentinel")
+		}
+	}
+}

--- a/internal/contract/schemas/shared/scope_result.json
+++ b/internal/contract/schemas/shared/scope_result.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/scope_result",
+  "title": "ScopeResult",
+  "description": "Output of a scoping pipeline: a list of child issue references plus aggregate effort metadata. Designed to be consumed by an iterate step that implements each child issue.",
+  "type": "object",
+  "required": ["child_issues"],
+  "properties": {
+    "child_issues": {
+      "type": "array",
+      "items": { "$ref": "wave://shared/issue_ref" }
+    },
+    "estimated_effort": {
+      "type": "string",
+      "enum": ["S", "M", "L", "XL"],
+      "description": "Aggregate complexity estimate across all child issues."
+    },
+    "parent": { "$ref": "wave://shared/issue_ref" },
+    "summary": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/internal/contract/schemas/shared/spec_ref.json
+++ b/internal/contract/schemas/shared/spec_ref.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/spec_ref",
+  "title": "SpecRef",
+  "description": "Reference to a specification document (speckit-style spec.md or similar).",
+  "type": "object",
+  "required": ["path"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repo-relative path to the spec file."
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable spec title."
+    },
+    "feature_id": {
+      "type": "string",
+      "description": "Stable feature identifier (e.g. speckit feature ID)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/contract/schemas/shared/workspace_ref.json
+++ b/internal/contract/schemas/shared/workspace_ref.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/workspace_ref",
+  "title": "WorkspaceRef",
+  "description": "Reference to a workspace (filesystem root, optionally a git worktree).",
+  "type": "object",
+  "required": ["root"],
+  "properties": {
+    "root": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Absolute or repo-relative root directory of the workspace."
+    },
+    "worktree_path": {
+      "type": "string",
+      "description": "Absolute path to the git worktree (if workspace is a worktree)."
+    },
+    "branch": {
+      "type": "string",
+      "description": "Branch checked out in the worktree."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/defaults/pipelines/audit-closed.yaml
+++ b/internal/defaults/pipelines/audit-closed.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "last 30 days -- audit recent closed work"
   schema:
     type: string
@@ -38,6 +39,7 @@ pipeline_outputs:
   report:
     step: triage
     artifact: triage-report
+    type: findings_report
 
 steps:
   - id: inventory

--- a/internal/defaults/pipelines/audit-consolidate.yaml
+++ b/internal/defaults/pipelines/audit-consolidate.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline — check for redundant patterns"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-dead-code-issue.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-issue.yaml
@@ -18,6 +18,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "scan all packages for dead code and report findings"
 
 chat_context:
@@ -36,6 +37,7 @@ pipeline_outputs:
   findings:
     step: create-issue
     artifact: issue-result
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-dead-code-review.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-review.yaml
@@ -17,6 +17,7 @@ skills:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/re-cinq/wave/pull/42"
 
 chat_context:
@@ -35,6 +36,7 @@ pipeline_outputs:
   report:
     step: publish
     artifact: publish-result
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-dead-code.yaml
+++ b/internal/defaults/pipelines/audit-dead-code.yaml
@@ -16,6 +16,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "find and remove dead code in internal/pipeline"
 
 chat_context:
@@ -35,9 +36,11 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: findings_report
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-doc.yaml
+++ b/internal/defaults/pipelines/audit-doc.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "full -- scan all documentation for inconsistencies with the codebase"
   schema:
     type: string
@@ -35,6 +36,7 @@ pipeline_outputs:
   findings:
     step: publish
     artifact: issue-result
+    type: findings_report
 
 steps:
   - id: scan-changes

--- a/internal/defaults/pipelines/audit-dual.yaml
+++ b/internal/defaults/pipelines/audit-dual.yaml
@@ -30,6 +30,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "analyze the authentication module"
 
 chat_context:
@@ -47,6 +48,7 @@ pipeline_outputs:
   report:
     step: merge
     artifact: report
+    type: findings_report
 
 steps:
   # ── Track A: Code Quality ──────────────────────────────────────────

--- a/internal/defaults/pipelines/audit-dx.yaml
+++ b/internal/defaults/pipelines/audit-dx.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the contributor onboarding experience"
   schema:
     type: string
@@ -35,9 +36,11 @@ pipeline_outputs:
   findings:
     step: audit
     artifact: findings
+    type: findings_report
   report:
     step: audit
     artifact: report
+    type: findings_report
 
 steps:
   - id: audit

--- a/internal/defaults/pipelines/audit-junk-code.yaml
+++ b/internal/defaults/pipelines/audit-junk-code.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/ — find accidental complexity and dead weight"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: scan
     artifact: findings
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-quality-loop.yaml
+++ b/internal/defaults/pipelines/audit-quality-loop.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "last pipeline run"
   schema:
     type: string
@@ -35,6 +36,7 @@ pipeline_outputs:
   quality-check:
     step: quality-check
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: quality-check

--- a/internal/defaults/pipelines/audit-security.yaml
+++ b/internal/defaults/pipelines/audit-security.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the authentication module for vulnerabilities"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/audit-ux.yaml
+++ b/internal/defaults/pipelines/audit-ux.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "audit the CLI onboarding flow for new users"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   findings:
     step: audit
     artifact: findings
+    type: findings_report
 
 steps:
   - id: audit

--- a/internal/defaults/pipelines/bench-solve.yaml
+++ b/internal/defaults/pipelines/bench-solve.yaml
@@ -10,6 +10,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   schema:
     type: string
     description: "Problem statement describing the bug or feature to implement"
@@ -28,6 +29,7 @@ pipeline_outputs:
   solution:
     step: solve
     artifact: solve
+    type: findings_report
 
 steps:
   - id: solve

--- a/internal/defaults/pipelines/doc-changelog.yaml
+++ b/internal/defaults/pipelines/doc-changelog.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "generate changelog from v0.1.0 to HEAD"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   changelog:
     step: format
     artifact: changelog
+    type: findings_report
 
 steps:
   - id: analyze-commits

--- a/internal/defaults/pipelines/doc-explain.yaml
+++ b/internal/defaults/pipelines/doc-explain.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "explain the pipeline execution system and how steps are scheduled"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   explanation:
     step: document
     artifact: explanation
+    type: findings_report
 
 steps:
   - id: explore

--- a/internal/defaults/pipelines/doc-fix.yaml
+++ b/internal/defaults/pipelines/doc-fix.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "sync docs with current implementation"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: findings_report
 
 steps:
   - id: scan-changes

--- a/internal/defaults/pipelines/doc-onboard.yaml
+++ b/internal/defaults/pipelines/doc-onboard.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "create an onboarding guide for this project"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   guide:
     step: guide
     artifact: guide
+    type: findings_report
 
 steps:
   - id: survey

--- a/internal/defaults/pipelines/impl-feature.yaml
+++ b/internal/defaults/pipelines/impl-feature.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "add a --dry-run flag to the run command"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: explore

--- a/internal/defaults/pipelines/impl-hotfix.yaml
+++ b/internal/defaults/pipelines/impl-hotfix.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "fix panic in pipeline executor when step has nil context"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   verdict:
     step: verify
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: investigate

--- a/internal/defaults/pipelines/impl-improve.yaml
+++ b/internal/defaults/pipelines/impl-improve.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "improve error handling in internal/pipeline"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   result:
     step: verify
     artifact: verification
+    type: findings_report
 
 steps:
   - id: assess

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -23,9 +23,11 @@ pipeline_outputs:
   assessment:
     step: fetch-assess
     artifact: assessment
+    type: findings_report
   plan:
     step: plan
     artifact: impl-plan
+    type: pr_ref
 
 skills:
   - "{{ project.skill }}"
@@ -38,6 +40,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   schema:
     type: string
     description: "GitHub repository and issue number"

--- a/internal/defaults/pipelines/impl-issue.yaml
+++ b/internal/defaults/pipelines/impl-issue.yaml
@@ -34,15 +34,17 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   schema:
     type: string
-    description: "GitHub repository and issue number"
+    description: "GitHub repository and issue number (accepts typed issue_ref or 'owner/repo number' text)"
   example: "re-cinq/wave 42"
 
 pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: fetch-assess

--- a/internal/defaults/pipelines/impl-prototype.yaml
+++ b/internal/defaults/pipelines/impl-prototype.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "build a REST API for user management with CRUD operations"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   pr:
     step: pr-create
     artifact: pr-info
+    type: pr_ref
 
 steps:
   # Phase 1: Spec - Requirements capture with speckit integration

--- a/internal/defaults/pipelines/impl-recinq.yaml
+++ b/internal/defaults/pipelines/impl-recinq.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline"
 
 chat_context:
@@ -42,6 +43,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: gather

--- a/internal/defaults/pipelines/impl-refactor.yaml
+++ b/internal/defaults/pipelines/impl-refactor.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "extract workspace manager from executor into its own package"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   result:
     step: verify
     artifact: verification
+    type: findings_report
 
 steps:
   - id: analyze

--- a/internal/defaults/pipelines/impl-research.yaml
+++ b/internal/defaults/pipelines/impl-research.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42"
   schema:
     type: string
@@ -34,6 +35,7 @@ pipeline_outputs:
   verdict:
     step: review
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: research

--- a/internal/defaults/pipelines/impl-review-loop.yaml
+++ b/internal/defaults/pipelines/impl-review-loop.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/owner/repo/issues/42"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   verdict:
     step: review-fix
     artifact: verdict
+    type: findings_report
 
 skills:
   - "{{ project.skill }}"

--- a/internal/defaults/pipelines/impl-smart-route.yaml
+++ b/internal/defaults/pipelines/impl-smart-route.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/owner/repo/issues/42"
 
 chat_context:
@@ -29,6 +30,7 @@ pipeline_outputs:
   assessment:
     step: assess
     artifact: assessment
+    type: findings_report
 
 steps:
   - id: assess

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -22,6 +22,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "add user authentication with JWT tokens"
   schema:
     type: string
@@ -44,6 +45,7 @@ pipeline_outputs:
   pr:
     step: create-pr
     artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: specify

--- a/internal/defaults/pipelines/ops-bootstrap.yaml
+++ b/internal/defaults/pipelines/ops-bootstrap.yaml
@@ -11,6 +11,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   schema:
     type: string
     description: "Project description and intent (e.g. 'Rust CLI tool for processing CSV files')"
@@ -31,6 +32,7 @@ pipeline_outputs:
   assessment:
     step: assess
     artifact: assessment
+    type: workspace_ref
 
 steps:
   - id: assess

--- a/internal/defaults/pipelines/ops-debug.yaml
+++ b/internal/defaults/pipelines/ops-debug.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "TestPipelineExecutor fails with nil pointer on resume"
 
 chat_context:
@@ -31,6 +32,7 @@ pipeline_outputs:
   fix:
     step: fix
     artifact: fix
+    type: findings_report
 
 steps:
   - id: reproduce

--- a/internal/defaults/pipelines/ops-epic-runner.yaml
+++ b/internal/defaults/pipelines/ops-epic-runner.yaml
@@ -12,10 +12,11 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave 42"
   schema:
     type: string
-    description: "GitHub epic reference (owner/repo number)"
+    description: "GitHub epic reference (owner/repo number). Parsed by the scope sub-pipeline."
 
 chat_context:
   artifact_summaries:
@@ -36,12 +37,16 @@ pipeline_outputs:
 steps:
   - id: scope
     pipeline: plan-scope
+    # Legacy string input is fine: plan-scope declares input.type: string.
     input: "{{input}}"
 
   - id: implement-all
     dependencies: [scope]
-    pipeline: impl-speckit
-    input: "{{item.url}} — child of {{input}}, see parent for full context"
+    pipeline: impl-issue
+    # Typed wiring: iterate binds each element of scope's child_issues
+    # (element type = issue_ref) as {{item}}, and impl-issue declares
+    # input.type: issue_ref. See docs/adr/010-pipeline-io-protocol.md.
     iterate:
       over: "{{scope.output.child_issues}}"
       mode: sequential
+    input: "{{item.owner}}/{{item.repo}} {{item.number}}"

--- a/internal/defaults/pipelines/ops-epic-runner.yaml
+++ b/internal/defaults/pipelines/ops-epic-runner.yaml
@@ -33,6 +33,7 @@ pipeline_outputs:
   scope:
     step: scope
     artifact: scope
+    type: scope_result
 
 steps:
   - id: scope

--- a/internal/defaults/pipelines/ops-hello-world.yaml
+++ b/internal/defaults/pipelines/ops-hello-world.yaml
@@ -8,6 +8,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "testing Wave"
 
 steps:

--- a/internal/defaults/pipelines/ops-implement-epic.yaml
+++ b/internal/defaults/pipelines/ops-implement-epic.yaml
@@ -29,6 +29,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "https://github.com/re-cinq/wave/issues/184"
   schema:
     type: string
@@ -50,6 +51,7 @@ pipeline_outputs:
   summary:
     step: summarise
     artifact: epic-summary
+    type: findings_report
 
 steps:
   # ── Step 1: fetch parent issue, emit child issue URLs ─────────────────────

--- a/internal/defaults/pipelines/ops-issue-quality.yaml
+++ b/internal/defaults/pipelines/ops-issue-quality.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave"
   schema:
     type: string
@@ -39,6 +40,7 @@ pipeline_outputs:
   report:
     step: enhance
     artifact: enhancement-summary
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/ops-parallel-audit.yaml
+++ b/internal/defaults/pipelines/ops-parallel-audit.yaml
@@ -30,6 +30,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "internal/pipeline"
   schema:
     type: string
@@ -50,6 +51,7 @@ pipeline_outputs:
   report:
     step: report
     artifact: audit-report
+    type: findings_report
 
 steps:
   # ── Step 1: fan out over the three audit types in parallel ────────────────

--- a/internal/defaults/pipelines/ops-pr-fix-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-fix-review.yaml
@@ -34,6 +34,7 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   schema:
     type: string
     description: "Pull request URL"
@@ -43,6 +44,7 @@ pipeline_outputs:
   result:
     step: reply-comments
     artifact: resolution-summary
+    type: findings_report
 
 steps:
   - id: fetch-review

--- a/internal/defaults/pipelines/ops-pr-review-core.yaml
+++ b/internal/defaults/pipelines/ops-pr-review-core.yaml
@@ -35,15 +35,18 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/owner/repo/pull/42"
 
 pipeline_outputs:
   verdict:
     step: summary
     artifact: verdict
+    type: findings_report
   diff:
     step: diff-analysis
     artifact: diff
+    type: findings_report
 
 steps:
   - id: diff-analysis

--- a/internal/defaults/pipelines/ops-pr-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-review.yaml
@@ -37,12 +37,14 @@ requires:
 
 input:
   source: cli
+  type: pr_ref
   example: "https://github.com/owner/repo/pull/42"
 
 pipeline_outputs:
   verdict:
     step: publish
     artifact: publish-result
+    type: findings_report
 
 steps:
   # ─── Phase 1: Core review (diff, security, quality, slop, verdict) ──────

--- a/internal/defaults/pipelines/ops-refresh.yaml
+++ b/internal/defaults/pipelines/ops-refresh.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 45 -- acceptance criteria are outdated after the worktree refactor"
   schema:
     type: string
@@ -39,6 +40,7 @@ pipeline_outputs:
   result:
     step: apply-update
     artifact: update_result
+    type: issue_ref
 
 steps:
   - id: gather-context

--- a/internal/defaults/pipelines/ops-release-harden.yaml
+++ b/internal/defaults/pipelines/ops-release-harden.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "v1.0.0"
   schema:
     type: string
@@ -32,6 +33,7 @@ pipeline_outputs:
   scan:
     step: scan
     artifact: report
+    type: findings_report
 
 steps:
   - id: scan

--- a/internal/defaults/pipelines/ops-rewrite.yaml
+++ b/internal/defaults/pipelines/ops-rewrite.yaml
@@ -18,6 +18,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42 or https://github.com/re-cinq/wave/issues/42"
   schema:
     type: string
@@ -38,6 +39,7 @@ pipeline_outputs:
   result:
     step: apply-enhancements
     artifact: enhancement_results
+    type: findings_report
 
 steps:
   - id: scan-and-score

--- a/internal/defaults/pipelines/ops-supervise.yaml
+++ b/internal/defaults/pipelines/ops-supervise.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "review the last pipeline run for quality and process issues"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   verdict:
     step: verdict
     artifact: verdict
+    type: findings_report
 
 steps:
   - id: gather

--- a/internal/defaults/pipelines/plan-adr.yaml
+++ b/internal/defaults/pipelines/plan-adr.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "ADR: should we use SQLite or PostgreSQL for pipeline state?"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   pr:
     step: publish
     artifact: pr-result
+    type: plan_ref
 
 steps:
   - id: explore-context

--- a/internal/defaults/pipelines/plan-approve-implement.yaml
+++ b/internal/defaults/pipelines/plan-approve-implement.yaml
@@ -12,6 +12,7 @@ metadata:
 
 input:
   source: argument
+  type: string
   schema:
     type: string
     description: "Description of the feature or change to implement"
@@ -31,6 +32,7 @@ pipeline_outputs:
   plan:
     step: plan
     artifact: plan
+    type: plan_ref
 
 steps:
   - id: plan

--- a/internal/defaults/pipelines/plan-research.yaml
+++ b/internal/defaults/pipelines/plan-research.yaml
@@ -19,6 +19,7 @@ requires:
 
 input:
   source: cli
+  type: issue_ref
   example: "re-cinq/wave 42"
   schema:
     type: string
@@ -40,6 +41,7 @@ pipeline_outputs:
   result:
     step: post-comment
     artifact: comment-result
+    type: plan_ref
 
 steps:
   - id: fetch-issue

--- a/internal/defaults/pipelines/plan-scope.yaml
+++ b/internal/defaults/pipelines/plan-scope.yaml
@@ -19,10 +19,11 @@ requires:
 
 input:
   source: cli
+  type: string
   example: "re-cinq/wave 184"
   schema:
     type: string
-    description: "GitHub repository with epic issue number (e.g. 'owner/repo 42')"
+    description: "GitHub repository with epic issue number (e.g. 'owner/repo 42'). Accepts free-text; the fetch-epic step parses it into an issue_ref."
 
 chat_context:
   artifact_summaries:
@@ -39,6 +40,10 @@ pipeline_outputs:
   report:
     step: verify-report
     artifact: scope_report
+  scope:
+    step: scope-and-create
+    artifact: scope_plan
+    type: scope_result
 
 steps:
   - id: fetch-epic

--- a/internal/defaults/pipelines/plan-scope.yaml
+++ b/internal/defaults/pipelines/plan-scope.yaml
@@ -40,6 +40,7 @@ pipeline_outputs:
   report:
     step: verify-report
     artifact: scope_report
+    type: string
   scope:
     step: scope-and-create
     artifact: scope_plan

--- a/internal/defaults/pipelines/plan-task.yaml
+++ b/internal/defaults/pipelines/plan-task.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "add webhook support for pipeline completion events"
 
 chat_context:
@@ -32,6 +33,7 @@ pipeline_outputs:
   review:
     step: review
     artifact: review
+    type: plan_ref
 
 steps:
   - id: explore

--- a/internal/defaults/pipelines/test-gen.yaml
+++ b/internal/defaults/pipelines/test-gen.yaml
@@ -14,6 +14,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "generate tests for internal/pipeline to improve coverage"
 
 chat_context:
@@ -30,6 +31,7 @@ pipeline_outputs:
   result:
     step: verify-coverage
     artifact: verification
+    type: findings_report
 
 steps:
   - id: analyze-coverage

--- a/internal/defaults/pipelines/wave-land.yaml
+++ b/internal/defaults/pipelines/wave-land.yaml
@@ -15,6 +15,7 @@ skills:
 
 input:
   source: cli
+  type: string
   example: "fix onboarding wizard bugs — personas missing from manifest, model at wrong level"
 
 chat_context:
@@ -33,6 +34,7 @@ pipeline_outputs:
   pr:
     step: ship
     artifact: ship-result
+    type: pr_ref
 
 steps:
   - id: commit

--- a/internal/defaults/pipelines/wave-ontology-empty.yaml
+++ b/internal/defaults/pipelines/wave-ontology-empty.yaml
@@ -21,6 +21,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology empty contexts"
 
 steps:

--- a/internal/defaults/pipelines/wave-ontology-inherit.yaml
+++ b/internal/defaults/pipelines/wave-ontology-inherit.yaml
@@ -22,6 +22,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology inherit-all"
 
 steps:

--- a/internal/defaults/pipelines/wave-ontology-warn.yaml
+++ b/internal/defaults/pipelines/wave-ontology-warn.yaml
@@ -24,6 +24,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify ontology warnings"
 
 steps:

--- a/internal/defaults/pipelines/wave-smoke-skills-claude.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-claude.yaml
@@ -24,6 +24,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify claude skills provisioning"
 
 steps:

--- a/internal/defaults/pipelines/wave-smoke-skills-codex.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-codex.yaml
@@ -15,6 +15,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify codex skills provisioning"
 
 steps:

--- a/internal/defaults/pipelines/wave-smoke-skills-gemini.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-gemini.yaml
@@ -15,6 +15,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify gemini skills provisioning"
 
 steps:

--- a/internal/defaults/pipelines/wave-smoke-skills-opencode.yaml
+++ b/internal/defaults/pipelines/wave-smoke-skills-opencode.yaml
@@ -15,6 +15,7 @@ metadata:
 
 input:
   source: cli
+  type: string
   example: "verify opencode skills provisioning"
 
 steps:

--- a/internal/pipeline/all_pipelines_load_test.go
+++ b/internal/pipeline/all_pipelines_load_test.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAllShippedPipelinesLoad asserts that every YAML pipeline in
+// .agents/pipelines and internal/defaults/pipelines parses through
+// YAMLPipelineLoader (which also runs ValidatePipelineIOTypes). This is a
+// regression guard for the typed I/O protocol (docs/adr/010).
+//
+// Any pipeline that fails to load — due to unknown type names, broken step
+// references, or malformed input_ref — will fail this test.
+func TestAllShippedPipelinesLoad(t *testing.T) {
+	// Walk up from this package to the repo root (two levels: ../..).
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	dirs := []string{
+		filepath.Join(repoRoot, ".agents", "pipelines"),
+		filepath.Join(repoRoot, "internal", "defaults", "pipelines"),
+	}
+
+	loader := &YAMLPipelineLoader{}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+				continue
+			}
+			name := e.Name()
+			path := filepath.Join(dir, name)
+			t.Run(filepath.Base(dir)+"/"+name, func(t *testing.T) {
+				if _, err := loader.Load(path); err != nil {
+					t.Fatalf("load %s: %v", path, err)
+				}
+			})
+		}
+	}
+}

--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -543,7 +543,30 @@ func (c *CompositionExecutor) runSubPipeline(ctx context.Context, name, input st
 }
 
 // resolveStepInput resolves the input template for a step.
+//
+// Resolution order:
+//  1. step.InputRef.From      ("<step_id>.<output_name>") — looked up in
+//     the template context's StepOutputs; resolves to the raw JSON value.
+//  2. step.InputRef.Literal   (template string)
+//  3. step.SubInput           (legacy string template)
+//  4. parent input (c.tmplCtx.Input)
 func (c *CompositionExecutor) resolveStepInput(step *Step) (string, error) {
+	if step.InputRef != nil {
+		if step.InputRef.From != "" {
+			srcStep, _, ok := splitDot(step.InputRef.From)
+			if !ok {
+				return "", fmt.Errorf("step %q: input_ref.from %q must be '<step>.<output>'", step.ID, step.InputRef.From)
+			}
+			raw, has := c.tmplCtx.StepOutputs[srcStep]
+			if !has {
+				return "", fmt.Errorf("step %q: input_ref.from references step %q which has no recorded output", step.ID, srcStep)
+			}
+			return string(raw), nil
+		}
+		if step.InputRef.Literal != "" {
+			return ResolveTemplate(step.InputRef.Literal, c.tmplCtx)
+		}
+	}
 	if step.SubInput != "" {
 		return ResolveTemplate(step.SubInput, c.tmplCtx)
 	}

--- a/internal/pipeline/dag.go
+++ b/internal/pipeline/dag.go
@@ -35,6 +35,13 @@ func (l *YAMLPipelineLoader) Unmarshal(data []byte) (*Pipeline, error) {
 
 	applyPipelineDefaults(&pipeline)
 
+	// Type-check I/O protocol declarations (input.type, pipeline_outputs[*].type,
+	// step input_ref) against the shared schema registry. Catches misspelled
+	// type names before any step runs. See docs/adr/010-pipeline-io-protocol.md.
+	if err := ValidatePipelineIOTypes(&pipeline); err != nil {
+		return nil, err
+	}
+
 	return &pipeline, nil
 }
 

--- a/internal/pipeline/iotypes.go
+++ b/internal/pipeline/iotypes.go
@@ -1,0 +1,159 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/recinq/wave/internal/contract/schemas/shared"
+)
+
+// ValidatePipelineIOTypes checks that all type names declared on a pipeline's
+// Input and PipelineOutputs resolve against the shared schema registry (or are
+// the "string" sentinel). This runs at load time so misspelled type names
+// fail fast, before any step executes.
+//
+// See docs/adr/010-pipeline-io-protocol.md.
+func ValidatePipelineIOTypes(p *Pipeline) error {
+	if p == nil {
+		return nil
+	}
+
+	if t := p.Input.EffectiveType(); !shared.Exists(t) {
+		return fmt.Errorf("pipeline %q: input.type %q is not a registered shared schema (known: %v, or use %q)",
+			p.Metadata.Name, t, shared.Names(), shared.TypeString)
+	}
+
+	stepIDs := make(map[string]bool, len(p.Steps))
+	for _, s := range p.Steps {
+		stepIDs[s.ID] = true
+	}
+
+	for name, out := range p.PipelineOutputs {
+		if t := out.EffectiveType(); !shared.Exists(t) {
+			return fmt.Errorf("pipeline %q: pipeline_outputs[%q].type %q is not a registered shared schema (known: %v, or use %q)",
+				p.Metadata.Name, name, t, shared.Names(), shared.TypeString)
+		}
+		if out.Step != "" && !stepIDs[out.Step] {
+			return fmt.Errorf("pipeline %q: pipeline_outputs[%q].step %q is not a declared step",
+				p.Metadata.Name, name, out.Step)
+		}
+	}
+
+	// Validate composition steps: InputRef must set exactly one of From/Literal.
+	for _, step := range p.Steps {
+		if step.InputRef == nil {
+			continue
+		}
+		ir := step.InputRef
+		if ir.From == "" && ir.Literal == "" {
+			return fmt.Errorf("pipeline %q step %q: input_ref must specify either 'from' or 'literal'",
+				p.Metadata.Name, step.ID)
+		}
+		if ir.From != "" && ir.Literal != "" {
+			return fmt.Errorf("pipeline %q step %q: input_ref.from and input_ref.literal are mutually exclusive",
+				p.Metadata.Name, step.ID)
+		}
+	}
+
+	return nil
+}
+
+// TypedWiringCheck verifies cross-pipeline type compatibility. Given a parent
+// pipeline and a loader for child pipelines, it walks every sub-pipeline step
+// with a typed InputRef and confirms the produced output type matches the
+// child pipeline's declared input type.
+//
+// If childLoader is nil, this returns nil (runtime will catch unresolved refs).
+// Unknown-child errors are non-fatal here — they already surface via
+// detectSubPipelineCycles and the runtime loader.
+func TypedWiringCheck(p *Pipeline, childLoader SubPipelineLoader, pipelinesDir string) error {
+	if p == nil || childLoader == nil {
+		return nil
+	}
+
+	outputsByStep := map[string]*Pipeline{} // parent step id -> child pipeline
+	// First pass: collect child pipelines and their declared input types.
+	childInputType := map[string]string{} // step id -> child input type
+	childSourceOutputType := map[string]map[string]string{} // step id -> (output name -> type)
+	_ = outputsByStep
+
+	for _, step := range p.Steps {
+		if step.SubPipeline == "" {
+			continue
+		}
+		child, err := childLoader(pipelinesDir, step.SubPipeline)
+		if err != nil {
+			// Tolerate missing child pipelines here — treat as soft check.
+			continue
+		}
+		childInputType[step.ID] = child.Input.EffectiveType()
+	}
+
+	// For from-wiring, we need to know each step's produced outputs by name.
+	// Build a map of parent-step-id -> (output_name -> type) by inspecting the
+	// child pipelines' PipelineOutputs for each composition step.
+	for _, step := range p.Steps {
+		if step.SubPipeline == "" {
+			continue
+		}
+		child, err := childLoader(pipelinesDir, step.SubPipeline)
+		if err != nil {
+			continue
+		}
+		out := make(map[string]string, len(child.PipelineOutputs))
+		for name, po := range child.PipelineOutputs {
+			out[name] = po.EffectiveType()
+		}
+		childSourceOutputType[step.ID] = out
+	}
+
+	// Second pass: validate each InputRef.from binding.
+	for _, step := range p.Steps {
+		if step.InputRef == nil || step.InputRef.From == "" {
+			continue
+		}
+		srcStep, srcField, ok := splitDot(step.InputRef.From)
+		if !ok {
+			return fmt.Errorf("pipeline %q step %q: input_ref.from %q must be '<step>.<output>'",
+				p.Metadata.Name, step.ID, step.InputRef.From)
+		}
+
+		srcOutputs, ok := childSourceOutputType[srcStep]
+		if !ok {
+			// Source step is not a sub-pipeline step — may be a direct
+			// sibling step within this pipeline; skip for now (covered by
+			// composition template validation).
+			continue
+		}
+		sourceType, ok := srcOutputs[srcField]
+		if !ok {
+			return fmt.Errorf("pipeline %q step %q: input_ref.from %q references unknown output %q of step %q",
+				p.Metadata.Name, step.ID, step.InputRef.From, srcField, srcStep)
+		}
+
+		// If this step is itself a sub-pipeline step, compare against the child's input.
+		if childTy, ok := childInputType[step.ID]; ok {
+			if childTy != sourceType {
+				return fmt.Errorf(
+					"pipeline %q step %q: typed I/O mismatch — source %q produces %q but child pipeline expects %q",
+					p.Metadata.Name, step.ID, step.InputRef.From, sourceType, childTy,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// splitDot splits "a.b" into ("a", "b", true); returns (_, _, false) if
+// the input does not contain exactly one dot.
+func splitDot(s string) (string, string, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			if i == 0 || i == len(s)-1 {
+				return "", "", false
+			}
+			return s[:i], s[i+1:], true
+		}
+	}
+	return "", "", false
+}

--- a/internal/pipeline/iotypes_test.go
+++ b/internal/pipeline/iotypes_test.go
@@ -1,0 +1,235 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePipelineIOTypes_KnownTypes(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "good"},
+		Input:    InputConfig{Source: "cli", Type: "issue_ref"},
+		PipelineOutputs: map[string]PipelineOutput{
+			"pr": {Step: "create-pr", Artifact: "pr-result", Type: "pr_ref"},
+		},
+		Steps: []Step{{ID: "create-pr"}},
+	}
+	if err := ValidatePipelineIOTypes(p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatePipelineIOTypes_EmptyTypeTreatedAsString(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "legacy"},
+		Input:    InputConfig{Source: "cli"}, // Type omitted
+		PipelineOutputs: map[string]PipelineOutput{
+			"report": {Step: "s1", Artifact: "report"}, // Type omitted
+		},
+		Steps: []Step{{ID: "s1"}},
+	}
+	if err := ValidatePipelineIOTypes(p); err != nil {
+		t.Fatalf("expected legacy (untyped) pipeline to pass validation, got: %v", err)
+	}
+}
+
+func TestValidatePipelineIOTypes_ExplicitString(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "str"},
+		Input:    InputConfig{Source: "cli", Type: "string"},
+		Steps:    []Step{{ID: "only"}},
+	}
+	if err := ValidatePipelineIOTypes(p); err != nil {
+		t.Fatalf("string sentinel must pass: %v", err)
+	}
+}
+
+func TestValidatePipelineIOTypes_UnknownInputType(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad"},
+		Input:    InputConfig{Source: "cli", Type: "not_a_real_type"},
+		Steps:    []Step{{ID: "only"}},
+	}
+	err := ValidatePipelineIOTypes(p)
+	if err == nil {
+		t.Fatal("expected error for unknown input.type, got nil")
+	}
+	if !strings.Contains(err.Error(), "not_a_real_type") {
+		t.Errorf("error should mention the bad type, got: %v", err)
+	}
+}
+
+func TestValidatePipelineIOTypes_UnknownOutputType(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad"},
+		Input:    InputConfig{Source: "cli", Type: "string"},
+		PipelineOutputs: map[string]PipelineOutput{
+			"x": {Step: "s1", Artifact: "a", Type: "made_up"},
+		},
+		Steps: []Step{{ID: "s1"}},
+	}
+	if err := ValidatePipelineIOTypes(p); err == nil {
+		t.Fatal("expected error for unknown output.type, got nil")
+	}
+}
+
+func TestValidatePipelineIOTypes_OutputStepMustExist(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad"},
+		Input:    InputConfig{Source: "cli"},
+		PipelineOutputs: map[string]PipelineOutput{
+			"x": {Step: "ghost", Artifact: "a"},
+		},
+		Steps: []Step{{ID: "real"}},
+	}
+	if err := ValidatePipelineIOTypes(p); err == nil {
+		t.Fatal("expected error when pipeline_outputs references a non-existent step")
+	}
+}
+
+func TestValidatePipelineIOTypes_InputRefExclusivity(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad"},
+		Input:    InputConfig{Source: "cli"},
+		Steps: []Step{
+			{ID: "a"},
+			{ID: "b", SubPipeline: "child", InputRef: &StepInput{From: "a.out", Literal: "x"}},
+		},
+	}
+	if err := ValidatePipelineIOTypes(p); err == nil {
+		t.Fatal("expected error when input_ref sets both from and literal")
+	}
+}
+
+func TestValidatePipelineIOTypes_InputRefEmpty(t *testing.T) {
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad"},
+		Input:    InputConfig{Source: "cli"},
+		Steps: []Step{
+			{ID: "a"},
+			{ID: "b", SubPipeline: "child", InputRef: &StepInput{}},
+		},
+	}
+	if err := ValidatePipelineIOTypes(p); err == nil {
+		t.Fatal("expected error when input_ref is empty")
+	}
+}
+
+// YAMLLoader integration: type-checking happens in the loader, so malformed
+// pipelines must reject at Unmarshal time.
+func TestYAMLPipelineLoader_RejectsUnknownType(t *testing.T) {
+	data := []byte(`kind: WavePipeline
+metadata:
+  name: bogus
+input:
+  source: cli
+  type: totally_not_a_type
+steps:
+  - id: only
+    persona: navigator
+    workspace: {}
+    exec:
+      type: prompt
+      source: hi
+    memory:
+      strategy: fresh
+`)
+	loader := &YAMLPipelineLoader{}
+	_, err := loader.Unmarshal(data)
+	if err == nil {
+		t.Fatal("expected loader to reject unknown type, got nil error")
+	}
+	if !strings.Contains(err.Error(), "totally_not_a_type") {
+		t.Errorf("expected error to mention bad type name, got: %v", err)
+	}
+}
+
+func TestYAMLPipelineLoader_AcceptsTypedIO(t *testing.T) {
+	data := []byte(`kind: WavePipeline
+metadata:
+  name: typed
+input:
+  source: cli
+  type: issue_ref
+pipeline_outputs:
+  pr:
+    step: s1
+    artifact: pr-result
+    type: pr_ref
+steps:
+  - id: s1
+    persona: craftsman
+    workspace: {}
+    exec:
+      type: prompt
+      source: go
+    memory:
+      strategy: fresh
+`)
+	loader := &YAMLPipelineLoader{}
+	p, err := loader.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("expected typed pipeline to load, got: %v", err)
+	}
+	if got := p.Input.EffectiveType(); got != "issue_ref" {
+		t.Errorf("Input.EffectiveType() = %q, want issue_ref", got)
+	}
+	out := p.PipelineOutputs["pr"]
+	if got := out.EffectiveType(); got != "pr_ref" {
+		t.Errorf("output pr type = %q, want pr_ref", got)
+	}
+}
+
+// StepInput wiring resolution at runtime: resolveStepInput should pull the
+// raw JSON from c.tmplCtx.StepOutputs[srcStep] when InputRef.From is set.
+func TestResolveStepInput_FromWiring(t *testing.T) {
+	ctx := NewTemplateContext("parent-input", "/tmp")
+	ctx.SetStepOutput("scope", []byte(`{"child_issues":[{"number":42}]}`))
+	c := &CompositionExecutor{tmplCtx: ctx}
+
+	step := &Step{
+		ID:          "implement",
+		SubPipeline: "impl-issue",
+		InputRef:    &StepInput{From: "scope.child_issues"},
+	}
+	got, err := c.resolveStepInput(step)
+	if err != nil {
+		t.Fatalf("resolveStepInput: %v", err)
+	}
+	want := `{"child_issues":[{"number":42}]}`
+	if got != want {
+		t.Errorf("resolveStepInput from-wiring = %q, want %q", got, want)
+	}
+}
+
+func TestResolveStepInput_LiteralWiring(t *testing.T) {
+	ctx := NewTemplateContext("parent-input", "/tmp")
+	c := &CompositionExecutor{tmplCtx: ctx}
+
+	step := &Step{
+		ID:          "s",
+		SubPipeline: "child",
+		InputRef:    &StepInput{Literal: "re-cinq/wave 99"},
+	}
+	got, err := c.resolveStepInput(step)
+	if err != nil {
+		t.Fatalf("resolveStepInput: %v", err)
+	}
+	if got != "re-cinq/wave 99" {
+		t.Errorf("literal wiring = %q, want %q", got, "re-cinq/wave 99")
+	}
+}
+
+// Legacy string-template fallback still works when InputRef is absent.
+func TestResolveStepInput_LegacyStringFallback(t *testing.T) {
+	ctx := NewTemplateContext("legacy-input", "/tmp")
+	c := &CompositionExecutor{tmplCtx: ctx}
+	step := &Step{ID: "s", SubInput: "{{ input }}"}
+	got, err := c.resolveStepInput(step)
+	if err != nil {
+		t.Fatalf("resolveStepInput: %v", err)
+	}
+	if got != "legacy-input" {
+		t.Errorf("legacy fallback = %q, want %q", got, "legacy-input")
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -122,11 +122,27 @@ type InputConfig struct {
 	Example     string       `yaml:"example,omitempty"`
 	LabelFilter string       `yaml:"label_filter,omitempty"`
 	BatchSize   int          `yaml:"batch_size,omitempty"`
+	// Type is the canonical I/O protocol type name for this pipeline's input.
+	// It must be either "string" (free-text) or a name registered in
+	// internal/contract/schemas/shared (e.g. "issue_ref", "pr_ref").
+	// Empty string is treated as "string" for backward-compat with legacy
+	// pipelines whose input is unstructured.
+	// See docs/adr/010-pipeline-io-protocol.md.
+	Type string `yaml:"type,omitempty"`
 }
 
 type InputSchema struct {
 	Type        string `yaml:"type,omitempty"`
 	Description string `yaml:"description,omitempty"`
+}
+
+// EffectiveType returns the declared I/O type, defaulting to "string"
+// when the pipeline author has not declared a typed input.
+func (c *InputConfig) EffectiveType() string {
+	if c == nil || c.Type == "" {
+		return "string"
+	}
+	return c.Type
 }
 
 // RetryConfig controls step retry behavior on failure.
@@ -316,7 +332,8 @@ type Step struct {
 
 	// Composition primitives
 	SubPipeline string             `yaml:"pipeline,omitempty"`  // Child pipeline to execute
-	SubInput    string             `yaml:"input,omitempty"`     // Input template for child pipeline
+	SubInput    string             `yaml:"input,omitempty"`     // Input template for child pipeline (legacy, string-typed children)
+	InputRef    *StepInput         `yaml:"input_ref,omitempty"` // Typed input wiring (from/literal). See docs/adr/010-pipeline-io-protocol.md.
 	Config      *SubPipelineConfig `yaml:"config,omitempty"`    // Sub-pipeline configuration (artifact flow, lifecycle)
 	Iterate     *IterateConfig     `yaml:"iterate,omitempty"`   // Iteration over items
 	Branch      *BranchConfig      `yaml:"branch,omitempty"`    // Conditional branching
@@ -687,4 +704,38 @@ type PipelineOutput struct {
 	Step     string `yaml:"step"`            // Source step ID
 	Artifact string `yaml:"artifact"`        // Artifact name
 	Field    string `yaml:"field,omitempty"` // Optional JSON field extraction
+	// Type is the canonical I/O protocol type name for this output.
+	// Must resolve via internal/contract/schemas/shared (or be "string").
+	// Empty = "string". See docs/adr/010-pipeline-io-protocol.md.
+	Type string `yaml:"type,omitempty"`
+}
+
+// EffectiveType returns the declared I/O type for this output, defaulting
+// to "string" when untyped.
+func (o *PipelineOutput) EffectiveType() string {
+	if o == nil || o.Type == "" {
+		return "string"
+	}
+	return o.Type
+}
+
+// StepInput declares how a composition step's input is wired.
+//
+// Exactly one of From / Literal must be set.
+//
+//   - From:    "<step_id>.<output_name>" — resolves at runtime to the named
+//     pipeline_output of that prior step. Type must match the
+//     child pipeline's declared input type.
+//   - Literal: "<free text>"            — a static string (templates allowed).
+//
+// This replaces the legacy `input: "<string template>"` field on sub-pipeline
+// steps. The legacy field is still accepted for "string"-typed children.
+type StepInput struct {
+	From    string `yaml:"from,omitempty"`
+	Literal string `yaml:"literal,omitempty"`
+}
+
+// IsSet reports whether the StepInput carries any wiring instruction.
+func (s *StepInput) IsSet() bool {
+	return s != nil && (s.From != "" || s.Literal != "")
 }


### PR DESCRIPTION
# ADR-011: Introduce a Unified In-Memory Caching Layer

## Status
Proposed

## Date
2026-04-20

## Context
Wave is a Go 1.25+ multi-agent pipeline orchestrator that wraps Claude Code and other LLM CLIs via subprocess execution. It ships as a single static binary with `modernc.org/sqlite` persistence and ephemeral, run-scoped workspaces. Today the codebase contains three unrelated ad-hoc caches: a TTL-based in-memory map in `internal/webui/cache.go` (RWMutex, prefix invalidation, `POST /api/cache/refresh` endpoint), prompt-cache token accounting in `internal/adapter/claude.go` (tracks `cache_read_input_tokens` and `cache_creation_input_tokens` for cost calculation), and memoized TypeScript schema parsing in `internal/contract/typescript.go`. There is no shared abstraction, no configurable cache block in `wave.yaml`, no persistent backend, and no consistent key/invalidation discipline across packages.

The cost of this fragmentation is rising. Several expensive hotspots are entirely uncached: Claude subprocess calls (5–120 s latency, $0.01–$1+ per call), relay context compaction/summarization, manifest/persona/pipeline parsing on every CLI invocation, the skill directory walk, artifact injection file I/O, and the TUI list providers (`internal/tui/contract_provider.go`, `health_provider.go`, `pipeline_detail_provider.go`). Each new hotspot currently acquires its own local memoization, diverging invalidation rules, and no visibility into hit/miss rates.

Several recently-proposed ADRs make this decision time-sensitive but also constrained. ADR-006 (cost-infrastructure) defers dynamic routing, the decision log, and Iron Rule enforcement pending real cost data — data that cache hit/miss counters would produce. ADR-007 (StateStore consolidation) mandates that any new SQLite access go through the single StateStore handle, so a persistent cache cannot simply open its own database. ADR-002 targets a 40–50% complexity reduction in `internal/pipeline/executor.go` (6 469 lines); threading caching through the executor before the StepExecutor extraction would enlarge that refactor. ADR-005 replaces `TopologicalSort` with a graph `NextSteps` model, meaning any invalidation strategy tied to step ordering must be graph-aware.

A decision is needed now to stop further divergence (every new hotspot ships its own cache), to unblock ADR-006 observability with a concrete hit/miss signal, and to pick an approach that does not pre-empt ADR-007, ADR-002, or ADR-005 sequencing.

## Decision
Adopt a unified in-memory cache package at `internal/cache`, extracted from the proven `internal/webui/cache.go` pattern. The package exposes typed `Get`/`Set`/`Invalidate` operations with per-tier TTL, prefix invalidation, `singleflight` deduplication of concurrent identical lookups, and hit/miss counters wired to the cost ledger. Configuration lives in a new `runtime.cache` block in `wave.yaml` (enable flags and TTLs per tier, mirroring the existing `runtime.timeouts` and `runtime.pricing` patterns). The existing webui and TypeScript caches migrate onto it; `internal/adapter`, `internal/relay`, `internal/manifest`, `internal/skill`, and the TUI providers opt in incrementally.

This option wins on risk/value against the current ADR queue. It uses only Go stdlib plus `golang.org/x/sync` (already in `go.mod`), preserves the single-binary deployment model, and introduces no SQLite schema — so it does not couple to ADR-007 StateStore sequencing or to the ADR-002 executor extraction. `singleflight` alone delivers a measurable win for parallel pipeline steps that issue identical Claude prompts within a run. Exposing hit/miss metrics is the concrete feed ADR-006 needs to decide whether a persistent backend is worth the correctness cost later. Persistence is deliberately out of scope: LLM cache-key correctness (prompt + context + model hash invalidating on codebase/manifest change) and Claude SDK prompt-cache coordination (avoiding double-count in `internal/cost`) are hard problems that should wait for real cost data from ADR-006 before being tackled.

## Options Considered

### Option 1: Status quo — keep ad-hoc per-package caches
Retain the three existing caches and let any new hotspot add its own local memoization, as `internal/contract/typescript.go` already does.

Pros: zero new code; no coupling to ADR-002/005/007; no interaction with the Claude SDK prompt cache, so no double-count risk in `internal/cost`; respects ADR-006's deferral of speculative optimization.

Cons: expensive hotspots stay uncached (Claude subprocess calls, relay compaction, manifest and skill parsing, artifact I/O); no persistence, so manifest parse and skill walk are cold on every CLI run; ADR-006 gets no hit/miss signal and cannot measure savings; invalidation discipline continues to diverge with every new local cache.

Effort: trivial. Reversibility: easy — this is the current state.

### Option 2: Unified in-memory cache package (`internal/cache`) — recommended
Extract the `internal/webui/cache.go` pattern into a reusable package with typed API, per-tier TTL, prefix invalidation, `singleflight`, and cost-ledger hooks. Add `runtime.cache` in `wave.yaml`. Migrate webui and TypeScript memoization; expose opt-in hooks for adapter, relay, manifest, and skill. No persistent backend.

Pros: single static binary preserved (stdlib + `golang.org/x/sync` only); leverages an already-accepted pattern, minimising novelty risk; `singleflight` collapses concurrent identical LLM prompts across parallel steps within a run; hit/miss counters feed ADR-006 directly; fits ADR-003 layering as a low-level utility package; touches no SQLite schema, so independent of ADR-007.

Cons: no cross-invocation persistence — manifest parse and skill walk are still cold on every `wave` CLI run; LLM response cache has limited value for one-shot CLI runs because the process exits immediately; the long-lived webui process needs a bounded eviction policy beyond TTL to avoid memory growth; integration in `internal/adapter/claude.go` must carefully separate SDK `cache_read` tokens from app-layer hits so `internal/cost` does not double-count.

Effort: medium. Reversibility: moderate — callers depend on the package, but the implementation can be swapped or disabled via `runtime.cache.enabled`.

### Option 3: Persistent SQLite-backed cache via StateStore
Add a `cache_entries` table behind `internal/state.StateStore` (per ADR-007) with key, BLOB value, tier tag, `created_at`, `expires_at`, `hit_count`. Build `internal/cache` with in-memory L1 and SQLite L2. Key schema hashes prompt+context+model for LLM entries, path+mtime for files, and config-hash for manifest. Database lives at a stable path (XDG cache or `.agents/cache.db`), not in an ephemeral workspace.

Pros: survives CLI invocations, so manifest parse, skill walk, and TypeScript schema warm on the second run — a real user-visible latency win; LLM response cache becomes genuinely useful for repeated dev loops that reissue the same prompt and context; routes through StateStore as ADR-007 mandates; hit/miss ledger joins trivially with the cost ledger in the same SQLite file; stable-path placement respects the ephemeral-workspace constraint.

Cons: couples directly to ADR-007 sequencing, which is still Proposed — this option either blocks or duplicates integration work; LLM cache-key correctness is semantically hard, and false hits produce stale replies (a correctness bug, not a performance bug); must coordinate with SDK prompt-cache tokens at `internal/adapter/claude.go:434-610` to avoid cost double-count; SQLite writes on every subprocess call add I/O to the hot path and need benchmarking; cache schema becomes part of StateStore migrations, which is effectively irreversible once users have populated caches; scope creep risk into `internal/pipeline/executor.go` that ADR-002 wants to extract first.

Effort: large. Reversibility: difficult.

### Option 4: Filesystem-keyed content-addressed cache (no DB)
Back `internal/cache` with content-addressed files under `XDG_CACHE_HOME/wave/` (`sha256(key)` → file) plus an in-memory L1 for hot keys. No SQLite dependency and no StateStore coupling. Pruning via LRU mtime sweep on startup. Configure via `runtime.cache.dir` and `max_size_mb`.

Pros: persistent without ADR-007 coupling, so ships independently; single binary preserved (only `os`, `path/filepath`, `crypto/sha256` from stdlib); content-addressing sidesteps invalidation for immutable inputs (file bytes, schemas keyed by content hash); natural fit for large LLM response blobs without bloating SQLite's page cache; `rm -rf` on the cache directory is a full reset.

Cons: two persistence mechanisms (SQLite for state, filesystem for cache) violate the ADR-007 consolidation spirit; no transactional guarantees — partial writes possible on crash, requiring tmp+rename discipline; LRU pruning is custom code, easy to get wrong and risking unbounded growth; no query surface, so the cost ledger cannot join hit statistics against run rows without bespoke indexing; per-entry metadata (hit counts, TTL) needs sidecar files or a JSON index, re-implementing what SQLite gives for free.

Effort: medium. Reversibility: easy.

### Option 5: Expand SDK-level prompt caching only (adapter-scoped)
Do not build a general cache. Instead, deepen use of the Claude SDK's native prompt caching in `internal/adapter/claude.go`: mark stable prefixes (system prompt, manifest digest, persona) with `cache_control`, let Anthropic's API handle TTL and invalidation, and surface `cache_read_input_tokens` savings in the ADR-006 cost ledger. Leave the webui and TypeScript caches untouched.

Pros: zero app-layer cache-correctness burden — Anthropic owns TTL and invalidation; infrastructure is already half-built, since `cache_read`/`cache_creation` token accounting exists at `claude.go:434-610`; immediate cost reduction on the most expensive hotspot (LLM calls) without introducing any new package; no coupling to ADR-002, ADR-005, or ADR-007; produces real cached-token telemetry for ADR-006.

Cons: does nothing for non-LLM hotspots (manifest parse, skill walk, artifact I/O, TUI providers stay cold); only applies to the Claude adapter — other LLM CLIs added per `docs/guides/adapter-development.md` gain nothing; Anthropic's server-side cache TTL (~5 minutes) limits cross-run benefit; does not address the underlying fragmentation of ad-hoc caches.

Effort: small. Reversibility: easy.

## Consequences

### Positive
- Ends cache fragmentation: `internal/webui/cache.go`, the `internal/contract/typescript.go` memoization, and future hotspots share one typed API, one invalidation model, and one TTL policy source.
- `singleflight` deduplication eliminates redundant concurrent Claude subprocess calls within a single pipeline run; parallel steps that compute the same prompt collapse to one 5–120 s invocation instead of N.
- Cache hit/miss counters flow into `internal/cost`, giving ADR-006 the concrete data it is waiting on to decide on dynamic routing and Iron Rule enforcement.
- TUI list providers (persona, pipeline, skill, contract) gain a process-scoped cache, cutting repeat-navigation latency inside a single TUI session to near-zero.
- No new runtime dependency, no SQLite schema change — the single static binary and existing `go.mod` stand unchanged.

### Negative
- No cross-invocation persistence: every `wave` CLI run re-parses `wave.yaml`, re-walks the skill directory, and re-parses TypeScript schemas. Mitigation: measure the aggregate cold-start cost; if it exceeds 50 ms per run, revisit option 3 once ADR-007 lands.
- LLM response caching in a one-shot CLI process has limited benefit (cache dies at exit). Mitigation: scope LLM caching to the webui and to long-running pipeline runs where `singleflight` within-run dedup is the primary win.
- Long-lived webui process memory grows with unique cache keys over time; TTL alone is insufficient. Mitigation: add a bounded max-entries policy with LRU eviction in the initial implementation; emit a cache-size metric.
- Integration in `internal/adapter/claude.go` must carefully separate SDK `cache_read_input_tokens` from app-layer hits to avoid double-counting cost. Mitigation: dedicated unit test covering a synthetic response with both `cache_read` tokens and an app-layer hit; assert `internal/cost` records each exactly once.

### Neutral
- `wave.yaml` gains a new top-level `runtime.cache` block (enable flag, per-tier TTL, max size); existing configs without it must default to current behavior.
- `POST /api/cache/refresh` endpoint moves from `internal/webui` to the shared package but keeps its URL and semantics.
- New package `internal/cache` enters the layered architecture below domain packages (consistent with ADR-003).
- An opt-in migration path for adapter/relay/manifest/skill means the ADR does not dictate ordering; those packages adopt the cache as their maintainers judge.

## Implementation Notes

Execution order:
1. Create `internal/cache` package. Lift the TTL map, RWMutex, prefix invalidation, and lazy expiration from `internal/webui/cache.go`. Add a typed generic API (`Get[T]`, `Set[T]`), `singleflight.Group` for dedup, bounded LRU eviction, and atomic hit/miss counters.
2. Add `runtime.cache` block to `wave.yaml` (fields: `enabled`, per-tier `ttl`, `max_entries`). Wire into `internal/manifest` config loading. Default `enabled: true` with conservative TTLs.
3. Migrate `internal/webui/cache.go` and `internal/webui/handlers_cache.go` to consume `internal/cache`. Preserve `POST /api/cache/refresh` semantics and route registration in `internal/webui/routes.go`.
4. Migrate `internal/contract/typescript.go` memoization to `internal/cache` with a `contract:` key prefix.
5. Wire hit/miss counters into `internal/cost`. Add a `cost.RecordCacheEvent` (or equivalent) and ensure it records separately from SDK `cache_read_input_tokens` already tracked in `internal/adapter/claude.go:434-610`.
6. Opt-in adopt in `internal/manifest` (parsed `wave.yaml`, persona, pipeline keyed by file hash), `internal/skill/store.go` (directory walk result keyed by dir mtime), and TUI providers (`internal/tui/contract_provider.go`, `health_provider.go`, `pipeline_detail_provider.go`).
7. Defer `internal/adapter/claude.go`, `internal/relay/relay.go`, and `internal/pipeline/executor.go` adoption. Relay and executor should wait on ADR-002's StepExecutor extraction to avoid enlarging that refactor.

Files changed or added:
- new: `internal/cache/cache.go`, `internal/cache/cache_test.go`, `internal/cache/singleflight.go`
- modified: `internal/webui/cache.go`, `internal/webui/handlers_cache.go`, `internal/webui/routes.go`, `internal/contract/typescript.go`, `internal/manifest/*`, `internal/skill/store.go`, `internal/tui/contract_provider.go`, `internal/tui/health_provider.go`, `internal/tui/pipeline_detail_provider.go`, `internal/cost/*`, `wave.yaml`, `docs/guides/adapter-development.md` (note for future adapter authors)
- not yet touched: `internal/adapter/claude.go`, `internal/relay/relay.go`, `internal/pipeline/executor.go`

Migration: callers of the old webui cache move to the new package in a single commit alongside the package creation; the public HTTP surface is preserved. No data migration needed (no persistence). If `runtime.cache.enabled: false`, all operations degrade to direct computation, giving a safe off-switch.

Testing:
- Unit tests in `internal/cache` for TTL expiry, prefix invalidation, `singleflight` dedup under concurrent callers, LRU eviction at `max_entries`, and nil-safe receiver.
- Regression test preserving existing `POST /api/cache/refresh` behavior.
- Cost double-count test: simulate a Claude response carrying `cache_read_input_tokens` and an `internal/cache` hit on the same call, assert `internal/cost` records each event exactly once.
- Benchmark: cold vs warm manifest parse and skill walk; record aggregate per-run cold-start cost as the signal for whether ADR-007-based persistence (option 3) is justified later.
- Race detector (`go test -race`) on concurrent `Get`/`Set`/`Invalidate` paths.
