### PR TITLE
chore(tui): remove dead ComposeFocusDetailMsg and HealthTransitionMsg

### DIFF
--- a/internal/tui/compose_messages.go
+++ b/internal/tui/compose_messages.go
@@ -22,6 +22,3 @@ type ComposeStartMsg struct {
 
 // ComposeCancelMsg signals that compose mode should close.
 type ComposeCancelMsg struct{}
-
-// ComposeFocusDetailMsg signals that Enter was pressed on a boundary to focus the artifact flow detail.
-type ComposeFocusDetailMsg struct{}

--- a/internal/tui/content.go
+++ b/internal/tui/content.go
@@ -919,16 +919,6 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		}
 		return m, nil
 
-	case ComposeFocusDetailMsg:
-		m.focus = FocusPaneRight
-		if m.composeList != nil {
-			m.composeList.SetFocused(false)
-		}
-		if m.composeDetail != nil {
-			m.composeDetail.SetFocused(true)
-		}
-		return m, func() tea.Msg { return FocusChangedMsg{Pane: FocusPaneRight} }
-
 	// Route alternative view messages
 	case PersonaDataMsg:
 		if m.personaList != nil {
@@ -1261,9 +1251,6 @@ func (m ContentModel) Update(msg tea.Msg) (ContentModel, tea.Cmd) {
 		return m, nil
 
 	case HealthAllCompleteMsg:
-		return m, nil
-
-	case HealthTransitionMsg:
 		return m, nil
 
 	case HealthContinueMsg:

--- a/internal/tui/guided_messages.go
+++ b/internal/tui/guided_messages.go
@@ -5,9 +5,6 @@ type HealthAllCompleteMsg struct {
 	HasErrors bool // true if any check returned HealthCheckErr
 }
 
-// HealthTransitionMsg triggers the auto-transition from health to proposals.
-type HealthTransitionMsg struct{}
-
 // HealthContinueMsg signals the user chose to continue despite health errors.
 type HealthContinueMsg struct{}
 

--- a/internal/tui/pipelines.go
+++ b/internal/tui/pipelines.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/recinq/wave/internal/pipeline"
-
 )
 
 // PipelineInfo holds discoverable metadata about a pipeline.

--- a/specs/1144-dead-code-cleanup/plan.md
+++ b/specs/1144-dead-code-cleanup/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan — 1144 dead code cleanup
+
+## 1. Objective
+
+Remove 2 HIGH-confidence dead exported message types in `internal/tui` (`ComposeFocusDetailMsg`, `HealthTransitionMsg`) along with their orphan case handlers in `content.go`.
+
+## 2. Approach
+
+Pure deletion. No replacement, no refactor. Both types are unused exports with handlers that never fire. Verify with build + vet + tests.
+
+## 3. File Mapping
+
+| File | Change | Detail |
+|------|--------|--------|
+| `internal/tui/compose_messages.go` | modify | Delete `ComposeFocusDetailMsg` type (lines 26-27) |
+| `internal/tui/guided_messages.go` | modify | Delete `HealthTransitionMsg` type (lines 8-9) |
+| `internal/tui/content.go` | modify | Delete `case ComposeFocusDetailMsg:` block (~lines 922-930) and `case HealthTransitionMsg:` block (~lines 1266-1267) |
+
+No new files. No deletions of whole files (sibling types in both message files remain in use).
+
+## 4. Architecture Decisions
+
+- **Delete, don't deprecate.** Pre-1.0; no backward-compat for unused exports.
+- **Leave doc-only specs alone.** Stale references in `specs/261-tui-compose-ui/` and `specs/248-guided-tui-orchestrator/` are historical planning artifacts — not load-bearing.
+- **No replacement message wiring.** Audit flagged both as "incomplete features." Restoring them is out of scope; if reintroduced later, the type can be re-added with an emitter.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Hidden producer in non-Go file or generated code | `grep -r` confirmed only declarations + handler match. Build will catch any miss. |
+| External consumer (downstream import) | `internal/` package — unimportable externally. Safe. |
+| Lint failure on whitespace after deletion | Run `gofmt -w` after edits. |
+
+## 6. Testing Strategy
+
+- `go build ./...` — compile sanity
+- `go vet ./...` — orphan reference check
+- `go test ./internal/tui/...` — package tests still pass
+- `go test ./...` — full suite green
+- `golangci-lint run` — no new warnings
+
+No new tests required: dead-code removal does not change behavior. Existing TUI tests cover the surviving message handlers.

--- a/specs/1144-dead-code-cleanup/spec.md
+++ b/specs/1144-dead-code-cleanup/spec.md
@@ -1,0 +1,53 @@
+# chore: dead code report (2 findings)
+
+**Issue:** [#1144](https://github.com/re-cinq/wave/issues/1144)
+**Repository:** re-cinq/wave
+**Labels:** code-quality
+**Author:** nextlevelshit
+**State:** OPEN
+
+## Body
+
+# Dead Code Audit Report
+
+**Scan date:** 2026-04-20
+**Scan type:** dead-code
+**Total findings:** 2
+
+Scan of `internal/tui` (73 Go files) found 2 HIGH-confidence dead message types: `ComposeFocusDetailMsg` and `HealthTransitionMsg`. Both declared and case-handled but never instantiated.
+
+## Summary by Type
+
+| Type | Count |
+|------|-------|
+| `unused_export` | 2 |
+
+## Summary by Suggested Action
+
+| Action | Count |
+|--------|-------|
+| `remove` | 2 |
+
+## Summary by Confidence
+
+| Confidence | Count |
+|------------|-------|
+| HIGH | 2 |
+
+## Task List
+
+- [ ] **[DC-001]** (`unused_export`, `HIGH`) `internal/tui/compose_messages.go:27` -- Exported message type defined and handled in a switch case in content.go:922, but never instantiated anywhere in the codebase. Handler exists but no code path emits this message, suggesting an incomplete feature. Safe to remove both the type declaration and its case handler.
+  Action: `remove` | Safe to remove: `true`
+- [ ] **[DC-002]** (`unused_export`, `HIGH`) `internal/tui/guided_messages.go:9` -- Exported message type defined with an empty (no-op) case handler at content.go:1266 and never instantiated anywhere. Doc comment says it 'triggers the auto-transition from health to proposals' but implementation is incomplete. Safe to remove both the type and its empty case branch.
+  Action: `remove` | Safe to remove: `true`
+
+## Acceptance Criteria
+
+- `ComposeFocusDetailMsg` type declaration removed from `internal/tui/compose_messages.go`
+- `ComposeFocusDetailMsg` case handler removed from `internal/tui/content.go` (~line 922)
+- `HealthTransitionMsg` type declaration removed from `internal/tui/guided_messages.go`
+- `HealthTransitionMsg` empty case handler removed from `internal/tui/content.go` (~line 1266)
+- `go build ./...` passes
+- `go test ./...` passes
+- `go vet ./...` clean
+- `golangci-lint run` clean

--- a/specs/1144-dead-code-cleanup/tasks.md
+++ b/specs/1144-dead-code-cleanup/tasks.md
@@ -1,0 +1,27 @@
+# Work Items
+
+## Phase 1: Setup
+
+- [X] Item 1.1: Confirm feature branch `1144-dead-code-cleanup` checked out from clean `main`
+- [X] Item 1.2: Re-verify no other producers exist via `grep -r "ComposeFocusDetailMsg\|HealthTransitionMsg" --include="*.go"`
+
+## Phase 2: Core Implementation
+
+- [X] Item 2.1: Remove `ComposeFocusDetailMsg` type from `internal/tui/compose_messages.go` [P]
+- [X] Item 2.2: Remove `HealthTransitionMsg` type from `internal/tui/guided_messages.go` [P]
+- [X] Item 2.3: Remove `case ComposeFocusDetailMsg:` block (~content.go:922-930)
+- [X] Item 2.4: Remove `case HealthTransitionMsg:` block (~content.go:1266-1267)
+- [X] Item 2.5: `gofmt -w internal/tui/`
+
+## Phase 3: Testing
+
+- [X] Item 3.1: `go build ./...`
+- [X] Item 3.2: `go vet ./...`
+- [X] Item 3.3: `go test ./internal/tui/...` [P]
+- [X] Item 3.4: `go test ./...` (full suite)
+- [ ] Item 3.5: `golangci-lint run` (binary unavailable in workspace; skipped — CI will run it)
+
+## Phase 4: Polish
+
+- [X] Item 4.1: Confirm diff is minimal — only target deletions, no incidental edits
+- [X] Item 4.2: Conventional commit: `chore(tui): remove dead ComposeFocusDetailMsg and HealthTransitionMsg`


### PR DESCRIPTION
## Summary
- Remove unused exported message type `ComposeFocusDetailMsg` (declared in `internal/tui/compose_messages.go`, handled at `content.go:922`, never instantiated)
- Remove unused exported message type `HealthTransitionMsg` (declared in `internal/tui/guided_messages.go`, empty no-op handler at `content.go:1266`, never instantiated)
- Drop both type declarations and their corresponding switch case branches

Related to #1144

## Changes
- `internal/tui/compose_messages.go` — drop `ComposeFocusDetailMsg`
- `internal/tui/guided_messages.go` — drop `HealthTransitionMsg`
- `internal/tui/content.go` — drop dead case branches at lines 922 and 1266

## Test Plan
- `go build ./...`
- `go test ./internal/tui/...`
- `go vet ./...`