### PR TITLE
config(pipelines): bump implement-class steps to strongest, strip default contexts

### DIFF
--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -149,7 +149,7 @@ steps:
 
   - id: deep-dive
     persona: auditor
-    model: balanced
+    model: strongest
     contexts: [security]
     max_concurrent_agents: 3
     dependencies: [scan]

--- a/.agents/pipelines/impl-issue-core.yaml
+++ b/.agents/pipelines/impl-issue-core.yaml
@@ -74,7 +74,7 @@ steps:
 
   - id: plan
     persona: implementer
-    model: balanced
+    model: strongest
     dependencies: [fetch-assess]
     memory:
       inject_artifacts:
@@ -113,7 +113,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
+    model: strongest
     contexts: [execution, delivery]
     thread: impl
     dependencies: [plan, fetch-assess]
@@ -147,7 +147,7 @@ steps:
 
   - id: fix-implement
     persona: craftsman
-    model: balanced
+    model: strongest
     rework_only: true
     thread: impl
     workspace:

--- a/.agents/pipelines/impl-issue.yaml
+++ b/.agents/pipelines/impl-issue.yaml
@@ -77,7 +77,7 @@ steps:
     # are automatically injected. This gives the planner the full domain picture.
     # See AGENTS.md § "Ontology Context Injection" for details.
     persona: implementer
-    model: balanced
+    model: strongest
     dependencies: [fetch-assess]
     memory:
       inject_artifacts:
@@ -116,7 +116,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
+    model: strongest
     contexts: [execution, delivery]
     thread: impl
     dependencies: [plan]
@@ -151,7 +151,7 @@ steps:
 
   - id: fix-implement
     persona: craftsman
-    model: balanced
+    model: strongest
     rework_only: true
     workspace:
       type: worktree

--- a/.agents/pipelines/impl-recinq.yaml
+++ b/.agents/pipelines/impl-recinq.yaml
@@ -247,7 +247,7 @@ steps:
   # ── Diamond 1: Define (CONVERGENT) ───────────────────────────────────
   - id: converge
     persona: validator
-    model: balanced
+    model: strongest
     dependencies: [diverge]
     memory:
       inject_artifacts:
@@ -484,7 +484,7 @@ steps:
   # ── Diamond 2: Deliver (CONVERGENT) ──────────────────────────────────
   - id: distill
     persona: synthesizer
-    model: balanced
+    model: strongest
     dependencies: [probe]
     memory:
       inject_artifacts:
@@ -618,7 +618,7 @@ steps:
   # ── Implementation ───────────────────────────────────────────────────
   - id: simplify
     persona: craftsman
-    model: balanced
+    model: strongest
     dependencies: [distill]
     memory:
       inject_artifacts:

--- a/.agents/pipelines/impl-speckit.yaml
+++ b/.agents/pipelines/impl-speckit.yaml
@@ -108,7 +108,7 @@ steps:
   - id: plan
     persona: implementer
     thread: speckit
-    model: balanced
+    model: strongest
     dependencies: [clarify, specify]
     memory:
       inject_artifacts:
@@ -139,7 +139,7 @@ steps:
   - id: tasks
     persona: implementer
     thread: speckit
-    model: balanced
+    model: strongest
     dependencies: [plan, specify]
     memory:
       inject_artifacts:
@@ -231,7 +231,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
+    model: strongest
     dependencies: [analyze, specify]
     max_concurrent_agents: 3
     memory:

--- a/internal/defaults/pipelines/audit-architecture.yaml
+++ b/internal/defaults/pipelines/audit-architecture.yaml
@@ -37,7 +37,6 @@ pipeline_outputs:
 steps:
   - id: scan
     persona: navigator
-    contexts: [validation]
     model: cheapest
     workspace:
       mount:
@@ -64,7 +63,6 @@ steps:
   - id: report
     persona: summarizer
     model: cheapest
-    contexts: [validation]
     dependencies: [scan]
     memory:
       inject_artifacts:

--- a/internal/defaults/pipelines/audit-dead-code-scan.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-scan.yaml
@@ -37,7 +37,6 @@ steps:
     persona: navigator
     model: cheapest
     max_concurrent_agents: 3
-    contexts: [configuration]
     workspace:
       mount:
         - source: ./

--- a/internal/defaults/pipelines/audit-doc-scan.yaml
+++ b/internal/defaults/pipelines/audit-doc-scan.yaml
@@ -37,7 +37,6 @@ steps:
     persona: navigator
     model: cheapest
     max_concurrent_agents: 3
-    contexts: [delivery, quality]
     workspace:
       mount:
         - source: ./

--- a/internal/defaults/pipelines/audit-duplicates.yaml
+++ b/internal/defaults/pipelines/audit-duplicates.yaml
@@ -38,7 +38,6 @@ steps:
     persona: navigator
     model: cheapest
     max_concurrent_agents: 3
-    contexts: [configuration]
     workspace:
       mount:
         - source: ./

--- a/internal/defaults/pipelines/audit-security.yaml
+++ b/internal/defaults/pipelines/audit-security.yaml
@@ -39,7 +39,6 @@ pipeline_outputs:
 steps:
   - id: scan
     persona: navigator
-    contexts: [security]
     model: balanced
     workspace:
       mount:
@@ -149,8 +148,7 @@ steps:
 
   - id: deep-dive
     persona: auditor
-    model: balanced
-    contexts: [security]
+    model: strongest
     max_concurrent_agents: 3
     dependencies: [scan]
     memory:
@@ -258,7 +256,6 @@ steps:
   - id: report
     persona: summarizer
     model: cheapest
-    contexts: [security]
     dependencies: [deep-dive, scan]
     memory:
       inject_artifacts:

--- a/internal/defaults/pipelines/audit-tests.yaml
+++ b/internal/defaults/pipelines/audit-tests.yaml
@@ -36,7 +36,6 @@ pipeline_outputs:
 steps:
   - id: scan
     persona: navigator
-    contexts: [validation]
     model: cheapest
     workspace:
       mount:
@@ -63,7 +62,6 @@ steps:
   - id: report
     persona: summarizer
     model: cheapest
-    contexts: [validation]
     dependencies: [scan]
     memory:
       inject_artifacts:

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -49,7 +49,6 @@ input:
 steps:
   - id: fetch-assess
     persona: implementer
-    contexts: [configuration]
     model: cheapest
     workspace:
       type: worktree
@@ -74,7 +73,7 @@ steps:
 
   - id: plan
     persona: implementer
-    model: balanced
+    model: strongest
     dependencies: [fetch-assess]
     memory:
       inject_artifacts:
@@ -113,8 +112,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
-    contexts: [execution, delivery]
+    model: strongest
     thread: impl
     dependencies: [plan]
     memory:

--- a/internal/defaults/pipelines/impl-issue.yaml
+++ b/internal/defaults/pipelines/impl-issue.yaml
@@ -49,7 +49,6 @@ pipeline_outputs:
 steps:
   - id: fetch-assess
     persona: implementer
-    contexts: [configuration]
     model: cheapest
     workspace:
       type: worktree
@@ -73,11 +72,8 @@ steps:
         on_failure: fail
 
   - id: plan
-    # No contexts: field — inherit-all behavior: all ontology contexts defined in wave.yaml
-    # are automatically injected. This gives the planner the full domain picture.
-    # See AGENTS.md § "Ontology Context Injection" for details.
     persona: implementer
-    model: balanced
+    model: strongest
     dependencies: [fetch-assess]
     memory:
       inject_artifacts:
@@ -116,8 +112,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
-    contexts: [execution, delivery]
+    model: strongest
     thread: impl
     dependencies: [plan]
     memory:
@@ -151,7 +146,7 @@ steps:
 
   - id: fix-implement
     persona: craftsman
-    model: balanced
+    model: strongest
     rework_only: true
     workspace:
       type: worktree
@@ -251,7 +246,6 @@ steps:
   - id: create-pr
     persona: "{{ forge.type }}-commenter"
     model: cheapest
-    contexts: [delivery]
     dependencies: [implement]
     memory:
       inject_artifacts:

--- a/internal/defaults/pipelines/impl-recinq.yaml
+++ b/internal/defaults/pipelines/impl-recinq.yaml
@@ -247,7 +247,7 @@ steps:
   # ── Diamond 1: Define (CONVERGENT) ───────────────────────────────────
   - id: converge
     persona: validator
-    model: balanced
+    model: strongest
     dependencies: [diverge]
     memory:
       inject_artifacts:
@@ -484,7 +484,7 @@ steps:
   # ── Diamond 2: Deliver (CONVERGENT) ──────────────────────────────────
   - id: distill
     persona: synthesizer
-    model: balanced
+    model: strongest
     dependencies: [probe]
     memory:
       inject_artifacts:
@@ -618,7 +618,7 @@ steps:
   # ── Implementation ───────────────────────────────────────────────────
   - id: simplify
     persona: craftsman
-    model: balanced
+    model: strongest
     dependencies: [distill]
     memory:
       inject_artifacts:

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -108,7 +108,7 @@ steps:
   - id: plan
     persona: implementer
     thread: speckit
-    model: balanced
+    model: strongest
     dependencies: [clarify, specify]
     memory:
       inject_artifacts:
@@ -139,7 +139,7 @@ steps:
   - id: tasks
     persona: implementer
     thread: speckit
-    model: balanced
+    model: strongest
     dependencies: [plan, specify]
     memory:
       inject_artifacts:
@@ -231,7 +231,7 @@ steps:
 
   - id: implement
     persona: craftsman
-    model: balanced
+    model: strongest
     dependencies: [analyze, specify]
     max_concurrent_agents: 3
     memory:

--- a/internal/defaults/pipelines/ops-pr-review-core.yaml
+++ b/internal/defaults/pipelines/ops-pr-review-core.yaml
@@ -51,7 +51,6 @@ pipeline_outputs:
 steps:
   - id: diff-analysis
     persona: navigator
-    contexts: [execution]
     model: cheapest
     workspace:
       mount:
@@ -151,7 +150,6 @@ steps:
     persona: reviewer
     thread: review-security
     model: balanced
-    contexts: [security]
     dependencies: [diff-analysis]
     memory:
       inject_artifacts:
@@ -270,7 +268,6 @@ steps:
     persona: reviewer
     thread: review-quality
     model: balanced
-    contexts: [validation]
     dependencies: [diff-analysis]
     memory:
       inject_artifacts:
@@ -387,7 +384,6 @@ steps:
     persona: reviewer
     thread: review-slop
     model: balanced
-    contexts: [validation]
     dependencies: [diff-analysis]
     memory:
       inject_artifacts:


### PR DESCRIPTION
Refs epic #1403. Bumps reasoning-heavy steps (plan/implement/fix-implement/refactor/deep-dive) from balanced to strongest after repeated balanced stalls. Strips step-level contexts arrays from internal/defaults/pipelines so shipped defaults are project-agnostic.