### PR TITLE
refactor(state): route CLI state reads through StateStore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,18 @@ linters:
         # These are string-literal rules depguard cannot express. See the
         # package doc in internal/ontology/service.go.
 
+        # Rule: Only internal/state may import database/sql (ADR-007).
+        # depguard rules apply to files matching `files:`; use negative globs
+        # so the rule fires everywhere *except* inside internal/state/**.
+        no-direct-sql:
+          list-mode: lax
+          files:
+            - "$all"
+            - "!**/internal/state/**"
+          deny:
+            - pkg: "database/sql"
+              desc: "ADR-007: only internal/state may import database/sql"
+
         # Rule 2: Infrastructure packages must not import Domain packages.
         infrastructure-no-domain:
           files:

--- a/cmd/wave/commands/clean.go
+++ b/cmd/wave/commands/clean.go
@@ -1,18 +1,16 @@
 package commands
 
 import (
-	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
-
-	_ "modernc.org/sqlite"
 )
 
 type CleanOptions struct {
@@ -65,36 +63,19 @@ func getWorkspacesWithStatus(status string) (map[string]bool, error) {
 		return result, nil
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewReadOnlyStateStore(dbPath)
 	if err != nil {
 		return result, nil // Fail silently, return empty set
 	}
-	defer db.Close()
+	defer store.Close()
 
-	// Query from pipeline_run table for status
-	rows, err := db.Query(`
-		SELECT DISTINCT pipeline_name FROM pipeline_run
-		WHERE LOWER(status) = LOWER(?)
-	`, status)
+	names, err := store.ListPipelineNamesByStatus(status)
 	if err != nil {
-		// Try fallback to pipeline_state table
-		rows, err = db.Query(`
-			SELECT DISTINCT pipeline_name FROM pipeline_state
-			WHERE LOWER(status) = LOWER(?)
-		`, status)
-		if err != nil {
-			return result, nil
-		}
+		return result, nil
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err == nil {
-			result[name] = true
-		}
+	for _, name := range names {
+		result[name] = true
 	}
-
 	return result, nil
 }
 

--- a/cmd/wave/commands/decisions.go
+++ b/cmd/wave/commands/decisions.go
@@ -1,16 +1,13 @@
 package commands
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-
-	_ "modernc.org/sqlite"
 )
 
 // DecisionsOptions holds options for the decisions command.
@@ -89,19 +86,20 @@ func runDecisions(opts DecisionsOptions) error {
 		return nil
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewReadOnlyStateStore(dbPath)
 	if err != nil {
 		return NewCLIError(CodeStateDBError, fmt.Sprintf("failed to open state database: %s", err), "Check .agents/state.db file permissions or run 'wave run' to create it").WithCause(err)
 	}
-	defer db.Close()
-
-	db.SetMaxOpenConns(1)
+	defer store.Close()
 
 	// Resolve run ID if not provided
 	runID := opts.RunID
 	if runID == "" {
-		runID, err = getMostRecentRunID(db)
+		runID, err = store.GetMostRecentRunID()
 		if err != nil {
+			return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query most recent run: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+		}
+		if runID == "" {
 			if opts.Format == "json" {
 				fmt.Println(`{"run_id":"","decisions":[]}`)
 				return nil
@@ -111,8 +109,11 @@ func runDecisions(opts DecisionsOptions) error {
 		}
 	}
 
-	// Verify run exists
-	if !runExists(db, runID) {
+	exists, err := store.RunExists(runID)
+	if err != nil {
+		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to verify run: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+	}
+	if !exists {
 		if opts.Format == "json" {
 			fmt.Printf(`{"run_id":"%s","decisions":[],"error":"run not found"}`, runID)
 			fmt.Println()
@@ -122,10 +123,15 @@ func runDecisions(opts DecisionsOptions) error {
 		return nil
 	}
 
-	decisions, err := queryDecisions(db, runID, opts)
+	records, err := store.GetDecisionsFiltered(runID, state.DecisionQueryOptions{
+		StepID:   opts.Step,
+		Category: opts.Category,
+	})
 	if err != nil {
-		return err
+		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query decisions: %s", err), "The state database may need migration -- try 'wave migrate up'").WithCause(err)
 	}
+
+	decisions := decisionRecordsToEntries(records)
 
 	if len(decisions) == 0 {
 		if opts.Format == "json" {
@@ -141,69 +147,26 @@ func runDecisions(opts DecisionsOptions) error {
 	return outputDecisions(runID, decisions, opts)
 }
 
-// queryDecisions retrieves decisions matching the options.
-func queryDecisions(db *sql.DB, runID string, opts DecisionsOptions) ([]DecisionEntry, error) {
-	query := `SELECT id, timestamp, step_id, category, decision, rationale, context_json
-	          FROM decision_log
-	          WHERE run_id = ?`
-	args := []any{runID}
-
-	if opts.Step != "" {
-		query += " AND step_id = ?"
-		args = append(args, opts.Step)
-	}
-
-	if opts.Category != "" {
-		query += " AND category = ?"
-		args = append(args, opts.Category)
-	}
-
-	query += " ORDER BY timestamp ASC, id ASC"
-
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, NewCLIError(CodeInternalError, fmt.Sprintf("failed to query decisions: %s", err), "The state database may need migration -- try 'wave migrate up'").WithCause(err)
-	}
-	defer rows.Close()
-
-	var decisions []DecisionEntry
-	for rows.Next() {
-		var d DecisionEntry
-		var timestamp int64
-		var stepID, rationale, contextJSON sql.NullString
-
-		err := rows.Scan(
-			&d.ID,
-			&timestamp,
-			&stepID,
-			&d.Category,
-			&d.Decision,
-			&rationale,
-			&contextJSON,
-		)
-		if err != nil {
-			return nil, NewCLIError(CodeInternalError, fmt.Sprintf("failed to scan decision: %s", err), "The state database may have schema issues -- try 'wave migrate up'").WithCause(err)
+// decisionRecordsToEntries converts state.DecisionRecord pointers into the
+// CLI's presentation DTO. Empty/`{}` context fields are stripped to keep the
+// JSON shape backward compatible with the prior raw-SQL implementation.
+func decisionRecordsToEntries(records []*state.DecisionRecord) []DecisionEntry {
+	out := make([]DecisionEntry, 0, len(records))
+	for _, r := range records {
+		entry := DecisionEntry{
+			ID:        r.ID,
+			Timestamp: r.Timestamp.Format("15:04:05"),
+			StepID:    r.StepID,
+			Category:  r.Category,
+			Decision:  r.Decision,
+			Rationale: r.Rationale,
 		}
-
-		d.Timestamp = time.Unix(timestamp, 0).Format("15:04:05")
-		if stepID.Valid {
-			d.StepID = stepID.String
+		if r.Context != "" && r.Context != "{}" {
+			entry.Context = json.RawMessage(r.Context)
 		}
-		if rationale.Valid {
-			d.Rationale = rationale.String
-		}
-		if contextJSON.Valid && contextJSON.String != "" && contextJSON.String != "{}" {
-			d.Context = json.RawMessage(contextJSON.String)
-		}
-
-		decisions = append(decisions, d)
+		out = append(out, entry)
 	}
-
-	if err := rows.Err(); err != nil {
-		return nil, NewCLIError(CodeInternalError, fmt.Sprintf("error iterating decisions: %s", err), "The state database may have schema issues -- try 'wave migrate up'").WithCause(err)
-	}
-
-	return decisions, nil
+	return out
 }
 
 // outputDecisions formats and outputs the decisions.
@@ -218,7 +181,6 @@ func outputDecisions(runID string, decisions []DecisionEntry, opts DecisionsOpti
 		return nil
 	}
 
-	// Text format
 	for _, d := range decisions {
 		printDecisionEntry(d)
 	}
@@ -231,7 +193,6 @@ func printDecisionEntry(d DecisionEntry) {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("[%s]", d.Timestamp))
 
-	// Color-code categories
 	categoryStr := fmt.Sprintf("%-15s", d.Category)
 	switch d.Category {
 	case "model_routing":

--- a/cmd/wave/commands/decisions_test.go
+++ b/cmd/wave/commands/decisions_test.go
@@ -2,17 +2,15 @@ package commands
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // decisionsTestHelper provides common utilities for decisions command tests.
@@ -20,7 +18,7 @@ type decisionsTestHelper struct {
 	t       *testing.T
 	tmpDir  string
 	origDir string
-	db      *sql.DB
+	store   state.StateStore
 }
 
 // newDecisionsTestHelper creates a new test helper with a temporary directory and database.
@@ -30,49 +28,19 @@ func newDecisionsTestHelper(t *testing.T) *decisionsTestHelper {
 	origDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get current directory")
 
-	// Create .wave directory
 	waveDir := filepath.Join(tmpDir, ".agents")
 	err = os.MkdirAll(waveDir, 0755)
 	require.NoError(t, err, "failed to create .wave directory")
 
-	// Create and initialize database
 	dbPath := filepath.Join(waveDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err, "failed to open database")
-
-	// Initialize schema (pipeline_run + decision_log)
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
-			input TEXT,
-			current_step TEXT,
-			total_tokens INTEGER DEFAULT 0,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER,
-			cancelled_at INTEGER,
-			error_message TEXT
-		);
-		CREATE TABLE IF NOT EXISTS decision_log (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			run_id TEXT NOT NULL,
-			step_id TEXT NOT NULL DEFAULT '',
-			timestamp INTEGER NOT NULL,
-			category TEXT NOT NULL,
-			decision TEXT NOT NULL,
-			rationale TEXT NOT NULL DEFAULT '',
-			context_json TEXT NOT NULL DEFAULT '{}',
-			FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
-		);
-	`)
-	require.NoError(t, err, "failed to initialize schema")
+	store, err := state.NewStateStore(dbPath)
+	require.NoError(t, err, "failed to create state store")
 
 	return &decisionsTestHelper{
 		t:       t,
 		tmpDir:  tmpDir,
 		origDir: origDir,
-		db:      db,
+		store:   store,
 	}
 }
 
@@ -83,36 +51,38 @@ func (h *decisionsTestHelper) chdir() {
 	require.NoError(h.t, err, "failed to change to temp directory")
 }
 
-// restore returns to the original directory and closes the database.
+// restore returns to the original directory and closes the store.
 func (h *decisionsTestHelper) restore() {
 	h.t.Helper()
 	_ = os.Chdir(h.origDir)
-	if h.db != nil {
-		h.db.Close()
+	if h.store != nil {
+		h.store.Close()
 	}
 }
 
 // createRun creates a run in the database.
 func (h *decisionsTestHelper) createRun(runID, pipelineName, status string, startedAt time.Time) {
 	h.t.Helper()
-	_, err := h.db.Exec(`
-		INSERT INTO pipeline_run (run_id, pipeline_name, status, total_tokens, started_at)
-		VALUES (?, ?, ?, 0, ?)
-	`, runID, pipelineName, status, startedAt.Unix())
-	require.NoError(h.t, err, "failed to create run")
+	require.NoError(h.t, state.SeedRun(h.store, state.SeedRunOptions{
+		RunID:        runID,
+		PipelineName: pipelineName,
+		Status:       status,
+		StartedAt:    startedAt,
+	}), "failed to create run")
 }
 
 // createDecision creates a decision entry in the database.
 func (h *decisionsTestHelper) createDecision(runID string, timestamp time.Time, stepID, category, decision, rationale, contextJSON string) {
 	h.t.Helper()
-	if contextJSON == "" {
-		contextJSON = "{}"
-	}
-	_, err := h.db.Exec(`
-		INSERT INTO decision_log (run_id, step_id, timestamp, category, decision, rationale, context_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, runID, stepID, timestamp.Unix(), category, decision, rationale, contextJSON)
-	require.NoError(h.t, err, "failed to create decision entry")
+	require.NoError(h.t, state.SeedDecision(h.store, state.SeedDecisionOptions{
+		RunID:     runID,
+		StepID:    stepID,
+		Timestamp: timestamp,
+		Category:  category,
+		Decision:  decision,
+		Rationale: rationale,
+		Context:   contextJSON,
+	}), "failed to create decision entry")
 }
 
 // executeDecisionsCmd runs the decisions command with given arguments and returns output/error.

--- a/cmd/wave/commands/list.go
+++ b/cmd/wave/commands/list.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,11 +12,10 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/display"
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-
-	_ "modernc.org/sqlite"
 )
 
 // JSON output structures
@@ -764,72 +762,48 @@ func collectRuns(opts ListRunsOptions) ([]RunInfo, error) {
 	return runs, nil
 }
 
-// collectRunsFromDB reads run information from the state database
+// collectRunsFromDB reads run information from the state database via StateStore.
 func collectRunsFromDB(dbPath string, opts ListRunsOptions) ([]RunInfo, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewReadOnlyStateStore(dbPath)
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
+	defer store.Close()
 
-	// Try pipeline_run table first (new schema from spec 016)
-	query := `
-		SELECT run_id, pipeline_name, status, started_at, completed_at
-		FROM pipeline_run
-		WHERE 1=1
-	`
-	args := []interface{}{}
-
-	if opts.Pipeline != "" {
-		query += " AND pipeline_name = ?"
-		args = append(args, opts.Pipeline)
+	listOpts := state.ListRunsOptions{
+		PipelineName: opts.Pipeline,
+		Status:       strings.ToLower(opts.Status),
+		Limit:        opts.Limit,
 	}
 
-	if opts.Status != "" {
-		query += " AND LOWER(status) = LOWER(?)"
-		args = append(args, opts.Status)
-	}
-
-	query += " ORDER BY started_at DESC LIMIT ?"
-	args = append(args, opts.Limit)
-
-	rows, err := db.Query(query, args...)
+	records, err := store.ListRuns(listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query pipeline runs: %w", err)
 	}
-	defer rows.Close()
 
-	var runs []RunInfo
-	for rows.Next() {
-		var runID, pipelineName, status string
-		var startedAt int64
-		var completedAt sql.NullInt64
-
-		if err := rows.Scan(&runID, &pipelineName, &status, &startedAt, &completedAt); err != nil {
-			continue
-		}
-
-		startTime := time.Unix(startedAt, 0)
+	runs := make([]RunInfo, 0, len(records))
+	for _, r := range records {
 		var duration string
 		var durationMs int64
 
 		switch {
-		case completedAt.Valid:
-			endTime := time.Unix(completedAt.Int64, 0)
-			durationMs = endTime.Sub(startTime).Milliseconds()
-			duration = formatDuration(endTime.Sub(startTime))
-		case strings.ToLower(status) == "running":
-			durationMs = time.Since(startTime).Milliseconds()
-			duration = formatDuration(time.Since(startTime)) + " (running)"
+		case r.CompletedAt != nil:
+			d := r.CompletedAt.Sub(r.StartedAt)
+			durationMs = d.Milliseconds()
+			duration = formatDuration(d)
+		case strings.ToLower(r.Status) == "running":
+			d := time.Since(r.StartedAt)
+			durationMs = d.Milliseconds()
+			duration = formatDuration(d) + " (running)"
 		default:
 			duration = "-"
 		}
 
 		runs = append(runs, RunInfo{
-			RunID:      runID,
-			Pipeline:   pipelineName,
-			Status:     status,
-			StartedAt:  startTime.Format("2006-01-02 15:04:05"),
+			RunID:      r.RunID,
+			Pipeline:   r.PipelineName,
+			Status:     r.Status,
+			StartedAt:  r.StartedAt.Format("2006-01-02 15:04:05"),
 			Duration:   duration,
 			DurationMs: durationMs,
 		})

--- a/cmd/wave/commands/list_test.go
+++ b/cmd/wave/commands/list_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,10 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // T084: Test helpers for list command tests
@@ -1148,29 +1146,19 @@ func TestListRunsCmd_WithDatabase(t *testing.T) {
 	require.NoError(t, err)
 
 	dbPath := filepath.Join(dbDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewStateStore(dbPath)
 	require.NoError(t, err)
-	defer db.Close()
+	defer store.Close()
 
-	// Create table
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER
-		)
-	`)
-	require.NoError(t, err)
-
-	// Insert test data
-	now := time.Now().Unix()
-	_, err = db.Exec(`
-		INSERT INTO pipeline_run (run_id, pipeline_name, status, started_at, completed_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, "run-123", "test-pipeline", "completed", now-3600, now)
-	require.NoError(t, err)
+	now := time.Now()
+	completed := now
+	require.NoError(t, state.SeedRun(store, state.SeedRunOptions{
+		RunID:        "run-123",
+		PipelineName: "test-pipeline",
+		Status:       "completed",
+		StartedAt:    now.Add(-1 * time.Hour),
+		CompletedAt:  &completed,
+	}))
 
 	stdout, _, err := executeListRunsCmd()
 
@@ -1195,30 +1183,28 @@ func TestListRunsCmd_StatusFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	dbPath := filepath.Join(dbDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewStateStore(dbPath)
 	require.NoError(t, err)
-	defer db.Close()
+	defer store.Close()
 
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER
-		)
-	`)
-	require.NoError(t, err)
+	now := time.Now()
+	completed1 := now
+	completed2 := now.Add(-1 * time.Hour)
+	require.NoError(t, state.SeedRun(store, state.SeedRunOptions{
+		RunID:        "run-1",
+		PipelineName: "pipeline-a",
+		Status:       "completed",
+		StartedAt:    now.Add(-1 * time.Hour),
+		CompletedAt:  &completed1,
+	}))
+	require.NoError(t, state.SeedRun(store, state.SeedRunOptions{
+		RunID:        "run-2",
+		PipelineName: "pipeline-b",
+		Status:       "failed",
+		StartedAt:    now.Add(-2 * time.Hour),
+		CompletedAt:  &completed2,
+	}))
 
-	now := time.Now().Unix()
-	_, err = db.Exec(`INSERT INTO pipeline_run VALUES (?, ?, ?, ?, ?)`,
-		"run-1", "pipeline-a", "completed", now-3600, now)
-	require.NoError(t, err)
-	_, err = db.Exec(`INSERT INTO pipeline_run VALUES (?, ?, ?, ?, ?)`,
-		"run-2", "pipeline-b", "failed", now-7200, now-3600)
-	require.NoError(t, err)
-
-	// Filter by status
 	stdout, _, err := executeListRunsCmd("--run-status", "completed")
 
 	require.NoError(t, err)
@@ -1238,25 +1224,19 @@ func TestListRunsCmd_JSONStructure(t *testing.T) {
 	require.NoError(t, err)
 
 	dbPath := filepath.Join(dbDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewStateStore(dbPath)
 	require.NoError(t, err)
-	defer db.Close()
+	defer store.Close()
 
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER
-		)
-	`)
-	require.NoError(t, err)
-
-	now := time.Now().Unix()
-	_, err = db.Exec(`INSERT INTO pipeline_run VALUES (?, ?, ?, ?, ?)`,
-		"test-run", "test-pipeline", "completed", now-60, now)
-	require.NoError(t, err)
+	now := time.Now()
+	completed := now
+	require.NoError(t, state.SeedRun(store, state.SeedRunOptions{
+		RunID:        "test-run",
+		PipelineName: "test-pipeline",
+		Status:       "completed",
+		StartedAt:    now.Add(-1 * time.Minute),
+		CompletedAt:  &completed,
+	}))
 
 	stdout, _, err := executeListRunsCmd("--format", "json")
 
@@ -1557,26 +1537,20 @@ func TestListRunsCmd_NoTruncationAtWideTerminal(t *testing.T) {
 	require.NoError(t, err)
 
 	dbPath := filepath.Join(dbDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewStateStore(dbPath)
 	require.NoError(t, err)
-	defer db.Close()
-
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER
-		)
-	`)
-	require.NoError(t, err)
+	defer store.Close()
 
 	longRunID := "gh-implement-20260227-093609-787b-extra-suffix"
-	now := time.Now().Unix()
-	_, err = db.Exec(`INSERT INTO pipeline_run VALUES (?, ?, ?, ?, ?)`,
-		longRunID, "feature-pipeline", "completed", now-3600, now)
-	require.NoError(t, err)
+	now := time.Now()
+	completed := now
+	require.NoError(t, state.SeedRun(store, state.SeedRunOptions{
+		RunID:        longRunID,
+		PipelineName: "feature-pipeline",
+		Status:       "completed",
+		StartedAt:    now.Add(-1 * time.Hour),
+		CompletedAt:  &completed,
+	}))
 
 	stdout, _, err := executeListRunsCmd()
 

--- a/cmd/wave/commands/logs.go
+++ b/cmd/wave/commands/logs.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,9 +10,8 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/audit"
+	"github.com/recinq/wave/internal/state"
 	"github.com/spf13/cobra"
-
-	_ "modernc.org/sqlite"
 )
 
 // LogsOptions holds options for the logs command.
@@ -108,20 +106,20 @@ func runLogs(opts LogsOptions) error {
 		return nil
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	store, err := state.NewReadOnlyStateStore(dbPath)
 	if err != nil {
 		return NewCLIError(CodeStateDBError, fmt.Sprintf("failed to open state database: %s", err), "Check .agents/state.db file permissions or run 'wave run' to create it").WithCause(err)
 	}
-	defer db.Close()
-
-	// Configure SQLite
-	db.SetMaxOpenConns(1)
+	defer store.Close()
 
 	// Resolve run ID if not provided
 	runID := opts.RunID
 	if runID == "" {
-		runID, err = getMostRecentRunID(db)
+		runID, err = store.GetMostRecentRunID()
 		if err != nil {
+			return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query most recent run: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+		}
+		if runID == "" {
 			if opts.Format == "json" {
 				fmt.Println(`{"run_id":"","logs":[]}`)
 				return nil
@@ -132,7 +130,11 @@ func runLogs(opts LogsOptions) error {
 	}
 
 	// Verify run exists
-	if !runExists(db, runID) {
+	exists, err := store.RunExists(runID)
+	if err != nil {
+		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to verify run: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+	}
+	if !exists {
 		if opts.Format == "json" {
 			fmt.Printf(`{"run_id":"%s","logs":[],"error":"run not found"}`, runID)
 			fmt.Println()
@@ -148,18 +150,59 @@ func runLogs(opts LogsOptions) error {
 	}
 
 	if opts.Follow {
-		return runLogsFollow(db, runID, opts)
+		return runLogsFollow(store, runID, opts)
 	}
 
-	return runLogsOnce(db, runID, opts)
+	return runLogsOnce(store, runID, opts)
+}
+
+// queryEventOptions translates LogsOptions to state.EventQueryOptions.
+func queryEventOptions(opts LogsOptions) (state.EventQueryOptions, error) {
+	q := state.EventQueryOptions{
+		StepID:     opts.Step,
+		ErrorsOnly: opts.Level == "error",
+		TailLimit:  opts.Tail,
+	}
+	if opts.Since != "" {
+		duration, err := parseDuration(opts.Since)
+		if err != nil {
+			return q, NewCLIError(CodeInvalidArgs, fmt.Sprintf("invalid --since duration: %s", err), "Use a duration like '10m', '1h', or '30s'").WithCause(err)
+		}
+		q.SinceUnix = time.Now().Add(-duration).Unix()
+	}
+	return q, nil
+}
+
+// recordsToEntries converts state.LogRecord values into the CLI's LogsEntry DTO.
+func recordsToEntries(records []state.LogRecord) []LogsEntry {
+	out := make([]LogsEntry, 0, len(records))
+	for _, r := range records {
+		out = append(out, LogsEntry{
+			Timestamp:  r.Timestamp.Format("15:04:05"),
+			State:      r.State,
+			StepID:     r.StepID,
+			Persona:    r.Persona,
+			Message:    r.Message,
+			TokensUsed: r.TokensUsed,
+			DurationMs: r.DurationMs,
+		})
+	}
+	return out
 }
 
 // runLogsOnce retrieves and displays logs once.
-func runLogsOnce(db *sql.DB, runID string, opts LogsOptions) error {
-	logs, err := queryLogs(db, runID, opts)
+func runLogsOnce(store state.StateStore, runID string, opts LogsOptions) error {
+	q, err := queryEventOptions(opts)
 	if err != nil {
 		return err
 	}
+
+	records, err := store.GetEvents(runID, q)
+	if err != nil {
+		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query logs: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+	}
+
+	logs := recordsToEntries(records)
 
 	if len(logs) == 0 {
 		if opts.Format == "json" {
@@ -172,21 +215,20 @@ func runLogsOnce(db *sql.DB, runID string, opts LogsOptions) error {
 		return nil
 	}
 
-	err = outputLogs(runID, logs, opts)
-	if err != nil {
+	if err := outputLogs(runID, logs, opts); err != nil {
 		return err
 	}
 
 	// Show performance summary in text mode (not for --errors or --step filters)
 	if opts.Format == "text" && !opts.Errors && opts.Step == "" {
-		renderPerformanceSummary(db, runID)
+		renderPerformanceSummary(store, runID)
 	}
 
 	return nil
 }
 
 // runLogsFollow streams logs in real-time.
-func runLogsFollow(db *sql.DB, runID string, opts LogsOptions) error {
+func runLogsFollow(store state.StateStore, runID string, opts LogsOptions) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -198,23 +240,42 @@ func runLogsFollow(db *sql.DB, runID string, opts LogsOptions) error {
 		cancel()
 	}()
 
-	var lastID int64 = 0
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
-	// Print initial logs
-	logs, err := queryLogs(db, runID, opts)
+	q, err := queryEventOptions(opts)
 	if err != nil {
 		return err
 	}
 
-	for _, log := range logs {
-		printLogEntry(log, opts.Format)
-		// Track the highest ID we've seen
-		id := getLogID(db, runID, log)
-		if id > lastID {
-			lastID = id
+	// Print initial logs and seed lastID from the highest event ID seen.
+	initial, err := store.GetEvents(runID, q)
+	if err != nil {
+		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query logs: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
+	}
+	for _, r := range initial {
+		printLogEntry(LogsEntry{
+			Timestamp:  r.Timestamp.Format("15:04:05"),
+			State:      r.State,
+			StepID:     r.StepID,
+			Persona:    r.Persona,
+			Message:    r.Message,
+			TokensUsed: r.TokensUsed,
+			DurationMs: r.DurationMs,
+		}, opts.Format)
+	}
+
+	var lastID int64
+	for _, r := range initial {
+		if r.ID > lastID {
+			lastID = r.ID
 		}
+	}
+
+	// Follow mode polls AfterID — TailLimit/SinceUnix only apply to the initial fetch.
+	pollOpts := state.EventQueryOptions{
+		StepID:     opts.Step,
+		ErrorsOnly: opts.Level == "error",
 	}
 
 	for {
@@ -222,220 +283,38 @@ func runLogsFollow(db *sql.DB, runID string, opts LogsOptions) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			// Check if pipeline is still running
-			status, err := getRunStatus(db, runID)
-			if err != nil {
+			status, statusErr := store.GetRunStatus(runID)
+			if statusErr != nil {
 				return nil
 			}
 
-			// Query new logs since lastID
-			newLogs, newLastID, err := queryNewLogs(db, runID, lastID, opts)
+			pollOpts.AfterID = lastID
+			newRecords, err := store.GetEvents(runID, pollOpts)
 			if err != nil {
 				continue
 			}
 
-			for _, log := range newLogs {
-				printLogEntry(log, opts.Format)
-			}
-			if newLastID > lastID {
-				lastID = newLastID
+			for _, r := range newRecords {
+				printLogEntry(LogsEntry{
+					Timestamp:  r.Timestamp.Format("15:04:05"),
+					State:      r.State,
+					StepID:     r.StepID,
+					Persona:    r.Persona,
+					Message:    r.Message,
+					TokensUsed: r.TokensUsed,
+					DurationMs: r.DurationMs,
+				}, opts.Format)
+				if r.ID > lastID {
+					lastID = r.ID
+				}
 			}
 
-			// Exit if pipeline completed
-			if status != "running" && status != "pending" {
+			// Exit if pipeline completed (or run vanished).
+			if status == "" || (status != "running" && status != "pending") {
 				return nil
 			}
 		}
 	}
-}
-
-// queryLogs retrieves logs matching the options.
-func queryLogs(db *sql.DB, runID string, opts LogsOptions) ([]LogsEntry, error) {
-	query := `SELECT timestamp, step_id, state, persona, message, tokens_used, duration_ms
-	          FROM event_log
-	          WHERE run_id = ?`
-	args := []any{runID}
-
-	if opts.Step != "" {
-		query += " AND step_id = ?"
-		args = append(args, opts.Step)
-	}
-
-	if opts.Level == "error" {
-		query += " AND state = 'failed'"
-	}
-
-	if opts.Since != "" {
-		duration, err := parseDuration(opts.Since)
-		if err != nil {
-			return nil, NewCLIError(CodeInvalidArgs, fmt.Sprintf("invalid --since duration: %s", err), "Use a duration like '10m', '1h', or '30s'").WithCause(err)
-		}
-		cutoff := time.Now().Add(-duration).Unix()
-		query += " AND timestamp >= ?"
-		args = append(args, cutoff)
-	}
-
-	query += " ORDER BY timestamp ASC, id ASC"
-
-	if opts.Tail > 0 {
-		query = `SELECT timestamp, step_id, state, persona, message, tokens_used, duration_ms
-		         FROM event_log
-		         WHERE run_id = ?`
-		args = []any{runID}
-
-		if opts.Step != "" {
-			query += " AND step_id = ?"
-			args = append(args, opts.Step)
-		}
-
-		if opts.Level == "error" {
-			query += " AND state = 'failed'"
-		}
-
-		if opts.Since != "" {
-			duration, _ := parseDuration(opts.Since)
-			cutoff := time.Now().Add(-duration).Unix()
-			query += " AND timestamp >= ?"
-			args = append(args, cutoff)
-		}
-
-		// Order DESC, limit, then we'll reverse in code
-		query += " ORDER BY timestamp DESC, id DESC LIMIT ?"
-		args = append(args, opts.Tail)
-	}
-
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, NewCLIError(CodeInternalError, fmt.Sprintf("failed to query logs: %s", err), "The state database may be corrupted -- try 'wave migrate validate'").WithCause(err)
-	}
-	defer rows.Close()
-
-	var logs []LogsEntry
-	for rows.Next() {
-		var log LogsEntry
-		var timestamp int64
-		var stepID, persona, message sql.NullString
-		var tokensUsed, durationMs sql.NullInt64
-
-		err := rows.Scan(
-			&timestamp,
-			&stepID,
-			&log.State,
-			&persona,
-			&message,
-			&tokensUsed,
-			&durationMs,
-		)
-		if err != nil {
-			return nil, NewCLIError(CodeInternalError, fmt.Sprintf("failed to scan log: %s", err), "The state database may have schema issues -- try 'wave migrate up'").WithCause(err)
-		}
-
-		log.Timestamp = time.Unix(timestamp, 0).Format("15:04:05")
-		if stepID.Valid {
-			log.StepID = stepID.String
-		}
-		if persona.Valid {
-			log.Persona = persona.String
-		}
-		if message.Valid {
-			log.Message = message.String
-		}
-		if tokensUsed.Valid {
-			log.TokensUsed = int(tokensUsed.Int64)
-		}
-		if durationMs.Valid {
-			log.DurationMs = durationMs.Int64
-		}
-
-		logs = append(logs, log)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, NewCLIError(CodeInternalError, fmt.Sprintf("error iterating logs: %s", err), "The state database may have schema issues -- try 'wave migrate up'").WithCause(err)
-	}
-
-	// Reverse if we used tail with DESC order
-	if opts.Tail > 0 && len(logs) > 0 {
-		for i, j := 0, len(logs)-1; i < j; i, j = i+1, j-1 {
-			logs[i], logs[j] = logs[j], logs[i]
-		}
-	}
-
-	return logs, nil
-}
-
-// queryNewLogs retrieves logs newer than lastID.
-func queryNewLogs(db *sql.DB, runID string, lastID int64, opts LogsOptions) ([]LogsEntry, int64, error) {
-	query := `SELECT id, timestamp, step_id, state, persona, message, tokens_used, duration_ms
-	          FROM event_log
-	          WHERE run_id = ? AND id > ?`
-	args := []any{runID, lastID}
-
-	if opts.Step != "" {
-		query += " AND step_id = ?"
-		args = append(args, opts.Step)
-	}
-
-	if opts.Level == "error" {
-		query += " AND state = 'failed'"
-	}
-
-	query += " ORDER BY id ASC"
-
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, lastID, NewCLIError(CodeInternalError, fmt.Sprintf("failed to query new logs: %s", err), "Database query error during follow mode").WithCause(err)
-	}
-	defer rows.Close()
-
-	var logs []LogsEntry
-	newLastID := lastID
-
-	for rows.Next() {
-		var log LogsEntry
-		var id, timestamp int64
-		var stepID, persona, message sql.NullString
-		var tokensUsed, durationMs sql.NullInt64
-
-		err := rows.Scan(
-			&id,
-			&timestamp,
-			&stepID,
-			&log.State,
-			&persona,
-			&message,
-			&tokensUsed,
-			&durationMs,
-		)
-		if err != nil {
-			return nil, lastID, NewCLIError(CodeInternalError, fmt.Sprintf("failed to scan log: %s", err), "Database schema mismatch -- try 'wave migrate up'").WithCause(err)
-		}
-
-		if id > newLastID {
-			newLastID = id
-		}
-
-		log.Timestamp = time.Unix(timestamp, 0).Format("15:04:05")
-		if stepID.Valid {
-			log.StepID = stepID.String
-		}
-		if persona.Valid {
-			log.Persona = persona.String
-		}
-		if message.Valid {
-			log.Message = message.String
-		}
-		if tokensUsed.Valid {
-			log.TokensUsed = int(tokensUsed.Int64)
-		}
-		if durationMs.Valid {
-			log.DurationMs = durationMs.Int64
-		}
-
-		logs = append(logs, log)
-	}
-
-	return logs, newLastID, nil
 }
 
 // outputLogs formats and outputs the logs.
@@ -450,7 +329,6 @@ func outputLogs(runID string, logs []LogsEntry, opts LogsOptions) error {
 		return nil
 	}
 
-	// Text format
 	for _, log := range logs {
 		printLogEntry(log, opts.Format)
 	}
@@ -507,55 +385,10 @@ func printLogEntry(log LogsEntry, format string) {
 	fmt.Println(strings.Join(parts, " "))
 }
 
-// getMostRecentRunID gets the most recent run ID.
-func getMostRecentRunID(db *sql.DB) (string, error) {
-	var runID string
-	err := db.QueryRow(`SELECT run_id FROM pipeline_run ORDER BY started_at DESC LIMIT 1`).Scan(&runID)
-	if err != nil {
-		return "", err
-	}
-	return runID, nil
-}
-
-// runExists checks if a run exists.
-func runExists(db *sql.DB, runID string) bool {
-	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM pipeline_run WHERE run_id = ?`, runID).Scan(&count)
-	return err == nil && count > 0
-}
-
-// getRunStatus gets the status of a run.
-func getRunStatus(db *sql.DB, runID string) (string, error) {
-	var status string
-	err := db.QueryRow(`SELECT status FROM pipeline_run WHERE run_id = ?`, runID).Scan(&status)
-	return status, err
-}
-
-// getLogID gets the ID of a log entry (for follow mode tracking).
-func getLogID(db *sql.DB, runID string, log LogsEntry) int64 {
-	// Parse timestamp back to unix time
-	t, err := time.Parse("15:04:05", log.Timestamp)
-	if err != nil {
-		return 0
-	}
-	// Combine with today's date
-	now := time.Now()
-	fullTime := time.Date(now.Year(), now.Month(), now.Day(), t.Hour(), t.Minute(), t.Second(), 0, time.Local)
-
-	var id int64
-	err = db.QueryRow(`SELECT id FROM event_log WHERE run_id = ? AND timestamp = ? AND state = ? LIMIT 1`,
-		runID, fullTime.Unix(), log.State).Scan(&id)
-	if err != nil {
-		return 0
-	}
-	return id
-}
-
 // runLogsTrace reads and displays structured NDJSON trace events from a debug trace file.
 func runLogsTrace(opts LogsOptions) error {
 	traceDir := ".agents/traces"
 
-	// If no run ID, find the most recent trace file.
 	runID := opts.RunID
 	if runID == "" {
 		dbPath := ".agents/state.db"
@@ -563,15 +396,17 @@ func runLogsTrace(opts LogsOptions) error {
 			fmt.Println("No trace files found (no runs recorded)")
 			return nil
 		}
-		db, err := sql.Open("sqlite", dbPath)
+		store, err := state.NewReadOnlyStateStore(dbPath)
 		if err != nil {
 			return NewCLIError(CodeStateDBError, fmt.Sprintf("failed to open state database: %s", err), "Check .agents/state.db file permissions").WithCause(err)
 		}
-		defer db.Close()
-		db.SetMaxOpenConns(1)
+		defer store.Close()
 
-		runID, err = getMostRecentRunID(db)
+		runID, err = store.GetMostRecentRunID()
 		if err != nil {
+			return NewCLIError(CodeInternalError, fmt.Sprintf("failed to query most recent run: %s", err), "The state database may be corrupted").WithCause(err)
+		}
+		if runID == "" {
 			fmt.Println("No pipeline runs found")
 			return nil
 		}
@@ -593,7 +428,6 @@ func runLogsTrace(opts LogsOptions) error {
 		return NewCLIError(CodeInternalError, fmt.Sprintf("failed to read trace file: %s", err), "The trace file may be corrupted or incomplete").WithCause(err)
 	}
 
-	// Filter by step if requested.
 	if opts.Step != "" {
 		var filtered []audit.TraceEvent
 		for _, ev := range events {
@@ -622,10 +456,8 @@ func runLogsTrace(opts LogsOptions) error {
 		return nil
 	}
 
-	// Text format.
 	for _, ev := range events {
 		ts := ev.Timestamp
-		// Shorten to time-only if it's a full RFC3339 timestamp.
 		if len(ts) > 19 {
 			if t, parseErr := time.Parse(time.RFC3339Nano, ts); parseErr == nil {
 				ts = t.Format("15:04:05.000")
@@ -640,7 +472,6 @@ func runLogsTrace(opts LogsOptions) error {
 			line += fmt.Sprintf(" %dms", ev.DurationMs)
 		}
 
-		// Print selected metadata inline.
 		for k, v := range ev.Metadata {
 			line += fmt.Sprintf(" %s=%s", k, v)
 		}
@@ -652,46 +483,32 @@ func runLogsTrace(opts LogsOptions) error {
 }
 
 // renderPerformanceSummary displays aggregated performance metrics for a run.
-func renderPerformanceSummary(db *sql.DB, runID string) {
-	// Query aggregated metrics
-	query := `SELECT
-	              COUNT(*) as total_events,
-	              SUM(COALESCE(tokens_used, 0)) as total_tokens,
-	              AVG(COALESCE(duration_ms, 0)) as avg_duration,
-	              MIN(COALESCE(duration_ms, 0)) as min_duration,
-	              MAX(COALESCE(duration_ms, 0)) as max_duration
-	          FROM event_log
-	          WHERE run_id = ? AND state IN ('completed', 'failed')`
-
-	var totalEvents, totalTokens int
-	var avgDuration, minDuration, maxDuration sql.NullFloat64
-
-	err := db.QueryRow(query, runID).Scan(&totalEvents, &totalTokens, &avgDuration, &minDuration, &maxDuration)
-	if err != nil || totalEvents == 0 {
+func renderPerformanceSummary(store state.StateStore, runID string) {
+	stats, err := store.GetEventAggregateStats(runID)
+	if err != nil || stats == nil || stats.TotalEvents == 0 {
 		return
 	}
 
 	fmt.Fprintln(os.Stderr, "\n--- Performance Summary ---")
-	fmt.Fprintf(os.Stderr, "Total Steps: %d\n", totalEvents)
+	fmt.Fprintf(os.Stderr, "Total Steps: %d\n", stats.TotalEvents)
 
-	if totalTokens > 0 {
-		fmt.Fprintf(os.Stderr, "Total Tokens: %s\n", formatTokens(totalTokens))
+	if stats.TotalTokens > 0 {
+		fmt.Fprintf(os.Stderr, "Total Tokens: %s\n", formatTokens(stats.TotalTokens))
 	}
 
-	if avgDuration.Valid && avgDuration.Float64 > 0 {
-		fmt.Fprintf(os.Stderr, "Avg Duration: %.1fs\n", avgDuration.Float64/1000.0)
+	if stats.AvgDurationMs > 0 {
+		fmt.Fprintf(os.Stderr, "Avg Duration: %.1fs\n", stats.AvgDurationMs/1000.0)
 	}
 
-	if minDuration.Valid && maxDuration.Valid && minDuration.Float64 > 0 {
+	if stats.MinDurationMs > 0 {
 		fmt.Fprintf(os.Stderr, "Duration Range: %.1fs - %.1fs\n",
-			minDuration.Float64/1000.0,
-			maxDuration.Float64/1000.0)
+			stats.MinDurationMs/1000.0,
+			stats.MaxDurationMs/1000.0)
 	}
 
-	// Calculate token burn rate
-	if avgDuration.Valid && avgDuration.Float64 > 0 && totalTokens > 0 {
-		totalDuration := avgDuration.Float64 * float64(totalEvents)
-		burnRate := float64(totalTokens) / (totalDuration / 1000.0)
+	if stats.AvgDurationMs > 0 && stats.TotalTokens > 0 {
+		totalDuration := stats.AvgDurationMs * float64(stats.TotalEvents)
+		burnRate := float64(stats.TotalTokens) / (totalDuration / 1000.0)
 		if burnRate >= 1.0 {
 			fmt.Fprintf(os.Stderr, "Token Burn Rate: %.1f tokens/s\n", burnRate)
 		}

--- a/cmd/wave/commands/logs_test.go
+++ b/cmd/wave/commands/logs_test.go
@@ -2,17 +2,15 @@ package commands
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // logsTestHelper provides common utilities for logs command tests.
@@ -20,7 +18,7 @@ type logsTestHelper struct {
 	t       *testing.T
 	tmpDir  string
 	origDir string
-	db      *sql.DB
+	store   state.StateStore
 }
 
 // newLogsTestHelper creates a new test helper with a temporary directory and database.
@@ -30,50 +28,19 @@ func newLogsTestHelper(t *testing.T) *logsTestHelper {
 	origDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get current directory")
 
-	// Create .wave directory
 	waveDir := filepath.Join(tmpDir, ".agents")
 	err = os.MkdirAll(waveDir, 0755)
 	require.NoError(t, err, "failed to create .wave directory")
 
-	// Create and initialize database
 	dbPath := filepath.Join(waveDir, "state.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err, "failed to open database")
-
-	// Initialize schema
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS pipeline_run (
-			run_id TEXT PRIMARY KEY,
-			pipeline_name TEXT NOT NULL,
-			status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
-			input TEXT,
-			current_step TEXT,
-			total_tokens INTEGER DEFAULT 0,
-			started_at INTEGER NOT NULL,
-			completed_at INTEGER,
-			cancelled_at INTEGER,
-			error_message TEXT
-		);
-		CREATE TABLE IF NOT EXISTS event_log (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			run_id TEXT NOT NULL,
-			timestamp INTEGER NOT NULL,
-			step_id TEXT,
-			state TEXT NOT NULL,
-			persona TEXT,
-			message TEXT,
-			tokens_used INTEGER,
-			duration_ms INTEGER,
-			FOREIGN KEY (run_id) REFERENCES pipeline_run(run_id) ON DELETE CASCADE
-		);
-	`)
-	require.NoError(t, err, "failed to initialize schema")
+	store, err := state.NewStateStore(dbPath)
+	require.NoError(t, err, "failed to create state store")
 
 	return &logsTestHelper{
 		t:       t,
 		tmpDir:  tmpDir,
 		origDir: origDir,
-		db:      db,
+		store:   store,
 	}
 }
 
@@ -84,35 +51,39 @@ func (h *logsTestHelper) chdir() {
 	require.NoError(h.t, err, "failed to change to temp directory")
 }
 
-// restore returns to the original directory and closes the database.
+// restore returns to the original directory and closes the store.
 func (h *logsTestHelper) restore() {
 	h.t.Helper()
 	_ = os.Chdir(h.origDir)
-	if h.db != nil {
-		h.db.Close()
+	if h.store != nil {
+		h.store.Close()
 	}
 }
 
 // createRun creates a run in the database.
 func (h *logsTestHelper) createRun(runID, pipelineName, status string, startedAt time.Time) {
 	h.t.Helper()
-
-	_, err := h.db.Exec(`
-		INSERT INTO pipeline_run (run_id, pipeline_name, status, total_tokens, started_at)
-		VALUES (?, ?, ?, 0, ?)
-	`, runID, pipelineName, status, startedAt.Unix())
-	require.NoError(h.t, err, "failed to create run")
+	require.NoError(h.t, state.SeedRun(h.store, state.SeedRunOptions{
+		RunID:        runID,
+		PipelineName: pipelineName,
+		Status:       status,
+		StartedAt:    startedAt,
+	}), "failed to create run")
 }
 
 // createLogEntry creates a log entry in the database.
-func (h *logsTestHelper) createLogEntry(runID string, timestamp time.Time, stepID, state, persona, message string, tokens int, durationMs int64) {
+func (h *logsTestHelper) createLogEntry(runID string, timestamp time.Time, stepID, evState, persona, message string, tokens int, durationMs int64) {
 	h.t.Helper()
-
-	_, err := h.db.Exec(`
-		INSERT INTO event_log (run_id, timestamp, step_id, state, persona, message, tokens_used, duration_ms)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, runID, timestamp.Unix(), stepID, state, persona, message, tokens, durationMs)
-	require.NoError(h.t, err, "failed to create log entry")
+	require.NoError(h.t, state.SeedEvent(h.store, state.SeedEventOptions{
+		RunID:      runID,
+		Timestamp:  timestamp,
+		StepID:     stepID,
+		State:      evState,
+		Persona:    persona,
+		Message:    message,
+		TokensUsed: tokens,
+		DurationMs: durationMs,
+	}), "failed to create log entry")
 }
 
 // executeLogsCmd runs the logs command with given arguments and returns output/error.

--- a/cmd/wave/commands/status_test.go
+++ b/cmd/wave/commands/status_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -13,8 +12,6 @@ import (
 	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // statusTestHelper provides common utilities for status command tests.
@@ -23,7 +20,6 @@ type statusTestHelper struct {
 	tmpDir  string
 	origDir string
 	store   state.StateStore
-	db      *sql.DB // direct connection for test data insertion with specific IDs
 }
 
 // newStatusTestHelper creates a new test helper with a temporary directory and database.
@@ -33,26 +29,19 @@ func newStatusTestHelper(t *testing.T) *statusTestHelper {
 	origDir, err := os.Getwd()
 	require.NoError(t, err, "failed to get current directory")
 
-	// Create .wave directory
 	waveDir := filepath.Join(tmpDir, ".agents")
 	err = os.MkdirAll(waveDir, 0755)
 	require.NoError(t, err, "failed to create .wave directory")
 
-	// Create state store (applies all migrations, ensuring full schema)
 	dbPath := filepath.Join(waveDir, "state.db")
 	store, err := state.NewStateStore(dbPath)
 	require.NoError(t, err, "failed to create state store")
-
-	// Open a direct SQL connection for inserting test data with specific run IDs
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err, "failed to open direct db connection")
 
 	return &statusTestHelper{
 		t:       t,
 		tmpDir:  tmpDir,
 		origDir: origDir,
 		store:   store,
-		db:      db,
 	}
 }
 
@@ -67,9 +56,6 @@ func (h *statusTestHelper) chdir() {
 func (h *statusTestHelper) restore() {
 	h.t.Helper()
 	_ = os.Chdir(h.origDir)
-	if h.db != nil {
-		h.db.Close()
-	}
 	if h.store != nil {
 		h.store.Close()
 	}
@@ -78,43 +64,28 @@ func (h *statusTestHelper) restore() {
 // createRun creates a run in the database.
 func (h *statusTestHelper) createRun(runID, pipelineName, status, currentStep string, tokens int, startedAt time.Time, completedAt *time.Time) {
 	h.t.Helper()
-
-	var completedAtUnix *int64
-	if completedAt != nil {
-		unix := completedAt.Unix()
-		completedAtUnix = &unix
-	}
-
-	var step any
-	if currentStep == "" {
-		step = nil
-	} else {
-		step = currentStep
-	}
-
-	_, err := h.db.Exec(`
-		INSERT INTO pipeline_run (run_id, pipeline_name, status, current_step, total_tokens, started_at, completed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, runID, pipelineName, status, step, tokens, startedAt.Unix(), completedAtUnix)
-	require.NoError(h.t, err, "failed to create run")
+	require.NoError(h.t, state.SeedRun(h.store, state.SeedRunOptions{
+		RunID:        runID,
+		PipelineName: pipelineName,
+		Status:       status,
+		CurrentStep:  currentStep,
+		TotalTokens:  tokens,
+		StartedAt:    startedAt,
+		CompletedAt:  completedAt,
+	}), "failed to create run")
 }
 
 // createRunWithInput creates a run with input and optional error message.
 func (h *statusTestHelper) createRunWithInput(runID, pipelineName, status, input string, startedAt time.Time, errorMsg string) {
 	h.t.Helper()
-
-	var errVal any
-	if errorMsg == "" {
-		errVal = nil
-	} else {
-		errVal = errorMsg
-	}
-
-	_, err := h.db.Exec(`
-		INSERT INTO pipeline_run (run_id, pipeline_name, status, input, total_tokens, started_at, error_message)
-		VALUES (?, ?, ?, ?, 0, ?, ?)
-	`, runID, pipelineName, status, input, startedAt.Unix(), errVal)
-	require.NoError(h.t, err, "failed to create run")
+	require.NoError(h.t, state.SeedRun(h.store, state.SeedRunOptions{
+		RunID:        runID,
+		PipelineName: pipelineName,
+		Status:       status,
+		Input:        input,
+		StartedAt:    startedAt,
+		ErrorMessage: errorMsg,
+	}), "failed to create run")
 }
 
 // executeStatusCmd runs the status command with given arguments and returns output/error.

--- a/docs/adr/007-consolidate-database-access-through-statestore-interface.md
+++ b/docs/adr/007-consolidate-database-access-through-statestore-interface.md
@@ -1,21 +1,21 @@
 # ADR-007: Consolidate Database Access Through StateStore Interface
 
 ## Status
-Proposed (not started — five bypass sites confirmed open as of 2026-04-26)
+Accepted (implemented 2026-04-27 in #1275)
 
 ## Date
 2026-04-13
 
 ## Implementation Status
 
-Not started. All bypass sites listed in this ADR remain open:
-- `cmd/wave/commands/logs.go` (lines ~111, ~566) — opens `sql.Open("sqlite", ...)` directly.
-- `cmd/wave/commands/list.go` — `database/sql` import, `collectRunsFromDB()`.
-- `cmd/wave/commands/decisions.go` — `database/sql` import, `queryDecisions()`.
-- `cmd/wave/commands/clean.go` (lines ~4, ~68) — opens `sql.Open` directly.
-- `internal/webui/server.go` (line ~219) — `backfillRunTokens()` opens `sql.Open` directly.
+Implemented. All bypass sites have been routed through `state.StateStore`:
+- `cmd/wave/commands/logs.go` — opens via `state.NewReadOnlyStateStore`; uses `GetMostRecentRunID`, `RunExists`, `GetRunStatus`, `GetEvents` (now honours `SinceUnix`, `TailLimit`, `OrderDesc`), and `GetEventAggregateStats`.
+- `cmd/wave/commands/decisions.go` — `GetDecisionsFiltered(runID, DecisionQueryOptions)` with `StepID`/`Category` filters.
+- `cmd/wave/commands/clean.go` — `ListPipelineNamesByStatus` with built-in `pipeline_state` fallback.
+- `cmd/wave/commands/list.go` — `ListRuns(state.ListRunsOptions)` replaces `collectRunsFromDB`.
+- `internal/webui/server.go` — `BackfillRunTokens()` on `StateStore`; the local helper is gone.
 
-`StateStore` interface unchanged (~50 methods). No new `EventQueryOptions.SinceTime`/`TailLimit`, no `DecisionQueryOptions`, no `ListPipelineNamesByStatus()`, no `GetEventAggregation()`. `.golangci.yml` has no rule blocking `database/sql` imports under `cmd/wave/commands/**` — see ADR-003 next-iteration note.
+`StateStore` interface gained 8 read methods (`GetMostRecentRunID`, `RunExists`, `GetRunStatus`, `ListPipelineNamesByStatus`, `BackfillRunTokens`, `GetEventAggregateStats`, `GetDecisionsFiltered`) plus `EventQueryOptions{SinceUnix, TailLimit, OrderDesc}` and the `DecisionQueryOptions` struct. `.golangci.yml` adds the `no-direct-sql` depguard rule denying `database/sql` outside `internal/state/**`. Test fixtures use `state.SeedRun`/`state.SeedEvent`/`state.SeedDecision` helpers. Repo-wide grep confirms `database/sql` lives only in `internal/state/`.
 
 ## Context
 

--- a/internal/state/seed.go
+++ b/internal/state/seed.go
@@ -1,0 +1,124 @@
+package state
+
+import (
+	"fmt"
+	"time"
+)
+
+// SeedRunOptions configures a deterministic run insert for fixtures.
+// Empty CompletedAt leaves the column NULL.
+type SeedRunOptions struct {
+	RunID        string
+	PipelineName string
+	Status       string
+	Input        string
+	CurrentStep  string
+	TotalTokens  int
+	StartedAt    time.Time
+	CompletedAt  *time.Time
+	ErrorMessage string
+}
+
+// SeedRun inserts a pipeline_run row with caller-specified fields.
+// Intended for test fixtures where deterministic run IDs and timestamps are
+// required (production code must use CreateRun).
+func SeedRun(store StateStore, opts SeedRunOptions) error {
+	s, ok := store.(*stateStore)
+	if !ok {
+		return fmt.Errorf("SeedRun requires a *stateStore implementation")
+	}
+
+	var completedUnix any
+	if opts.CompletedAt != nil {
+		completedUnix = opts.CompletedAt.Unix()
+	}
+
+	var step any
+	if opts.CurrentStep != "" {
+		step = opts.CurrentStep
+	}
+
+	var errMsg any
+	if opts.ErrorMessage != "" {
+		errMsg = opts.ErrorMessage
+	}
+
+	_, err := s.db.Exec(
+		`INSERT INTO pipeline_run (run_id, pipeline_name, status, input, current_step, total_tokens, started_at, completed_at, error_message)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		opts.RunID, opts.PipelineName, opts.Status, opts.Input, step, opts.TotalTokens,
+		opts.StartedAt.Unix(), completedUnix, errMsg,
+	)
+	if err != nil {
+		return fmt.Errorf("seed run: %w", err)
+	}
+	return nil
+}
+
+// SeedEventOptions configures a deterministic event_log insert for fixtures.
+type SeedEventOptions struct {
+	RunID      string
+	Timestamp  time.Time
+	StepID     string
+	State      string
+	Persona    string
+	Message    string
+	TokensUsed int
+	DurationMs int64
+	Model      string
+	Adapter    string
+}
+
+// SeedEvent inserts an event_log row with caller-specified fields. Intended
+// for test fixtures requiring back-dated timestamps.
+func SeedEvent(store StateStore, opts SeedEventOptions) error {
+	s, ok := store.(*stateStore)
+	if !ok {
+		return fmt.Errorf("SeedEvent requires a *stateStore implementation")
+	}
+
+	_, err := s.db.Exec(
+		`INSERT INTO event_log (run_id, timestamp, step_id, state, persona, message, tokens_used, duration_ms, model, configured_model, adapter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		opts.RunID, opts.Timestamp.Unix(), opts.StepID, opts.State, opts.Persona, opts.Message,
+		opts.TokensUsed, opts.DurationMs, opts.Model, "", opts.Adapter,
+	)
+	if err != nil {
+		return fmt.Errorf("seed event: %w", err)
+	}
+	return nil
+}
+
+// SeedDecisionOptions configures a deterministic decision_log insert for fixtures.
+type SeedDecisionOptions struct {
+	RunID     string
+	StepID    string
+	Timestamp time.Time
+	Category  string
+	Decision  string
+	Rationale string
+	Context   string
+}
+
+// SeedDecision inserts a decision_log row with caller-specified fields.
+func SeedDecision(store StateStore, opts SeedDecisionOptions) error {
+	s, ok := store.(*stateStore)
+	if !ok {
+		return fmt.Errorf("SeedDecision requires a *stateStore implementation")
+	}
+
+	ctxJSON := opts.Context
+	if ctxJSON == "" {
+		ctxJSON = "{}"
+	}
+
+	_, err := s.db.Exec(
+		`INSERT INTO decision_log (run_id, step_id, timestamp, category, decision, rationale, context_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		opts.RunID, opts.StepID, opts.Timestamp.Unix(), opts.Category, opts.Decision, opts.Rationale, ctxJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("seed decision: %w", err)
+	}
+	return nil
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -71,10 +71,16 @@ type StateStore interface {
 	GetRunningRuns() ([]RunRecord, error)
 	ListRuns(opts ListRunsOptions) ([]RunRecord, error)
 	DeleteRun(runID string) error
+	GetMostRecentRunID() (string, error)
+	RunExists(runID string) (bool, error)
+	GetRunStatus(runID string) (string, error)
+	ListPipelineNamesByStatus(status string) ([]string, error)
+	BackfillRunTokens() (int64, error)
 
 	// Event logging
 	LogEvent(runID string, stepID string, state string, persona string, message string, tokens int, durationMs int64, model string, configuredModel string, adapter string) error
 	GetEvents(runID string, opts EventQueryOptions) ([]LogRecord, error)
+	GetEventAggregateStats(runID string) (*EventAggregateStats, error)
 
 	// Artifact tracking
 	RegisterArtifact(runID string, stepID string, name string, path string, artifactType string, sizeBytes int64) error
@@ -151,6 +157,7 @@ type StateStore interface {
 	RecordDecision(record *DecisionRecord) error
 	GetDecisions(runID string) ([]*DecisionRecord, error)
 	GetDecisionsByStep(runID, stepID string) ([]*DecisionRecord, error)
+	GetDecisionsFiltered(runID string, opts DecisionQueryOptions) ([]*DecisionRecord, error)
 
 	// Audit log (cross-run event queries)
 	GetAuditEvents(states []string, limit, offset int) ([]LogRecord, error)
@@ -837,6 +844,113 @@ func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 	return s.queryRunsWithArgs(query, args...)
 }
 
+// GetMostRecentRunID returns the run_id with the most recent started_at.
+// Returns ("", nil) when no runs exist so callers can switch on empty string
+// without depending on database/sql sentinel errors.
+func (s *stateStore) GetMostRecentRunID() (string, error) {
+	var runID string
+	err := s.db.QueryRow(
+		`SELECT run_id FROM pipeline_run ORDER BY started_at DESC, run_id DESC LIMIT 1`,
+	).Scan(&runID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to query most recent run: %w", err)
+	}
+	return runID, nil
+}
+
+// RunExists reports whether a run with the given ID exists.
+func (s *stateStore) RunExists(runID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pipeline_run WHERE run_id = ?`, runID,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("failed to check run existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+// GetRunStatus returns the status of a run.
+// Returns ("", nil) when the run does not exist.
+func (s *stateStore) GetRunStatus(runID string) (string, error) {
+	var status string
+	err := s.db.QueryRow(
+		`SELECT status FROM pipeline_run WHERE run_id = ?`, runID,
+	).Scan(&status)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to query run status: %w", err)
+	}
+	return status, nil
+}
+
+// ListPipelineNamesByStatus returns distinct pipeline names whose status matches
+// the given status (case-insensitive). Falls back to pipeline_state if pipeline_run
+// query fails (legacy schema compatibility).
+func (s *stateStore) ListPipelineNamesByStatus(status string) ([]string, error) {
+	names, err := s.listDistinctPipelineNames(
+		`SELECT DISTINCT pipeline_name FROM pipeline_run WHERE LOWER(status) = LOWER(?)`,
+		status,
+	)
+	if err == nil {
+		return names, nil
+	}
+	// Fallback for legacy/partial schemas
+	return s.listDistinctPipelineNames(
+		`SELECT DISTINCT pipeline_name FROM pipeline_state WHERE LOWER(status) = LOWER(?)`,
+		status,
+	)
+}
+
+func (s *stateStore) listDistinctPipelineNames(query, status string) ([]string, error) {
+	rows, err := s.db.Query(query, status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query pipeline names by status: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("failed to scan pipeline name: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating pipeline names: %w", err)
+	}
+	return names, nil
+}
+
+// BackfillRunTokens updates pipeline_run.total_tokens from event_log for
+// finalized runs that still have 0 tokens. Idempotent — re-running yields 0
+// affected rows once all runs have been backfilled.
+func (s *stateStore) BackfillRunTokens() (int64, error) {
+	result, err := s.db.Exec(`
+		UPDATE pipeline_run SET total_tokens = (
+			SELECT COALESCE(SUM(el.tokens_used), 0)
+			FROM event_log el
+			WHERE el.run_id = pipeline_run.run_id AND el.tokens_used > 0
+		)
+		WHERE total_tokens = 0
+		AND status IN ('completed', 'failed', 'cancelled')
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to backfill run tokens: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read rows affected: %w", err)
+	}
+	return n, nil
+}
+
 // DeleteRun removes a run and its associated events, artifacts, and cancellation records.
 func (s *stateStore) DeleteRun(runID string) error {
 	// Due to foreign key ON DELETE CASCADE, deleting from pipeline_run
@@ -875,6 +989,13 @@ func (s *stateStore) LogEvent(runID string, stepID string, state string, persona
 }
 
 // GetEvents retrieves events for a run with optional filtering.
+//
+// Ordering rules:
+//   - TailLimit > 0: query runs in DESC order with LIMIT, results are reversed
+//     before return so callers always see ASC order. Other ordering flags are
+//     ignored in this mode.
+//   - OrderDesc: timestamp DESC, id DESC.
+//   - Default: timestamp ASC.
 func (s *stateStore) GetEvents(runID string, opts EventQueryOptions) ([]LogRecord, error) {
 	query := `SELECT id, run_id, timestamp, step_id, state, persona, message, tokens_used, duration_ms, model, configured_model, adapter
 	          FROM event_log
@@ -892,10 +1013,23 @@ func (s *stateStore) GetEvents(runID string, opts EventQueryOptions) ([]LogRecor
 	if opts.ErrorsOnly {
 		query += " AND state = 'failed'"
 	}
+	if opts.SinceUnix > 0 {
+		query += " AND timestamp >= ?"
+		args = append(args, opts.SinceUnix)
+	}
 
-	query += " ORDER BY timestamp ASC"
+	tailMode := opts.TailLimit > 0
+	switch {
+	case tailMode:
+		query += " ORDER BY timestamp DESC, id DESC LIMIT ?"
+		args = append(args, opts.TailLimit)
+	case opts.OrderDesc:
+		query += " ORDER BY timestamp DESC, id DESC"
+	default:
+		query += " ORDER BY timestamp ASC, id ASC"
+	}
 
-	if opts.Limit > 0 {
+	if !tailMode && opts.Limit > 0 {
 		query += " LIMIT ?"
 		args = append(args, opts.Limit)
 		if opts.Offset > 0 {
@@ -968,7 +1102,44 @@ func (s *stateStore) GetEvents(runID string, opts EventQueryOptions) ([]LogRecor
 		return nil, fmt.Errorf("error iterating events: %w", err)
 	}
 
+	// Tail mode queries DESC for SQL-side LIMIT correctness; flip to ASC for callers.
+	if tailMode && len(records) > 1 {
+		for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
+			records[i], records[j] = records[j], records[i]
+		}
+	}
+
 	return records, nil
+}
+
+// GetEventAggregateStats returns aggregate metrics over event_log entries in
+// terminal states (completed, failed) for the given run.
+func (s *stateStore) GetEventAggregateStats(runID string) (*EventAggregateStats, error) {
+	var stats EventAggregateStats
+	var avg, minD, maxD sql.NullFloat64
+	err := s.db.QueryRow(`
+		SELECT
+		    COUNT(*),
+		    COALESCE(SUM(COALESCE(tokens_used, 0)), 0),
+		    AVG(COALESCE(duration_ms, 0)),
+		    MIN(COALESCE(duration_ms, 0)),
+		    MAX(COALESCE(duration_ms, 0))
+		FROM event_log
+		WHERE run_id = ? AND state IN ('completed', 'failed')
+	`, runID).Scan(&stats.TotalEvents, &stats.TotalTokens, &avg, &minD, &maxD)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query event aggregate stats: %w", err)
+	}
+	if avg.Valid {
+		stats.AvgDurationMs = avg.Float64
+	}
+	if minD.Valid {
+		stats.MinDurationMs = minD.Float64
+	}
+	if maxD.Valid {
+		stats.MaxDurationMs = maxD.Float64
+	}
+	return &stats, nil
 }
 
 // GetAuditEvents retrieves events across all runs, filtered by state types,
@@ -2580,6 +2751,31 @@ func (s *stateStore) GetDecisionsByStep(runID, stepID string) ([]*DecisionRecord
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query decisions by step: %w", err)
+	}
+	defer rows.Close()
+	return scanDecisionRecords(rows)
+}
+
+// GetDecisionsFiltered returns decision records for a run filtered by step
+// and/or category. Empty filter values match all entries on that field.
+func (s *stateStore) GetDecisionsFiltered(runID string, opts DecisionQueryOptions) ([]*DecisionRecord, error) {
+	query := `SELECT id, run_id, step_id, timestamp, category, decision, rationale, context_json
+	          FROM decision_log WHERE run_id = ?`
+	args := []any{runID}
+
+	if opts.StepID != "" {
+		query += " AND step_id = ?"
+		args = append(args, opts.StepID)
+	}
+	if opts.Category != "" {
+		query += " AND category = ?"
+		args = append(args, opts.Category)
+	}
+	query += " ORDER BY timestamp ASC, id ASC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query decisions: %w", err)
 	}
 	defer rows.Close()
 	return scanDecisionRecords(rows)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2738,3 +2738,250 @@ func TestParentRunID_NotSetByDefault(t *testing.T) {
 	assert.Empty(t, run.ParentRunID, "ParentRunID should be empty by default")
 	assert.Empty(t, run.ParentStepID, "ParentStepID should be empty by default")
 }
+
+// TestGetMostRecentRunID covers happy path + empty DB.
+func TestGetMostRecentRunID(t *testing.T) {
+	t.Run("empty database returns empty id, no error", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		got, err := store.GetMostRecentRunID()
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns most recent run by started_at", func(t *testing.T) {
+		store, cleanup := setupTestStoreWithClock(t)
+		defer cleanup()
+
+		first, err := store.CreateRun("pipeline-a", "in")
+		require.NoError(t, err)
+		_, err = store.CreateRun("pipeline-b", "in")
+		require.NoError(t, err)
+		last, err := store.CreateRun("pipeline-c", "in")
+		require.NoError(t, err)
+
+		got, err := store.GetMostRecentRunID()
+		require.NoError(t, err)
+		assert.Equal(t, last, got)
+		assert.NotEqual(t, first, got)
+	})
+}
+
+// TestRunExists covers found, missing, and empty DB.
+func TestRunExists(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exists, err := store.RunExists("nope")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	runID, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	exists, err = store.RunExists(runID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = store.RunExists("still-nope")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestGetRunStatus returns the run status string; missing runs produce empty + nil.
+func TestGetRunStatus(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	got, err := store.GetRunStatus("missing")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	runID, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	status, err := store.GetRunStatus(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", status)
+
+	require.NoError(t, store.UpdateRunStatus(runID, "completed", "", 0))
+	status, err = store.GetRunStatus(runID)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", status)
+}
+
+// TestListPipelineNamesByStatus returns distinct pipeline names per status.
+func TestListPipelineNamesByStatus(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	names, err := store.ListPipelineNamesByStatus("failed")
+	require.NoError(t, err)
+	assert.Empty(t, names)
+
+	r1, err := store.CreateRun("alpha", "")
+	require.NoError(t, err)
+	r2, err := store.CreateRun("beta", "")
+	require.NoError(t, err)
+	r3, err := store.CreateRun("alpha", "")
+	require.NoError(t, err)
+	r4, err := store.CreateRun("gamma", "")
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateRunStatus(r1, "failed", "", 0))
+	require.NoError(t, store.UpdateRunStatus(r2, "failed", "", 0))
+	require.NoError(t, store.UpdateRunStatus(r3, "completed", "", 0))
+	require.NoError(t, store.UpdateRunStatus(r4, "failed", "", 0))
+
+	failed, err := store.ListPipelineNamesByStatus("failed")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"alpha", "beta", "gamma"}, failed)
+
+	completed, err := store.ListPipelineNamesByStatus("completed")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"alpha"}, completed)
+
+	upper, err := store.ListPipelineNamesByStatus("FAILED")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, failed, upper, "status match should be case-insensitive")
+}
+
+// TestBackfillRunTokens covers happy path, idempotency, and finalized-only guard.
+func TestBackfillRunTokens(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	completedRun, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+	runningRun, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	require.NoError(t, store.LogEvent(completedRun, "s", "completed", "", "", 100, 0, "", "", ""))
+	require.NoError(t, store.LogEvent(completedRun, "s", "completed", "", "", 200, 0, "", "", ""))
+	require.NoError(t, store.LogEvent(runningRun, "s", "completed", "", "", 999, 0, "", "", ""))
+
+	require.NoError(t, store.UpdateRunStatus(completedRun, "completed", "", 0))
+
+	n, err := store.BackfillRunTokens()
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n, "only finalized run should be backfilled")
+
+	rec, err := store.GetRun(completedRun)
+	require.NoError(t, err)
+	assert.Equal(t, 300, rec.TotalTokens)
+
+	running, err := store.GetRun(runningRun)
+	require.NoError(t, err)
+	assert.Zero(t, running.TotalTokens, "running run must not be backfilled")
+
+	// Idempotent: second call updates nothing
+	n2, err := store.BackfillRunTokens()
+	require.NoError(t, err)
+	assert.Zero(t, n2, "re-running should affect zero rows")
+}
+
+// TestGetEventAggregateStats covers empty + populated runs.
+func TestGetEventAggregateStats(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runID, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	stats, err := store.GetEventAggregateStats(runID)
+	require.NoError(t, err)
+	assert.Zero(t, stats.TotalEvents)
+	assert.Zero(t, stats.TotalTokens)
+
+	// Mix of states; only completed/failed are aggregated.
+	require.NoError(t, store.LogEvent(runID, "s1", "running", "", "", 50, 250, "", "", ""))
+	require.NoError(t, store.LogEvent(runID, "s1", "completed", "", "", 100, 1000, "", "", ""))
+	require.NoError(t, store.LogEvent(runID, "s2", "failed", "", "", 200, 3000, "", "", ""))
+
+	stats, err = store.GetEventAggregateStats(runID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.TotalEvents)
+	assert.Equal(t, 300, stats.TotalTokens)
+	assert.InDelta(t, 2000.0, stats.AvgDurationMs, 0.0001)
+	assert.InDelta(t, 1000.0, stats.MinDurationMs, 0.0001)
+	assert.InDelta(t, 3000.0, stats.MaxDurationMs, 0.0001)
+}
+
+// TestGetDecisionsFiltered covers all-filter combinations.
+func TestGetDecisionsFiltered(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runID, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	mk := func(stepID, category, decision string) {
+		require.NoError(t, store.RecordDecision(&DecisionRecord{
+			RunID:    runID,
+			StepID:   stepID,
+			Category: category,
+			Decision: decision,
+		}))
+	}
+	mk("plan", "model_routing", "p-mr")
+	mk("plan", "retry", "p-r")
+	mk("impl", "model_routing", "i-mr")
+	mk("impl", "contract", "i-c")
+
+	all, err := store.GetDecisionsFiltered(runID, DecisionQueryOptions{})
+	require.NoError(t, err)
+	assert.Len(t, all, 4)
+
+	byStep, err := store.GetDecisionsFiltered(runID, DecisionQueryOptions{StepID: "plan"})
+	require.NoError(t, err)
+	assert.Len(t, byStep, 2)
+
+	byCat, err := store.GetDecisionsFiltered(runID, DecisionQueryOptions{Category: "model_routing"})
+	require.NoError(t, err)
+	assert.Len(t, byCat, 2)
+
+	byBoth, err := store.GetDecisionsFiltered(runID, DecisionQueryOptions{StepID: "impl", Category: "contract"})
+	require.NoError(t, err)
+	require.Len(t, byBoth, 1)
+	assert.Equal(t, "i-c", byBoth[0].Decision)
+}
+
+// TestGetEventsExtendedOptions covers SinceUnix, TailLimit, OrderDesc.
+func TestGetEventsExtendedOptions(t *testing.T) {
+	store, cleanup := setupTestStoreWithClock(t)
+	defer cleanup()
+
+	runID, err := store.CreateRun("p", "")
+	require.NoError(t, err)
+
+	for i := 0; i < 6; i++ {
+		require.NoError(t, store.LogEvent(runID, "s", "running", "", "", i, 0, "", "", ""))
+	}
+
+	all, err := store.GetEvents(runID, EventQueryOptions{})
+	require.NoError(t, err)
+	require.Len(t, all, 6)
+	for i := 1; i < len(all); i++ {
+		assert.LessOrEqual(t, all[i-1].Timestamp.Unix(), all[i].Timestamp.Unix(), "ASC by default")
+	}
+
+	tailed, err := store.GetEvents(runID, EventQueryOptions{TailLimit: 3})
+	require.NoError(t, err)
+	require.Len(t, tailed, 3)
+	// Tail returns most recent 3 in ASC order
+	assert.Equal(t, all[3].ID, tailed[0].ID)
+	assert.Equal(t, all[5].ID, tailed[2].ID)
+
+	desc, err := store.GetEvents(runID, EventQueryOptions{OrderDesc: true})
+	require.NoError(t, err)
+	require.Len(t, desc, 6)
+	assert.Equal(t, all[5].ID, desc[0].ID)
+	assert.Equal(t, all[0].ID, desc[5].ID)
+
+	since := all[3].Timestamp.Unix()
+	sinceEvents, err := store.GetEvents(runID, EventQueryOptions{SinceUnix: since})
+	require.NoError(t, err)
+	require.Len(t, sinceEvents, 3)
+	assert.Equal(t, all[3].ID, sinceEvents[0].ID)
+}

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -71,6 +71,25 @@ type EventQueryOptions struct {
 	Limit      int
 	Offset     int
 	AfterID    int64 // Filter events with ID > AfterID (for SSE Last-Event-ID backfill)
+	SinceUnix  int64 // Only return events with timestamp >= SinceUnix
+	TailLimit  int   // Return the most recent N events (applied via DESC + reverse)
+	OrderDesc  bool  // Order by timestamp DESC, id DESC instead of ASC
+}
+
+// DecisionQueryOptions specifies filters for decision-log queries.
+type DecisionQueryOptions struct {
+	StepID   string
+	Category string
+}
+
+// EventAggregateStats holds aggregate metrics over a run's event log,
+// limited to events in completed/failed terminal states.
+type EventAggregateStats struct {
+	TotalEvents   int
+	TotalTokens   int
+	AvgDurationMs float64
+	MinDurationMs float64
+	MaxDurationMs float64
 }
 
 // ArtifactRecord holds artifact metadata.

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -557,6 +557,34 @@ func (m *MockStateStore) GetDecisionsByStep(runID, stepID string) ([]*state.Deci
 	return nil, nil
 }
 
+func (m *MockStateStore) GetDecisionsFiltered(runID string, opts state.DecisionQueryOptions) ([]*state.DecisionRecord, error) {
+	return nil, nil
+}
+
+func (m *MockStateStore) GetMostRecentRunID() (string, error) {
+	return "", nil
+}
+
+func (m *MockStateStore) RunExists(runID string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockStateStore) GetRunStatus(runID string) (string, error) {
+	return "", nil
+}
+
+func (m *MockStateStore) ListPipelineNamesByStatus(status string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockStateStore) BackfillRunTokens() (int64, error) {
+	return 0, nil
+}
+
+func (m *MockStateStore) GetEventAggregateStats(runID string) (*state.EventAggregateStats, error) {
+	return &state.EventAggregateStats{}, nil
+}
+
 func (m *MockStateStore) GetAuditEvents(states []string, limit, offset int) ([]state.LogRecord, error) {
 	return nil, nil
 }

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -149,6 +149,19 @@ func (b baseStateStore) GetDecisions(string) ([]*state.DecisionRecord, error) { 
 func (b baseStateStore) GetDecisionsByStep(string, string) ([]*state.DecisionRecord, error) {
 	return nil, nil
 }
+func (b baseStateStore) GetDecisionsFiltered(string, state.DecisionQueryOptions) ([]*state.DecisionRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) GetMostRecentRunID() (string, error)              { return "", nil }
+func (b baseStateStore) RunExists(string) (bool, error)                   { return false, nil }
+func (b baseStateStore) GetRunStatus(string) (string, error)              { return "", nil }
+func (b baseStateStore) ListPipelineNamesByStatus(string) ([]string, error) {
+	return nil, nil
+}
+func (b baseStateStore) BackfillRunTokens() (int64, error) { return 0, nil }
+func (b baseStateStore) GetEventAggregateStats(string) (*state.EventAggregateStats, error) {
+	return &state.EventAggregateStats{}, nil
+}
 func (b baseStateStore) GetAuditEvents([]string, int, int) ([]state.LogRecord, error) {
 	return nil, nil
 }

--- a/specs/1275-route-cli-statestore/plan.md
+++ b/specs/1275-route-cli-statestore/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan — Issue #1275
+
+## 1. Objective
+
+Eliminate every `database/sql` import outside `internal/state/` by routing the four bypassing CLI commands (`logs`, `decisions`, `clean`, `list`) and the webui `backfillRunTokens` migration through the `StateStore` interface, then enforce the boundary with a `depguard` rule.
+
+## 2. Approach
+
+Follow ADR-007 Option 2 (Consolidate into Existing StateStore Interface). The interface already covers most read paths; add a small set of focused methods to fill the gaps, then rewrite the call sites to depend only on `StateStore`. Keep behavioural parity (follow-mode polling cadence, color output, JSON shape) — this is a routing refactor, not a feature change.
+
+Concretely:
+
+1. **Extend types** in `internal/state/types.go`:
+   - `EventQueryOptions` gains `SinceUnix int64`, `TailLimit int`, `OrderDesc bool` (the existing `AfterID` already supports follow-mode).
+   - New `DecisionQueryOptions{ StepID, Category string }`.
+   - New `EventAggregateStats{ TotalEvents int; TotalTokens int; AvgDurationMs, MinDurationMs, MaxDurationMs float64 }`.
+
+2. **Add methods** on `StateStore` (`internal/state/store.go`, with read-only fallback in `internal/state/readonly.go` already automatic since both share `*stateStore`):
+   - `GetMostRecentRunID() (string, error)` — replaces `getMostRecentRunID(db)` in `logs.go`/`decisions.go`.
+   - `RunExists(runID string) (bool, error)` — replaces `runExists(db, runID)`.
+   - `GetRunStatus(runID string) (string, error)` — replaces `getRunStatus(db, runID)` (used in follow loop).
+   - Extend `GetEvents` to honour the new fields on `EventQueryOptions` (Since, TailLimit, OrderDesc) so `queryLogs`/`queryNewLogs` collapse into one call site.
+   - `GetEventAggregateStats(runID string) (*EventAggregateStats, error)` — replaces `renderPerformanceSummary`'s aggregate query.
+   - Replace `GetDecisions` filtering: introduce `GetDecisionsFiltered(runID string, opts DecisionQueryOptions) ([]*DecisionRecord, error)` (keep existing `GetDecisions` and `GetDecisionsByStep` to avoid breaking other callers, mark them as thin wrappers).
+   - `ListPipelineNamesByStatus(status string) ([]string, error)` — replaces `getWorkspacesWithStatus` in `clean.go` (the existing fallback to `pipeline_state` becomes part of the implementation).
+   - `BackfillRunTokens() (int64, error)` — replaces `webui.backfillRunTokens`. Lives on `StateStore` (read-write only); webui calls it via `rwStore`.
+
+3. **Migrate call sites**:
+   - `cmd/wave/commands/logs.go`: drop the `database/sql` import and the `_ "modernc.org/sqlite"` blank import. Open via `state.NewReadOnlyStateStore(".agents/state.db")`. Map `LogsOptions` → `EventQueryOptions`. Reuse `state.LogRecord` directly or keep `LogsEntry` as a presentation DTO. Follow mode keeps its 500ms ticker but uses `store.GetEvents(runID, EventQueryOptions{AfterID: lastID})`. `runLogsTrace` similarly opens via `NewReadOnlyStateStore` for the lookup.
+   - `cmd/wave/commands/decisions.go`: use `state.NewReadOnlyStateStore`, call `GetDecisionsFiltered`. Keep the printing layer untouched.
+   - `cmd/wave/commands/clean.go`: use `state.NewReadOnlyStateStore`, call `ListPipelineNamesByStatus`.
+   - `cmd/wave/commands/list.go`: replace `collectRunsFromDB` with a call to `state.NewReadOnlyStateStore` + `store.ListRuns(state.ListRunsOptions{...})`. Map results to `RunInfo`.
+   - `internal/webui/server.go`: `backfillRunTokens` becomes `s.rwStore.BackfillRunTokens()` and the function (along with `database/sql` and `_ "modernc.org/sqlite"` imports) is deleted.
+
+4. **Migrate tests**: rewrite `logs_test.go`, `decisions_test.go`, `list_test.go`, `status_test.go` (only the test imports `database/sql`) to seed fixtures via `state.NewStateStore` + the existing write methods (`CreateRun`, `LogEvent`, `RecordDecision`, etc.). Where direct ID control is needed, use `RecordStepAttempt` / `LogEvent` ordering since IDs are auto-increment in arrival order.
+
+5. **Add depguard rule** to `.golangci.yml`:
+   ```yaml
+   no-direct-sql:
+     files:
+       - "**/*.go"
+     deny:
+       - pkg: "database/sql"
+         desc: "ADR-007: only internal/state may import database/sql"
+   ```
+   Whitelist `internal/state/**` via depguard's `files` exclusion (use a separate rule, since depguard v2 matches by file pattern only; the standard pattern is to scope the rule's `files:` to everything *except* `internal/state/**`).
+
+## 3. File Mapping
+
+### Modified
+- `internal/state/types.go` — add `DecisionQueryOptions`, `EventAggregateStats`; extend `EventQueryOptions`.
+- `internal/state/store.go` — add new interface methods + impls (~150 LOC additions).
+- `internal/state/store_test.go` — unit tests for new methods.
+- `cmd/wave/commands/logs.go` — drop `database/sql`, route through StateStore (~150 LOC delta, mostly removals).
+- `cmd/wave/commands/logs_test.go` — re-seed via StateStore.
+- `cmd/wave/commands/decisions.go` — drop `database/sql`, route through StateStore.
+- `cmd/wave/commands/decisions_test.go` — re-seed via StateStore.
+- `cmd/wave/commands/clean.go` — drop `database/sql`, route through StateStore.
+- `cmd/wave/commands/list.go` — drop `database/sql`, route through StateStore.
+- `cmd/wave/commands/list_test.go` — re-seed via StateStore.
+- `cmd/wave/commands/status_test.go` — re-seed via StateStore (only the test file imports `database/sql`).
+- `internal/webui/server.go` — drop `backfillRunTokens` raw SQL, call `BackfillRunTokens()`.
+- `.golangci.yml` — add `no-direct-sql` depguard rule.
+- `docs/adr/007-consolidate-database-access-through-statestore-interface.md` — flip status from "Proposed (not started)" to "Accepted (implemented)" with the resolved bypass list.
+
+### Created
+- (none required — all changes land in existing files)
+
+### Deleted
+- (none)
+
+## 4. Architecture Decisions
+
+- **Reuse the existing `StateStore` interface** rather than introduce per-domain sub-interfaces. ADR-007 explicitly defers segregation to ADR-002. The +8 method growth is acceptable and documented in the ADR.
+- **Read-only commands use `NewReadOnlyStateStore`** to keep the existing `?mode=ro` + `query_only=ON` defense-in-depth.
+- **Keep `LogsEntry`/`DecisionEntry` as presentation DTOs** in the `commands` package; do not leak `state.LogRecord` field names into JSON output (output schema is part of the public CLI surface).
+- **`BackfillRunTokens` is idempotent** and only touches finalized runs — same semantics as today, just moved into `internal/state`.
+- **`depguard` rule is the enforcement mechanism**, not a docs-only TODO. Acceptance criterion #5 says "CI lint (or TODO issue)"; we choose the lint.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Behavioural drift in `logs --follow` (timing, missed events) | Keep ticker cadence and `AfterID` semantics identical; add a regression test that exercises follow over a polling tick. |
+| Performance regression: each CLI invocation now runs migrations on connect | Use `NewReadOnlyStateStore` for read-only commands (skips migrations entirely). `clean.go` and `list.go` are already read-only conceptually. |
+| Test fixture rewrite churn | Keep helper struct (`logsTestHelper`) but replace its body to use `state.NewStateStore` + write methods. Unit-test contracts unchanged. |
+| `depguard` rule blocks legitimate use in `internal/state` | Rule scope explicitly excludes `internal/state/**`; verified via running `go run ./cmd/wave` then `golangci-lint run`. |
+| Webui callers of `backfillRunTokens` lose log message | Keep equivalent log line in caller (`s.NewServer`) when the helper returns >0 rows. |
+| `JSON output shape` change for `wave logs --format json` etc. | Snapshot tests / table-driven assertions in existing `*_test.go` will catch any drift. |
+
+## 6. Testing Strategy
+
+- **Unit (state package)**: new tests in `internal/state/store_test.go` for each added method (`GetMostRecentRunID`, `RunExists`, `GetRunStatus`, `GetEventAggregateStats`, `GetDecisionsFiltered`, `ListPipelineNamesByStatus`, `BackfillRunTokens`, extended `EventQueryOptions` filters). Cover empty DB, single row, multi-row, error cases.
+- **Unit (commands)**: existing `*_test.go` files keep their public assertions but seed fixtures via `state.StateStore` write methods. Add a regression test that opens via the CLI `runLogs` path against an isolated tmp dir.
+- **Lint**: run `golangci-lint run ./...` to confirm the new `depguard` rule fires on a deliberately added test file (and only there), then remove it.
+- **End-to-end**: run `wave logs`, `wave decisions`, `wave clean --status failed`, `wave list runs` against a populated `.agents/state.db` from a real pipeline run; diff text output before/after to confirm parity.
+- **CI**: `go vet ./...`, `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` all pass.
+- **Boundary verification**: `grep -R "database/sql" --include='*.go' . | grep -v '^./internal/state/'` returns no matches.

--- a/specs/1275-route-cli-statestore/spec.md
+++ b/specs/1275-route-cli-statestore/spec.md
@@ -1,0 +1,45 @@
+# refactor: route CLI state reads through internal/state.StateStore (logs, decisions, clean, list)
+
+**Issue:** [#1275](https://github.com/re-cinq/wave/issues/1275)
+**Repository:** re-cinq/wave
+**Labels:** `scope-audit`
+**State:** OPEN
+**Author:** nextlevelshit
+
+## Context
+
+From wave-scope-audit run `wave-scope-audit-20260422-223006-df0b`.
+
+ADR-007 requires `internal/state.StateStore` be the only path to the SQLite database. Several CLI commands (logs, decisions, clean, list) currently bypass the StateStore and use `database/sql` directly, violating the boundary and preventing consistent read semantics, migrations, and instrumentation.
+
+Scope governance rule: *"No raw `database/sql` imports outside `internal/state`. CLI commands, webui, and tui must consume `StateStore` methods."*
+
+Related to #1159 (splitting StateStore into domain-scoped interfaces). This issue is the routing change that makes that split meaningful.
+
+## Acceptance Criteria
+
+- [ ] Identify every `database/sql` import outside `internal/state` (expected: `cmd/` logs, decisions, clean, list subcommands).
+- [ ] Add read methods on `StateStore` (or one of its domain-scoped interfaces) that cover the queries those commands need.
+- [ ] Replace the raw SQL in those commands with `StateStore` calls.
+- [ ] `go vet`/`go build`/`go test` pass, and a repo-wide grep confirms no `database/sql` imports outside `internal/state`.
+- [ ] Add a CI lint (or TODO issue) that fails on new `database/sql` imports outside `internal/state`.
+
+## Confirmed Bypass Sites (2026-04-27)
+
+`grep` against the working tree (matches ADR-007 status block):
+
+| File | Reason |
+|------|--------|
+| `cmd/wave/commands/logs.go` | `sql.Open("sqlite", ...)`, 7 helper funcs taking `*sql.DB`, includes follow-mode polling and perf aggregation queries |
+| `cmd/wave/commands/decisions.go` | `sql.Open`, `queryDecisions()` with category filter not exposed in `StateStore.GetDecisions` |
+| `cmd/wave/commands/clean.go` | `sql.Open`, `getWorkspacesWithStatus()` queries `pipeline_run`/`pipeline_state` for distinct pipeline names by status |
+| `cmd/wave/commands/list.go` | `sql.Open`, `collectRunsFromDB()` duplicates `StateStore.ListRuns` logic |
+| `internal/webui/server.go` | `sql.Open`, `backfillRunTokens()` runs raw `UPDATE ... SUM(tokens_used)` migration |
+| `cmd/wave/commands/logs_test.go`, `decisions_test.go`, `list_test.go`, `status_test.go` | Test fixtures use `sql.Open` to seed rows directly |
+
+## Reference
+
+- ADR-007 — Consolidate Database Access Through StateStore Interface (`docs/adr/007-consolidate-database-access-through-statestore-interface.md`)
+- ADR-003 — Layered architecture (Presentation must not import infrastructure-specific drivers)
+- Issue #1159 — Split StateStore into domain-scoped interfaces (downstream)
+- Issue URL: https://github.com/re-cinq/wave/issues/1275

--- a/specs/1275-route-cli-statestore/tasks.md
+++ b/specs/1275-route-cli-statestore/tasks.md
@@ -1,0 +1,44 @@
+# Work Items — Issue #1275
+
+## Phase 1: StateStore API Surface
+
+- [X] Item 1.1: Extend `internal/state/types.go` with `DecisionQueryOptions`, `EventAggregateStats`, and new fields on `EventQueryOptions` (`SinceUnix int64`, `TailLimit int`, `OrderDesc bool`).
+- [X] Item 1.2: Add `GetMostRecentRunID`, `RunExists`, `GetRunStatus` to `StateStore` interface and `stateStore` impl.
+- [X] Item 1.3: Extend `(s *stateStore) GetEvents` to honour `SinceUnix`, `TailLimit`, `OrderDesc` (preserve existing `AfterID` behaviour).
+- [X] Item 1.4: Add `GetEventAggregateStats(runID)` method (the COUNT/SUM/AVG query currently in `renderPerformanceSummary`).
+- [X] Item 1.5: Add `GetDecisionsFiltered(runID, DecisionQueryOptions)` method.
+- [X] Item 1.6: Add `ListPipelineNamesByStatus(status)` method (covers both `pipeline_run` and `pipeline_state` fallback).
+- [X] Item 1.7: Add `BackfillRunTokens() (int64, error)` method.
+
+## Phase 2: Unit Tests for New StateStore Methods
+
+- [X] Item 2.1: `internal/state/store_test.go` — happy path + empty DB tests for items 1.2–1.7. [P]
+- [X] Item 2.2: Coverage for `EventQueryOptions{TailLimit, SinceUnix, OrderDesc}` reordering and limit semantics. [P]
+- [X] Item 2.3: `BackfillRunTokens` test covers idempotency (re-running yields 0 affected rows) and only-finalized-runs guard. [P]
+
+## Phase 3: Migrate CLI Commands
+
+- [X] Item 3.1: Rewrite `cmd/wave/commands/logs.go` to use `state.NewReadOnlyStateStore` + new methods; delete local `*sql.DB` helpers (`getMostRecentRunID`, `runExists`, `getRunStatus`, `getLogID`, `queryLogs`, `queryNewLogs`, `renderPerformanceSummary`). [P]
+- [X] Item 3.2: Rewrite `cmd/wave/commands/decisions.go` to use `GetDecisionsFiltered`; remove `queryDecisions` and `database/sql` import. [P]
+- [X] Item 3.3: Rewrite `cmd/wave/commands/clean.go` `getWorkspacesWithStatus` to call `ListPipelineNamesByStatus`; drop `database/sql` import. [P]
+- [X] Item 3.4: Rewrite `cmd/wave/commands/list.go` `collectRunsFromDB` to use `store.ListRuns(state.ListRunsOptions{...})`; drop `database/sql` import. [P]
+- [X] Item 3.5: Replace `internal/webui/server.go` `backfillRunTokens` with call to `rwStore.BackfillRunTokens()`; drop `database/sql` and the local helper.
+
+## Phase 4: Migrate Test Fixtures
+
+- [X] Item 4.1: Rewrite `cmd/wave/commands/logs_test.go` `logsTestHelper` to seed via `state.NewStateStore` + `LogEvent` / `CreateRun`. [P]
+- [X] Item 4.2: Rewrite `cmd/wave/commands/decisions_test.go` setup to seed via `RecordDecision`. [P]
+- [X] Item 4.3: Rewrite `cmd/wave/commands/list_test.go` setup to seed via `CreateRun` + `UpdateRunStatus`. [P]
+- [X] Item 4.4: Rewrite `cmd/wave/commands/status_test.go` setup to seed via `StateStore` writes. [P]
+
+## Phase 5: Boundary Enforcement
+
+- [X] Item 5.1: Add `depguard` rule `no-direct-sql` to `.golangci.yml` denying `database/sql` outside `internal/state/**`.
+- [X] Item 5.2: Run `golangci-lint run ./...` and fix any residual hits (expected: zero after Phase 3–4).
+- [X] Item 5.3: Verify with `grep -R 'database/sql' --include='*.go' .` that only `internal/state/**` matches.
+
+## Phase 6: Polish & Docs
+
+- [X] Item 6.1: Update ADR-007 status block: flip from "Proposed (not started)" to "Accepted (implemented)", clear the bypass list, note the depguard rule.
+- [X] Item 6.2: Run full validation: `go vet ./...`, `go build ./...`, `go test -race ./...`, `golangci-lint run ./...`.
+- [X] Item 6.3: Smoke test against a real `.agents/state.db`: `wave logs`, `wave logs --follow` (briefly), `wave decisions`, `wave list runs`, `wave clean --status failed --dry-run`. Confirm output parity with pre-refactor binary.


### PR DESCRIPTION
Refs #1275 (Batch C step 7 of cleanup-sweep epic #1403). Replaces `sql.Open` in cmd/wave/commands/{logs,decisions,list}.go with `internal/state.StateStore` access.