### PR TITLE
fix(pipeline): impl-finding worktree workspace, parallel resolve

### DIFF
--- a/internal/defaults/pipelines/impl-finding.yaml
+++ b/internal/defaults/pipelines/impl-finding.yaml
@@ -48,10 +48,8 @@ steps:
     contexts: [execution, delivery]
     model: balanced
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -74,10 +72,20 @@ steps:
         2. Aggregated audit findings into a flat array.
         3. Triaged that array into actionable / deferred / rejected.
 
-        You receive a single actionable finding. The working directory is the
-        PR head branch (parent pipeline checked it out). You must touch only
-        the files implied by the finding's `remediation` field. Other findings
-        run in parallel — do NOT touch files outside your remediation scope.
+        Your CWD is a per-child git worktree on a throwaway branch
+        (`{{ pipeline_id }}`). The worktree shares its `origin` remote and ref
+        database with the project repo, so `git fetch origin <pr-branch>` and
+        `git push origin HEAD:<pr-branch>` reach the same remote the parent
+        pipeline saw. The PR head branch is NOT yet checked out — Step 2 fetches
+        it and switches the worktree onto it before any edits or tests run.
+
+        The parent pipeline injects `pr-context` into `.agents/artifacts/pr-context`
+        (via the `resolve-each` step's `config.inject`). Read that file to learn
+        the PR head branch name. You must touch only the files implied by the
+        finding's `remediation` field. Other findings run in parallel in their
+        own worktrees — your edits cannot collide with theirs at the working-tree
+        level, but you must still keep the commit minimal so reviewers can
+        understand each fix in isolation.
 
         ## Requirements
 
@@ -95,12 +103,37 @@ steps:
         resolution record with `status: "skipped"` and exit cleanly. Do NOT
         guess.
 
-        ### Step 2 — Read the target file
+        ### Step 2 — Switch the worktree onto the PR head branch
+
+        Your CWD is a per-child worktree currently on a throwaway branch
+        (`{{ pipeline_id }}`). Before reading or editing files, switch onto the
+        PR head branch so all subsequent edits, tests, and commits target the
+        right tree:
+
+        ```bash
+        BRANCH=$(jq -r .branch .agents/artifacts/pr-context)
+        if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
+          echo "refusing to proceed: pr-context artifact missing .branch" >&2
+          exit 1
+        fi
+        if ! git remote get-url origin >/dev/null 2>&1; then
+          echo "refusing to proceed: no 'origin' remote configured in worktree" >&2
+          exit 1
+        fi
+        git fetch origin "$BRANCH"
+        git checkout -B "$BRANCH" "origin/$BRANCH"
+        ```
+
+        After this step the working tree mirrors `origin/<pr-branch>` and the
+        throwaway branch label is repointed onto that tip — subsequent commits
+        chain cleanly on top of the real PR HEAD.
+
+        ### Step 3 — Read the target file
 
         Open `file`. If `line` is present, read a window around it. Read enough
         surrounding context to understand the code before editing.
 
-        ### Step 3 — Apply the fix
+        ### Step 4 — Apply the fix
 
         Make the minimal change implied by `type` + `remediation`:
 
@@ -116,40 +149,25 @@ steps:
         Do NOT bundle unrelated cleanups. Do NOT refactor surrounding code.
         One finding = one targeted edit (plus any necessary references).
 
-        ### Step 4 — Verify locally
+        ### Step 5 — Verify locally
 
-        Run `{{ project.contract_test_command }}`. If it fails, attempt one
-        repair pass. If it still fails, capture the failure in the resolution
-        record but commit anyway — the parent verify step will gate the loop.
+        Run `{{ project.contract_test_command }}` from the worktree CWD. If it
+        fails, attempt one repair pass. If it still fails, capture the failure
+        in the resolution record but commit anyway — the parent verify step
+        will gate the loop.
 
-        ### Step 5 — Commit and push (against the project repo, not the workspace)
+        ### Step 6 — Commit and push from the worktree
 
-        The mount-based workspace gives you a fresh `git init` at the workspace
-        root and the project filesystem at `/project`. To make commits visible
-        on the PR head branch, run all `git` commands from `/project` (the
-        mounted project repo with the real `origin` remote and the PR branch
-        checked out), not from the workspace root.
-
-        Stage only the files you edited (no `git add -A`). Read the PR head
-        branch from `.agents/output/pr-context.json` (`.branch`) and refuse to
-        push if `/project` is not currently on that branch — this guards against
-        detached HEAD or wrong-branch state silently pushing to whatever upstream
-        happens to be set. Verify the push actually landed by checking the
-        remote ref before reporting success.
+        Step 2 already switched the worktree onto the PR head branch and
+        confirmed `origin` is configured. Stage only the files you edited
+        (no `git add -A`). Push to `origin/<pr-branch>` and verify the push
+        actually landed by comparing local SHA with the remote ref before
+        reporting success.
 
         ```bash
-        BRANCH=$(jq -r .branch .agents/output/pr-context.json)
-        cd /project
-
-        CURRENT=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$CURRENT" != "$BRANCH" ]; then
-          echo "refusing to push: /project HEAD is '$CURRENT', expected PR head '$BRANCH'" >&2
-          exit 1
-        fi
-        if ! git remote get-url origin >/dev/null 2>&1; then
-          echo "refusing to push: no 'origin' remote configured in /project" >&2
-          exit 1
-        fi
+        # $BRANCH was resolved in Step 2 from .agents/artifacts/pr-context.
+        # Re-resolve here in case this step runs in a fresh shell.
+        BRANCH=$(jq -r .branch .agents/artifacts/pr-context)
 
         git add <file1> [<file2>...]
         git commit -m "fix({{ '<finding-id>' }}): <one-line summary from remediation>"
@@ -167,7 +185,7 @@ steps:
 
         Capture the commit SHA from `git rev-parse HEAD`.
 
-        ### Step 6 — Write the resolution record
+        ### Step 7 — Write the resolution record
 
         Write `.agents/output/resolution.md` with:
 

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -343,12 +343,16 @@ steps:
         - id: resolve-each
           pipeline: impl-finding
           input: "{{ item }}"
+          # Inject pr-context so each impl-finding child can read the PR head
+          # branch from .agents/artifacts/pr-context. With per-child worktree
+          # workspaces (see impl-finding.yaml) the mount-based filesystem
+          # handoff no longer applies, so injection is the supported path.
+          config:
+            inject: ["pr-context"]
           iterate:
             over: "{{ triage.out.triaged-findings.actionable }}"
-            # Serial until impl-finding gets per-child workspace isolation
-            # (see #1413). Parallel children share the /project mount and race
-            # on the working tree + git push, which silently drops commits.
-            mode: serial
+            mode: parallel
+            max_concurrent: 6
 
         - id: verify
           type: command

--- a/internal/pipeline/impl_finding_workspace_test.go
+++ b/internal/pipeline/impl_finding_workspace_test.go
@@ -1,0 +1,112 @@
+package pipeline
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestImplFindingDeclaresWorktreeWorkspace asserts that impl-finding's apply-fix
+// step uses a per-child worktree workspace. Issue #1413: the prior mount-based
+// workspace had no `origin` remote, so `git push` silently no-op'd and ~19
+// commits were dropped on a real run. Switching to `type: worktree` is the
+// architectural fix; this test guards against regression.
+func TestImplFindingDeclaresWorktreeWorkspace(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	path := filepath.Join(repoRoot, "internal", "defaults", "pipelines", "impl-finding.yaml")
+
+	loader := &YAMLPipelineLoader{}
+	pipe, err := loader.Load(path)
+	if err != nil {
+		t.Fatalf("load impl-finding.yaml: %v", err)
+	}
+
+	var apply *Step
+	for i := range pipe.Steps {
+		if pipe.Steps[i].ID == "apply-fix" {
+			apply = &pipe.Steps[i]
+			break
+		}
+	}
+	if apply == nil {
+		t.Fatal("impl-finding.yaml has no apply-fix step")
+	}
+
+	if apply.Workspace.Type != "worktree" {
+		t.Errorf("apply-fix workspace.type = %q, want %q", apply.Workspace.Type, "worktree")
+	}
+	if len(apply.Workspace.Mount) != 0 {
+		t.Errorf("apply-fix workspace.mount must be empty for worktree workspaces, got %d entries", len(apply.Workspace.Mount))
+	}
+	if apply.Workspace.Branch == "" {
+		t.Error("apply-fix workspace.branch must be set for worktree workspaces (e.g. \"{{ pipeline_id }}\")")
+	}
+}
+
+// TestOpsPRRespondResolveEachInjectsPRContext asserts the resolve-each step
+// inside ops-pr-respond's resolve-and-verify loop:
+//   - injects pr-context into each impl-finding child via config.inject (so the
+//     child can read the PR head branch from .agents/artifacts/pr-context),
+//   - runs in parallel mode (per-child worktrees fully isolate working trees,
+//     so the prior serial pin from #1413 is no longer needed).
+func TestOpsPRRespondResolveEachInjectsPRContext(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	path := filepath.Join(repoRoot, "internal", "defaults", "pipelines", "ops-pr-respond.yaml")
+
+	loader := &YAMLPipelineLoader{}
+	pipe, err := loader.Load(path)
+	if err != nil {
+		t.Fatalf("load ops-pr-respond.yaml: %v", err)
+	}
+
+	var resolveAndVerify *Step
+	for i := range pipe.Steps {
+		if pipe.Steps[i].ID == "resolve-and-verify" {
+			resolveAndVerify = &pipe.Steps[i]
+			break
+		}
+	}
+	if resolveAndVerify == nil {
+		t.Fatal("ops-pr-respond.yaml has no resolve-and-verify step")
+	}
+	if resolveAndVerify.Loop == nil {
+		t.Fatal("resolve-and-verify must declare a loop")
+	}
+
+	var resolveEach *Step
+	for i := range resolveAndVerify.Loop.Steps {
+		if resolveAndVerify.Loop.Steps[i].ID == "resolve-each" {
+			resolveEach = &resolveAndVerify.Loop.Steps[i]
+			break
+		}
+	}
+	if resolveEach == nil {
+		t.Fatal("resolve-and-verify.loop.steps has no resolve-each entry")
+	}
+
+	if resolveEach.Config == nil {
+		t.Fatal("resolve-each.config must be set so pr-context can be injected into impl-finding children")
+	}
+	found := false
+	for _, name := range resolveEach.Config.Inject {
+		if name == "pr-context" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("resolve-each.config.inject must contain \"pr-context\"; got %v", resolveEach.Config.Inject)
+	}
+
+	if resolveEach.Iterate == nil {
+		t.Fatal("resolve-each must declare iterate")
+	}
+	if resolveEach.Iterate.Mode != "parallel" {
+		t.Errorf("resolve-each.iterate.mode = %q, want %q (per-child worktrees isolate working trees)", resolveEach.Iterate.Mode, "parallel")
+	}
+}

--- a/specs/1413-impl-finding-worktree/plan.md
+++ b/specs/1413-impl-finding-worktree/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: 1413-impl-finding-worktree
+
+## Objective
+
+Replace `impl-finding`'s mount workspace with a per-child worktree workspace anchored on the PR head branch so commits actually push to `origin`. Restore `resolve-each` to `mode: parallel` once children no longer race on a shared working tree.
+
+## Approach
+
+1. Switch `internal/defaults/pipelines/impl-finding.yaml` from `workspace.mount` to `workspace.type: worktree`.
+2. Use the proven `impl-issue-core` pattern: `branch: "{{ pipeline_id }}"` (per-child unique throwaway branch). The worktree inherits the parent repo's `origin` and full ref database.
+3. Inject the parent's `pr-context` artifact into the child via `config.inject` on the parent's `resolve-each` step so the child can read the PR head branch name.
+4. Rewrite the prompt's git steps: `git fetch origin <pr-branch>` then `git checkout -B <pr-branch> origin/<pr-branch>` inside the worktree. Drop the `cd /project` indirection — the worktree IS a real checkout.
+5. Keep the `git ls-remote` push verification (already correct, just relocate to operate on the worktree's origin).
+6. Flip `ops-pr-respond.yaml` `resolve-each.iterate.mode` from `serial` back to `parallel`. Remove the now-stale comment that pinned it to serial.
+
+## File Mapping
+
+### Modify
+
+- `internal/defaults/pipelines/impl-finding.yaml`
+  - Replace `workspace.mount` block with `workspace.type: worktree` + `branch: "{{ pipeline_id }}"`.
+  - Rewrite Step 5 prompt section: drop `cd /project`, use worktree CWD, fetch + checkout PR branch, commit, push, verify.
+  - Update Step 4 prompt note about CWD (worktree root, not workspace root).
+  - Update doc comments in prompt header (Context section) about the working directory.
+
+- `internal/defaults/pipelines/ops-pr-respond.yaml`
+  - Add `config.inject: ["pr-context"]` to the `resolve-each` step so each `impl-finding` child receives the PR context artifact.
+  - Flip `resolve-each.iterate.mode` from `serial` to `parallel`. Keep `max_concurrent` if present, or set a reasonable cap (e.g. 6) consistent with `parallel-review`.
+  - Remove the `# Serial until impl-finding gets per-child workspace isolation (#1413)` comment.
+
+### Add (tests only)
+
+- `internal/pipeline/impl_finding_workspace_test.go` (or extend existing pipeline contract tests)
+  - Assert `impl-finding.yaml` declares `workspace.type: worktree`.
+  - Assert no `workspace.mount` block exists on the `apply-fix` step.
+  - Assert `ops-pr-respond.yaml` `resolve-each` declares `config.inject` containing `pr-context`.
+  - Assert `resolve-each.iterate.mode == parallel`.
+
+### Delete
+
+- None.
+
+## Architecture Decisions
+
+### A1. Reuse `branch: "{{ pipeline_id }}"` instead of templating PR branch into workspace.branch
+
+**Why:** Step-output template references resolve only against the *current* pipeline's completed steps. `impl-finding` is invoked as an iterate child whose own pipeline has no `fetch-pr` step. Templating `{{ steps.fetch-pr.artifacts.pr-context.branch }}` in the child's workspace config would resolve against the child's empty step graph and fail.
+
+`{{ pipeline_id }}` produces a unique branch name per child run (e.g. `impl-finding-20260427-...`), guaranteeing worktree isolation. The prompt then explicitly fetches and checks out the real PR head branch on top of that worktree's working copy. This matches the impl-issue-core pattern and keeps the failure modes well-understood.
+
+### A2. Rely on `config.inject` for cross-pipeline artifact handoff
+
+**Why:** With the mount gone, the child no longer sees `.agents/output/pr-context.json` via filesystem mount. `SubPipelineConfig.Inject` is the supported mechanism for parent-to-child artifact propagation. Wave's executor copies named parent artifacts into the child workspace before the child runs.
+
+### A3. Keep `git ls-remote` verification
+
+**Why:** Defense in depth. The worktree fix removes the silent-no-op-push class of bug, but pre-receive hooks, network glitches, or branch protection can still reject a push without the local commit knowing. Cross-checking the remote SHA is cheap and turns any future failure mode loud.
+
+### A4. Restore parallel mode in same PR
+
+**Why:** Issue acceptance criterion: "`resolve-each` can return to `mode: parallel`." Per-child worktrees fully isolate working trees, so parallel children no longer race. Splitting parallelism into a follow-up PR would leave the user-visible regression (serial findings = ~6× slower) unfixed despite the underlying race being solved.
+
+## Risks
+
+### R1. Worktree creation overhead per child
+
+20 parallel `git worktree add` calls hit the parent repo's lockfile briefly. Git serializes `worktree add` against the index lock but each call is sub-second. **Mitigation:** keep `max_concurrent` at 6 (matches `parallel-review`) so worktree creation is bounded.
+
+### R2. `config.inject` compatibility with iterate steps
+
+The explore probe noted iterate-step children may not honour `step.Config.Inject`. **Mitigation:** verify by running `ops-pr-respond` end-to-end against a small representative PR before declaring done. If inject is silently ignored, fallback: have the child read PR branch from `{{ input }}` (the iterate item itself includes the branch context if we extend the input shape) — but this is the contingency, not the primary path.
+
+### R3. Worktree cleanup on parallel failure
+
+If a child errors mid-run, its worktree may stick around. Wave's worktree manager already handles cleanup on pipeline completion, but parallel partial-failure paths are less battle-tested. **Mitigation:** rely on existing `worktree.NewManager()` cleanup; document the manual `git worktree prune` recovery path in the resolution record on failure.
+
+### R4. PR branch fetch races
+
+Multiple children fetching the same `origin <pr-branch>` simultaneously is safe (git handles concurrent fetches), but if branch protection or auth drops a fetch, the child sees a stale local ref. **Mitigation:** the existing push verification step catches this — if local SHA differs from remote after push, the child fails loudly.
+
+## Testing Strategy
+
+### Unit / Pipeline Schema Tests
+
+- Assert `impl-finding.yaml` schema: `workspace.type == worktree`, no `mount` block.
+- Assert `ops-pr-respond.yaml` schema: `resolve-each.config.inject` contains `pr-context`, `iterate.mode == parallel`.
+- Existing pipeline lint / contract validation (`go test ./internal/pipeline/...`) covers structural validity.
+
+### Integration / Manual Validation
+
+The spec's acceptance criterion is empirical: "A second run of `ops-pr-respond` on a representative PR produces commits that show up on `origin/<pr-branch>` without manual salvage." This requires an end-to-end run, not a Go test.
+
+Plan:
+1. Build the binary locally.
+2. Pick a low-stakes test PR with ≥3 plausible findings.
+3. Run `wave run ops-pr-respond <PR>`.
+4. Verify on `origin/<pr-branch>`: every actionable resolution record's commit SHA appears in `git log origin/<pr-branch>` *and* matches `git ls-remote origin <pr-branch>` HEAD progression.
+5. Repeat with `iterate.mode: parallel` to confirm no race regressions (concurrent file edits don't clobber each other).
+
+Document the validation run id in the PR description.
+
+### Regression Coverage
+
+- `go test -race ./internal/pipeline/...` — guards against any data race introduced by the inject path.
+- `golangci-lint run` — catches yaml-loader regressions if the schema changes propagate.

--- a/specs/1413-impl-finding-worktree/spec.md
+++ b/specs/1413-impl-finding-worktree/spec.md
@@ -1,0 +1,97 @@
+# fix(pipeline): impl-finding mount workspace silently drops commits — git push has no remote
+
+**Issue:** [re-cinq/wave#1413](https://github.com/re-cinq/wave/issues/1413)
+**Labels:** bug
+**State:** OPEN
+**Author:** nextlevelshit
+
+## Body
+
+### Root cause: `impl-finding` mount workspace has no remote, so `git push` silently no-ops
+
+#### Symptom
+
+When `ops-pr-respond` was run on PR #1407 (run `ops-pr-respond-20260426-203623-b73e`), all 19 actionable findings were classified, all 19 `impl-finding` sub-pipelines ran to completion, and the comment-back step posted a resolution table claiming SHAs `8243ae93`, `e7a34a84`, etc. for each `f1`–`f19` fix.
+
+But the PR head branch (`origin/1401-ops-pr-respond-v2`) saw none of those commits. Only the original PR commit + the unrelated `f6` AGENTS.md fix landed remotely.
+
+The 19 commits did exist locally — each in its own isolated child workspace under `.agents/workspaces/impl-finding-*/apply-fix/`. They never reached `origin`.
+
+#### Root cause
+
+`internal/defaults/pipelines/impl-finding.yaml` declares the workspace as:
+
+```yaml
+workspace:
+  mount:
+    - source: ./
+      target: /project
+      mode: readwrite
+```
+
+A mount-based workspace creates a fresh `git init` at the workspace root and mounts the project filesystem at `/project`. The workspace's own git has:
+
+- **No `origin` remote.**
+- **No tracking branch.**
+- A default branch name (`master` / `main`), not the PR head branch.
+
+The pipeline's Step 5 then runs:
+
+```bash
+BRANCH=$(jq -r .branch .agents/output/pr-context.json)
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT" != "$BRANCH" ]; then
+  echo "refusing to push..." >&2
+  exit 1
+fi
+git add ...
+git commit -m "fix(<id>): ..."
+git push origin HEAD:"$BRANCH"
+```
+
+What actually happened:
+
+1. The precondition check should have fired `exit 1` (workspace HEAD is `master`, PR branch is `1401-ops-pr-respond-v2`). Several children apparently bypassed it (the LLM rewrote or skipped the guard).
+2. Even when the guard passed, `git push origin HEAD:<branch>` runs against the workspace's own git, which has no `origin` remote. The push silently no-ops with a non-error.
+3. The local `git commit` succeeds (workspace git writes the commit), so the resolution record reports the commit SHA as if it landed.
+4. The comment-back step reads the resolution records and posts the table — every entry shows `applied` because the local commit succeeded.
+
+#### Why the mount layout exists
+
+Mount workspaces are intentional for read-only steps where the agent inspects the project tree. They predate the worktree workspace mode. `fetch-pr` and several audit-* pipelines use mount appropriately.
+
+`impl-finding` is the only pipeline that needs to **commit and push to the PR head branch** but uses mount.
+
+#### Proposed fix
+
+Change `impl-finding.yaml` to a worktree workspace that checks out the PR head branch. Existing pipelines (`impl-issue-core`, `impl-recinq`) already use this pattern.
+
+A worktree gives a real git checkout with the same `origin` as the parent repo. `git push origin HEAD:branch` will then actually push.
+
+If artifact templating is not available at workspace-config time, use the impl-issue pattern (`branch: "{{ pipeline_id }}"`) and have the prompt's first step run `git fetch origin <pr-branch>` + `git checkout <pr-branch>` explicitly.
+
+#### Secondary issues (file separately if confirmed)
+
+- **Race on shared mount**: 19 parallel `impl-finding` children all share `/project` read-write. They can clobber each other's working-tree state during the LLM-driven file edit phase.
+- **Resolution record trusts local commit**: Step 6 records `Status: applied` whenever `git commit` succeeded, without checking that the push actually landed.
+- **comment-back step does not verify remote**: it reads resolution.md per child and trusts the SHAs listed.
+
+#### Validation
+
+Hand-salvage of the 19 lost commits from this run: see commits `76d1264e`..`14ffa8ea` on `1401-ops-pr-respond-v2` (force-pushed 2026-04-26).
+
+#### Source
+
+Empirical baseline: `ops-pr-respond-20260426-203623-b73e` on PR #1407 (lost 19 commits, hand-recovered from child workspaces).
+
+## Comments
+
+**nextlevelshit:**
+> Partial mitigation landed in PR #1407 (commit c30870ef): push step now runs against /project mount, push is verified via git ls-remote, origin-remote precondition added, resolve-each switched to mode: serial. Full fix (worktree-based isolated checkout per child to restore mode: parallel) still owned by this issue. Acceptance criteria unchanged.
+
+## Acceptance Criteria
+
+- `impl-finding` workspace is a worktree (or equivalent isolated git checkout) of the PR head branch.
+- A second run of `ops-pr-respond` on a representative PR produces commits that show up on `origin/<pr-branch>` without manual salvage.
+- Resolution records cross-check `git ls-remote origin <branch>` to confirm the commit pushed before reporting `applied`.
+- `resolve-each` can return to `mode: parallel` without races on shared `/project` working tree.

--- a/specs/1413-impl-finding-worktree/tasks.md
+++ b/specs/1413-impl-finding-worktree/tasks.md
@@ -1,0 +1,20 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Re-read `internal/defaults/pipelines/impl-issue-core.yaml` worktree pattern + `worktree.Manager.Create()` semantics so the new `impl-finding.yaml` matches existing conventions exactly.
+- [X] Item 1.2: Confirm `config.inject` semantics on iterate-step sub-pipelines via a focused unit test or executor read-through.
+
+## Phase 2: Core Implementation
+- [X] Item 2.1: Rewrite `internal/defaults/pipelines/impl-finding.yaml` workspace block from `mount` to `type: worktree` + `branch: "{{ pipeline_id }}"`. [P]
+- [X] Item 2.2: Rewrite Step 5 of the impl-finding prompt: drop `cd /project`, fetch + checkout PR branch into the worktree, commit, push, verify via `git ls-remote`. Update Step 4 CWD note. [P]
+- [X] Item 2.3: Update `internal/defaults/pipelines/ops-pr-respond.yaml` `resolve-each` step: add `config.inject: ["pr-context"]`, flip `iterate.mode` from `serial` to `parallel`, set `max_concurrent: 6`, remove the stale `# Serial until ... #1413` comment. [P]
+
+## Phase 3: Testing
+- [X] Item 3.1: Add or extend a pipeline schema test asserting `impl-finding` declares worktree workspace and `ops-pr-respond` `resolve-each` injects `pr-context` + runs parallel.
+- [X] Item 3.2: Run `go test -race ./internal/pipeline/...` and `go test ./...` locally; fix any breakage.
+- [ ] Item 3.3: End-to-end manual validation: build binary, run `ops-pr-respond` against a small test PR, verify resolution-record commit SHAs land on `origin/<pr-branch>` and `git ls-remote` matches. (Deferred: requires live PR + admin approval — record run id in implementation PR description before merge.)
+
+## Phase 4: Polish
+- [X] Item 4.1: Update inline comments in both yaml files to reflect the new model (no more "shared mount race" caveats).
+- [X] Item 4.2: Run `golangci-lint run` and `go vet ./...`.
+- [ ] Item 4.3: Reference the validation run id (and resulting PR's `origin/<pr-branch>` log diff) in the implementation PR description. (Performed at PR-creation time, not in this commit.)


### PR DESCRIPTION
## Summary

- Replace `impl-finding` mount workspace with per-child worktree on throwaway branch (`{{ pipeline_id }}`); worktree shares `origin` so `git push` reaches remote — fixes silent no-op push that dropped 19 commits in run `ops-pr-respond-20260426-203623`.
- Prompt now fetches and checks out PR head branch into the worktree as Step 2, then edits, tests, commits, and pushes from that checkout.
- PR head branch is read from parent's `pr-context` artifact and injected into each child via `SubPipelineConfig.Inject`.
- `ops-pr-respond` `resolve-each` restored to `mode: parallel` with `max_concurrent: 6` — per-child worktrees fully isolate working trees (no shared `/project` race).
- Adds `internal/pipeline/impl_finding_workspace_test.go` schema regression guard asserting `workspace.type=worktree` on `impl-finding` and `config.inject` contains `pr-context` with `iterate.mode=parallel` on `ops-pr-respond`.

Related to #1413

## Changes

- `internal/defaults/pipelines/impl-finding.yaml` — workspace switched from mount to worktree; prompt updated to fetch+checkout PR head branch from injected `pr-context`.
- `internal/defaults/pipelines/ops-pr-respond.yaml` — `resolve-each` restored to `mode: parallel`, `max_concurrent: 6`; `config.inject: ["pr-context"]` propagates PR ref to every child.
- `internal/pipeline/impl_finding_workspace_test.go` — new schema regression test.
- `specs/1413-impl-finding-worktree/{spec,plan,tasks}.md` — planning docs.

## Test Plan

- [x] `go test ./internal/pipeline/... -run ImplFinding` (schema regression guard passes)
- [x] `go test -race ./...`
- [ ] Re-run `ops-pr-respond` on a representative PR; verify 19 child commits land on `origin/<pr-branch>` without manual salvage
- [ ] Confirm `resolve-each` runs children in parallel without working-tree clobber