### PR TITLE
fix(state): unified zombie run reconciliation, wired into webui server

### DIFF
--- a/cmd/wave/commands/status.go
+++ b/cmd/wave/commands/status.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/recinq/wave/internal/display"
@@ -204,7 +203,12 @@ func showRunningRuns(store state.StateStore, opts StatusOptions) error {
 		return err
 	}
 
-	records = reconcileZombies(store, records)
+	if state.ReconcileZombies(store, 0) > 0 {
+		records, err = store.GetRunningRuns()
+		if err != nil {
+			return err
+		}
+	}
 
 	if len(records) == 0 {
 		if opts.Format == "json" {
@@ -321,46 +325,6 @@ func outputRuns(runs []StatusRunInfo, opts StatusOptions) error {
 	}
 
 	return nil
-}
-
-// reconcileZombies walks records still flagged as "running" and marks any
-// whose tracked process is gone as "failed". Returns the records that survived
-// reconciliation. Runs without a tracked PID (PID == 0, e.g. foreground
-// `wave run` invocations) are reconciled by age: if the started_at timestamp
-// is older than zombieAgeThreshold and no completion has been recorded, the
-// run is treated as orphaned.
-//
-// The state DB has no liveness ping today, so this is the best signal we have
-// without the executor itself writing heartbeats. Errors during reconciliation
-// are non-fatal — the run is left as-is and shown to the user.
-func reconcileZombies(store state.StateStore, records []state.RunRecord) []state.RunRecord {
-	const zombieAgeThreshold = 1 * time.Hour
-	live := make([]state.RunRecord, 0, len(records))
-	for _, r := range records {
-		if r.Status != "running" {
-			live = append(live, r)
-			continue
-		}
-		if isZombie(r, zombieAgeThreshold) {
-			_ = store.UpdateRunStatus(r.RunID, "failed", "process gone (orphaned)", r.TotalTokens)
-			continue
-		}
-		live = append(live, r)
-	}
-	return live
-}
-
-// isZombie reports whether a "running" record has lost its underlying process.
-// Returns true if the tracked PID no longer exists, or if the run has no PID
-// and is older than ageThreshold (proxy for "this should have finished by now").
-func isZombie(r state.RunRecord, ageThreshold time.Duration) bool {
-	if r.PID > 0 {
-		if err := syscall.Kill(r.PID, 0); err == syscall.ESRCH {
-			return true
-		}
-		return false
-	}
-	return time.Since(r.StartedAt) > ageThreshold
 }
 
 // statusColor returns the ANSI color code for a status.

--- a/cmd/wave/commands/status_test.go
+++ b/cmd/wave/commands/status_test.go
@@ -445,8 +445,8 @@ func TestReconcileZombies_PIDZeroOldRunMarkedFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, running, 1, "fixture should produce one running record")
 
-	live := reconcileZombies(h.store, running)
-	assert.Empty(t, live, "old PID=0 running run should be reaped")
+	reaped := state.ReconcileZombies(h.store, 0)
+	assert.Equal(t, 1, reaped, "old PID=0 running run should be reaped")
 
 	rec, err := h.store.GetRun("zombie-old")
 	require.NoError(t, err)
@@ -462,11 +462,11 @@ func TestReconcileZombies_FreshRunSurvives(t *testing.T) {
 	recent := time.Now().Add(-2 * time.Minute)
 	h.createRun("fresh", "test-pipeline", "running", "", 0, recent, nil)
 
-	running, err := h.store.GetRunningRuns()
+	_, err := h.store.GetRunningRuns()
 	require.NoError(t, err)
 
-	live := reconcileZombies(h.store, running)
-	assert.Len(t, live, 1, "recent PID=0 run should survive reconciliation")
+	reaped := state.ReconcileZombies(h.store, 0)
+	assert.Equal(t, 0, reaped, "recent PID=0 run should survive reconciliation")
 }
 
 // TestReconcileZombies_DeadPIDReaped verifies that a record with a PID that
@@ -483,9 +483,9 @@ func TestReconcileZombies_DeadPIDReaped(t *testing.T) {
 	// allocate a high number that is overwhelmingly unlikely to be live.
 	require.NoError(t, h.store.UpdateRunPID("dead-pid", 0x7ffffffe))
 
-	running, err := h.store.GetRunningRuns()
+	_, err := h.store.GetRunningRuns()
 	require.NoError(t, err)
 
-	live := reconcileZombies(h.store, running)
-	assert.Empty(t, live, "dead PID should be reaped")
+	reaped := state.ReconcileZombies(h.store, 0)
+	assert.Equal(t, 1, reaped, "dead PID should be reaped")
 }

--- a/internal/state/reconcile.go
+++ b/internal/state/reconcile.go
@@ -1,0 +1,54 @@
+package state
+
+import (
+	"syscall"
+	"time"
+)
+
+// ZombieAgeThreshold is the default age beyond which a "running" run with no
+// tracked PID is treated as orphaned. Five minutes is short enough that real
+// dead processes do not linger, long enough that a freshly launched run is not
+// mistaken for a zombie before its first event is recorded.
+const ZombieAgeThreshold = 5 * time.Minute
+
+// ReconcileZombies marks "running" pipeline runs as failed when their tracked
+// process is gone, or when no PID is tracked and the run is older than
+// ageThreshold. Returns the number of runs reclaimed.
+//
+// Reconciliation is the single defense against parent processes that die
+// without updating the DB (terminal close, OOM, signal, kernel panic). Without
+// it, the webui run list and CLI status accumulate "running" rows forever.
+//
+// Pass the zero value to use ZombieAgeThreshold.
+func ReconcileZombies(store StateStore, ageThreshold time.Duration) int {
+	if ageThreshold <= 0 {
+		ageThreshold = ZombieAgeThreshold
+	}
+	runs, err := store.ListRuns(ListRunsOptions{Status: "running", Limit: 1000})
+	if err != nil {
+		return 0
+	}
+	reclaimed := 0
+	for _, r := range runs {
+		if !isZombie(r, ageThreshold) {
+			continue
+		}
+		if err := store.UpdateRunStatus(r.RunID, "failed", "process gone (orphaned)", r.TotalTokens); err == nil {
+			reclaimed++
+		}
+	}
+	return reclaimed
+}
+
+// isZombie reports whether a "running" record has lost its underlying process.
+// Returns true if the tracked PID no longer exists, or if the run has no PID
+// and is older than ageThreshold (proxy for "this should have finished by now").
+func isZombie(r RunRecord, ageThreshold time.Duration) bool {
+	if r.PID > 0 {
+		if err := syscall.Kill(r.PID, 0); err == syscall.ESRCH {
+			return true
+		}
+		return false
+	}
+	return time.Since(r.StartedAt) > ageThreshold
+}

--- a/internal/state/reconcile_test.go
+++ b/internal/state/reconcile_test.go
@@ -1,0 +1,128 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func newReconcileStore(t *testing.T) *stateStore {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewStateStore(filepath.Join(dir, "wave.db"))
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store.(*stateStore)
+}
+
+func TestReconcileZombies_AgeBased(t *testing.T) {
+	store := newReconcileStore(t)
+
+	freshID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun fresh: %v", err)
+	}
+	if err := store.UpdateRunStatus(freshID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus fresh: %v", err)
+	}
+	staleID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun stale: %v", err)
+	}
+	if err := store.UpdateRunStatus(staleID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus stale: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`UPDATE pipeline_run SET started_at = ? WHERE run_id = ?`,
+		time.Now().Add(-30*time.Minute).Unix(), staleID,
+	); err != nil {
+		t.Fatalf("seed stale started_at: %v", err)
+	}
+
+	if got := ReconcileZombies(store, ZombieAgeThreshold); got != 1 {
+		t.Fatalf("ReconcileZombies = %d, want 1", got)
+	}
+
+	freshStatus, err := store.GetRunStatus(freshID)
+	if err != nil {
+		t.Fatalf("GetRunStatus fresh: %v", err)
+	}
+	if freshStatus != "running" {
+		t.Errorf("fresh run status = %q, want running", freshStatus)
+	}
+	staleStatus, err := store.GetRunStatus(staleID)
+	if err != nil {
+		t.Fatalf("GetRunStatus stale: %v", err)
+	}
+	if staleStatus != "failed" {
+		t.Errorf("stale run status = %q, want failed", staleStatus)
+	}
+}
+
+func TestReconcileZombies_PIDLive(t *testing.T) {
+	store := newReconcileStore(t)
+	runID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := store.UpdateRunStatus(runID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus running: %v", err)
+	}
+	if err := store.UpdateRunPID(runID, os.Getpid()); err != nil {
+		t.Fatalf("UpdateRunPID: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`UPDATE pipeline_run SET started_at = ? WHERE run_id = ?`,
+		time.Now().Add(-30*time.Minute).Unix(), runID,
+	); err != nil {
+		t.Fatalf("seed started_at: %v", err)
+	}
+
+	if got := ReconcileZombies(store, ZombieAgeThreshold); got != 0 {
+		t.Fatalf("ReconcileZombies (live PID) = %d, want 0", got)
+	}
+	status, _ := store.GetRunStatus(runID)
+	if status != "running" {
+		t.Errorf("status = %q, want running (live PID must not be reaped)", status)
+	}
+}
+
+func TestReconcileZombies_PIDGone(t *testing.T) {
+	store := newReconcileStore(t)
+	runID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := store.UpdateRunStatus(runID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus running: %v", err)
+	}
+	deadPID := findDeadPID(t)
+	if err := store.UpdateRunPID(runID, deadPID); err != nil {
+		t.Fatalf("UpdateRunPID: %v", err)
+	}
+
+	if got := ReconcileZombies(store, ZombieAgeThreshold); got != 1 {
+		t.Fatalf("ReconcileZombies (dead PID) = %d, want 1", got)
+	}
+	status, _ := store.GetRunStatus(runID)
+	if status != "failed" {
+		t.Errorf("status = %q, want failed", status)
+	}
+}
+
+// findDeadPID picks a PID that is not currently in use. Skips the test if a
+// dead PID cannot be located (extremely unlikely on a typical system).
+func findDeadPID(t *testing.T) int {
+	t.Helper()
+	for pid := 99999; pid > 90000; pid-- {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return pid
+		}
+	}
+	t.Skip("could not locate dead PID for test")
+	return 0
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/state"
@@ -133,7 +132,7 @@ func RunTUI(deps LaunchDependencies) error {
 
 	// Clean up orphaned runs from previous sessions
 	if deps.Store != nil {
-		cleanStaleRuns(deps.Store)
+		state.ReconcileZombies(deps.Store, 0)
 	}
 
 	// Build content providers from launch dependencies
@@ -194,28 +193,3 @@ func RunTUI(deps LaunchDependencies) error {
 	return err
 }
 
-// cleanStaleRuns marks orphaned pending/running runs as failed on TUI startup.
-// These are runs from previous sessions whose processes died without updating the DB.
-func cleanStaleRuns(store interface{}) {
-	type staleRunCleaner interface {
-		ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error)
-		UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
-	}
-	s, ok := store.(staleRunCleaner)
-	if !ok {
-		return
-	}
-
-	cutoff := time.Now().Add(-5 * time.Minute)
-	for _, status := range []string{"pending", "running"} {
-		runs, err := s.ListRuns(state.ListRunsOptions{Status: status, Limit: 100})
-		if err != nil {
-			continue
-		}
-		for _, r := range runs {
-			if r.StartedAt.Before(cutoff) {
-				_ = s.UpdateRunStatus(r.RunID, "failed", "orphaned — previous session exited", 0)
-			}
-		}
-	}
-}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -100,6 +100,13 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to open read-write state store: %w", err)
 	}
 
+	// Reclaim zombie runs left over from previously-killed wave run processes
+	// (terminal close, OOM, signal). Without this, the run list accumulates
+	// "running" rows forever — see fix/zombie-reconciliation for context.
+	if reclaimed := state.ReconcileZombies(rwStore, 0); reclaimed > 0 {
+		log.Printf("[webui] reconciled %d zombie run(s) on boot", reclaimed)
+	}
+
 	// Generate a per-session CSRF token
 	csrfBytes := make([]byte, 32)
 	if _, err := rand.Read(csrfBytes); err != nil {
@@ -239,6 +246,24 @@ func (s *Server) pollAttention(ctx context.Context) {
 	}
 }
 
+// reconcileZombiesLoop periodically scans the DB for "running" runs whose
+// owning process is gone and marks them failed. This complements the one-shot
+// reconcile that runs at server boot, catching runs that died after boot.
+func (s *Server) reconcileZombiesLoop(ctx context.Context) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if reclaimed := state.ReconcileZombies(s.rwStore, 0); reclaimed > 0 {
+				log.Printf("[webui] reconciled %d zombie run(s)", reclaimed)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func (s *Server) syncAttentionFromDB() {
 	if s.attention == nil {
 		return
@@ -283,6 +308,7 @@ func (s *Server) Start() error {
 	attentionCtx, attentionCancel := context.WithCancel(context.Background())
 	defer attentionCancel()
 	go s.pollAttention(attentionCtx)
+	go s.reconcileZombiesLoop(attentionCtx)
 
 	addr := fmt.Sprintf("%s:%d", s.bind, s.port)
 	listener, err := net.Listen("tcp", addr)


### PR DESCRIPTION
## Root cause

Two duplicate reconcilers existed but neither ran inside `wave serve`:
- `cmd/wave/commands/status.go: reconcileZombies` — only on `wave status`
- `internal/tui/app.go: cleanStaleRuns` — only on TUI startup

When a wave run process died (terminal close, OOM, signal), the run row stayed at status="running" until the user happened to open status or TUI. The webui run list accumulated zombies forever.

## Fix

- Consolidate into `internal/state.ReconcileZombies` (single impl, exported).
- Wire into webui:
  - One-shot reconcile on `NewServer` boot.
  - 60s periodic ticker via `reconcileZombiesLoop`.
- Threshold lowered from 1h to 5m (matches the prior TUI heuristic).
- PID-based check still wins when a PID is tracked.
- `cmd status` and TUI startup now share the same function.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/state/ ./internal/webui/ ./internal/tui/ ./cmd/wave/commands/`
- [x] 3 new unit tests: AgeBased, PIDLive, PIDGone
- [ ] CI green