### PR TITLE
feat(state): heartbeat liveness signal for running pipelines

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -608,6 +608,13 @@ func runRun(opts RunOptions, debug bool) error {
 	// Transition run from pending → running so dashboards and wave status reflect active execution.
 	if store != nil {
 		_ = store.UpdateRunStatus(runID, "running", "", 0)
+		_ = store.UpdateRunHeartbeat(runID)
+		// Periodic heartbeat: lets the reconciler distinguish a live run from
+		// a parent process that died without updating the DB. Goroutine exits
+		// when heartbeatCancel fires (deferred just below this block).
+		heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+		defer heartbeatCancel()
+		go runHeartbeatLoop(heartbeatCtx, store, runID)
 	}
 
 	var execErr error
@@ -1224,4 +1231,23 @@ func (a *relayCompactionAdapter) RunCompaction(ctx context.Context, cfg relay.Co
 	}
 
 	return result.ResultContent, nil
+}
+
+// runHeartbeatLoop periodically refreshes pipeline_run.last_heartbeat for the
+// running pipeline. The reconciler reads this column to distinguish live runs
+// from runs whose owning process died without updating the DB.
+//
+// Cadence is 30s — well below state.HeartbeatStaleThreshold (90s) so two
+// missed beats are tolerated before reaping.
+func runHeartbeatLoop(ctx context.Context, store state.StateStore, runID string) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			_ = store.UpdateRunHeartbeat(runID)
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/internal/state/migration_definitions.go
+++ b/internal/state/migration_definitions.go
@@ -539,5 +539,13 @@ ALTER TABLE pipeline_outcome ADD COLUMN metadata TEXT NOT NULL DEFAULT '';`,
 			Down: `ALTER TABLE pipeline_outcome DROP COLUMN description;
 ALTER TABLE pipeline_outcome DROP COLUMN metadata;`,
 		},
+		{
+			Version:     26,
+			Description: "Add last_heartbeat column to pipeline_run for liveness tracking",
+			Up: `ALTER TABLE pipeline_run ADD COLUMN last_heartbeat INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_run_heartbeat ON pipeline_run(last_heartbeat) WHERE status = 'running';`,
+			Down: `DROP INDEX IF EXISTS idx_run_heartbeat;
+ALTER TABLE pipeline_run DROP COLUMN last_heartbeat;`,
+		},
 	}
 }

--- a/internal/state/migrations_test.go
+++ b/internal/state/migrations_test.go
@@ -465,7 +465,7 @@ func TestInitializeWithMigrations_ExistingDatabase(t *testing.T) {
 	manager := NewMigrationManager(db)
 	applied, err := manager.GetAppliedMigrations()
 	assert.NoError(t, err)
-	assert.Len(t, applied, 25) // All 25 defined migrations
+	assert.Len(t, applied, 26) // All 26 defined migrations
 }
 
 func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
@@ -496,11 +496,11 @@ func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
 func TestMigrationDefinitions(t *testing.T) {
 	migrations := GetAllMigrations()
 
-	// Should have 25 migrations based on our definition
-	assert.Len(t, migrations, 25)
+	// Should have 26 migrations based on our definition
+	assert.Len(t, migrations, 26)
 
 	// Check version sequence
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 	for i, migration := range migrations {
 		assert.Equal(t, expectedVersions[i], migration.Version)
 		assert.NotEmpty(t, migration.Description)

--- a/internal/state/reconcile.go
+++ b/internal/state/reconcile.go
@@ -6,20 +6,30 @@ import (
 )
 
 // ZombieAgeThreshold is the default age beyond which a "running" run with no
-// tracked PID is treated as orphaned. Five minutes is short enough that real
-// dead processes do not linger, long enough that a freshly launched run is not
-// mistaken for a zombie before its first event is recorded.
+// tracked PID and no heartbeat is treated as orphaned. Five minutes is short
+// enough that real dead processes do not linger, long enough that a freshly
+// launched run is not mistaken for a zombie before its first event is recorded.
 const ZombieAgeThreshold = 5 * time.Minute
 
-// ReconcileZombies marks "running" pipeline runs as failed when their tracked
-// process is gone, or when no PID is tracked and the run is older than
-// ageThreshold. Returns the number of runs reclaimed.
+// HeartbeatStaleThreshold is the maximum gap between heartbeats before a
+// running run is considered orphaned. wave run writes a heartbeat every 30s,
+// so a 90s threshold tolerates two missed beats before reaping. This is the
+// primary liveness signal: when present, it overrides PID and age checks.
+const HeartbeatStaleThreshold = 90 * time.Second
+
+// ReconcileZombies marks "running" pipeline runs as failed when their owning
+// process is gone. Returns the number of runs reclaimed. Liveness signals are
+// checked in priority order:
 //
-// Reconciliation is the single defense against parent processes that die
-// without updating the DB (terminal close, OOM, signal, kernel panic). Without
-// it, the webui run list and CLI status accumulate "running" rows forever.
+//  1. Heartbeat: if the run wrote a heartbeat within HeartbeatStaleThreshold,
+//     it is alive — regardless of PID or age. If the last heartbeat is older,
+//     it is a zombie.
+//  2. PID: if the run has a tracked PID and the OS reports ESRCH, it is a
+//     zombie. A live PID without a recent heartbeat keeps the run.
+//  3. Age fallback: legacy runs with no PID and no heartbeat are reaped once
+//     their started_at is older than ageThreshold.
 //
-// Pass the zero value to use ZombieAgeThreshold.
+// Pass the zero value for ageThreshold to use ZombieAgeThreshold.
 func ReconcileZombies(store StateStore, ageThreshold time.Duration) int {
 	if ageThreshold <= 0 {
 		ageThreshold = ZombieAgeThreshold
@@ -40,10 +50,15 @@ func ReconcileZombies(store StateStore, ageThreshold time.Duration) int {
 	return reclaimed
 }
 
-// isZombie reports whether a "running" record has lost its underlying process.
-// Returns true if the tracked PID no longer exists, or if the run has no PID
-// and is older than ageThreshold (proxy for "this should have finished by now").
+// isZombie reports whether a "running" record has lost its owning process.
+// Heartbeat freshness is the primary signal; PID and age are fallbacks for
+// runs that have not yet started writing heartbeats (legacy data, or a run
+// reaped before the first heartbeat goroutine tick).
 func isZombie(r RunRecord, ageThreshold time.Duration) bool {
+	if !r.LastHeartbeat.IsZero() {
+		// Heartbeat exists: trust it absolutely. A late heartbeat is a zombie.
+		return time.Since(r.LastHeartbeat) > HeartbeatStaleThreshold
+	}
 	if r.PID > 0 {
 		if err := syscall.Kill(r.PID, 0); err == syscall.ESRCH {
 			return true

--- a/internal/state/reconcile_test.go
+++ b/internal/state/reconcile_test.go
@@ -114,6 +114,69 @@ func TestReconcileZombies_PIDGone(t *testing.T) {
 	}
 }
 
+func TestReconcileZombies_HeartbeatFresh(t *testing.T) {
+	store := newReconcileStore(t)
+	runID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := store.UpdateRunStatus(runID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+	if err := store.UpdateRunHeartbeat(runID); err != nil {
+		t.Fatalf("UpdateRunHeartbeat: %v", err)
+	}
+	// Fresh heartbeat must keep the run alive even with a dead tracked PID
+	// and an old started_at — heartbeat is the priority signal.
+	if err := store.UpdateRunPID(runID, findDeadPID(t)); err != nil {
+		t.Fatalf("UpdateRunPID: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`UPDATE pipeline_run SET started_at = ? WHERE run_id = ?`,
+		time.Now().Add(-1*time.Hour).Unix(), runID,
+	); err != nil {
+		t.Fatalf("seed started_at: %v", err)
+	}
+
+	if got := ReconcileZombies(store, ZombieAgeThreshold); got != 0 {
+		t.Fatalf("ReconcileZombies (fresh heartbeat) = %d, want 0", got)
+	}
+	status, _ := store.GetRunStatus(runID)
+	if status != "running" {
+		t.Errorf("status = %q, want running (fresh heartbeat must outrank PID/age)", status)
+	}
+}
+
+func TestReconcileZombies_HeartbeatStale(t *testing.T) {
+	store := newReconcileStore(t)
+	runID, err := store.CreateRun("p", "in")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := store.UpdateRunStatus(runID, "running", "", 0); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+	// Stale heartbeat (older than HeartbeatStaleThreshold) must reap even
+	// when the tracked PID is alive — process may be wedged.
+	if err := store.UpdateRunPID(runID, os.Getpid()); err != nil {
+		t.Fatalf("UpdateRunPID: %v", err)
+	}
+	if _, err := store.db.Exec(
+		`UPDATE pipeline_run SET last_heartbeat = ? WHERE run_id = ?`,
+		time.Now().Add(-5*time.Minute).Unix(), runID,
+	); err != nil {
+		t.Fatalf("seed last_heartbeat: %v", err)
+	}
+
+	if got := ReconcileZombies(store, ZombieAgeThreshold); got != 1 {
+		t.Fatalf("ReconcileZombies (stale heartbeat) = %d, want 1", got)
+	}
+	status, _ := store.GetRunStatus(runID)
+	if status != "failed" {
+		t.Errorf("status = %q, want failed (stale heartbeat must reap even with live PID)", status)
+	}
+}
+
 // findDeadPID picks a PID that is not currently in use. Skips the test if a
 // dead PID cannot be located (extremely unlikely on a typical system).
 func findDeadPID(t *testing.T) int {

--- a/internal/state/runstore.go
+++ b/internal/state/runstore.go
@@ -30,6 +30,7 @@ type RunStore interface {
 	UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
 	UpdateRunBranch(runID string, branch string) error
 	UpdateRunPID(runID string, pid int) error
+	UpdateRunHeartbeat(runID string) error
 	GetRun(runID string) (*RunRecord, error)
 	GetRunningRuns() ([]RunRecord, error)
 	ListRuns(opts ListRunsOptions) ([]RunRecord, error)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -119,6 +119,10 @@ type StateStore interface {
 
 	// Process tracking (detached subprocess execution)
 	UpdateRunPID(runID string, pid int) error
+	// Liveness tracking — running processes call this periodically so the
+	// reconciler can flag zombies whose owning process died without
+	// updating the DB.
+	UpdateRunHeartbeat(runID string) error
 
 	// Step attempt tracking (retry/recovery)
 	RecordStepAttempt(record *StepAttemptRecord) error
@@ -684,11 +688,23 @@ func (s *stateStore) UpdateRunPID(runID string, pid int) error {
 	return nil
 }
 
+// UpdateRunHeartbeat refreshes the last_heartbeat timestamp for a running
+// pipeline. The reconciler reads this column to distinguish runs whose owning
+// process is still alive from runs whose process died without updating the DB.
+func (s *stateStore) UpdateRunHeartbeat(runID string) error {
+	query := `UPDATE pipeline_run SET last_heartbeat = ? WHERE run_id = ?`
+	_, err := s.db.Exec(query, s.now().Unix(), runID)
+	if err != nil {
+		return fmt.Errorf("failed to update run heartbeat: %w", err)
+	}
+	return nil
+}
+
 // GetRun retrieves a single run record by ID.
 func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
 	          FROM pipeline_run
 	          WHERE run_id = ?`
 
@@ -698,6 +714,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
 	var pid sql.NullInt64
 	var parentRunID, parentStepID, forkedFromRunID sql.NullString
+	var lastHeartbeat int64
 
 	err := s.db.QueryRow(query, runID).Scan(
 		&record.RunID,
@@ -716,6 +733,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 		&parentRunID,
 		&parentStepID,
 		&forkedFromRunID,
+		&lastHeartbeat,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -763,6 +781,9 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	if forkedFromRunID.Valid {
 		record.ForkedFromRunID = forkedFromRunID.String
 	}
+	if lastHeartbeat > 0 {
+		record.LastHeartbeat = time.Unix(lastHeartbeat, 0)
+	}
 
 	return &record, nil
 }
@@ -771,7 +792,7 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
 	          FROM pipeline_run
 	          WHERE (status = 'running' OR (status = 'pending' AND started_at > unixepoch() - 300))
 	          ORDER BY started_at DESC`
@@ -783,7 +804,7 @@ func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
 	          FROM pipeline_run
 	          WHERE 1=1`
 	args := []any{}
@@ -1384,6 +1405,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		var input, currentStep, errorMessage, tagsJSON, branchName sql.NullString
 		var pid sql.NullInt64
 		var parentRunID, parentStepID, forkedFromRunID sql.NullString
+		var lastHeartbeat int64
 
 		err := rows.Scan(
 			&record.RunID,
@@ -1402,6 +1424,7 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 			&parentRunID,
 			&parentStepID,
 			&forkedFromRunID,
+			&lastHeartbeat,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan run: %w", err)
@@ -1445,6 +1468,9 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		}
 		if forkedFromRunID.Valid {
 			record.ForkedFromRunID = forkedFromRunID.String
+		}
+		if lastHeartbeat > 0 {
+			record.LastHeartbeat = time.Unix(lastHeartbeat, 0)
 		}
 
 		records = append(records, record)
@@ -2602,7 +2628,7 @@ func (s *stateStore) SetParentRun(childRunID, parentRunID, stepID string) error 
 func (s *stateStore) GetChildRuns(parentRunID string) ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
 	          FROM pipeline_run
 	          WHERE parent_run_id = ?
 	          ORDER BY started_at ASC`

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -19,6 +19,7 @@ type RunRecord struct {
 	Tags            []string // Tags for categorization and filtering
 	BranchName      string   // Worktree branch for this run
 	PID             int      // OS process ID of the detached executor (0 = unknown/in-process)
+	LastHeartbeat   time.Time // Last liveness ping written by the running pipeline (zero = never reported)
 	ParentRunID     string   // Parent pipeline run ID (empty for top-level runs)
 	ParentStepID    string   // Step ID in parent pipeline that launched this child run
 	ForkedFromRunID string   // Run ID this was forked from (empty if not a fork)

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -402,6 +402,10 @@ func (m *MockStateStore) UpdateRunPID(runID string, pid int) error {
 	return nil
 }
 
+func (m *MockStateStore) UpdateRunHeartbeat(runID string) error {
+	return nil
+}
+
 func (m *MockStateStore) RecordStepAttempt(record *state.StepAttemptRecord) error {
 	if m.recordStepAttempt != nil {
 		return m.recordStepAttempt(record)

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -103,6 +103,7 @@ func (b baseStateStore) GetRunTags(string) ([]string, error) { return nil, nil }
 func (b baseStateStore) AddRunTag(string, string) error      { return nil }
 func (b baseStateStore) RemoveRunTag(string, string) error   { return nil }
 func (b baseStateStore) UpdateRunPID(string, int) error      { return nil }
+func (b baseStateStore) UpdateRunHeartbeat(string) error      { return nil }
 func (b baseStateStore) RecordStepAttempt(*state.StepAttemptRecord) error {
 	return nil
 }


### PR DESCRIPTION
## Stacks on #1430

This is **Layer 1** of the zombie-prevention plan: a 30s heartbeat written by `wave run` so the reconciler can distinguish a live pipeline from a parent process that died without updating the DB.

## Liveness priority

`isZombie` now checks signals in priority order:

1. **Heartbeat present + fresh** (<90s) → alive
2. **Heartbeat present + stale** (>=90s) → zombie, even if PID is live
3. **No heartbeat + tracked PID alive** → keep (legacy behavior)
4. **No heartbeat + tracked PID dead** → reap
5. **No heartbeat + no PID + old** → reap by `ZombieAgeThreshold` (5m)

## What this catches

- **Parent silently dies** (terminal close, OOM, signal): no heartbeat refresh, reaped in <90s instead of 5m.
- **Subprocess wedges with live PID**: stale heartbeat trips the zombie check even though `syscall.Kill(pid, 0)` still succeeds.

## Wiring

- Migration 26: `last_heartbeat INTEGER` column with partial index on `status='running'`
- `StateStore.UpdateRunHeartbeat(runID)`
- `runHeartbeatLoop` ticks every 30s in `cmd/wave/commands/run.go`
- `state.ReconcileZombies` consults heartbeat first

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/state/ ./internal/webui/ ./internal/tui/ ./cmd/wave/commands/`
- [x] 5 unit tests: AgeBased, PIDLive, PIDGone, HeartbeatFresh, HeartbeatStale
- [ ] CI green