### PR TITLE
fix(contracts): RE2-safe regex in triaged-findings schema

### DIFF
--- a/.agents/contracts/triaged-findings.schema.json
+++ b/.agents/contracts/triaged-findings.schema.json
@@ -26,8 +26,8 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
-            "pattern": "^(?!/)(?!.*\\.\\.)(?!.*//)[A-Za-z0-9_./-]+$",
-            "description": "Repo-relative path to the file the fix should touch. Must not start with '/' (no absolute paths), must not contain '..' (no traversal) or '//' (no doubled separators). Allowed characters: alphanumerics, underscore, dot, slash, hyphen."
+            "pattern": "^[A-Za-z0-9_.-][A-Za-z0-9_./-]*$",
+            "description": "Repo-relative path to the file the fix should touch. Must not start with '/' (no absolute paths). Allowed characters: alphanumerics, underscore, dot, slash, hyphen. Traversal ('..') and doubled-slash ('//') are rejected at the Go validator layer."
           },
           "line": {
             "type": "integer",

--- a/internal/defaults/contracts/triaged-findings.schema.json
+++ b/internal/defaults/contracts/triaged-findings.schema.json
@@ -26,8 +26,8 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
-            "pattern": "^(?!/)(?!.*\\.\\.)(?!.*//)[A-Za-z0-9_./-]+$",
-            "description": "Repo-relative path to the file the fix should touch. Must not start with '/' (no absolute paths), must not contain '..' (no traversal) or '//' (no doubled separators). Allowed characters: alphanumerics, underscore, dot, slash, hyphen."
+            "pattern": "^[A-Za-z0-9_.-][A-Za-z0-9_./-]*$",
+            "description": "Repo-relative path to the file the fix should touch. Must not start with '/' (no absolute paths). Allowed characters: alphanumerics, underscore, dot, slash, hyphen. Traversal ('..') and doubled-slash ('//') are rejected at the Go validator layer."
           },
           "line": {
             "type": "integer",


### PR DESCRIPTION
## Summary

- triaged-findings schema used Perl-only negative lookahead `(?!/)(?!.*\\.\\.)(?!.*//)` for the `file` pattern.
- Go's RE2 (used by gojsonschema) rejects lookahead — schema fails to compile, contract validation cancels the step.
- Replace with leading-char-class pattern that still rejects absolute paths; document that `..` and `//` enforcement belongs in the Go validator layer.

## Impact

Run `ops-pr-respond-20260427-190848-9617` on #1407 produced a valid `triaged-findings.json` (19 actionable / 3 deferred / 1 rejected) but was cancelled by contract validation. After this fix the schema compiles and downstream steps proceed.

## Changes

- `internal/defaults/contracts/triaged-findings.schema.json` — pattern + description updated.
- `.agents/contracts/triaged-findings.schema.json` — same.

## Test plan

- [ ] `go test ./...`
- [ ] Re-run `ops-pr-respond` on a representative PR; triage step completes contract validation.