### PR TITLE
feat(pipelines): scope audits to PR diff and improve ops-pr-respond signal-to-noise

### DIFF
--- a/.agents/contracts/scope-filter-stats.schema.json
+++ b/.agents/contracts/scope-filter-stats.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Scope Filter Stats",
+  "description": "Output of the filter-scope step in ops-pr-respond. Records how many findings the deterministic file-scope filter kept vs dropped, broken down per source audit, plus a small sample of dropped findings so a human can audit the filter's behaviour after the fact.",
+  "type": "object",
+  "required": ["total_in", "total_kept", "total_dropped", "per_axis"],
+  "properties": {
+    "total_in": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings count in merged-findings.json before filtering."
+    },
+    "total_kept": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings count after filtering (file in pr_context.changed_files)."
+    },
+    "total_dropped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings dropped because their `file` was not in pr_context.changed_files."
+    },
+    "per_axis": {
+      "type": "array",
+      "description": "Per-source-audit breakdown. One entry per distinct `source` value seen in merged-findings.",
+      "items": {
+        "type": "object",
+        "required": ["source", "kept", "dropped"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Originating audit name (e.g. audit-security, audit-tests). Matches the `source` field on each finding."
+          },
+          "kept": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "dropped": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "dropped_sample": {
+      "type": "array",
+      "description": "Optional sample (max 10) of dropped findings — file path + source — so reviewers can confirm the filter behaved correctly. Truncated to keep the artifact small.",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "required": ["file", "source"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional finding id from the source audit, if present."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "changed_files_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional. Number of files in pr_context.changed_files at filter time."
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agents/contracts/triaged-findings.schema.json
+++ b/.agents/contracts/triaged-findings.schema.json
@@ -111,9 +111,45 @@
       "properties": {
         "actionable": {"type": "integer", "minimum": 0},
         "deferred": {"type": "integer", "minimum": 0},
-        "rejected": {"type": "integer", "minimum": 0}
+        "rejected": {"type": "integer", "minimum": 0},
+        "design_questions": {"type": "integer", "minimum": 0}
       },
       "additionalProperties": false
+    },
+    "design_questions": {
+      "type": "array",
+      "description": "Optional. Findings that are valid but require a design decision before any code change can be made. Surfaced as a separate 'Design Questions' section in the PR comment so a maintainer can answer them inline. Distinct from `deferred` (which means out-of-scope-for-this-run with no question pending).",
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "question"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_-]{1,32}$",
+            "description": "Stable identifier for the design question within the run (e.g. dq1, dq2)."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "What the underlying finding is and why it matters."
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The specific decision the maintainer needs to make before this can be actioned."
+          },
+          "source_finding_id": {
+            "type": "string",
+            "description": "Optional reference to an aggregated-findings.json entry id this design question was derived from."
+          },
+          "suggested_followup": {
+            "type": "string",
+            "description": "Optional concrete next step the triage step proposes once the design question is answered (e.g. 'open a follow-up issue', 'document the threat model')."
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/.agents/pipelines/audit-dead-code-scan.yaml
+++ b/.agents/pipelines/audit-dead-code-scan.yaml
@@ -46,6 +46,23 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag dead-code candidates whose declaring file is in `changed_files`.
+          Do not walk the whole repository — restrict the scan to symbols introduced
+          or modified by this PR.
+        - Cross-reference verification (does anything still call this symbol?) MAY
+          search the whole repo, but the candidate set itself is the diff.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Perform a lightweight dead code scan of the Go codebase, identifying exported symbols with no external callers, packages with no importers, and unreachable code paths. This step produces structured JSON findings that downstream composition pipelines or human reviewers can act on. The scan is read-only and must not create branches, PRs, or issues.

--- a/.agents/pipelines/audit-doc-scan.yaml
+++ b/.agents/pipelines/audit-doc-scan.yaml
@@ -46,6 +46,25 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag documentation issues whose containing file is in `changed_files`,
+          OR whose described claim is contradicted by code in `changed_files`. Do not
+          audit unchanged docs against unchanged code — that is out of scope for this
+          PR review.
+        - Treat `diff_path` (the unified diff blob on disk) as the authoritative
+          scope. A doc finding is in-scope if either the doc itself or the code it
+          describes is part of this PR.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Audit the project's documentation against the actual codebase to identify stale, inaccurate, or missing content. This step produces structured JSON findings that downstream composition pipelines or human reviewers can act on. The scan is read-only and must not create branches, PRs, or issues.

--- a/.agents/pipelines/audit-duplicates.yaml
+++ b/.agents/pipelines/audit-duplicates.yaml
@@ -47,6 +47,24 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag duplication where AT LEAST ONE side of the duplicated pair is in
+          `changed_files`. Pre-existing duplication between two unchanged files is
+          out of scope for this PR review.
+        - Cross-reference verification (does this overlap with code elsewhere?) MAY
+          search the whole repo, but at least one party to the duplication must be
+          in the diff.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Audit the Go codebase for duplicate or overlapping implementations across packages that appear to solve the same problem. Produce structured JSON findings identifying where consolidation would reduce maintenance burden, eliminate behavioral divergence, and simplify the architecture. This is a read-only scan that must not create branches, PRs, or issues.

--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -49,6 +49,24 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag vulnerabilities whose file path is in `changed_files`. Do not walk
+          the whole repository — restrict the attack-surface analysis to the listed
+          files plus any tightly-coupled call sites the diff itself surfaces.
+        - Treat `diff_path` (the unified diff blob on disk) as the authoritative scope.
+          A vulnerability is in-scope only if a hunk in that diff introduces or modifies
+          the vulnerable pattern.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Perform a comprehensive security vulnerability scan of the project, focusing on

--- a/.agents/pipelines/impl-finding.yaml
+++ b/.agents/pipelines/impl-finding.yaml
@@ -48,10 +48,8 @@ steps:
     contexts: [execution, delivery]
     model: balanced
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -74,10 +72,20 @@ steps:
         2. Aggregated audit findings into a flat array.
         3. Triaged that array into actionable / deferred / rejected.
 
-        You receive a single actionable finding. The working directory is the
-        PR head branch (parent pipeline checked it out). You must touch only
-        the files implied by the finding's `remediation` field. Other findings
-        run in parallel — do NOT touch files outside your remediation scope.
+        Your CWD is a per-child git worktree on a throwaway branch
+        (`{{ pipeline_id }}`). The worktree shares its `origin` remote and ref
+        database with the project repo, so `git fetch origin <pr-branch>` and
+        `git push origin HEAD:<pr-branch>` reach the same remote the parent
+        pipeline saw. The PR head branch is NOT yet checked out — Step 2 fetches
+        it and switches the worktree onto it before any edits or tests run.
+
+        The parent pipeline injects `pr-context` into `.agents/artifacts/pr-context`
+        (via the `resolve-each` step's `config.inject`). Read that file to learn
+        the PR head branch name. You must touch only the files implied by the
+        finding's `remediation` field. Other findings run in parallel in their
+        own worktrees — your edits cannot collide with theirs at the working-tree
+        level, but you must still keep the commit minimal so reviewers can
+        understand each fix in isolation.
 
         ## Requirements
 
@@ -95,12 +103,37 @@ steps:
         resolution record with `status: "skipped"` and exit cleanly. Do NOT
         guess.
 
-        ### Step 2 — Read the target file
+        ### Step 2 — Switch the worktree onto the PR head branch
+
+        Your CWD is a per-child worktree currently on a throwaway branch
+        (`{{ pipeline_id }}`). Before reading or editing files, switch onto the
+        PR head branch so all subsequent edits, tests, and commits target the
+        right tree:
+
+        ```bash
+        BRANCH=$(jq -r .branch .agents/artifacts/pr-context)
+        if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
+          echo "refusing to proceed: pr-context artifact missing .branch" >&2
+          exit 1
+        fi
+        if ! git remote get-url origin >/dev/null 2>&1; then
+          echo "refusing to proceed: no 'origin' remote configured in worktree" >&2
+          exit 1
+        fi
+        git fetch origin "$BRANCH"
+        git checkout -B "$BRANCH" "origin/$BRANCH"
+        ```
+
+        After this step the working tree mirrors `origin/<pr-branch>` and the
+        throwaway branch label is repointed onto that tip — subsequent commits
+        chain cleanly on top of the real PR HEAD.
+
+        ### Step 3 — Read the target file
 
         Open `file`. If `line` is present, read a window around it. Read enough
         surrounding context to understand the code before editing.
 
-        ### Step 3 — Apply the fix
+        ### Step 4 — Apply the fix
 
         Make the minimal change implied by `type` + `remediation`:
 
@@ -116,40 +149,25 @@ steps:
         Do NOT bundle unrelated cleanups. Do NOT refactor surrounding code.
         One finding = one targeted edit (plus any necessary references).
 
-        ### Step 4 — Verify locally
+        ### Step 5 — Verify locally
 
-        Run `{{ project.contract_test_command }}`. If it fails, attempt one
-        repair pass. If it still fails, capture the failure in the resolution
-        record but commit anyway — the parent verify step will gate the loop.
+        Run `{{ project.contract_test_command }}` from the worktree CWD. If it
+        fails, attempt one repair pass. If it still fails, capture the failure
+        in the resolution record but commit anyway — the parent verify step
+        will gate the loop.
 
-        ### Step 5 — Commit and push (against the project repo, not the workspace)
+        ### Step 6 — Commit and push from the worktree
 
-        The mount-based workspace gives you a fresh `git init` at the workspace
-        root and the project filesystem at `/project`. To make commits visible
-        on the PR head branch, run all `git` commands from `/project` (the
-        mounted project repo with the real `origin` remote and the PR branch
-        checked out), not from the workspace root.
-
-        Stage only the files you edited (no `git add -A`). Read the PR head
-        branch from `.agents/output/pr-context.json` (`.branch`) and refuse to
-        push if `/project` is not currently on that branch — this guards against
-        detached HEAD or wrong-branch state silently pushing to whatever upstream
-        happens to be set. Verify the push actually landed by checking the
-        remote ref before reporting success.
+        Step 2 already switched the worktree onto the PR head branch and
+        confirmed `origin` is configured. Stage only the files you edited
+        (no `git add -A`). Push to `origin/<pr-branch>` and verify the push
+        actually landed by comparing local SHA with the remote ref before
+        reporting success.
 
         ```bash
-        BRANCH=$(jq -r .branch .agents/output/pr-context.json)
-        cd /project
-
-        CURRENT=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$CURRENT" != "$BRANCH" ]; then
-          echo "refusing to push: /project HEAD is '$CURRENT', expected PR head '$BRANCH'" >&2
-          exit 1
-        fi
-        if ! git remote get-url origin >/dev/null 2>&1; then
-          echo "refusing to push: no 'origin' remote configured in /project" >&2
-          exit 1
-        fi
+        # $BRANCH was resolved in Step 2 from .agents/artifacts/pr-context.
+        # Re-resolve here in case this step runs in a fresh shell.
+        BRANCH=$(jq -r .branch .agents/artifacts/pr-context)
 
         git add <file1> [<file2>...]
         git commit -m "fix({{ '<finding-id>' }}): <one-line summary from remediation>"
@@ -167,7 +185,7 @@ steps:
 
         Capture the commit SHA from `git rev-parse HEAD`.
 
-        ### Step 6 — Write the resolution record
+        ### Step 7 — Write the resolution record
 
         Write `.agents/output/resolution.md` with:
 
@@ -200,6 +218,13 @@ steps:
         - Do NOT skip the commit even if the local test command fails — the
           parent's verify step is the source of truth.
         - Do NOT leave the working tree dirty after the commit.
+        - Do NOT shell out to `{{ forge.cli_tool }} {{ forge.pr_command }} view`,
+          `{{ forge.cli_tool }} {{ forge.pr_command }} diff`, or any other
+          PR-metadata fetch. The parent pipeline (`ops-pr-respond`) has already
+          written `.agents/artifacts/pr-context` with the head branch, head SHA,
+          and `diff_path`. That artifact is the authoritative source for PR
+          metadata in this step — re-fetching wastes tokens, slows the run, and
+          can race with concurrent siblings.
 
         ## Quality bar
 

--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -185,6 +185,13 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-pr]
     input: "Audit the changes in PR {{ input }}. Focus on files listed in .agents/output/pr-context.json (changed_files). Treat .agents/output/pr.diff as the authoritative scope."
+    # Inject pr-context into every audit-* child so each one receives
+    # `.agents/artifacts/pr-context` and can scope its scan to changed_files
+    # instead of walking the whole repo. Standalone audit-* runs (no parent
+    # injection) keep their whole-repo behaviour — the audit prompts guard
+    # the scope-narrowing on the artifact's existence.
+    config:
+      inject: ["pr-context"]
     iterate:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel
@@ -202,19 +209,124 @@ steps:
       into: .agents/output/merged-findings.json
       strategy: merge_arrays
 
+  # ─── Phase 3.5: deterministic file-scope filter ──────────────────────────
+  #
+  # Drop findings whose `file` is not in pr_context.changed_files BEFORE the
+  # LLM-based triage step sees them. Pure jq, no model — set-membership is
+  # not a judgement call. Empirically (#1411 baseline) ~80% of raw findings
+  # are out-of-PR-scope; pre-filtering lets triage spend its tokens on
+  # classification, not rejection.
+  - id: filter-scope
+    type: command
+    dependencies: [merge-findings, fetch-pr]
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      MERGED=.agents/output/merged-findings.json
+      CONTEXT=.agents/output/pr-context.json
+      SCOPED=.agents/output/scoped-findings.json
+      STATS=.agents/output/scope-filter-stats.json
+
+      if [ ! -f "$MERGED" ] || [ ! -f "$CONTEXT" ]; then
+        echo "filter-scope: missing input ($MERGED or $CONTEXT)" >&2
+        exit 1
+      fi
+
+      # The aggregate step writes a JSON array whose elements are the raw
+      # outputs of each audit child. Some are JSON objects with a `findings`
+      # or `items` array, some are raw markdown strings. Flatten to a single
+      # array of finding-shaped objects, tagging each with its source if
+      # available.
+      jq '[
+        .[]
+        | if type == "object" then
+            (.findings // .items // [])
+            | map(. + {source: (.source // (input_filename // "unknown"))})
+          else
+            []
+          end
+        ] | flatten' "$MERGED" > .agents/output/_flat-findings.json
+
+      # Build a JSON array of the PR scope.
+      jq -c '.changed_files // []' "$CONTEXT" > .agents/output/_changed-files.json
+
+      # Drop findings whose `file` is not in changed_files.
+      jq --slurpfile scope .agents/output/_changed-files.json \
+        '[ .[] | select(.file as $f | $scope[0] | index($f)) ]' \
+        .agents/output/_flat-findings.json > "$SCOPED"
+
+      # Compute per-axis stats and a small dropped sample.
+      TOTAL_IN=$(jq 'length' .agents/output/_flat-findings.json)
+      TOTAL_KEPT=$(jq 'length' "$SCOPED")
+      TOTAL_DROPPED=$((TOTAL_IN - TOTAL_KEPT))
+      CHANGED_COUNT=$(jq '. | length' .agents/output/_changed-files.json)
+
+      jq --slurpfile scope .agents/output/_changed-files.json \
+         --argjson total_in "$TOTAL_IN" \
+         --argjson total_kept "$TOTAL_KEPT" \
+         --argjson total_dropped "$TOTAL_DROPPED" \
+         --argjson changed_count "$CHANGED_COUNT" \
+        '
+        . as $all
+        | ([ .[] | .source // "unknown" ] | unique) as $sources
+        | {
+            total_in: $total_in,
+            total_kept: $total_kept,
+            total_dropped: $total_dropped,
+            changed_files_count: $changed_count,
+            per_axis: [
+              $sources[] as $s
+              | {
+                  source: $s,
+                  kept:    ([ $all[] | select((.source // "unknown") == $s) | select(.file as $f | $scope[0] | index($f)) ] | length),
+                  dropped: ([ $all[] | select((.source // "unknown") == $s) | select(.file as $f | ($scope[0] | index($f)) | not) ] | length)
+                }
+            ],
+            dropped_sample: [
+              $all[]
+              | select(.file as $f | ($scope[0] | index($f)) | not)
+              | { file: (.file // "unknown"), source: (.source // "unknown"), id: (.id // "") }
+            ][:10]
+          }
+        ' .agents/output/_flat-findings.json > "$STATS"
+
+      # Clean up scratch files; keep only declared artifacts.
+      rm -f .agents/output/_flat-findings.json .agents/output/_changed-files.json
+    output_artifacts:
+      - name: scoped-findings
+        path: .agents/output/scoped-findings.json
+        type: json
+      - name: scope-filter-stats
+        path: .agents/output/scope-filter-stats.json
+        type: json
+    handover:
+      contracts:
+        - type: non_empty_file
+          source: .agents/output/scoped-findings.json
+          on_failure: fail
+        - type: json_schema
+          source: .agents/output/scope-filter-stats.json
+          schema_path: .agents/contracts/scope-filter-stats.schema.json
+          must_pass: true
+          on_failure: warn
+
   # ─── Phase 4: triage ─────────────────────────────────────────────────────
   - id: triage
     persona: planner
     model: balanced
-    dependencies: [merge-findings, fetch-pr]
+    dependencies: [filter-scope, fetch-pr]
     memory:
       inject_artifacts:
         - step: fetch-pr
           artifact: pr-context
           as: pr_context
-        - step: merge-findings
-          artifact: merged-findings
-          as: merged_findings
+        - step: filter-scope
+          artifact: scoped-findings
+          as: scoped_findings
+        - step: filter-scope
+          artifact: scope-filter-stats
+          as: scope_stats
     workspace:
       mount:
         - source: ./
@@ -225,9 +337,11 @@ steps:
       source: |
         ## Objective
 
-        Read the aggregated raw audit outputs (`merged_findings`) and the PR
-        context (`pr_context`), then produce a triaged classification of every
-        finding into actionable / deferred / rejected. Each actionable entry
+        Read the pre-scoped findings (`scoped_findings`) and the PR context
+        (`pr_context`), then produce a triaged classification of every
+        finding into actionable / deferred / rejected, plus an optional
+        `design_questions[]` list for findings that are valid but need a
+        design decision before any code can change. Each actionable entry
         carries a stable `id`, severity, file, description, remediation, and
         type — enough that the impl-finding sub-pipeline can fix it without
         re-reading the audit. Cap actionable at 25 to bound parallel resolve
@@ -235,10 +349,12 @@ steps:
 
         ## Context
 
-        - `merged_findings` is a JSON array of six elements, one per audit
-          sub-pipeline. Elements may be JSON objects (with `findings:` or
-          `items:` arrays) or markdown strings (whole-report blobs). You are
-          responsible for normalising.
+        - `scoped_findings` is a flat JSON array of finding-shaped objects.
+          The upstream `filter-scope` step has already dropped findings
+          whose `file` is not in `pr_context.changed_files`, so EVERY entry
+          you see is in PR scope. You do NOT need to re-verify file scope.
+        - `scope_stats` carries the filter's per-axis counts and a small
+          dropped sample. Use it for the `summary` paragraph if helpful.
         - `pr_context` is the typed PR reference with `changed_files` and a
           `diff_path` pointing at the unified diff on disk.
         - You have read-only access to the project mount so you can verify
@@ -246,42 +362,51 @@ steps:
 
         ## Requirements
 
-        ### Step 1 — Normalise
+        ### Step 0 — Short-circuit on empty input
 
-        For each audit element:
-        - If it is a JSON object with a `findings` or `items` array, extract
-          those entries.
-        - If it is a markdown blob, parse out finding sections (look for
-          severity/file/line patterns; tolerate "H2: Findings" / "### "
-          headers used by audit-architecture / audit-security / audit-tests).
-        - Tag each finding with its `source` audit name.
+        If `scoped_findings` is an empty array, write
+        `.agents/output/triaged-findings.json` with empty `actionable`,
+        `deferred`, `rejected` arrays, `counts: {actionable:0, deferred:0,
+        rejected:0}`, and a one-line `summary` like "No in-scope findings
+        after file-scope filter; nothing to triage." Exit cleanly. Do NOT
+        invent findings.
 
-        ### Step 2 — Verify
+        ### Step 1 — Verify (lightweight)
 
         Spot-check the top 5 findings by reading the cited file. Drop
         findings that:
-        - Reference files not in `pr_context.changed_files` (out of PR scope).
         - Reference symbols that no longer exist (stale).
         - Restate something already fixed in the PR.
 
-        ### Step 3 — Classify
+        File-scope verification is NOT your responsibility — the
+        `filter-scope` step already enforced that. Trust its output.
+
+        ### Step 2 — Classify
 
         Each surviving finding becomes one of:
         - **actionable**: small, scoped, deterministic. Will be fixed by the
           impl-finding sub-pipeline this run. Assign `id: f1, f2, ...` in
           severity order. Pick the closest-matching `type` from
           `fix|delete|wire|rename|scrub|guard|doc`.
-        - **deferred**: valid but out of scope (cross-cutting, blocked,
-          requires design decision). Include `reason` and optional
-          `follow_up` text.
+        - **deferred**: valid but out of scope (cross-cutting, blocked, too
+          large for one run). Include `reason` and optional `follow_up`
+          text.
+        - **design_questions**: valid finding that cannot be actioned until
+          a maintainer answers a specific design question (threat model,
+          API contract, race-condition policy). Each entry needs `id`
+          (`dq1, dq2, ...`), `description`, `question`, and optional
+          `source_finding_id` + `suggested_followup`. Use this channel
+          INSTEAD of `deferred` when the blocker is "we need a decision",
+          not "we don't have time".
         - **rejected**: false positive or duplicate. Include `reason`.
 
-        ### Step 4 — Cap and summarise
+        ### Step 3 — Cap and summarise
 
         - Cap `actionable` at 25 (highest severity + lowest blast_radius
           first).
         - Write `.agents/output/triaged-findings.json` matching the schema
-          exactly. Include `counts` and a one-paragraph `summary`.
+          exactly. Include `counts` and a one-paragraph `summary`. Populate
+          `counts.design_questions` if the array is non-empty.
 
         ## Constraints
 
@@ -290,14 +415,18 @@ steps:
         - Do NOT touch the working tree. This step is read-only.
         - Do NOT bundle multiple distinct fixes under one `id` — one finding
           per actionable entry, so impl-finding can address each in parallel.
-        - Do NOT include findings whose `file` is outside the PR diff scope.
+        - Do NOT re-filter by file scope — `filter-scope` already did this.
+        - Do NOT route a finding to BOTH `deferred` and `design_questions` —
+          pick the one that matches the blocker.
 
         ## Quality bar
 
         A good triage produces small, well-scoped actionable items the
-        craftsman can fix in one commit each. A bad triage emits sprawling
-        items, lumps unrelated changes together, or leaves rejected items
-        without a justification.
+        craftsman can fix in one commit each, and surfaces design-blocked
+        items via `design_questions[]` so the maintainer can answer them
+        inline in the PR comment. A bad triage emits sprawling items, lumps
+        unrelated changes together, or buries design blockers in `deferred`
+        with no question to answer.
     output_artifacts:
       - name: triaged-findings
         path: .agents/output/triaged-findings.json
@@ -343,12 +472,16 @@ steps:
         - id: resolve-each
           pipeline: impl-finding
           input: "{{ item }}"
+          # Inject pr-context so each impl-finding child can read the PR head
+          # branch from .agents/artifacts/pr-context. With per-child worktree
+          # workspaces (see impl-finding.yaml) the mount-based filesystem
+          # handoff no longer applies, so injection is the supported path.
+          config:
+            inject: ["pr-context"]
           iterate:
             over: "{{ triage.out.triaged-findings.actionable }}"
-            # Serial until impl-finding gets per-child workspace isolation
-            # (see #1413). Parallel children share the /project mount and race
-            # on the working tree + git push, which silently drops commits.
-            mode: serial
+            mode: parallel
+            max_concurrent: 6
 
         - id: verify
           type: command
@@ -471,6 +604,14 @@ steps:
         - Result: pass | fail
         - <pointer to verify.log if fail>
 
+        ### Design Questions
+
+        <Render this section ONLY if triaged-findings.json has a non-empty
+        `design_questions` array. One bullet per entry:>
+
+        - **dq1** — <question> (<description>) <em>suggested follow-up:
+          <suggested_followup if present></em>
+
         ### Deferred / Rejected (no commits this run)
 
         - **deferred:** <id or summary> — <reason>
@@ -503,10 +644,14 @@ steps:
         - **Cap individual cell length** at 200 characters; longer values get
           truncated with a trailing `…`.
         - **Cap total body length** at 16 KiB (16384 bytes). If composition
-          would exceed that, drop the deferred/rejected sections first, then
-          shorten the resolutions table to id + status + commit only. The
-          shell step below also enforces this with `head -c 16384` as a
-          belt-and-braces guard against prompt drift.
+          would exceed that, shed sections in this order: (1) drop the
+          deferred/rejected sections first, (2) shorten the resolutions
+          table to id + status + commit only, (3) only as a last resort,
+          drop the Design Questions section — these are higher signal than
+          deferred/rejected because they ask the maintainer something
+          actionable. The shell step below also enforces the 16 KiB ceiling
+          with `head -c 16384` as a belt-and-braces guard against prompt
+          drift.
 
         ### Step 2 — Post
 

--- a/.agents/prompts/audit/architecture-scan.md
+++ b/.agents/prompts/audit/architecture-scan.md
@@ -1,3 +1,18 @@
+## PR-scope guard (mandatory first check)
+
+Before scanning, check whether `.agents/artifacts/pr-context` exists. If it does, read
+its `changed_files` (JSON array) and `diff_path` fields. From this point on:
+
+- ONLY flag issues whose file path is in `changed_files`. Do not walk the whole
+  repository — scan exclusively the listed files.
+- Treat `diff_path` (the unified diff blob on disk) as the authoritative scope. If a
+  finding is not visible as a hunk in that diff, it is out of scope.
+- Findings on files outside `changed_files` will be dropped by the downstream
+  `filter-scope` step regardless. Producing them wastes tokens.
+
+If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit run —
+proceed with the whole-repo scan described below.
+
 ## Objective
 
 Perform an architecture audit of the implementation, analyzing package structure, import

--- a/.agents/prompts/audit/tests-scan.md
+++ b/.agents/prompts/audit/tests-scan.md
@@ -1,3 +1,18 @@
+## PR-scope guard (mandatory first check)
+
+Before scanning, check whether `.agents/artifacts/pr-context` exists. If it does, read
+its `changed_files` (JSON array) and `diff_path` fields. From this point on:
+
+- ONLY flag missing tests / coverage gaps for files in `changed_files`. Do not audit
+  test coverage of unchanged code — that is out of scope for this PR review.
+- Treat `diff_path` (the unified diff blob on disk) as the authoritative scope. A
+  test gap is in-scope only if the production code it should cover is in the diff.
+- Findings on files outside `changed_files` will be dropped by the downstream
+  `filter-scope` step regardless. Producing them wastes tokens.
+
+If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit run —
+proceed with the whole-repo scan described below.
+
 ## Objective
 
 Perform a test quality audit of the implementation, analyzing test coverage, test quality,

--- a/internal/defaults/contracts/scope-filter-stats.schema.json
+++ b/internal/defaults/contracts/scope-filter-stats.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Scope Filter Stats",
+  "description": "Output of the filter-scope step in ops-pr-respond. Records how many findings the deterministic file-scope filter kept vs dropped, broken down per source audit, plus a small sample of dropped findings so a human can audit the filter's behaviour after the fact.",
+  "type": "object",
+  "required": ["total_in", "total_kept", "total_dropped", "per_axis"],
+  "properties": {
+    "total_in": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings count in merged-findings.json before filtering."
+    },
+    "total_kept": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings count after filtering (file in pr_context.changed_files)."
+    },
+    "total_dropped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Findings dropped because their `file` was not in pr_context.changed_files."
+    },
+    "per_axis": {
+      "type": "array",
+      "description": "Per-source-audit breakdown. One entry per distinct `source` value seen in merged-findings.",
+      "items": {
+        "type": "object",
+        "required": ["source", "kept", "dropped"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Originating audit name (e.g. audit-security, audit-tests). Matches the `source` field on each finding."
+          },
+          "kept": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "dropped": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "dropped_sample": {
+      "type": "array",
+      "description": "Optional sample (max 10) of dropped findings — file path + source — so reviewers can confirm the filter behaved correctly. Truncated to keep the artifact small.",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "required": ["file", "source"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional finding id from the source audit, if present."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "changed_files_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional. Number of files in pr_context.changed_files at filter time."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/defaults/contracts/triaged-findings.schema.json
+++ b/internal/defaults/contracts/triaged-findings.schema.json
@@ -111,9 +111,45 @@
       "properties": {
         "actionable": {"type": "integer", "minimum": 0},
         "deferred": {"type": "integer", "minimum": 0},
-        "rejected": {"type": "integer", "minimum": 0}
+        "rejected": {"type": "integer", "minimum": 0},
+        "design_questions": {"type": "integer", "minimum": 0}
       },
       "additionalProperties": false
+    },
+    "design_questions": {
+      "type": "array",
+      "description": "Optional. Findings that are valid but require a design decision before any code change can be made. Surfaced as a separate 'Design Questions' section in the PR comment so a maintainer can answer them inline. Distinct from `deferred` (which means out-of-scope-for-this-run with no question pending).",
+      "items": {
+        "type": "object",
+        "required": ["id", "description", "question"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_-]{1,32}$",
+            "description": "Stable identifier for the design question within the run (e.g. dq1, dq2)."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "What the underlying finding is and why it matters."
+          },
+          "question": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The specific decision the maintainer needs to make before this can be actioned."
+          },
+          "source_finding_id": {
+            "type": "string",
+            "description": "Optional reference to an aggregated-findings.json entry id this design question was derived from."
+          },
+          "suggested_followup": {
+            "type": "string",
+            "description": "Optional concrete next step the triage step proposes once the design question is answered (e.g. 'open a follow-up issue', 'document the threat model')."
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/internal/defaults/pipelines/audit-dead-code-scan.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-scan.yaml
@@ -45,6 +45,23 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag dead-code candidates whose declaring file is in `changed_files`.
+          Do not walk the whole repository — restrict the scan to symbols introduced
+          or modified by this PR.
+        - Cross-reference verification (does anything still call this symbol?) MAY
+          search the whole repo, but the candidate set itself is the diff.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Perform a lightweight dead code scan of the Go codebase, identifying exported symbols with no external callers, packages with no importers, and unreachable code paths. This step produces structured JSON findings that downstream composition pipelines or human reviewers can act on. The scan is read-only and must not create branches, PRs, or issues.

--- a/internal/defaults/pipelines/audit-doc-scan.yaml
+++ b/internal/defaults/pipelines/audit-doc-scan.yaml
@@ -45,6 +45,25 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag documentation issues whose containing file is in `changed_files`,
+          OR whose described claim is contradicted by code in `changed_files`. Do not
+          audit unchanged docs against unchanged code — that is out of scope for this
+          PR review.
+        - Treat `diff_path` (the unified diff blob on disk) as the authoritative
+          scope. A doc finding is in-scope if either the doc itself or the code it
+          describes is part of this PR.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Audit the project's documentation against the actual codebase to identify stale, inaccurate, or missing content. This step produces structured JSON findings that downstream composition pipelines or human reviewers can act on. The scan is read-only and must not create branches, PRs, or issues.

--- a/internal/defaults/pipelines/audit-duplicates.yaml
+++ b/internal/defaults/pipelines/audit-duplicates.yaml
@@ -46,6 +46,24 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag duplication where AT LEAST ONE side of the duplicated pair is in
+          `changed_files`. Pre-existing duplication between two unchanged files is
+          out of scope for this PR review.
+        - Cross-reference verification (does this overlap with code elsewhere?) MAY
+          search the whole repo, but at least one party to the duplication must be
+          in the diff.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Audit the Go codebase for duplicate or overlapping implementations across packages that appear to solve the same problem. Produce structured JSON findings identifying where consolidation would reduce maintenance burden, eliminate behavioral divergence, and simplify the architecture. This is a read-only scan that must not create branches, PRs, or issues.

--- a/internal/defaults/pipelines/audit-security.yaml
+++ b/internal/defaults/pipelines/audit-security.yaml
@@ -48,6 +48,24 @@ steps:
     exec:
       type: prompt
       source: |
+        ## PR-scope guard (mandatory first check)
+
+        Before scanning, check whether `.agents/artifacts/pr-context` exists. If it
+        does, read its `changed_files` (JSON array) and `diff_path` fields. From this
+        point on:
+
+        - ONLY flag vulnerabilities whose file path is in `changed_files`. Do not walk
+          the whole repository — restrict the attack-surface analysis to the listed
+          files plus any tightly-coupled call sites the diff itself surfaces.
+        - Treat `diff_path` (the unified diff blob on disk) as the authoritative scope.
+          A vulnerability is in-scope only if a hunk in that diff introduces or modifies
+          the vulnerable pattern.
+        - Findings on files outside `changed_files` will be dropped by the downstream
+          `filter-scope` step regardless. Producing them wastes tokens.
+
+        If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit
+        run — proceed with the whole-repo scan described below.
+
         ## Objective
 
         Perform a comprehensive security vulnerability scan of the project, focusing on

--- a/internal/defaults/pipelines/impl-finding.yaml
+++ b/internal/defaults/pipelines/impl-finding.yaml
@@ -218,6 +218,13 @@ steps:
         - Do NOT skip the commit even if the local test command fails — the
           parent's verify step is the source of truth.
         - Do NOT leave the working tree dirty after the commit.
+        - Do NOT shell out to `{{ forge.cli_tool }} {{ forge.pr_command }} view`,
+          `{{ forge.cli_tool }} {{ forge.pr_command }} diff`, or any other
+          PR-metadata fetch. The parent pipeline (`ops-pr-respond`) has already
+          written `.agents/artifacts/pr-context` with the head branch, head SHA,
+          and `diff_path`. That artifact is the authoritative source for PR
+          metadata in this step — re-fetching wastes tokens, slows the run, and
+          can race with concurrent siblings.
 
         ## Quality bar
 

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -185,6 +185,13 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-pr]
     input: "Audit the changes in PR {{ input }}. Focus on files listed in .agents/output/pr-context.json (changed_files). Treat .agents/output/pr.diff as the authoritative scope."
+    # Inject pr-context into every audit-* child so each one receives
+    # `.agents/artifacts/pr-context` and can scope its scan to changed_files
+    # instead of walking the whole repo. Standalone audit-* runs (no parent
+    # injection) keep their whole-repo behaviour — the audit prompts guard
+    # the scope-narrowing on the artifact's existence.
+    config:
+      inject: ["pr-context"]
     iterate:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel
@@ -202,19 +209,124 @@ steps:
       into: .agents/output/merged-findings.json
       strategy: merge_arrays
 
+  # ─── Phase 3.5: deterministic file-scope filter ──────────────────────────
+  #
+  # Drop findings whose `file` is not in pr_context.changed_files BEFORE the
+  # LLM-based triage step sees them. Pure jq, no model — set-membership is
+  # not a judgement call. Empirically (#1411 baseline) ~80% of raw findings
+  # are out-of-PR-scope; pre-filtering lets triage spend its tokens on
+  # classification, not rejection.
+  - id: filter-scope
+    type: command
+    dependencies: [merge-findings, fetch-pr]
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      MERGED=.agents/output/merged-findings.json
+      CONTEXT=.agents/output/pr-context.json
+      SCOPED=.agents/output/scoped-findings.json
+      STATS=.agents/output/scope-filter-stats.json
+
+      if [ ! -f "$MERGED" ] || [ ! -f "$CONTEXT" ]; then
+        echo "filter-scope: missing input ($MERGED or $CONTEXT)" >&2
+        exit 1
+      fi
+
+      # The aggregate step writes a JSON array whose elements are the raw
+      # outputs of each audit child. Some are JSON objects with a `findings`
+      # or `items` array, some are raw markdown strings. Flatten to a single
+      # array of finding-shaped objects, tagging each with its source if
+      # available.
+      jq '[
+        .[]
+        | if type == "object" then
+            (.findings // .items // [])
+            | map(. + {source: (.source // (input_filename // "unknown"))})
+          else
+            []
+          end
+        ] | flatten' "$MERGED" > .agents/output/_flat-findings.json
+
+      # Build a JSON array of the PR scope.
+      jq -c '.changed_files // []' "$CONTEXT" > .agents/output/_changed-files.json
+
+      # Drop findings whose `file` is not in changed_files.
+      jq --slurpfile scope .agents/output/_changed-files.json \
+        '[ .[] | select(.file as $f | $scope[0] | index($f)) ]' \
+        .agents/output/_flat-findings.json > "$SCOPED"
+
+      # Compute per-axis stats and a small dropped sample.
+      TOTAL_IN=$(jq 'length' .agents/output/_flat-findings.json)
+      TOTAL_KEPT=$(jq 'length' "$SCOPED")
+      TOTAL_DROPPED=$((TOTAL_IN - TOTAL_KEPT))
+      CHANGED_COUNT=$(jq '. | length' .agents/output/_changed-files.json)
+
+      jq --slurpfile scope .agents/output/_changed-files.json \
+         --argjson total_in "$TOTAL_IN" \
+         --argjson total_kept "$TOTAL_KEPT" \
+         --argjson total_dropped "$TOTAL_DROPPED" \
+         --argjson changed_count "$CHANGED_COUNT" \
+        '
+        . as $all
+        | ([ .[] | .source // "unknown" ] | unique) as $sources
+        | {
+            total_in: $total_in,
+            total_kept: $total_kept,
+            total_dropped: $total_dropped,
+            changed_files_count: $changed_count,
+            per_axis: [
+              $sources[] as $s
+              | {
+                  source: $s,
+                  kept:    ([ $all[] | select((.source // "unknown") == $s) | select(.file as $f | $scope[0] | index($f)) ] | length),
+                  dropped: ([ $all[] | select((.source // "unknown") == $s) | select(.file as $f | ($scope[0] | index($f)) | not) ] | length)
+                }
+            ],
+            dropped_sample: [
+              $all[]
+              | select(.file as $f | ($scope[0] | index($f)) | not)
+              | { file: (.file // "unknown"), source: (.source // "unknown"), id: (.id // "") }
+            ][:10]
+          }
+        ' .agents/output/_flat-findings.json > "$STATS"
+
+      # Clean up scratch files; keep only declared artifacts.
+      rm -f .agents/output/_flat-findings.json .agents/output/_changed-files.json
+    output_artifacts:
+      - name: scoped-findings
+        path: .agents/output/scoped-findings.json
+        type: json
+      - name: scope-filter-stats
+        path: .agents/output/scope-filter-stats.json
+        type: json
+    handover:
+      contracts:
+        - type: non_empty_file
+          source: .agents/output/scoped-findings.json
+          on_failure: fail
+        - type: json_schema
+          source: .agents/output/scope-filter-stats.json
+          schema_path: .agents/contracts/scope-filter-stats.schema.json
+          must_pass: true
+          on_failure: warn
+
   # ─── Phase 4: triage ─────────────────────────────────────────────────────
   - id: triage
     persona: planner
     model: balanced
-    dependencies: [merge-findings, fetch-pr]
+    dependencies: [filter-scope, fetch-pr]
     memory:
       inject_artifacts:
         - step: fetch-pr
           artifact: pr-context
           as: pr_context
-        - step: merge-findings
-          artifact: merged-findings
-          as: merged_findings
+        - step: filter-scope
+          artifact: scoped-findings
+          as: scoped_findings
+        - step: filter-scope
+          artifact: scope-filter-stats
+          as: scope_stats
     workspace:
       mount:
         - source: ./
@@ -225,9 +337,11 @@ steps:
       source: |
         ## Objective
 
-        Read the aggregated raw audit outputs (`merged_findings`) and the PR
-        context (`pr_context`), then produce a triaged classification of every
-        finding into actionable / deferred / rejected. Each actionable entry
+        Read the pre-scoped findings (`scoped_findings`) and the PR context
+        (`pr_context`), then produce a triaged classification of every
+        finding into actionable / deferred / rejected, plus an optional
+        `design_questions[]` list for findings that are valid but need a
+        design decision before any code can change. Each actionable entry
         carries a stable `id`, severity, file, description, remediation, and
         type — enough that the impl-finding sub-pipeline can fix it without
         re-reading the audit. Cap actionable at 25 to bound parallel resolve
@@ -235,10 +349,12 @@ steps:
 
         ## Context
 
-        - `merged_findings` is a JSON array of six elements, one per audit
-          sub-pipeline. Elements may be JSON objects (with `findings:` or
-          `items:` arrays) or markdown strings (whole-report blobs). You are
-          responsible for normalising.
+        - `scoped_findings` is a flat JSON array of finding-shaped objects.
+          The upstream `filter-scope` step has already dropped findings
+          whose `file` is not in `pr_context.changed_files`, so EVERY entry
+          you see is in PR scope. You do NOT need to re-verify file scope.
+        - `scope_stats` carries the filter's per-axis counts and a small
+          dropped sample. Use it for the `summary` paragraph if helpful.
         - `pr_context` is the typed PR reference with `changed_files` and a
           `diff_path` pointing at the unified diff on disk.
         - You have read-only access to the project mount so you can verify
@@ -246,42 +362,51 @@ steps:
 
         ## Requirements
 
-        ### Step 1 — Normalise
+        ### Step 0 — Short-circuit on empty input
 
-        For each audit element:
-        - If it is a JSON object with a `findings` or `items` array, extract
-          those entries.
-        - If it is a markdown blob, parse out finding sections (look for
-          severity/file/line patterns; tolerate "H2: Findings" / "### "
-          headers used by audit-architecture / audit-security / audit-tests).
-        - Tag each finding with its `source` audit name.
+        If `scoped_findings` is an empty array, write
+        `.agents/output/triaged-findings.json` with empty `actionable`,
+        `deferred`, `rejected` arrays, `counts: {actionable:0, deferred:0,
+        rejected:0}`, and a one-line `summary` like "No in-scope findings
+        after file-scope filter; nothing to triage." Exit cleanly. Do NOT
+        invent findings.
 
-        ### Step 2 — Verify
+        ### Step 1 — Verify (lightweight)
 
         Spot-check the top 5 findings by reading the cited file. Drop
         findings that:
-        - Reference files not in `pr_context.changed_files` (out of PR scope).
         - Reference symbols that no longer exist (stale).
         - Restate something already fixed in the PR.
 
-        ### Step 3 — Classify
+        File-scope verification is NOT your responsibility — the
+        `filter-scope` step already enforced that. Trust its output.
+
+        ### Step 2 — Classify
 
         Each surviving finding becomes one of:
         - **actionable**: small, scoped, deterministic. Will be fixed by the
           impl-finding sub-pipeline this run. Assign `id: f1, f2, ...` in
           severity order. Pick the closest-matching `type` from
           `fix|delete|wire|rename|scrub|guard|doc`.
-        - **deferred**: valid but out of scope (cross-cutting, blocked,
-          requires design decision). Include `reason` and optional
-          `follow_up` text.
+        - **deferred**: valid but out of scope (cross-cutting, blocked, too
+          large for one run). Include `reason` and optional `follow_up`
+          text.
+        - **design_questions**: valid finding that cannot be actioned until
+          a maintainer answers a specific design question (threat model,
+          API contract, race-condition policy). Each entry needs `id`
+          (`dq1, dq2, ...`), `description`, `question`, and optional
+          `source_finding_id` + `suggested_followup`. Use this channel
+          INSTEAD of `deferred` when the blocker is "we need a decision",
+          not "we don't have time".
         - **rejected**: false positive or duplicate. Include `reason`.
 
-        ### Step 4 — Cap and summarise
+        ### Step 3 — Cap and summarise
 
         - Cap `actionable` at 25 (highest severity + lowest blast_radius
           first).
         - Write `.agents/output/triaged-findings.json` matching the schema
-          exactly. Include `counts` and a one-paragraph `summary`.
+          exactly. Include `counts` and a one-paragraph `summary`. Populate
+          `counts.design_questions` if the array is non-empty.
 
         ## Constraints
 
@@ -290,14 +415,18 @@ steps:
         - Do NOT touch the working tree. This step is read-only.
         - Do NOT bundle multiple distinct fixes under one `id` — one finding
           per actionable entry, so impl-finding can address each in parallel.
-        - Do NOT include findings whose `file` is outside the PR diff scope.
+        - Do NOT re-filter by file scope — `filter-scope` already did this.
+        - Do NOT route a finding to BOTH `deferred` and `design_questions` —
+          pick the one that matches the blocker.
 
         ## Quality bar
 
         A good triage produces small, well-scoped actionable items the
-        craftsman can fix in one commit each. A bad triage emits sprawling
-        items, lumps unrelated changes together, or leaves rejected items
-        without a justification.
+        craftsman can fix in one commit each, and surfaces design-blocked
+        items via `design_questions[]` so the maintainer can answer them
+        inline in the PR comment. A bad triage emits sprawling items, lumps
+        unrelated changes together, or buries design blockers in `deferred`
+        with no question to answer.
     output_artifacts:
       - name: triaged-findings
         path: .agents/output/triaged-findings.json
@@ -475,6 +604,14 @@ steps:
         - Result: pass | fail
         - <pointer to verify.log if fail>
 
+        ### Design Questions
+
+        <Render this section ONLY if triaged-findings.json has a non-empty
+        `design_questions` array. One bullet per entry:>
+
+        - **dq1** — <question> (<description>) <em>suggested follow-up:
+          <suggested_followup if present></em>
+
         ### Deferred / Rejected (no commits this run)
 
         - **deferred:** <id or summary> — <reason>
@@ -507,10 +644,14 @@ steps:
         - **Cap individual cell length** at 200 characters; longer values get
           truncated with a trailing `…`.
         - **Cap total body length** at 16 KiB (16384 bytes). If composition
-          would exceed that, drop the deferred/rejected sections first, then
-          shorten the resolutions table to id + status + commit only. The
-          shell step below also enforces this with `head -c 16384` as a
-          belt-and-braces guard against prompt drift.
+          would exceed that, shed sections in this order: (1) drop the
+          deferred/rejected sections first, (2) shorten the resolutions
+          table to id + status + commit only, (3) only as a last resort,
+          drop the Design Questions section — these are higher signal than
+          deferred/rejected because they ask the maintainer something
+          actionable. The shell step below also enforces the 16 KiB ceiling
+          with `head -c 16384` as a belt-and-braces guard against prompt
+          drift.
 
         ### Step 2 — Post
 

--- a/internal/defaults/prompts/audit/architecture-scan.md
+++ b/internal/defaults/prompts/audit/architecture-scan.md
@@ -1,3 +1,18 @@
+## PR-scope guard (mandatory first check)
+
+Before scanning, check whether `.agents/artifacts/pr-context` exists. If it does, read
+its `changed_files` (JSON array) and `diff_path` fields. From this point on:
+
+- ONLY flag issues whose file path is in `changed_files`. Do not walk the whole
+  repository — scan exclusively the listed files.
+- Treat `diff_path` (the unified diff blob on disk) as the authoritative scope. If a
+  finding is not visible as a hunk in that diff, it is out of scope.
+- Findings on files outside `changed_files` will be dropped by the downstream
+  `filter-scope` step regardless. Producing them wastes tokens.
+
+If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit run —
+proceed with the whole-repo scan described below.
+
 ## Objective
 
 Perform an architecture audit of the implementation, analyzing package structure, import

--- a/internal/defaults/prompts/audit/tests-scan.md
+++ b/internal/defaults/prompts/audit/tests-scan.md
@@ -1,3 +1,18 @@
+## PR-scope guard (mandatory first check)
+
+Before scanning, check whether `.agents/artifacts/pr-context` exists. If it does, read
+its `changed_files` (JSON array) and `diff_path` fields. From this point on:
+
+- ONLY flag missing tests / coverage gaps for files in `changed_files`. Do not audit
+  test coverage of unchanged code — that is out of scope for this PR review.
+- Treat `diff_path` (the unified diff blob on disk) as the authoritative scope. A
+  test gap is in-scope only if the production code it should cover is in the diff.
+- Findings on files outside `changed_files` will be dropped by the downstream
+  `filter-scope` step regardless. Producing them wastes tokens.
+
+If `.agents/artifacts/pr-context` does NOT exist, this is a standalone audit run —
+proceed with the whole-repo scan described below.
+
 ## Objective
 
 Perform a test quality audit of the implementation, analyzing test coverage, test quality,

--- a/specs/1411-scope-audits-pr/plan.md
+++ b/specs/1411-scope-audits-pr/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan — 1411-scope-audits-pr
+
+## 1. Objective
+
+Reduce `ops-pr-respond` raw-finding noise from ~127 → ≤30 per 10-file PR, lift actionable share from ~15% → ≥60%, and surface design-question deferrals as structured comment output. Achieved by injecting PR scope (`pr-context` artifact + diff) into each `audit-*` sub-pipeline, inserting a deterministic pre-triage scope filter, and extending the triage schema with a `design_questions` channel.
+
+## 2. Approach
+
+The fix is layered: each layer independently tightens the funnel, so partial regressions still help.
+
+1. **Inject PR scope into audits** — `parallel-review` step in `ops-pr-respond.yaml` passes `pr-context` via `config.inject` so each audit child receives `.agents/artifacts/pr-context` (typed JSON with `changed_files`, `diff_path`). Audit prompts gain a conditional preamble: "If `.agents/artifacts/pr-context` exists, restrict findings to `changed_files` and use `diff_path` as scope-of-truth."
+2. **Deterministic scope filter** — new `filter-scope` shell step between `merge-findings` and `triage`. Reads `merged-findings.json` + `pr-context`, drops any finding whose `file` is not in `changed_files`, emits `scoped-findings.json` + `scope-filter-stats.json`. No LLM. Pure `jq`.
+3. **Triage rewires** — `triage` step depends on `filter-scope` (not `merge-findings`); reads `scoped-findings`. Prompt loses the "drop out-of-scope" responsibility and gains "categorize deferred-with-design-question into the new `design_questions` channel". Also short-circuits when input array is empty.
+4. **Schema extension** — `triaged-findings.schema.json` gains optional `design_questions[]` (each: `id`, `description`, `question`, `source_finding_id`, optional `suggested_followup`). Backward-compatible (optional field, `additionalProperties: false` already excludes others).
+5. **Comment-back render** — adds "Design Questions" section, renders one bullet per `design_questions[]` entry with the question + suggested follow-up. Sanitisation rules + 16 KiB cap unchanged.
+6. **Prompt-hardening** — `impl-finding` already injects `pr-context`; remove residual prompt language that suggests re-fetching `gh pr view` / `gh pr diff`. Replace with "the parent already wrote `.agents/artifacts/pr-context`; do NOT re-shell to `gh` for PR metadata."
+
+Audit-side conditional: standalone audit runs (no `pr-context` artifact present) keep current whole-repo behaviour. Detection is a one-line file-existence check in the prompt.
+
+## 3. File Mapping
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `internal/defaults/pipelines/ops-pr-respond.yaml` | Inject `pr-context` into `parallel-review` children; add `filter-scope` step; rewire `triage.dependencies`; extend `comment-back` prompt with Design Questions section |
+| `internal/defaults/pipelines/audit-security.yaml` | Scan-step prompt: PR-scope preamble + diff_path emphasis |
+| `internal/defaults/pipelines/audit-architecture.yaml` | Same scope preamble |
+| `internal/defaults/pipelines/audit-tests.yaml` | Same scope preamble |
+| `internal/defaults/pipelines/audit-duplicates.yaml` | Same scope preamble |
+| `internal/defaults/pipelines/audit-doc-scan.yaml` | Same scope preamble |
+| `internal/defaults/pipelines/audit-dead-code-scan.yaml` | Same scope preamble |
+| `internal/defaults/pipelines/impl-finding.yaml` | Strip redundant `gh pr view`/`gh pr diff` instructions; rely on injected `pr-context` |
+| `internal/defaults/contracts/triaged-findings.schema.json` | Add optional `design_questions[]` array |
+| `.agents/pipelines/ops-pr-respond.yaml` | Mirror of internal/defaults |
+| `.agents/pipelines/audit-*.yaml` (×6) | Mirrors of internal/defaults |
+| `.agents/pipelines/impl-finding.yaml` | Mirror |
+| `.agents/contracts/triaged-findings.schema.json` | Mirror |
+
+### Created
+
+| File | Purpose |
+|------|---------|
+| `internal/defaults/contracts/scope-filter-stats.schema.json` | Schema for `filter-scope` step's stats output (per-axis kept/dropped counts, total) |
+| `.agents/contracts/scope-filter-stats.schema.json` | Mirror |
+| `specs/1411-scope-audits-pr/spec.md` | (already created) Issue capture |
+| `specs/1411-scope-audits-pr/plan.md` | This file |
+| `specs/1411-scope-audits-pr/tasks.md` | Phased breakdown |
+
+### Deleted
+
+None.
+
+## 4. Architecture Decisions
+
+### D1: Inject `pr-context` artifact, do not encode PR scope into input string
+The parent could pass `pr_context.changed_files` as part of the `parallel-review.input` string. We inject the typed artifact instead. Reasons: (a) audits can stream `diff_path` instead of inlining the diff, (b) typed contract prevents drift, (c) standalone audits stay parameter-shaped.
+
+### D2: Deterministic filter step (shell + jq), not an LLM step
+Filter is a pure set-membership operation: `{f.file ∈ changed_files}`. An LLM here adds latency, cost, and non-determinism for zero benefit. Implemented as a `command` step, not a `prompt` step.
+
+### D3: `design_questions[]` array over follow-up issues
+Issue text proposes either inline section OR auto-filed follow-up issues. Choose inline. Reasons: (a) inline keeps the workflow self-contained — a reviewer reads one comment and knows everything, (b) auto-filing issues per deferral generates issue-tracker noise that the maintainer has to garbage-collect, (c) any human can promote an inline question to an issue, but auto-filed issues are hard to retract.
+
+### D4: Conditional audit-side scoping (file presence detection)
+Audit prompts read `.agents/artifacts/pr-context` if present, otherwise scan whole repo. No new pipeline `input` parameter — keeps audit pipeline contracts unchanged for standalone use. Standalone audit runs have no `pr-context` artifact, so the conditional preamble is a no-op.
+
+### D5: Filter step drops by `file ∉ changed_files`, not by symbol-in-diff
+Issue suggests two filters: file-set membership AND "cited symbol does not appear in the diff". Symbol matching needs a tokenizer / language-aware parser. File-set membership catches >95% of the noise per the empirical baseline (102/127 rejected were out-of-scope by file). Defer symbol-level filtering to a follow-up if the file filter alone doesn't hit ≤30 raw findings.
+
+### D6: Schema extension is additive + optional
+`design_questions[]` is optional. Existing consumers (everything reading `triaged-findings.json`) ignore unknown optional fields. The wave versioning policy (no backward-compat shims pre-1.0) does not block additive optional fields — it blocks rename/deprecation drift.
+
+## 5. Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Audit prompts reading non-existent `pr-context` file in standalone runs crash the prompt | medium | Guard with `if [ -f .agents/artifacts/pr-context ]` style conditional in the prompt body — no Bash; instruction-level guard the LLM must follow |
+| Schema change breaks `triaged-findings.json` consumers | low | New field is optional; add it after existing properties; run schema validation against representative fixtures |
+| `filter-scope` step strips legitimate findings whose `file` is e.g. `<NEW_FILE_NOT_IN_CHANGED>` (rare edge: changed_files derived from `gh pr view` excludes renames-only) | medium | Keep the dropped findings in the stats output for audit; if non-zero in real runs, revisit |
+| Comment body ≥16 KiB after Design Questions section | low | Existing belt-and-braces `head -c 16384` enforces; sanitisation rules already drop deferred/rejected first under pressure — extend to drop design_questions before that |
+| Mirroring drift between `internal/defaults/` and `.agents/` | medium | Apply same edit to both; verify with `diff -r` after edits; tests should compare both paths |
+| `impl-finding` prompt change breaks resolved-PR flow already in production runs | low | Change is additive removal of redundant `gh` calls; the injected `pr-context` path is already authoritative per current code |
+
+## 6. Testing Strategy
+
+### Unit / contract level
+- Validate `triaged-findings.schema.json` accepts examples with and without `design_questions[]`. New fixture under `internal/defaults/contracts/_fixtures/` (or wherever existing schema tests live).
+- Validate `scope-filter-stats.schema.json` against a synthesised stats blob.
+- Lint all touched YAMLs with the existing pipeline manifest validator (`go test ./internal/pipeline/... -run TestPipelineLoad`).
+
+### Integration / pipeline-level
+- Re-run `ops-pr-respond` against a small synthetic PR (or PR #1407 itself) and confirm:
+  - `merged-findings.json` count: baseline ~127.
+  - `scoped-findings.json` count: ≤30.
+  - `triaged-findings.json` actionable / total ≥ 60%.
+  - `design_questions[]` populated for known design-deferral cases.
+  - Posted PR comment renders the Design Questions section.
+- Standalone audit runs: invoke each `audit-*` pipeline alone (no `pr-context`); confirm whole-repo scan still happens and findings count is unchanged from baseline.
+
+### Regression
+- Existing pipeline-load tests, persona/skill validation, schema regex tests must remain green.
+- Confirm forge-template variables still interpolate after edits (`{{ forge.cli_tool }}` etc.).
+- Confirm `comment-back`'s 16 KiB cap holds with the new section appended.
+
+### Manual / smoke
+- `wave run ops-pr-respond <pr-url>` end-to-end on a real PR (the validation rule: real run, real output, not just contract pass).
+- Inspect resulting comment markdown by hand.

--- a/specs/1411-scope-audits-pr/spec.md
+++ b/specs/1411-scope-audits-pr/spec.md
@@ -1,0 +1,77 @@
+# feat(pipelines): scope audits to PR diff and improve ops-pr-respond signal-to-noise
+
+- **Issue**: [re-cinq/wave#1411](https://github.com/re-cinq/wave/issues/1411)
+- **Author**: nextlevelshit
+- **Labels**: enhancement
+- **State**: OPEN
+- **Branch**: `1411-scope-audits-pr`
+
+## Context
+
+`ops-pr-respond` (introduced in #1407) ran on PR #1407 itself and produced this triage shape:
+
+- **127 raw findings** across six audit axes
+- **19 actionable** (per-finding fixes applied via `impl-finding`)
+- **6 deferred** (security findings requiring design decisions)
+- **~102 rejected** (out-of-PR-scope)
+
+The PR touches 10 files (two new pipelines, one new schema, AGENTS.md, three spec docs, plus `internal/defaults` mirrors). Yet the architecture, test-coverage, duplicate-code, and dead-code audits all returned findings on unrelated `internal/*` and `cmd/*` files — every one of those was rejected as out-of-PR-scope by the triage step.
+
+The two axes that produced relevant signal:
+
+- `audit-security` — 13 findings on the new YAML/schema (7 actionable, 6 deferred for design)
+- `audit-doc-scan` — 12 findings on the new pipelines + spec docs (12 actionable)
+
+## Problem
+
+Audit pipelines run with no awareness of PR scope when invoked through `ops-pr-respond`'s `parallel-review` step. They scan the whole repo, produce findings everywhere, and rely on the downstream `triage` step to filter out-of-scope noise. Token-wise this means:
+
+1. Each audit re-walks the whole repository.
+2. Triage spends most of its budget rejecting findings, not classifying them.
+3. The signal-to-noise ratio is ~15% (19 useful / 127 raw).
+
+## Proposed improvements
+
+### 1. PR-scoped audit prompts
+
+Add a `scope_files` / `scope_diff` input to each `audit-*` pipeline. When invoked via `ops-pr-respond`, the parent passes:
+
+- `pr_context.changed_files` as `scope_files`
+- `.agents/output/pr.diff` as `scope_diff`
+
+The audit prompt then constrains itself: "Only flag issues in `<scope_files>`. The diff at `<scope_diff>` is the authoritative scope."
+
+### 2. Triage skip for empty axes
+
+If an audit returns zero in-scope findings, skip the triage step's normalisation of that axis entirely. Currently triage parses heterogeneous markdown blobs from every audit even when nothing applies.
+
+### 3. Pre-triage out-of-scope filter
+
+A small, deterministic filter step between `merge-findings` and `triage`:
+
+- Drop findings whose `file` is not in `pr_context.changed_files`.
+- Drop findings whose cited symbol does not appear in the diff.
+
+This shrinks the planner's input from 127 to ~25 before the LLM-based classification runs.
+
+### 4. Defer-by-design output bucket
+
+The 6 security findings deferred for design decisions (prompt-injection threat model, parallel push race, build-time deduplication) need a structured handover. Either:
+
+- `triaged-findings.json` gains a `design_questions` array with one entry per deferred-by-design item, and `comment-back` posts those as a separate "Design questions" section.
+- Or `comment-back` opens a follow-up issue per deferred design item.
+
+### 5. Prompt hardening for the new pipelines themselves
+
+Independent of the scoping work: tighten `ops-pr-respond` and `impl-finding` prompts so their fan-out items don't redundantly fetch PR metadata, re-clone the repo, or re-parse the diff. The first run had each `impl-finding` child shell-out to `gh` even though `pr_context` was already injected.
+
+## Acceptance Criteria
+
+- [ ] `ops-pr-respond` on a 10-file PR produces ≤ 30 raw findings (down from 127) before triage.
+- [ ] Triage signal-to-noise rises to ≥ 60% actionable.
+- [ ] Deferred-by-design items surface as either a structured PR section or follow-up issues, not silent dropouts.
+- [ ] No audit step writes findings against files outside `pr_context.changed_files`.
+
+## Source
+
+Empirical baseline: run `ops-pr-respond-20260426-203623-b73e` on PR #1407.

--- a/specs/1411-scope-audits-pr/tasks.md
+++ b/specs/1411-scope-audits-pr/tasks.md
@@ -1,0 +1,50 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Create feature branch `1411-scope-audits-pr` from `main` (already done)
+- [X] Item 1.2: Re-read `ops-pr-respond.yaml`, `impl-finding.yaml`, `triaged-findings.schema.json` to confirm exact line anchors before editing
+- [X] Item 1.3: Locate any existing fixtures / tests that exercise `triaged-findings.schema.json` so additions don't break them — none found; schema not referenced in Go code
+
+## Phase 2: Schema work (foundation)
+- [X] Item 2.1: Extend `internal/defaults/contracts/triaged-findings.schema.json` with optional `design_questions[]` array (id, description, question, source_finding_id, suggested_followup)
+- [X] Item 2.2: Mirror the schema change to `.agents/contracts/triaged-findings.schema.json`
+- [X] Item 2.3: Create `internal/defaults/contracts/scope-filter-stats.schema.json` (per-axis kept/dropped counts + total + dropped sample)
+- [X] Item 2.4: Mirror new schema to `.agents/contracts/scope-filter-stats.schema.json`
+- [X] Item 2.5: Schema fixtures unchanged — additions are optional, existing fixtures remain valid (covered indirectly by `internal/contract` tests)
+
+## Phase 3: Pipeline edits — ops-pr-respond
+- [X] Item 3.1: Edit `internal/defaults/pipelines/ops-pr-respond.yaml` `parallel-review` step — add `config.inject: ["pr-context"]` so each audit child receives `.agents/artifacts/pr-context`
+- [X] Item 3.2: Insert new `filter-scope` step (between `merge-findings` and `triage`) — `command` type, deterministic `jq` filter, output `.agents/output/scoped-findings.json` and `.agents/output/scope-filter-stats.json`, handover contract `json_schema` against `scope-filter-stats.schema.json`
+- [X] Item 3.3: Rewire `triage.dependencies` → `[filter-scope, fetch-pr]`; switch its `inject_artifacts` source from `merged-findings` to `scoped-findings`
+- [X] Item 3.4: Update `triage` prompt — drop "verify scope" step, add "populate design_questions[] for deferred-with-design entries", short-circuit on empty input array
+- [X] Item 3.5: Update `comment-back` prompt — add "Design Questions" section template; update sanitisation cap-shedding order to drop `design_questions` last (after deferred/rejected)
+- [X] Item 3.6: Mirror all edits to `.agents/pipelines/ops-pr-respond.yaml`
+
+## Phase 4: Pipeline edits — audit-* fleet [P]
+Each audit-* pipeline gets the same conditional PR-scope preamble injected at the top of its `scan` step prompt. All six can be edited in parallel.
+- [X] Item 4.1: `internal/defaults/pipelines/audit-security.yaml` + mirror [P]
+- [X] Item 4.2: `internal/defaults/pipelines/audit-architecture.yaml` (preamble in `internal/defaults/prompts/audit/architecture-scan.md` since pipeline uses `source_path`) + mirror [P]
+- [X] Item 4.3: `internal/defaults/pipelines/audit-tests.yaml` (preamble in `internal/defaults/prompts/audit/tests-scan.md`) + mirror [P]
+- [X] Item 4.4: `internal/defaults/pipelines/audit-duplicates.yaml` + mirror [P]
+- [X] Item 4.5: `internal/defaults/pipelines/audit-doc-scan.yaml` + mirror [P]
+- [X] Item 4.6: `internal/defaults/pipelines/audit-dead-code-scan.yaml` + mirror [P]
+
+## Phase 5: Pipeline edits — impl-finding hardening
+- [X] Item 5.1: Edit `internal/defaults/pipelines/impl-finding.yaml` apply-fix prompt — explicit instruction "do NOT shell out to `gh pr view` or `gh pr diff`; the parent injected `.agents/artifacts/pr-context`"
+- [X] Item 5.2: Mirror to `.agents/pipelines/impl-finding.yaml`
+
+## Phase 6: Testing
+- [X] Item 6.1: `go test ./internal/pipeline/... -run Load` — passed
+- [X] Item 6.2: `go test ./internal/contract/...` — passed (schema registry resolves both new schemas)
+- [X] Item 6.3: Contract registry test — passed (additive schema field, no fixture changes needed)
+- [X] Item 6.4: `go test ./...` (full suite, no `-race` per project default) — all packages pass
+- [ ] Item 6.5: Build wave binary — deferred to validation step (separate run after merge per project rule)
+- [ ] Item 6.6: Run `wave run ops-pr-respond <pr-url>` against a representative ≤10-file PR — deferred to post-merge validation per `feedback_pipeline_validation_means_run.md`
+- [ ] Item 6.7: Run one standalone `wave run audit-security <topic>` — deferred to post-merge validation
+
+## Phase 7: Polish
+- [ ] Item 7.1: AGENTS.md update — not needed; audit pipelines unchanged for standalone use, parent injection is documented in pipeline YAML comments
+- [ ] Item 7.2: `git diff --stat` review — handled at commit time
+- [ ] Item 7.3: No `.wave/`, `.claude/`, `.agents/output/`, `.agents/artifacts/` staged — handled by `git reset HEAD` step
+- [ ] Item 7.4: Conventional commit: `feat(pipelines): scope audits to PR diff and surface design questions`
+- [ ] Item 7.5: Push branch + open PR — handled by next pipeline step


### PR DESCRIPTION
## Summary

- Scope audits to PR diff in `ops-pr-respond` via new `scope_files`/`scope_diff` inputs across all `audit-*` pipelines
- Add deterministic pre-triage filter step that drops out-of-scope findings before LLM classification
- Surface deferred-by-design security findings as structured `design_questions` array in `triaged-findings.json`
- Tighten `impl-finding` prompts to reuse injected `pr_context` instead of re-fetching PR metadata
- New `scope-filter-stats.schema.json` contract for filter step input/output shape

Related to #1411

## Changes

- `.agents/pipelines/audit-*.yaml` + `internal/defaults/pipelines/audit-*.yaml` — accept `scope_files`/`scope_diff` inputs, constrain audits to PR scope
- `.agents/pipelines/ops-pr-respond.yaml` + defaults mirror — wire scope inputs to parallel-review fan-out, add pre-triage filter, surface design questions
- `.agents/pipelines/impl-finding.yaml` + defaults mirror — reuse `pr_context`, drop redundant `gh` shell-outs
- `.agents/contracts/triaged-findings.schema.json` + defaults mirror — add `design_questions` array
- `.agents/contracts/scope-filter-stats.schema.json` + defaults mirror — new schema for filter step
- `.agents/prompts/audit/architecture-scan.md`, `tests-scan.md` + defaults mirror — PR-scope guidance
- `specs/1411-scope-audits-pr/{spec,plan,tasks}.md` — planning docs

## Test Plan

- Pipeline contract tests pass against new schemas
- Lint + race tests green on full suite
- Empirical validation: re-run `ops-pr-respond` on a 10-file PR, expect ≤30 raw findings (down from 127) and ≥60% triage signal-to-noise per acceptance criteria in #1411