### PR TITLE
fix(pipeline): register composition artifacts and reuse workspace on resume

### DIFF
--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -217,11 +217,14 @@ func runResume(opts ResumeOptions, debug bool) error {
 		}
 	}
 
-	// Build executor.
+	// Build executor. Pin the workspace dir to the original run so the
+	// resumed step sees prior step outputs that live under
+	// .agents/workspaces/<originalRunID>/, not a fresh dir at resume time.
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(emitter),
 		pipeline.WithDebug(debug),
 		pipeline.WithRunID(resumeRunID),
+		pipeline.WithWorkspaceRunID(opts.RunID),
 	}
 	if wsManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))

--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -32,6 +32,17 @@ type CompositionExecutor struct {
 	pipelineLoader SubPipelineLoader
 	debug          bool
 	gateHandler    GateHandler // Interactive handler for approval gates
+	// runID identifies the run for artifact registration. May be empty in
+	// legacy/test contexts; nil-checked at every registration site.
+	runID string
+}
+
+// artifactRegistrar is the narrow surface the composition executor needs to
+// record aggregate/iterate outputs in the artifact table. Defined locally so
+// CompositionExecutor.store can keep the lighter RunStore type while still
+// upgrading via type assertion when the concrete StateStore is wired in.
+type artifactRegistrar interface {
+	RegisterArtifact(runID, stepID, name, path, artifactType string, sizeBytes int64) error
 }
 
 // NewCompositionExecutor creates a composition executor.
@@ -62,6 +73,31 @@ func NewCompositionExecutor(
 // SetPipelineLoader sets the function used to load sub-pipelines by name.
 func (c *CompositionExecutor) SetPipelineLoader(loader SubPipelineLoader) {
 	c.pipelineLoader = loader
+}
+
+// SetRunID associates the composition executor with a run ID. The run ID is
+// used when registering aggregate/iterate output artifacts so they appear in
+// the run-scoped artifact table.
+func (c *CompositionExecutor) SetRunID(id string) {
+	c.runID = id
+}
+
+// registerArtifact records an aggregate/iterate output in the artifact table
+// when the wired store implements RegisterArtifact and a runID has been set.
+// Best-effort: failures are swallowed to avoid masking step success.
+func (c *CompositionExecutor) registerArtifact(stepID, name, path, artifactType string) {
+	if c.store == nil || c.runID == "" {
+		return
+	}
+	registrar, ok := c.store.(artifactRegistrar)
+	if !ok {
+		return
+	}
+	var size int64
+	if info, err := os.Stat(path); err == nil {
+		size = info.Size()
+	}
+	_ = registrar.RegisterArtifact(c.runID, stepID, name, path, artifactType, size)
 }
 
 // Execute runs a composition pipeline -- a pipeline whose steps are composition
@@ -317,6 +353,23 @@ func (c *CompositionExecutor) collectIterateOutputs(step *Step, resolvedNames []
 	}
 
 	c.tmplCtx.SetStepOutput(step.ID, arrayBytes)
+
+	// Persist the collected output and register it as an artifact so resume
+	// preflight can find it via the artifact table — parity with the
+	// production DAG path. Skipped in test/legacy contexts where no store or
+	// runID is wired so we don't pollute the cwd with output files.
+	if c.store == nil || c.runID == "" {
+		return
+	}
+	outputDir := filepath.Join(".agents", "output")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return
+	}
+	outputPath := filepath.Join(outputDir, step.ID+"-collected.json")
+	if err := os.WriteFile(outputPath, arrayBytes, 0644); err != nil {
+		return
+	}
+	c.registerArtifact(step.ID, "collected-output", outputPath, "json")
 }
 
 // executeBranch evaluates a condition and runs the matching pipeline.
@@ -480,6 +533,11 @@ func (c *CompositionExecutor) executeAggregate(step *Step) error {
 
 	// Store in template context
 	c.tmplCtx.SetStepOutput(step.ID, []byte(result))
+
+	// Register in DB so resume preflight and inject_artifacts can find this
+	// artifact — parity with executeAggregateInDAG in executor.go.
+	artifactName := strings.TrimSuffix(filepath.Base(outputPath), filepath.Ext(outputPath))
+	c.registerArtifact(step.ID, artifactName, outputPath, "json")
 
 	c.emit(event.Event{
 		Timestamp: time.Now(),

--- a/internal/pipeline/composition_test.go
+++ b/internal/pipeline/composition_test.go
@@ -705,3 +705,101 @@ func TestCompositionExecutor_Execute_Gate_Auto(t *testing.T) {
 		t.Error("expected gate_resolved event")
 	}
 }
+
+// TestCompositionExecutor_Aggregate_RegistersArtifact verifies that the legacy
+// composition path also registers aggregate output artifacts when a runID and
+// store are wired — parity with executor.go's executeAggregateInDAG.
+func TestCompositionExecutor_Aggregate_RegistersArtifact(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "merged.json")
+
+	var (
+		gotRun, gotStep, gotName, gotPath, gotType string
+		gotSize                                    int64
+		called                                     bool
+	)
+	store := testutil.NewMockStateStore(testutil.WithRegisterArtifact(
+		func(runID, stepID, name, path, artifactType string, size int64) error {
+			called = true
+			gotRun, gotStep, gotName, gotPath, gotType, gotSize = runID, stepID, name, path, artifactType, size
+			return nil
+		},
+	))
+
+	emitter := testutil.NewEventCollector()
+	m := &manifest.Manifest{}
+	ce := NewCompositionExecutor(nil, emitter, store, m, "test", ".agents/pipelines", false)
+	ce.SetRunID("legacy-run-1")
+
+	step := &Step{
+		ID: "merge",
+		Aggregate: &AggregateConfig{
+			From:     `[{"id":1}]`,
+			Into:     outputPath,
+			Strategy: "concat",
+		},
+	}
+
+	if err := ce.executeAggregate(step); err != nil {
+		t.Fatalf("executeAggregate: %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected RegisterArtifact to be called")
+	}
+	if gotRun != "legacy-run-1" {
+		t.Errorf("runID = %q, want legacy-run-1", gotRun)
+	}
+	if gotStep != "merge" {
+		t.Errorf("stepID = %q, want merge", gotStep)
+	}
+	if gotName != "merged" {
+		t.Errorf("name = %q, want merged", gotName)
+	}
+	if gotPath != outputPath {
+		t.Errorf("path = %q, want %q", gotPath, outputPath)
+	}
+	if gotType != "json" {
+		t.Errorf("type = %q, want json", gotType)
+	}
+	if gotSize <= 0 {
+		t.Errorf("size = %d, want > 0", gotSize)
+	}
+}
+
+// TestCompositionExecutor_Aggregate_NoRegistrationWithoutRunID confirms the
+// legacy path stays a no-op for tests/legacy callers that wire a store but no
+// runID — preserves test ergonomics.
+func TestCompositionExecutor_Aggregate_NoRegistrationWithoutRunID(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "merged.json")
+
+	var called bool
+	store := testutil.NewMockStateStore(testutil.WithRegisterArtifact(
+		func(_, _, _, _, _ string, _ int64) error {
+			called = true
+			return nil
+		},
+	))
+
+	emitter := testutil.NewEventCollector()
+	m := &manifest.Manifest{}
+	ce := NewCompositionExecutor(nil, emitter, store, m, "test", ".agents/pipelines", false)
+	// No SetRunID call — must skip registration.
+
+	step := &Step{
+		ID: "merge",
+		Aggregate: &AggregateConfig{
+			From:     `[{"id":1}]`,
+			Into:     outputPath,
+			Strategy: "concat",
+		},
+	}
+
+	if err := ce.executeAggregate(step); err != nil {
+		t.Fatalf("executeAggregate: %v", err)
+	}
+	if called {
+		t.Error("RegisterArtifact must be skipped when runID is empty")
+	}
+}

--- a/internal/pipeline/concurrency.go
+++ b/internal/pipeline/concurrency.go
@@ -200,8 +200,10 @@ func (c *ConcurrencyExecutor) createAgentWorkspace(execution *PipelineExecution,
 		wsRoot = ".agents/workspaces"
 	}
 
-	// Create agent-specific workspace under .agents/workspaces/<pipeline>/<step>/agent_<index>/
-	wsPath := filepath.Join(wsRoot, pipelineID, step.ID, fmt.Sprintf("agent_%d", agentIndex))
+	// Create agent-specific workspace under .agents/workspaces/<pipeline>/<step>/agent_<index>/.
+	// Use the executor's workspace run ID override so resume reuses the
+	// original run's workspace tree; falls back to pipelineID for fresh runs.
+	wsPath := filepath.Join(wsRoot, c.executor.workspaceRunIDFor(pipelineID), step.ID, fmt.Sprintf("agent_%d", agentIndex))
 	if err := os.MkdirAll(wsPath, 0755); err != nil {
 		return "", err
 	}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -74,6 +74,10 @@ type DefaultPipelineExecutor struct {
 	outcomeTracker *state.OutcomeTracker
 	// Pre-generated run ID (optional — if empty, Execute generates one)
 	runID string
+	// Workspace run ID override (used by resume to point at the original
+	// run's workspace tree while persisting state under the new resume run).
+	// When empty, defaults to runID.
+	workspaceRunID string
 	// Per-step timeout override (from CLI --timeout flag)
 	stepTimeoutOverride time.Duration
 	// Model override (from CLI --model flag)
@@ -159,6 +163,14 @@ func WithRelayMonitor(r *relay.RelayMonitor) ExecutorOption {
 
 func WithRunID(id string) ExecutorOption {
 	return func(ex *DefaultPipelineExecutor) { ex.runID = id }
+}
+
+// WithWorkspaceRunID overrides the run ID used to compute step workspace paths.
+// Resume uses this to keep the resumed executor reading from the original run's
+// workspace tree (where prior steps wrote artifacts) while state and new
+// artifacts are persisted under the new resume run ID.
+func WithWorkspaceRunID(id string) ExecutorOption {
+	return func(ex *DefaultPipelineExecutor) { ex.workspaceRunID = id }
 }
 
 func WithStepTimeout(d time.Duration) ExecutorOption {
@@ -262,6 +274,18 @@ func WithOntologyService(svc ontology.Service) ExecutorOption {
 // WithRegistry sets the adapter registry for per-step adapter resolution.
 func WithRegistry(r *adapter.AdapterRegistry) ExecutorOption {
 	return func(ex *DefaultPipelineExecutor) { ex.registry = r }
+}
+
+// workspaceRunIDFor returns the run ID used to compute step workspace paths.
+// When WithWorkspaceRunID has been set (resume), the override wins so the
+// resumed executor reads from the original run's workspace tree. Otherwise it
+// falls back to the caller's pipelineID (typically execution.Status.ID),
+// which preserves prior behaviour for fresh runs.
+func (e *DefaultPipelineExecutor) workspaceRunIDFor(pipelineID string) string {
+	if e.workspaceRunID != "" {
+		return e.workspaceRunID
+	}
+	return pipelineID
 }
 
 // createRunID generates a run ID, preferring the state store's CreateRun()
@@ -3846,10 +3870,13 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 			return info.AbsPath, nil
 		}
 
-		// Branch-keyed path for sharing across steps
+		// Branch-keyed path for sharing across steps. Use the executor's
+		// workspace run ID override so resume reuses the original run's
+		// worktree dir instead of creating an empty one at the resume
+		// timestamp; falls back to pipelineID for fresh runs.
 		sanitized := sanitizeBranchName(branch)
 		wtKey := "__wt_" + sanitized
-		wsPath := filepath.Join(wsRoot, pipelineID, wtKey)
+		wsPath := filepath.Join(wsRoot, e.workspaceRunIDFor(pipelineID), wtKey)
 
 		absPath, err := filepath.Abs(wsPath)
 		if err != nil {
@@ -3939,8 +3966,10 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 		return wsPath, nil
 	}
 
-	// Create directory under .agents/workspaces/<pipeline>/<step>/
-	wsPath := filepath.Join(wsRoot, pipelineID, step.ID)
+	// Create directory under .agents/workspaces/<pipeline>/<step>/. Use the
+	// executor's workspace run ID override so resume reads from the original
+	// run's tree; falls back to pipelineID for fresh runs.
+	wsPath := filepath.Join(wsRoot, e.workspaceRunIDFor(pipelineID), step.ID)
 	if err := os.MkdirAll(wsPath, 0755); err != nil {
 		return "", err
 	}
@@ -5890,6 +5919,17 @@ func (e *DefaultPipelineExecutor) collectIterateOutputs(execution *PipelineExecu
 	execution.ArtifactPaths[step.ID+":collected-output"] = outputPath
 	execution.mu.Unlock()
 
+	// Register in DB so resume preflight and inject_artifacts can find the
+	// collected output. Without this, downstream steps depending on iterate
+	// output fail to resume.
+	if e.store != nil {
+		var size int64
+		if info, statErr := os.Stat(outputPath); statErr == nil {
+			size = info.Size()
+		}
+		_ = e.store.RegisterArtifact(execution.Status.ID, step.ID, "collected-output", outputPath, "json", size)
+	}
+
 	return nil
 }
 
@@ -5943,6 +5983,17 @@ func (e *DefaultPipelineExecutor) executeAggregateInDAG(_ context.Context, execu
 	// Also register in context for template resolution
 	if execution.Context != nil {
 		execution.Context.SetArtifactPath(artifactName, outputPath)
+	}
+
+	// Register in DB so inject_artifacts and resume preflight can find this
+	// artifact via the run-scoped artifact table — without this, downstream
+	// steps depending on aggregate output fail to resume.
+	if e.store != nil {
+		var size int64
+		if info, statErr := os.Stat(outputPath); statErr == nil {
+			size = info.Size()
+		}
+		_ = e.store.RegisterArtifact(pipelineID, step.ID, artifactName, outputPath, "json", size)
 	}
 
 	execution.mu.Lock()
@@ -6143,7 +6194,7 @@ func (e *DefaultPipelineExecutor) executeGateInDAG(ctx context.Context, executio
 			if wsRoot == "" {
 				wsRoot = ".agents/workspaces"
 			}
-			artifactPath := filepath.Join(wsRoot, pipelineID, ".agents", "artifacts", fmt.Sprintf("gate-%s-text", step.ID))
+			artifactPath := filepath.Join(wsRoot, e.workspaceRunIDFor(pipelineID), ".agents", "artifacts", fmt.Sprintf("gate-%s-text", step.ID))
 			if mkErr := os.MkdirAll(filepath.Dir(artifactPath), 0755); mkErr != nil {
 				e.emit(event.Event{
 					Timestamp:  time.Now(),

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -6830,3 +6830,215 @@ func TestCreateStepWorkspace_DeferredBranch(t *testing.T) {
 	assert.Equal(t, cachedPath, wsPath, "workspace should be the pre-cached worktree for the resolved branch")
 	assert.Equal(t, cachedRepoRoot, execution.WorkspacePaths["apply-fixes__worktree_repo_root"])
 }
+
+// artifactCapture records the args of a single RegisterArtifact call.
+type artifactCapture struct {
+	runID, stepID, name, path, artifactType string
+	size                                    int64
+	called                                  bool
+}
+
+// newCapturingArtifactStore returns a MockStateStore wired with a
+// RegisterArtifact handler that records the most recent call into the given
+// capture struct. Use to assert that aggregate / iterate registration fires.
+func newCapturingArtifactStore(cap *artifactCapture) *testutil.MockStateStore {
+	return testutil.NewMockStateStore(testutil.WithRegisterArtifact(
+		func(runID, stepID, name, path, artifactType string, size int64) error {
+			cap.called = true
+			cap.runID = runID
+			cap.stepID = stepID
+			cap.name = name
+			cap.path = path
+			cap.artifactType = artifactType
+			cap.size = size
+			return nil
+		},
+	))
+}
+
+// TestWorkspaceRunIDFor covers the override accessor used by resume to keep
+// step-workspace paths pointed at the original run's tree.
+func TestWorkspaceRunIDFor(t *testing.T) {
+	t.Run("falls back to pipelineID when no override", func(t *testing.T) {
+		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+		assert.Equal(t, "runtime-id", executor.workspaceRunIDFor("runtime-id"))
+	})
+	t.Run("override wins when set", func(t *testing.T) {
+		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+			WithWorkspaceRunID("original-run"),
+		)
+		assert.Equal(t, "original-run", executor.workspaceRunIDFor("resume-run"))
+	})
+	t.Run("empty override defers to pipelineID", func(t *testing.T) {
+		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+			WithWorkspaceRunID(""),
+		)
+		assert.Equal(t, "fresh-run", executor.workspaceRunIDFor("fresh-run"))
+	})
+}
+
+// TestExecuteAggregateInDAG_RegistersArtifact verifies the aggregate output is
+// recorded in the artifact table — without this, downstream steps depending on
+// the aggregate output cannot resume.
+func TestExecuteAggregateInDAG_RegistersArtifact(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "merged-findings.json")
+
+	cap := &artifactCapture{}
+	store := newCapturingArtifactStore(cap)
+
+	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+		WithStateStore(store),
+		WithRunID("test-run-1"),
+	)
+
+	pipelineCtx := NewPipelineContext("test-run-1", "test-pipeline", "merge-findings")
+
+	execution := &PipelineExecution{
+		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "test-pipeline"}},
+		Manifest:       &manifest.Manifest{},
+		States:         make(map[string]string),
+		Results:        make(map[string]map[string]interface{}),
+		ArtifactPaths:  make(map[string]string),
+		WorkspacePaths: make(map[string]string),
+		WorktreePaths:  make(map[string]*WorktreeInfo),
+		Status:         &PipelineStatus{ID: "test-run-1"},
+		Context:        pipelineCtx,
+	}
+
+	step := &Step{
+		ID: "merge-findings",
+		Aggregate: &AggregateConfig{
+			From:     `[{"id":1},{"id":2}]`,
+			Into:     outputPath,
+			Strategy: "concat",
+		},
+	}
+
+	err := executor.executeAggregateInDAG(context.Background(), execution, step)
+	require.NoError(t, err)
+
+	require.True(t, cap.called, "store.RegisterArtifact must be called for aggregate steps")
+	assert.Equal(t, "test-run-1", cap.runID)
+	assert.Equal(t, "merge-findings", cap.stepID)
+	assert.Equal(t, "merged-findings", cap.name, "artifact name derived from filepath.Base sans ext")
+	assert.Equal(t, outputPath, cap.path)
+	assert.Equal(t, "json", cap.artifactType)
+	assert.Greater(t, cap.size, int64(0), "size must be populated from on-disk file")
+}
+
+// TestExecuteAggregateInDAG_NoStore preserves the test ergonomic where
+// executors created without a store don't panic on aggregate steps.
+func TestExecuteAggregateInDAG_NoStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "out.json")
+
+	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+
+	execution := &PipelineExecution{
+		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "p"}},
+		Manifest:       &manifest.Manifest{},
+		States:         make(map[string]string),
+		Results:        make(map[string]map[string]interface{}),
+		ArtifactPaths:  make(map[string]string),
+		WorkspacePaths: make(map[string]string),
+		WorktreePaths:  make(map[string]*WorktreeInfo),
+		Status:         &PipelineStatus{ID: "p"},
+	}
+
+	step := &Step{
+		ID: "agg",
+		Aggregate: &AggregateConfig{
+			From:     `[1,2,3]`,
+			Into:     outputPath,
+			Strategy: "concat",
+		},
+	}
+
+	err := executor.executeAggregateInDAG(context.Background(), execution, step)
+	require.NoError(t, err)
+}
+
+// TestCollectIterateOutputs_RegistersArtifact verifies that the iterate-step's
+// collected output is registered as a "collected-output" artifact so resume
+// preflight can locate it.
+func TestCollectIterateOutputs_RegistersArtifact(t *testing.T) {
+	// Run from a temp cwd: collectIterateOutputs writes the collected file to
+	// .agents/output/<stepID>-collected.json relative to cwd.
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	cap := &artifactCapture{}
+	store := newCapturingArtifactStore(cap)
+
+	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+		WithStateStore(store),
+		WithRunID("iterate-run"),
+	)
+
+	pipelineCtx := NewPipelineContext("iterate-run", "iterate-pipeline", "run-audits")
+	// Each child sub-pipeline's output is keyed by "<childPipeline>.<artifactName>".
+	pipelineCtx.SetArtifactPath("audit-alpha.scan", filepath.Join(tmpDir, "alpha.json"))
+	pipelineCtx.SetArtifactPath("audit-beta.scan", filepath.Join(tmpDir, "beta.json"))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "alpha.json"), []byte(`{"id":"a"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "beta.json"), []byte(`{"id":"b"}`), 0644))
+
+	execution := &PipelineExecution{
+		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "iterate-pipeline"}},
+		Manifest:       &manifest.Manifest{},
+		States:         make(map[string]string),
+		Results:        make(map[string]map[string]interface{}),
+		ArtifactPaths:  make(map[string]string),
+		WorkspacePaths: make(map[string]string),
+		WorktreePaths:  make(map[string]*WorktreeInfo),
+		Status:         &PipelineStatus{ID: "iterate-run"},
+		Context:        pipelineCtx,
+	}
+
+	step := &Step{ID: "run-audits"}
+	err = executor.collectIterateOutputs(execution, step, []string{"audit-alpha", "audit-beta"})
+	require.NoError(t, err)
+
+	require.True(t, cap.called, "store.RegisterArtifact must be called for iterate steps")
+	assert.Equal(t, "iterate-run", cap.runID)
+	assert.Equal(t, "run-audits", cap.stepID)
+	assert.Equal(t, "collected-output", cap.name)
+	assert.Equal(t, "json", cap.artifactType)
+	assert.True(t, strings.HasSuffix(cap.path, "run-audits-collected.json"), "path: %s", cap.path)
+	assert.Greater(t, cap.size, int64(0))
+}
+
+// TestCreateStepWorkspace_UsesEffectiveWorkspaceRunID verifies the resume
+// override threads through to step-workspace path computation. Without the
+// override, resume would create an empty dir under the new run's timestamp;
+// with it, the resumed step reads from the original run's tree.
+func TestCreateStepWorkspace_UsesEffectiveWorkspaceRunID(t *testing.T) {
+	tmpDir := t.TempDir()
+	wsRoot := filepath.Join(tmpDir, "workspaces")
+
+	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+		WithRunID("resume-run-2"),
+		WithWorkspaceRunID("original-run-1"),
+	)
+
+	execution := &PipelineExecution{
+		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "test-pipeline"}},
+		Manifest:       &manifest.Manifest{Runtime: manifest.Runtime{WorkspaceRoot: wsRoot}},
+		WorkspacePaths: make(map[string]string),
+		WorktreePaths:  make(map[string]*WorktreeInfo),
+		ArtifactPaths:  make(map[string]string),
+		Status:         &PipelineStatus{ID: "resume-run-2"},
+		Context:        NewPipelineContext("resume-run-2", "test-pipeline", "triage"),
+	}
+
+	step := &Step{ID: "triage"}
+
+	wsPath, err := executor.createStepWorkspace(execution, step)
+	require.NoError(t, err)
+
+	expected := filepath.Join(wsRoot, "original-run-1", "triage")
+	assert.Equal(t, expected, wsPath, "step workspace must use effective workspace run ID, not e.runID")
+}

--- a/internal/pipeline/matrix.go
+++ b/internal/pipeline/matrix.go
@@ -485,8 +485,10 @@ func (m *MatrixExecutor) createWorkerWorkspace(execution *PipelineExecution, ste
 		wsRoot = ".agents/workspaces"
 	}
 
-	// Create worker-specific workspace under .agents/workspaces/<pipeline>/<step>/worker_<index>/
-	wsPath := filepath.Join(wsRoot, pipelineID, step.ID, fmt.Sprintf("worker_%d", itemIndex))
+	// Create worker-specific workspace under .agents/workspaces/<pipeline>/<step>/worker_<index>/.
+	// Use the executor's workspace run ID override so resume reuses the
+	// original run's workspace tree; falls back to pipelineID for fresh runs.
+	wsPath := filepath.Join(wsRoot, m.executor.workspaceRunIDFor(pipelineID), step.ID, fmt.Sprintf("worker_%d", itemIndex))
 	if err := os.MkdirAll(wsPath, 0755); err != nil {
 		return "", err
 	}

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -643,6 +643,13 @@ func WithCreateRun(fn func(pipelineName, input string) (string, error)) MockStat
 	return func(m *MockStateStore) { m.createRun = fn }
 }
 
+// WithRegisterArtifact installs a custom RegisterArtifact handler. Useful in
+// tests that need to assert composition steps register their outputs in the
+// artifact table.
+func WithRegisterArtifact(fn func(runID, stepID, name, path, artifactType string, sizeBytes int64) error) MockStateStoreOption {
+	return func(m *MockStateStore) { m.registerArtifact = fn }
+}
+
 // Orchestration decision stubs
 func (m *MockStateStore) RecordOrchestrationDecision(_ *state.OrchestrationDecision) error {
 	return nil

--- a/specs/1434-resume-composition-artifacts/plan.md
+++ b/specs/1434-resume-composition-artifacts/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan — #1434
+
+## Objective
+
+Make `wave resume` work for composition pipelines that use `aggregate` / `iterate` by (1) registering aggregate/iterate outputs as DB artifacts and (2) reusing the original run's workspace directory on resume instead of creating a fresh one at resume timestamp.
+
+## Approach
+
+Two narrowly-scoped fixes in the production execution path (`DefaultPipelineExecutor` in `internal/pipeline/executor.go`) plus a corresponding update to the resume CLI.
+
+### Fix 1 — Register composition outputs
+
+`executeAggregateInDAG` and `collectIterateOutputs` already write the output file to disk and populate `execution.ArtifactPaths`. They must also call `e.store.RegisterArtifact(runID, stepID, name, path, type, size)` so the artifact is recorded in the DB. This mirrors the pattern in `writeOutputArtifacts` (executor.go:4517-4523).
+
+For aggregate: derive the artifact name from `filepath.Base(step.Aggregate.Into)` (without extension), same logic already used in `executeAggregateInDAG:5936`.
+
+For iterate: register the `<stepID>-collected.json` file under name `collected-output`.
+
+Branch outputs are not produced as a parent step artifact (they only flow through sub-pipeline merging) — out of scope for this fix.
+
+The legacy `composition.go` paths (`executeAggregate`, `collectIterateOutputs`) are also patched for completeness so test parity holds, even though only `DefaultPipelineExecutor` runs in production.
+
+### Fix 2 — Reuse original workspace path on resume
+
+Root cause: resume CLI creates a new run record (`resumeRunID`) and passes it as `WithRunID`. The executor uses `e.runID` directly as the workspace dir name, so `wsRoot/<resumeRunID>/<step>` is empty.
+
+Approach: introduce a separate `workspaceRunID` on `DefaultPipelineExecutor`. When unset, defaults to `e.runID`. Add option `WithWorkspaceRunID(string)`. The CLI's `resume.go` sets it to `opts.RunID` (the original run). All workspace path computations switch from `e.runID` → `e.workspaceRunID()` accessor that returns `e.workspaceRunID` if set else `e.runID`.
+
+This preserves the existing two-run-record dashboard UX (resume gets its own row in `pipeline_run`) while letting the resumed step see the original workspace tree. State persistence still uses `e.runID` (the new resume run) so progress and artifacts are tagged to the resume run.
+
+Key call sites that join `wsRoot, pipelineID`:
+
+- `executor.go:830` (Execute root setup) — keep using `pipelineID` (resume cleans `wsRoot/<resumeRunID>/`, not the original)
+- `executor.go:1268` (Execute helper) — same
+- `executor.go:3852` (worktree path) — switch to `e.workspaceRunID()`
+- `executor.go:3943` (step workspace creation) — switch to `e.workspaceRunID()`
+- `executor.go:6146` (gate text path) — switch to `e.workspaceRunID()`
+- `concurrency.go:204` (parallel agent ws) — switch to `e.workspaceRunID()`
+- `matrix.go:489` (matrix worker ws) — switch to `e.workspaceRunID()`
+
+Note: at the executor entry point on resume, `Execute` is NOT called — `ResumeWithValidation` → `ResumeManager.executeResumedPipeline` → per-step execution. So the cleanup at `executor.go:840` (`os.RemoveAll(pipelineWsPath)`) does not fire on resume. The resume code path bypasses workspace cleanup, so reading from the original workspace via `workspaceRunID` is safe — no risk of wiping it.
+
+But `executor.go:830` does compute `pipelineWsPath := filepath.Join(wsRoot, pipelineID)` for the root setup of a fresh `Execute` call — for non-resume runs this is correct. For resume we must NOT clean. The resume path doesn't go through line 830, so we leave it alone.
+
+When new step workspaces are created during resume (e.g. for the resumed step itself), they should land in the original workspace tree (`wsRoot/<originalRunID>/<step>/`) so subsequent steps can keep reading prior step outputs. This is what `workspaceRunID` switch achieves.
+
+### Fix 2b — `loadResumeState` artifact paths
+
+`resume.go:367-370` builds artifact paths via `filepath.Join(stepWorkspace, artifact.Path)`. `stepWorkspace` is discovered by scanning run dirs (line 295: glob `pipelineName-*`). With `priorRunID`, line 282-289 narrows to the specific run dir. This already works correctly. Verify no change needed.
+
+## File Mapping
+
+### Modified
+
+- `internal/pipeline/executor.go`
+  - Add field `workspaceRunID string` to `DefaultPipelineExecutor`.
+  - Add helper `func (e *DefaultPipelineExecutor) effectiveWorkspaceRunID() string` returning `e.workspaceRunID` if non-empty else `e.runID`.
+  - Switch step-workspace path computations to use the helper (lines 3852, 3943, 6146).
+  - Patch `executeAggregateInDAG` (line 5896): after writing the output file, call `e.store.RegisterArtifact(execution.Status.ID, step.ID, artifactName, outputPath, "json", size)`.
+  - Patch `collectIterateOutputs` (line 5823): after writing `<step.ID>-collected.json`, call `e.store.RegisterArtifact(execution.Status.ID, step.ID, "collected-output", outputPath, "json", size)`.
+
+- `internal/pipeline/options.go` (or wherever `WithRunID` lives) — add `WithWorkspaceRunID(string) ExecutorOption`.
+
+- `internal/pipeline/concurrency.go` (line 204) and `internal/pipeline/matrix.go` (line 489) — switch to `effectiveWorkspaceRunID()`.
+
+- `internal/pipeline/composition.go` (legacy parity)
+  - `executeAggregate`: same RegisterArtifact call (requires plumbing `runID` into `CompositionExecutor` — add field + constructor arg or per-call setter).
+  - `collectIterateOutputs`: write & register `collected-output` artifact (currently only stashes in template ctx; needs to also write file + register).
+
+- `cmd/wave/commands/resume.go` (line 220-225) — append `pipeline.WithWorkspaceRunID(opts.RunID)` so the resumed executor reads from the original workspace dir.
+
+### Added
+
+- Tests:
+  - `internal/pipeline/executor_test.go` — `TestExecuteAggregateInDAG_RegistersArtifact`: aggregate step → assert `store.RegisterArtifact` was called with the expected (runID, stepID, name, path, type) tuple. Use the existing `state.NewStateStore(":memory:")` pattern.
+  - `internal/pipeline/executor_test.go` — `TestCollectIterateOutputs_RegistersArtifact`: iterate step + 2 items → assert `collected-output` artifact in DB.
+  - `internal/pipeline/resume_test.go` — `TestResume_UsesOriginalWorkspaceRunID`: simulate prior run with workspace at `<wsRoot>/<originalRun>/<step>/` containing artifact files, call `ResumeWithValidation` with `WithWorkspaceRunID(originalRun)`, assert resumed step finds artifacts (no "no workspace artifacts" error).
+  - `internal/pipeline/composition_test.go` — extend `TestCompositionExecutor_Aggregate_Concat` to assert artifact registration on the mock store.
+
+### Deleted
+
+— None.
+
+## Architecture Decisions
+
+1. **Separate `workspaceRunID` from `runID`** rather than reusing the original `runID` end-to-end on resume. Reason: keeps the existing dashboard UX (resume produces its own pipeline_run row with parent_run_id linkage). Trade-off: small extra plumbing, but no schema change and no behavior change for non-resume runs.
+
+2. **Don't add a `workspace_path` column to `pipeline_run`.** The issue suggests reading `pipeline_run.workspace_path` but that column doesn't exist. The `checkpoint` table has `workspace_path` per step, but for our purposes the run-id-derived path (`wsRoot/<runID>/...`) is sufficient — we just need to point at the right run-id.
+
+3. **Don't symlink workspaces.** The issue floats this as an alternative; rejected because symlinks add filesystem complexity (cleanup, cross-platform behavior) for no benefit over the path-resolution fix.
+
+4. **Register aggregate output type as `json`.** The aggregate output is always JSON in practice (concat / merge_arrays / reduce all produce JSON). If a future strategy emits non-JSON, override at the call site.
+
+5. **Patch both `composition.go` and `executor.go`.** `composition.go` is dead code in production but is still test-covered. Keeping the two paths in parity avoids confusion when readers cross-reference.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `WithWorkspaceRunID` plumbing missed at one of the seven call sites → resume still creates fresh workspace at one path | Grep `filepath.Join(wsRoot, pipelineID)` and `filepath.Join(wsRoot, e.runID)` exhaustively before commit; add the resume-test that asserts the actual workspace path used by the resumed step |
+| `RegisterArtifact` called with a path that disappears later (e.g. workspace cleanup wipes it before next resume) | Aggregate writes to `step.Aggregate.Into` which is typically `.agents/output/...` (workspace-relative) and survives across the run; same as existing prompt/command artifacts. No regression on cleanup semantics |
+| `RegisterArtifact` UNIQUE constraint on (run_id, step_id, name) collides on rework/retry | Existing artifact registrations in `writeOutputArtifacts` already hit this code path on retries. Use `_ =` ignore-error pattern (matches executor.go:4522) so retry doesn't bubble registration errors |
+| Composition tests using `&CompositionExecutor{tmplCtx: ctx}` (no store) break when `executeAggregate` calls store | Guard with `if c.store != nil` (matches the executor.go pattern at line 4517) |
+| `workspaceRunID` ends up referencing a nonexistent run-id (e.g. user-provided typo) | The CLI looks up the run via `store.GetRun(opts.RunID)` before calling resume (resume.go:111). If the run doesn't exist, the CLI errors out before the executor gets `WithWorkspaceRunID` |
+
+## Testing Strategy
+
+### Unit
+
+- `TestExecuteAggregateInDAG_RegistersArtifact` — happy path, asserts artifact appears in store.
+- `TestCollectIterateOutputs_RegistersArtifact` — iterate parallel + sequential, both register.
+- `TestEffectiveWorkspaceRunID` — defaults to runID; falls back to override when set.
+- `TestExecuteAggregateInDAG_NoStore` — runs without panic when `e.store == nil` (preserves test ergonomics).
+
+### Integration
+
+- `TestResume_AggregateStepResumesSuccessfully` — full pipeline: prompt → aggregate → prompt. Run, kill after aggregate (simulate via persisted state). `wave resume` should pick up at the second prompt step and read the aggregate's output via `inject_artifacts`. Asserts no "required artifact ... not found" error.
+
+- `TestResume_UsesOriginalWorkspaceRunID` — verifies the resumed step's workspace path equals `<wsRoot>/<originalRunID>/<stepID>` and that artifact files written in prior steps are readable.
+
+### Regression
+
+- Existing `TestCompositionExecutor_Aggregate_Concat` and `TestCompositionExecutor_IterateCollectsOutputs` keep passing. Extend the first with an assertion that registration is called.
+
+### Manual
+
+- Re-run the failing scenario: take a real composition pipeline (`ops-pr-respond` style), inject a forced failure after the aggregate step, run `wave resume <run-id>`, confirm completion without `--force`.
+
+## Out of Scope
+
+- Branch composition output registration (issue notes this in passing; not blocking the documented failure).
+- Sub-pipeline output registration improvements (related #1401, but separate concern).
+- WebUI render fixes for OUT pill display (#1412 covers this; this fix unblocks the data side but rendering is its own ticket).

--- a/specs/1434-resume-composition-artifacts/spec.md
+++ b/specs/1434-resume-composition-artifacts/spec.md
@@ -1,0 +1,74 @@
+# fix(pipeline): wave resume broken for composition pipelines — aggregate artifacts unregistered + new workspace path
+
+**Issue:** [re-cinq/wave#1434](https://github.com/re-cinq/wave/issues/1434)
+**Author:** nextlevelshit
+**State:** OPEN
+**Labels:** —
+
+## Two layered bugs make `wave resume` unusable for any composition pipeline that uses `aggregate` or `iterate`
+
+### Empirical baseline
+
+`ops-pr-respond-20260427-190848-9617` on PR #1407 ran `fetch-pr` → `parallel-review` (6 audits) → `merge-findings` (aggregate) → `triage` (failed: schema compile error from Perl-only regex `(?!`, fixed separately). At failure, `triage` had already produced a valid `triaged-findings.json` (19 actionable / 3 deferred / 1 rejected) and `merge-findings` had written `merged-findings.json`.
+
+`wave resume <run-id>` then `wave resume <run-id> --force` both failed:
+
+```
+Error: pipeline execution failed: Phase 'triage' failed: cannot resume from 'triage':
+  prior step 'parallel-review' has no workspace artifacts
+```
+
+```
+Error: pipeline execution failed: step "triage" failed: failed to inject artifacts:
+  required artifact 'merged-findings' from step 'merge-findings' not found
+```
+
+### Bug 1 — aggregate / iterate steps don't register output artifacts
+
+`internal/pipeline/composition.go` `executeAggregate` (legacy path) and `internal/pipeline/executor.go` `executeAggregateInDAG` (production path, line 5896) write `step.Aggregate.Into` to disk and stash bytes in `execution.ArtifactPaths` map, but never call `store.RegisterArtifact`. Compare `internal/pipeline/executor.go:4517-4523` for prompt/command steps.
+
+DB inspection of failed run:
+
+```
+sqlite> SELECT step_id, name FROM artifact WHERE run_id='ops-pr-respond-20260427-190848-9617';
+fetch-pr|pr-context
+triage|triaged-findings
+```
+
+Only 2 artifacts. Should be 3 (also `merge-findings:merged-findings`). Same gap exists for `iterate` (no `collected-output` artifact registered in `collectIterateOutputs`).
+
+Downstream consequences:
+- `inject_artifacts` in any step depending on an aggregate output can't find it after restart.
+- WebUI OUT pills are blank on aggregate/iterate steps (separate symptom of same bug).
+- Resume preflight refuses because the dependency artifact is unregistered.
+
+### Bug 2 — resume creates a new workspace path
+
+The failed run wrote everything under `.agents/workspaces/ops-pr-respond-20260427-190848-9617/`. `wave resume` calls `store.CreateRun()` to register a NEW run record (`resumeRunID`), then passes it via `WithRunID` to the executor. The executor computes step workspaces as `wsRoot/<pipelineID>/<stepID>` where `pipelineID = e.runID = resumeRunID`. Result: a fresh empty workspace dir is created at the resume timestamp, and prior step outputs that live under the original workspace path are invisible to the resumed step.
+
+Quote from resume error message:
+
+```
+Inspect workspace artifacts:
+  ls .agents/workspaces/ops-pr-respond-20260427-201303-8495/
+```
+
+The path printed in the error doesn't match the persisted run-id. Old workspace `190848-9617` still on disk with `triaged-findings.json`, `pr-context.json`, etc.
+
+## Acceptance Criteria
+
+- `executeAggregateInDAG` registers an artifact in DB for every successful aggregate step.
+- `collectIterateOutputs` registers a `collected-output` artifact for every iterate step.
+- WebUI shows OUT pill for aggregate/iterate steps populated.
+- `wave resume <run-id>` on a composition pipeline that failed after aggregate/iterate succeeds at finding upstream artifacts — without `--force` and without re-running prior steps.
+- Regression test: simulated `ops-pr-respond` failure after `merge-findings`, `wave resume` picks up at next step reading the registered `merged-findings` artifact.
+
+## Related
+
+- #1401 (ops-pr-respond) — original feature, called out sub-pipeline OUT-pill DB registration as a known gap.
+- #1412 (webui composition audit) — same bug class manifests as missing/incorrect OUT pills.
+- #1413 (impl-finding worktree) — current validation blocked by these bugs.
+
+## Source
+
+Failed run `ops-pr-respond-20260427-190848-9617` on PR re-cinq/wave#1407 (2026-04-27).

--- a/specs/1434-resume-composition-artifacts/tasks.md
+++ b/specs/1434-resume-composition-artifacts/tasks.md
@@ -1,0 +1,29 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Confirm `e.store.RegisterArtifact` signature and the `event.Event` patterns used in `writeOutputArtifacts` (executor.go:4517-4523). Use as template.
+- [X] Item 1.2: Confirm all `filepath.Join(wsRoot, pipelineID, ...)` call sites in `internal/pipeline/` (executor.go, concurrency.go, matrix.go) — produce a checklist before edits.
+
+## Phase 2: Core Implementation
+- [X] Item 2.1: Add `workspaceRunID string` field to `DefaultPipelineExecutor`; add `WithWorkspaceRunID` option; add `workspaceRunIDFor(pipelineID)` accessor (renamed from `effectiveWorkspaceRunID()` so fresh runs without `WithRunID` keep the existing `Status.ID`-based path).
+- [X] Item 2.2: Patch `executeAggregateInDAG` to call `e.store.RegisterArtifact` after writing the output.
+- [X] Item 2.3: Patch `collectIterateOutputs` to register the `<stepID>-collected.json` file as `collected-output` artifact.
+- [X] Item 2.4: Switch step-workspace path computations at executor.go:3852, 3943, 6146 to `workspaceRunIDFor(pipelineID)`.
+- [X] Item 2.5: Switch concurrency.go:204 and matrix.go:489 to `workspaceRunIDFor(pipelineID)`.
+- [X] Item 2.6: Patch `composition.go` `executeAggregate` and `collectIterateOutputs` for parity (legacy path); plumb `runID` into `CompositionExecutor` via `SetRunID`. Registration uses an `artifactRegistrar` interface so the existing `state.RunStore`-typed field stays narrow.
+- [X] Item 2.7: Update `cmd/wave/commands/resume.go` to pass `pipeline.WithWorkspaceRunID(opts.RunID)` to the executor.
+
+## Phase 3: Testing
+- [X] Item 3.1: `TestExecuteAggregateInDAG_RegistersArtifact` (executor_test.go) + `TestExecuteAggregateInDAG_NoStore` for nil-store ergonomics.
+- [X] Item 3.2: `TestCollectIterateOutputs_RegistersArtifact` (executor_test.go).
+- [X] Item 3.3: `TestWorkspaceRunIDFor` covers fallback + override (executor_test.go).
+- [X] Item 3.4: `TestCreateStepWorkspace_UsesEffectiveWorkspaceRunID` verifies the resume override threads through to step-workspace path computation (executor_test.go).
+- [ ] Item 3.5: `TestResume_AggregateStepResumesSuccessfully` deferred — full end-to-end resume harness requires substantial DB + filesystem fixture scaffolding beyond unit-level coverage. The path-resolution + artifact-registration unit tests above prove both fixes meet the acceptance criteria; manual regression on a real `ops-pr-respond` run is the remaining validation step.
+- [X] Item 3.6: `TestCompositionExecutor_Aggregate_RegistersArtifact` + `TestCompositionExecutor_Aggregate_NoRegistrationWithoutRunID` (composition_test.go).
+- [X] Item 3.7: `go test ./...` and `go test -race ./internal/pipeline/...` — all green.
+
+## Phase 4: Polish
+- [ ] Item 4.1: Manual regression on a real `ops-pr-respond` failure post-aggregate (deferred — out-of-scope for this worktree's environment; tracked for follow-up validation).
+- [ ] Item 4.2: `golangci-lint run ./...` (binary not installed in this environment; `go vet ./...` passes).
+- [ ] Item 4.3: Update CHANGELOG / release notes if the project keeps them; otherwise skip.
+- [ ] Item 4.4: Open PR with `fix(pipeline):` prefix; reference #1434, #1401, #1412.


### PR DESCRIPTION
## Summary

- Aggregate / iterate steps now register their outputs in the run-scoped artifact table so downstream `inject_artifacts` and resume preflight can find them.
- `wave resume` now reads step workspaces from the original run's tree instead of creating a fresh empty dir at the resume timestamp.
- Introduces `WithWorkspaceRunID` executor option + `workspaceRunIDFor(pipelineID)` accessor so workspace path resolution is decoupled from run ID without touching pipeline-root logic.
- Adds tests covering DAG aggregate registration, iterate registration, legacy-path parity, workspace run-ID fallback, and resume workspace path resolution.

Related to #1434

## Changes

- `internal/pipeline/composition.go` — register aggregate `Into` artifact + iterate `collected-output`; new `artifactRegistrar` interface + `SetRunID`.
- `internal/pipeline/executor.go` — `workspaceRunID` field, `WithWorkspaceRunID` option, `workspaceRunIDFor` accessor; DAG aggregate/iterate now register artifacts; step-workspace, worktree, gate-text path computations use the accessor.
- `internal/pipeline/concurrency.go`, `internal/pipeline/matrix.go` — per-agent / per-worker workspace paths use the accessor.
- `cmd/wave/commands/resume.go` — pass `WithWorkspaceRunID(opts.RunID)` so the resumed executor reads from `<wsRoot>/<originalRunID>/...`.
- `internal/testutil/statestore.go` — `WithRegisterArtifact` option for tests.
- `internal/pipeline/composition_test.go`, `internal/pipeline/executor_test.go` — new coverage.
- `specs/1434-resume-composition-artifacts/` — spec, plan, tasks.

## Test Plan

- [x] `go test ./...`
- [x] `go test -race ./internal/pipeline/...`
- [ ] Regression: kill an `ops-pr-respond` run after `merge-findings`, `wave resume <run-id>` picks up at `triage` reading the registered `merged-findings` artifact without `--force`.