### PR TITLE
fix(pipeline): sub-pipeline inject can resolve persona-step outputs

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -5481,11 +5481,34 @@ func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execu
 		childOpts = append(childOpts, withSkillStore(e.skillStore))
 	}
 
-	// Inject parent artifacts into child executor when config specifies injection
+	// Inject parent artifacts into child executor when config specifies injection.
+	//
+	// Two registration paths produce parent artifacts the child may inject:
+	//   - Persona/command step outputs land in execution.ArtifactPaths under
+	//     keys of the form "<step.ID>:<artifact.Name>" (executor.go:4460,4472).
+	//   - Composition aggregate/iterate outputs ALSO call
+	//     execution.Context.SetArtifactPath(<artifact.Name>) so they show up
+	//     in the bare-name namespace used by templating.
+	// The lookup walks the bare-name space first (the natural author-facing
+	// API), then falls back to the dep-scoped ArtifactPaths map keyed by
+	// "<dep>:<name>" for any declared step dependency. Without this fallback,
+	// injecting a persona-step output (e.g. fetch-pr/pr-context) into a
+	// downstream iterate step fails with "artifact … not found in parent
+	// context for sub-pipeline injection" even though the artifact exists.
 	if step.Config != nil && len(step.Config.Inject) > 0 {
 		paths := make(map[string]string, len(step.Config.Inject))
 		for _, name := range step.Config.Inject {
 			path := execution.Context.GetArtifactPath(name)
+			if path == "" {
+				execution.mu.Lock()
+				for _, dep := range step.Dependencies {
+					if p, ok := execution.ArtifactPaths[dep+":"+name]; ok {
+						path = p
+						break
+					}
+				}
+				execution.mu.Unlock()
+			}
 			if path == "" {
 				return fmt.Errorf("artifact %q not found in parent context for sub-pipeline injection", name)
 			}


### PR DESCRIPTION
## Summary

`ops-pr-respond` on PR re-cinq/wave#1441 failed at the `parallel-review` step with:

```
artifact \"pr-context\" not found in parent context for sub-pipeline injection
```

even though `fetch-pr` had registered the `pr-context` artifact on disk (visible in the WebUI as the green OUT pill on the parent step) and in the `artifact` table.

## Root cause

DefaultPipelineExecutor's iterate / sub-pipeline launch (executor.go:5485–5495) resolves each `step.config.inject` entry against `execution.Context.ArtifactPaths` only — the bare-name namespace used by templating and (post-PR #1441) by composition primitives like aggregate / iterate. Persona-step outputs land in a different map: `execution.ArtifactPaths[\"<step.ID>:<art.Name>\"]`. PR #1441 unified the two stores for composition outputs but persona-step outputs were never propagated to the bare-name map, so any sub-pipeline trying to inject a persona-produced parent artifact (the canonical case being `ops-pr-respond.parallel-review` injecting `fetch-pr/pr-context`) failed at step entry.

`resolve-each` in the same pipeline didn't trip the bug because by the time it runs other lookups have populated the bare-name namespace; `parallel-review` runs immediately after `fetch-pr` and gets nothing.

## Changes

- `internal/pipeline/executor.go` — after the bare-name lookup misses, fall back to scanning `execution.ArtifactPaths` for `<dep>:<name>` where `<dep>` is one of the step's declared dependencies. Dep-scoped fallback keeps the namespace tight (no cross-step collision). Acquires `execution.mu` for the read.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pipeline/`
- [ ] Re-run `ops-pr-respond` on a representative PR. Expect parallel-review to start its 6 audit children instead of failing at injection time.

## Related

- PR #1441 (resume composition artifacts) — introduced the bare-name registration for composition outputs but did not unify persona outputs.
- #1442 (audit-issue pipeline showcase) — same composition pattern; needs this fix to ship.