### PR TITLE
fix(pipeline): iterate.on_failure=continue + bump default step timeout (composition resilience)

### DIFF
--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -196,6 +196,11 @@ steps:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel
       max_concurrent: 6
+      # Per-axis failures are tolerated. If 1-2 audits time out or hit a
+      # contract failure, downstream merge-findings still has the
+      # successful audits' output to triage. Hard-failing the whole run
+      # because of one slow axis defeats the multi-axis design.
+      on_failure: continue
 
   # ─── Phase 3: aggregate audit outputs ────────────────────────────────────
   #

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -196,6 +196,11 @@ steps:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel
       max_concurrent: 6
+      # Per-axis failures are tolerated. If 1-2 audits time out or hit a
+      # contract failure, downstream merge-findings still has the
+      # successful audits' output to triage. Hard-failing the whole run
+      # because of one slow axis defeats the multi-axis design.
+      on_failure: continue
 
   # ─── Phase 3: aggregate audit outputs ────────────────────────────────────
   #

--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/recinq/wave/internal/event"
@@ -238,7 +239,16 @@ func (c *CompositionExecutor) executeIterateSequential(ctx context.Context, p *P
 
 		// Load and execute the sub-pipeline (iterate: key by pipelineName; step.ID is aggregated later)
 		if err := c.runSubPipeline(ctx, "", resolvedName, input); err != nil {
-			return fmt.Errorf("item %d: pipeline %q failed: %w", i, resolvedName, err)
+			if step.Iterate.OnFailure != OnFailureContinue {
+				return fmt.Errorf("item %d: pipeline %q failed: %w", i, resolvedName, err)
+			}
+			c.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: p.Metadata.Name,
+				StepID:     step.ID,
+				State:      "warning",
+				Message:    fmt.Sprintf("iterate item %q failed (on_failure: continue): %v", resolvedName, err),
+			})
 		}
 	}
 
@@ -289,8 +299,14 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 		resolvedInputs[i] = input
 	}
 
+	tolerateFailures := step.Iterate.OnFailure == OnFailureContinue
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrent)
+
+	var (
+		failuresMu sync.Mutex
+		failures   []string
+	)
 
 	for i := range items {
 		resolvedName := resolvedNames[i]
@@ -305,7 +321,27 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 		})
 
 		g.Go(func() error {
-			return c.runSubPipeline(gctx, "", resolvedName, input)
+			err := c.runSubPipeline(gctx, "", resolvedName, input)
+			if err == nil {
+				return nil
+			}
+			if !tolerateFailures {
+				return err
+			}
+			// Record the failure and let the iterate continue. errgroup
+			// short-circuits on first error otherwise — swallowing the
+			// error here keeps siblings running.
+			failuresMu.Lock()
+			failures = append(failures, fmt.Sprintf("%s: %v", resolvedName, err))
+			failuresMu.Unlock()
+			c.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: p.Metadata.Name,
+				StepID:     step.ID,
+				State:      "warning",
+				Message:    fmt.Sprintf("iterate item %q failed (on_failure: continue): %v", resolvedName, err),
+			})
+			return nil
 		})
 	}
 
@@ -317,12 +353,17 @@ func (c *CompositionExecutor) executeIterateParallel(ctx context.Context, p *Pip
 	// iterate step's ID so downstream steps can reference {{ stepID.output }}.
 	c.collectIterateOutputs(step, resolvedNames)
 
+	completedMsg := fmt.Sprintf("all %d items completed (parallel)", len(items))
+	if len(failures) > 0 {
+		completedMsg = fmt.Sprintf("%d/%d items completed (parallel); %d failed but continued: %s",
+			len(items)-len(failures), len(items), len(failures), strings.Join(failures, "; "))
+	}
 	c.emit(event.Event{
 		Timestamp:  time.Now(),
 		PipelineID: p.Metadata.Name,
 		StepID:     step.ID,
 		State:      event.StateIterationCompleted,
-		Message:    fmt.Sprintf("all %d items completed (parallel)", len(items)),
+		Message:    completedMsg,
 	})
 
 	return nil

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -567,6 +567,7 @@ type IterateConfig struct {
 	Over          string `yaml:"over"`                     // Template expression resolving to JSON array
 	Mode          string `yaml:"mode"`                     // "sequential" or "parallel"
 	MaxConcurrent int    `yaml:"max_concurrent,omitempty"` // Max parallel workers (parallel mode)
+	OnFailure     string `yaml:"on_failure,omitempty"`     // "fail" (default) or "continue" — per-item failure handling
 }
 
 // BranchConfig configures conditional pipeline selection.

--- a/wave.yaml
+++ b/wave.yaml
@@ -473,7 +473,7 @@ runtime:
         strategy: summarize_to_checkpoint
         token_threshold_percent: 80
     timeouts:
-        step_default_minutes: 5
+        step_default_minutes: 15
         relay_compaction_minutes: 5
         meta_default_minutes: 30
         skill_install_seconds: 120


### PR DESCRIPTION
## Summary

ops-pr-respond's parallel-review iterate fan-out hit two issues that combined to make the showcase pipeline impossible to drive to completion:

1. **Default step timeout `step_default_minutes: 5` killed the audit-* sub-pipelines' deep-dive step** (strongest model, 5–10 min typical). Bump to 15 minutes covers the realistic upper bound for an LLM-driven audit step without giving runaway prompts free rein.
2. **iterate had no `on_failure` switch** — any single child failure killed the whole iterate via errgroup short-circuit. With six audit children and a five-minute squeeze, even one timeout flat-killed the run, defeating the multi-axis design.

## Changes

- `internal/pipeline/types.go` — adds `IterateConfig.OnFailure` (yaml `on_failure`, default `"fail"`, accepts `"continue"`).
- `internal/pipeline/composition.go`
  - **parallel mode**: per-goroutine errors are recorded and swallowed; siblings keep running. The completion event reports the surviving count and the failing items.
  - **sequential mode**: per-item error logged as a warning, loop continues.
- `internal/defaults/pipelines/ops-pr-respond.yaml` + `.agents/pipelines/ops-pr-respond.yaml` — wires `on_failure: continue` into `parallel-review` (six audits). `impl-finding`'s `resolve-each` stays at default `"fail"` — fixes must succeed atomically.
- `wave.yaml` — `step_default_minutes: 5 → 15`.

## Empirical baseline

Run `ops-pr-respond-20260427-222912-3df6` on PR re-cinq/wave#1441 before this PR: 3 of 6 audits hit the 5-min default; iterate failed; pipeline halted. Post-fix expectation: 5+ of 6 complete and the run proceeds to merge-findings → filter-scope → triage.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pipeline/`
- [ ] CI validate
- [ ] Re-run ops-pr-respond on a fresh PR; verify (a) audit deep-dive doesn't time out at 5 min and (b) one audit failure no longer kills the run.

## Related

- #1401 (ops-pr-respond e2e validation) — gated on this PR landing before the close-out run can succeed.
- #1411 (scope audits to PR diff) — partial fix already merged via PR #1436; this PR is the resilience layer that lets the scoping pay off.
- #1442 (audit-issue pipeline showcase) — also relies on iterate.on_failure once it lands.