### PR TITLE
fix(pipeline): skip stall watchdog for composition steps

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1857,17 +1857,27 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 		// Start progress ticker for smooth animation updates during step execution
 		cancelTicker := e.startProgressTicker(ctx, pipelineID, step.ID)
 
-		// Start stall watchdog if configured
+		// Start stall watchdog if configured. Composition steps (iterate /
+		// aggregate / branch / loop / sub_pipeline) do not produce their
+		// own stream events — their work happens in spawned child
+		// pipelines under separate run IDs. Wiring a stall watchdog to
+		// them would fire after the configured timeout regardless of
+		// whether children are healthy. Skip the watchdog for those step
+		// kinds; each child pipeline owns its own stall watchdog.
 		stepCtx := ctx
 		var watchdog *StallWatchdog
-		if stallTimeout := e.parseStallTimeout(execution.Manifest); stallTimeout > 0 {
-			w, err := NewStallWatchdog(stallTimeout)
-			if err != nil {
-				cancelTicker()
-				return fmt.Errorf("step %s: stall watchdog setup: %w", step.ID, err)
+		isCompositionStep := step.Iterate != nil || step.Aggregate != nil ||
+			step.Branch != nil || step.Loop != nil || step.SubPipeline != ""
+		if !isCompositionStep {
+			if stallTimeout := e.parseStallTimeout(execution.Manifest); stallTimeout > 0 {
+				w, err := NewStallWatchdog(stallTimeout)
+				if err != nil {
+					cancelTicker()
+					return fmt.Errorf("step %s: stall watchdog setup: %w", step.ID, err)
+				}
+				watchdog = w
+				stepCtx = watchdog.Start(stepCtx)
 			}
-			watchdog = w
-			stepCtx = watchdog.Start(stepCtx)
 		}
 
 		// Store watchdog on execution so runStepExecution can wire NotifyActivity


### PR DESCRIPTION
## Summary

Composition steps (iterate / aggregate / branch / loop / sub_pipeline) don't emit their own stream events — their work happens in spawned child pipelines under separate run IDs. The parent's stall watchdog therefore receives no `NotifyActivity` calls and trips after the configured `stall_timeout` (default 10 m) regardless of child health.

## Empirical baseline

`ops-pr-respond-20260427-225629-8d83` on PR re-cinq/wave#1441. The `parallel-review` step fanned out six audit children all making progress. The parent's watchdog saw no activity for 13 minutes (every stream event flowed under a child run ID), then context-cancelled all six children simultaneously and reported the iterate as failed even though five had completed successfully.

```
sub-pipeline "audit-dead-code-scan" failed: step "scan" failed:
  adapter execution failed: general_error: context canceled
```

(Six children, six identical errors at the same second.)

## Changes

- `internal/pipeline/executor.go` — gate the watchdog creation on a non-composition check. Composition steps now run without a watchdog at the parent level. Children own their own watchdogs; per-child stall detection still fires for genuine stalls.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pipeline/`
- [ ] Re-run ops-pr-respond on a representative PR. Expect the parent step to wait for parallel-review to complete (10–15 minutes) without context-cancelling its own children.

## Related

- #1401 (ops-pr-respond e2e validation) — gated on this PR landing.
- #1446 (composition resilience: iterate.on_failure + step timeout bump) — orthogonal; this PR fixes a different layer of the same cascade.