### PR TITLE
fix(pipeline): bind .agents/output into filter-scope command workspace

### DIFF
--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -224,6 +224,19 @@ steps:
   - id: filter-scope
     type: command
     dependencies: [merge-findings, fetch-pr]
+    # Bind the project's `.agents/output/` into the command workspace so the
+    # script can read upstream artifacts (`merged-findings.json` from the
+    # aggregate step, `pr-context.json` from fetch-pr — both written at the
+    # project root) AND write its own outputs (`scoped-findings.json`,
+    # `scope-filter-stats.json`) where downstream steps expect them. Command
+    # steps run in an isolated workspace dir by default and have no
+    # `memory.inject_artifacts` plumbing, so a workspace mount is the
+    # natural way to share a directory.
+    workspace:
+      mount:
+        - source: .agents/output
+          target: .agents/output
+          mode: readwrite
     script: |
       set -o pipefail
       mkdir -p .agents/output

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -224,6 +224,19 @@ steps:
   - id: filter-scope
     type: command
     dependencies: [merge-findings, fetch-pr]
+    # Bind the project's `.agents/output/` into the command workspace so the
+    # script can read upstream artifacts (`merged-findings.json` from the
+    # aggregate step, `pr-context.json` from fetch-pr — both written at the
+    # project root) AND write its own outputs (`scoped-findings.json`,
+    # `scope-filter-stats.json`) where downstream steps expect them. Command
+    # steps run in an isolated workspace dir by default and have no
+    # `memory.inject_artifacts` plumbing, so a workspace mount is the
+    # natural way to share a directory.
+    workspace:
+      mount:
+        - source: .agents/output
+          target: .agents/output
+          mode: readwrite
     script: |
       set -o pipefail
       mkdir -p .agents/output


### PR DESCRIPTION
## Summary

`filter-scope` is a `type: command` step. Command steps run in an isolated workspace dir that has no link to the project's `.agents/output/`. The aggregate step (`merge-findings`) writes `merged-findings.json` and `fetch-pr` writes `pr-context.json` at the project root, so filter-scope's relative-path reads returned ENOENT and the script exited 1 with `filter-scope: missing input`.

Bind-mount `.agents/output/` from the project into the command's workspace at the same target path, readwrite (the script also writes `scoped-findings.json` + `scope-filter-stats.json`). Command steps don't support `memory.inject_artifacts`, so a workspace mount is the natural plumbing.

## Empirical baseline

`ops-pr-respond-20260427-233305-a9d7` on PR re-cinq/wave#1441. All 6 audits + merge-findings completed; pipeline died at filter-scope with `filter-scope: missing input (.agents/output/merged-findings.json or .agents/output/pr-context.json)`.

## Changes

- `internal/defaults/pipelines/ops-pr-respond.yaml` + `.agents/pipelines/ops-pr-respond.yaml` — add `workspace.mount` to the `filter-scope` step. No script changes — paths stay the same.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pipeline/`
- [ ] Re-run ops-pr-respond on PR 1441; verify filter-scope reads upstream artifacts and produces `scoped-findings.json` for triage.

## Related

- #1411 (scope audits) — introduced filter-scope but never validated with command-step workspace semantics.
- #1401 (ops-pr-respond e2e) — validation gated on this PR landing.