### PR TITLE
fix(adapter): pipe Claude prompt via stdin to avoid E2BIG

### DIFF
--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -68,6 +68,9 @@ func (a *ClaudeAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapter
 	args := a.buildArgs(cfg)
 	cmd := exec.CommandContext(ctx, a.claudePath, args...)
 	cmd.Dir = workspacePath
+	if cfg.Prompt != "" {
+		cmd.Stdin = strings.NewReader(cfg.Prompt)
+	}
 
 	if cfg.Debug {
 		fmt.Printf("[DEBUG] Claude command: %s %s\n", a.claudePath, shelljoinArgs(args))
@@ -421,9 +424,10 @@ func (a *ClaudeAdapter) buildArgs(cfg AdapterRunConfig) []string {
 	args = append(args, "--dangerously-skip-permissions")
 	args = append(args, "--no-session-persistence")
 
-	if cfg.Prompt != "" {
-		args = append(args, cfg.Prompt)
-	}
+	// Prompt is piped via stdin (see Run). Linux ARG_MAX is ~2 MB and the
+	// argv shares that budget with envp; large prompts (relay compaction
+	// chat history with thousands of tool_use events) blew through it as
+	// E2BIG ("fork/exec: argument list too long"). stdin has no size cap.
 
 	return args
 }


### PR DESCRIPTION
## Summary

The Claude adapter passed `cfg.Prompt` as a positional argv element. On Linux argv shares ARG_MAX (~2 MB) with envp; the practical ceiling is closer to 1.5 MB. Relay-compaction passes the entire chat history as its prompt, and on busy impl-issue runs (thousands of stream events × tool_use payloads) the chatHistory routinely exceeds that ceiling, producing:

```
fork/exec /etc/profiles/per-user/mwc/bin/claude: argument list too long
```

after which the compaction step warns out and the run loses context-window slack.

## Fix

Pipe the prompt through stdin instead. The Claude CLI reads the prompt from stdin when no positional argument is supplied. One-line change in `Run` plus removing the argv append in `buildArgs`. No size limit applies to stdin.

## Empirical baseline

`impl-issue-20260427-202621-eb94` (the impl-issue on issue #1411) implement step emitted:

```
relay compaction failed: compaction failed: compaction failed:
  compaction adapter failed: failed to start claude:
  fork/exec /etc/profiles/per-user/mwc/bin/claude:
  argument list too long
```

at the 80 % token threshold compaction trigger.

## Changes

- `internal/adapter/claude.go`
  - `buildArgs`: drop the `args = append(args, cfg.Prompt)` line; argv stays compact.
  - `Run`: set `cmd.Stdin = strings.NewReader(cfg.Prompt)` when prompt is non-empty.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/`
- [ ] Re-run a long impl-issue / ops-pr-respond pipeline; verify relay compaction succeeds at 80 % threshold without E2BIG.

## Side effects

Every `Run` call (regular runs, not just compaction) now uses stdin for the prompt. Other adapters (`codex`, `gemini`, `opencode`) already use file/stdin patterns; this brings Claude in line.

## Related

- #8 (compaction E2BIG investigation) — closes this work.