### PR TITLE
fix(personas): register webui-capturer in wave.yaml

### DIFF
--- a/wave.yaml
+++ b/wave.yaml
@@ -204,6 +204,15 @@ personas:
                 - "*"
             deny: []
         system_prompt_file: .agents/personas/summarizer.md
+    webui-capturer:
+        adapter: claude
+        description: Browser-driven WebUI screenshot capture via the chromedp adapter
+        #temperature: 0.0
+        permissions:
+            allowed_tools:
+                - "*"
+            deny: []
+        system_prompt_file: .agents/personas/webui-capturer.md
     github-analyst:
         adapter: claude
         description: GitHub issue analysis and quality assessment


### PR DESCRIPTION
## Summary

PR #1445 shipped the webui-capturer persona's source files (`.agents/personas/webui-capturer.{md,yaml}` and `internal/defaults/personas/` mirrors) but did not add the persona entry to `wave.yaml`'s `personas:` map. The manifest registry is the loader's source of truth; without the entry, `audit-webui-shots` fails at step entry with:

```
sub-pipeline "audit-webui-shots" failed: step "capture" failed:
  persona "webui-capturer" not found in manifest
```

## Empirical baseline

`audit-issue-20260428-000751-f1e2` on issue re-cinq/wave#1450 — all four `parallel-evidence` children failed at 1 s because `audit-webui-shots` couldn't resolve its persona.

## Changes

- `wave.yaml` — add the `webui-capturer` entry next to `summarizer` (Claude adapter, `*` allowed tools, deny `[]`, `system_prompt_file: .agents/personas/webui-capturer.md`).

## Test plan

- [x] `go test ./internal/defaults/`
- [x] `wave validate`
- [ ] Re-run `audit-issue` on a representative issue; verify `audit-webui-shots` resolves the persona and proceeds.

## Related

- #1442 (audit-issue proposal)
- PR #1445 (audit-issue impl — original ship; this is its missing manifest entry)