### PR TITLE
feat(pipeline): native auto-injection of upstream dependency artifacts (#1452 PR1)

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -1,0 +1,285 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/recinq/wave/internal/event"
+)
+
+// ResolvedArtifact describes one artifact produced by a dependency that
+// has been located on disk and is ready for injection into a downstream
+// step's workspace.
+type ResolvedArtifact struct {
+	DepStep  string // ID of the dependency step
+	Name     string // artifact name as declared in OutputArtifacts
+	Path     string // absolute path to the artifact source file
+	Type     string // declared artifact type (json/text/markdown/binary)
+	Optional bool   // mirrors ArtifactDef.Required (negated)
+}
+
+// ResolveDependencyArtifacts inspects step.Dependencies, reads every declared
+// upstream OutputArtifact and locates each one on disk by walking, in order:
+//
+//  1. execution.ArtifactPaths[<dep>:<name>] (in-memory, parent process).
+//  2. e.store.GetArtifacts(runID, dep) (DB, resume-safe, cross-process).
+//  3. execution.Context.ArtifactPaths[<dep>.<name>] (composition namespaced).
+//  4. <dep_workspace>/.agents/artifacts/<dep>/<name> (filesystem fallback).
+//
+// Returned map is keyed "<dep>:<name>".
+//
+// Optional artifacts that cannot be located are silently skipped. Required
+// artifacts that cannot be located return an error naming both dep and name.
+func (e *DefaultPipelineExecutor) ResolveDependencyArtifacts(execution *PipelineExecution, step *Step) (map[string]ResolvedArtifact, error) {
+	resolved := make(map[string]ResolvedArtifact)
+	if execution == nil || step == nil || len(step.Dependencies) == 0 || execution.Pipeline == nil {
+		return resolved, nil
+	}
+
+	for _, depID := range step.Dependencies {
+		depStep := findStepByID(execution.Pipeline, depID)
+		if depStep == nil {
+			// Dependency not declared in pipeline — skip silently.
+			// DAG validation already errors on undeclared deps.
+			continue
+		}
+
+		for _, art := range depStep.OutputArtifacts {
+			required := art.Required
+			path, found := e.locateDepArtifact(execution, depID, art.Name)
+			if !found {
+				if required {
+					return nil, fmt.Errorf("dependency %q output artifact %q not found", depID, art.Name)
+				}
+				continue
+			}
+			key := depID + ":" + art.Name
+			resolved[key] = ResolvedArtifact{
+				DepStep:  depID,
+				Name:     art.Name,
+				Path:     path,
+				Type:     art.Type,
+				Optional: !required,
+			}
+		}
+	}
+
+	return resolved, nil
+}
+
+// locateDepArtifact walks the four lookup tiers documented on
+// ResolveDependencyArtifacts. Returns the located absolute path and true
+// when found and the file exists on disk.
+func (e *DefaultPipelineExecutor) locateDepArtifact(execution *PipelineExecution, depID, name string) (string, bool) {
+	// Tier 1: in-memory ArtifactPaths.
+	execution.mu.Lock()
+	path, ok := execution.ArtifactPaths[depID+":"+name]
+	execution.mu.Unlock()
+	if ok && fileExists(path) {
+		return path, true
+	}
+
+	// Tier 2: DB.
+	if e.store != nil && execution.Status != nil && execution.Status.ID != "" {
+		if records, err := e.store.GetArtifacts(execution.Status.ID, depID); err == nil {
+			for _, rec := range records {
+				if rec.Name == name && fileExists(rec.Path) {
+					return rec.Path, true
+				}
+			}
+		}
+	}
+
+	// Tier 3: composition-namespaced context.
+	if execution.Context != nil {
+		if p := execution.Context.GetArtifactPath(depID + "." + name); p != "" && fileExists(p) {
+			return p, true
+		}
+		// Some composition writers register under bare name as well.
+		if p := execution.Context.GetArtifactPath(name); p != "" && fileExists(p) {
+			return p, true
+		}
+	}
+
+	// Tier 4: filesystem fallback inside the dep's own workspace.
+	execution.mu.Lock()
+	depWorkspace := execution.WorkspacePaths[depID]
+	execution.mu.Unlock()
+	if depWorkspace != "" {
+		candidates := []string{
+			filepath.Join(depWorkspace, ".agents", "artifacts", depID, name),
+			filepath.Join(depWorkspace, ".agents", "artifacts", name),
+			filepath.Join(depWorkspace, ".agents", "output", name),
+		}
+		for _, c := range candidates {
+			if fileExists(c) {
+				return c, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// injectDependencyArtifacts resolves every dependency artifact for the
+// given step and copies (symlinks where possible) the resolved files into
+// the step's workspace at canonical locations:
+//
+//	<workspace>/.agents/artifacts/<dep>/<name>           (canonical)
+//	<workspace>/.agents/output/<name>                    (back-compat alias)
+//
+// It also registers the canonical path in execution.Context under the
+// "<dep>.<name>" namespace so {{ artifacts.<dep>.<name> }} resolves.
+//
+// Failures on optional artifacts are warnings; required artifacts that
+// cannot be linked or copied propagate as errors.
+func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineExecution, step *Step, workspacePath string) error {
+	if execution == nil || step == nil || workspacePath == "" {
+		return nil
+	}
+
+	resolved, err := e.ResolveDependencyArtifacts(execution, step)
+	if err != nil {
+		return err
+	}
+	if len(resolved) == 0 {
+		return nil
+	}
+
+	pipelineID := ""
+	if execution.Status != nil {
+		pipelineID = execution.Status.ID
+	}
+
+	artifactsRoot := filepath.Join(workspacePath, ".agents", "artifacts")
+	outputRoot := filepath.Join(workspacePath, ".agents", "output")
+	if err := os.MkdirAll(artifactsRoot, 0755); err != nil {
+		return fmt.Errorf("failed to create artifacts dir: %w", err)
+	}
+	if err := os.MkdirAll(outputRoot, 0755); err != nil {
+		return fmt.Errorf("failed to create output dir: %w", err)
+	}
+
+	// Track collisions on the back-compat alias path so we can warn but
+	// not fail when two deps both produce the same bare artifact name.
+	aliasOwners := make(map[string]string)
+
+	for _, art := range resolved {
+		canonicalDir := filepath.Join(artifactsRoot, art.DepStep)
+		if err := os.MkdirAll(canonicalDir, 0755); err != nil {
+			return fmt.Errorf("failed to create canonical dir %q: %w", canonicalDir, err)
+		}
+		canonicalPath := filepath.Join(canonicalDir, art.Name)
+
+		if err := linkOrCopy(art.Path, canonicalPath); err != nil {
+			if art.Optional {
+				e.emit(event.Event{
+					Timestamp:  time.Now(),
+					PipelineID: pipelineID,
+					StepID:     step.ID,
+					State:      "step_progress",
+					Message:    fmt.Sprintf("optional dep artifact %s/%s skipped: %v", art.DepStep, art.Name, err),
+				})
+				continue
+			}
+			return fmt.Errorf("failed to inject %s/%s: %w", art.DepStep, art.Name, err)
+		}
+
+		// Back-compat alias at .agents/output/<name>. Warn on collision.
+		aliasPath := filepath.Join(outputRoot, art.Name)
+		if prev, exists := aliasOwners[art.Name]; exists && prev != art.DepStep {
+			e.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: pipelineID,
+				StepID:     step.ID,
+				State:      "step_progress",
+				Message:    fmt.Sprintf("dep artifact name collision on %q: %s vs %s — alias .agents/output/%s won by %s; canonical paths remain unambiguous", art.Name, prev, art.DepStep, art.Name, art.DepStep),
+			})
+		}
+		_ = os.Remove(aliasPath)
+		if err := linkOrCopy(canonicalPath, aliasPath); err != nil {
+			// Alias failure is non-fatal — canonical path still works.
+			e.emit(event.Event{
+				Timestamp:  time.Now(),
+				PipelineID: pipelineID,
+				StepID:     step.ID,
+				State:      "step_progress",
+				Message:    fmt.Sprintf("alias .agents/output/%s could not be created: %v", art.Name, err),
+			})
+		} else {
+			aliasOwners[art.Name] = art.DepStep
+		}
+
+		// Register canonical path under {{ artifacts.<dep>.<name> }}.
+		if execution.Context != nil {
+			execution.Context.SetArtifactPath(art.DepStep+"."+art.Name, canonicalPath)
+		}
+	}
+
+	return nil
+}
+
+// findStepByID returns the step in p whose ID matches id, or nil.
+func findStepByID(p *Pipeline, id string) *Step {
+	if p == nil {
+		return nil
+	}
+	for i := range p.Steps {
+		if p.Steps[i].ID == id {
+			return &p.Steps[i]
+		}
+	}
+	return nil
+}
+
+// fileExists reports whether path refers to an existing filesystem entry.
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// linkOrCopy attempts to symlink dest → src (cheap, atomic). Falls back to
+// a hard copy when the filesystem rejects symlinks (e.g. Windows CI) or
+// when src and dest live on filesystems that disagree.
+func linkOrCopy(src, dest string) error {
+	if src == dest {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+	// If dest already exists pointing to src, leave it.
+	if existing, err := os.Readlink(dest); err == nil && existing == src {
+		return nil
+	}
+	_ = os.Remove(dest)
+	if err := os.Symlink(src, dest); err == nil {
+		return nil
+	}
+	// Fallback: copy.
+	srcF, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcF.Close()
+	destF, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(destF, srcF); err != nil {
+		destF.Close()
+		return err
+	}
+	return destF.Close()
+}
+
+// ErrDepArtifactMissing is returned when a required dep artifact cannot be
+// located on disk via any tier of the resolver.
+var ErrDepArtifactMissing = errors.New("dep artifact missing")

--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -279,7 +278,3 @@ func linkOrCopy(src, dest string) error {
 	}
 	return destF.Close()
 }
-
-// ErrDepArtifactMissing is returned when a required dep artifact cannot be
-// located on disk via any tier of the resolver.
-var ErrDepArtifactMissing = errors.New("dep artifact missing")

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -1,0 +1,218 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/manifest"
+)
+
+// fixtureExecution constructs a PipelineExecution with a two-step pipeline:
+// the upstream "fetch" step declares a single output artifact "pr-context".
+// The caller decides how to register the artifact (in-memory, context, fs).
+func fixtureExecution(t *testing.T, fetchOutputs []ArtifactDef) *PipelineExecution {
+	t.Helper()
+	pipe := &Pipeline{
+		Steps: []Step{
+			{ID: "fetch", OutputArtifacts: fetchOutputs},
+			{ID: "consume", Dependencies: []string{"fetch"}},
+		},
+	}
+	exec := &PipelineExecution{
+		Pipeline:       pipe,
+		Manifest:       &manifest.Manifest{},
+		ArtifactPaths:  map[string]string{},
+		WorkspacePaths: map[string]string{},
+		WorktreePaths:  map[string]*WorktreeInfo{},
+		Status:         &PipelineStatus{ID: "test-run-1"},
+		Context:        NewPipelineContext("test-run-1", "test", "consume"),
+	}
+	return exec
+}
+
+// writeArtifactFile is a tiny helper that writes content under tmp and returns the path.
+func writeArtifactFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// TestResolveDependencyArtifacts_InMemoryArtifactPaths covers tier 1: the
+// primary lookup path used by persona / command steps that successfully
+// registered their outputs in execution.ArtifactPaths.
+func TestResolveDependencyArtifacts_InMemoryArtifactPaths(t *testing.T) {
+	tmp := t.TempDir()
+	src := writeArtifactFile(t, tmp, "pr-context.json", `{"pr":1441}`)
+
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "pr-context", Type: "json", Required: true},
+	})
+	exec.ArtifactPaths["fetch:pr-context"] = src
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, ok := resolved["fetch:pr-context"]
+	if !ok {
+		t.Fatalf("missing fetch:pr-context entry; got %v", resolved)
+	}
+	if got.Path != src {
+		t.Errorf("path = %q, want %q", got.Path, src)
+	}
+	if got.Optional {
+		t.Error("expected required (Optional=false)")
+	}
+}
+
+// TestResolveDependencyArtifacts_ContextNamespacedFallback covers tier 3:
+// composition writers register under "<dep>.<name>" in the context.
+func TestResolveDependencyArtifacts_ContextNamespacedFallback(t *testing.T) {
+	tmp := t.TempDir()
+	src := writeArtifactFile(t, tmp, "merged-findings.json", `[]`)
+
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "merged-findings", Type: "json", Required: true},
+	})
+	exec.Context.SetArtifactPath("fetch.merged-findings", src)
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, ok := resolved["fetch:merged-findings"]
+	if !ok {
+		t.Fatalf("missing entry; got %v", resolved)
+	}
+	if got.Path != src {
+		t.Errorf("path = %q, want %q", got.Path, src)
+	}
+}
+
+// TestResolveDependencyArtifacts_FilesystemFallback covers tier 4: the
+// dep registered nothing, but the file is present in its workspace at the
+// canonical path.
+func TestResolveDependencyArtifacts_FilesystemFallback(t *testing.T) {
+	tmp := t.TempDir()
+	depWorkspace := filepath.Join(tmp, "ws-fetch")
+	canonicalDir := filepath.Join(depWorkspace, ".agents", "artifacts", "fetch")
+	src := writeArtifactFile(t, canonicalDir, "pr-context", `{"pr":1452}`)
+
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "pr-context", Type: "json", Required: true},
+	})
+	exec.WorkspacePaths["fetch"] = depWorkspace
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, ok := resolved["fetch:pr-context"]
+	if !ok {
+		t.Fatalf("missing entry; got %v", resolved)
+	}
+	if got.Path != src {
+		t.Errorf("path = %q, want %q", got.Path, src)
+	}
+}
+
+// TestResolveDependencyArtifacts_RequiredMissingErrors verifies a clear
+// error is returned naming both dep and artifact when nothing matches.
+func TestResolveDependencyArtifacts_RequiredMissingErrors(t *testing.T) {
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "pr-context", Type: "json", Required: true},
+	})
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	_, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err == nil {
+		t.Fatal("expected error for missing required artifact")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "fetch") || !strings.Contains(msg, "pr-context") {
+		t.Errorf("error should name dep and artifact; got: %v", err)
+	}
+}
+
+// TestResolveDependencyArtifacts_OptionalMissingNoError verifies optional
+// artifacts that cannot be located are silently skipped.
+func TestResolveDependencyArtifacts_OptionalMissingNoError(t *testing.T) {
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "pr-context", Type: "json", Required: false},
+	})
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err != nil {
+		t.Fatalf("optional missing should not error; got: %v", err)
+	}
+	if _, ok := resolved["fetch:pr-context"]; ok {
+		t.Errorf("optional missing should be omitted; got %v", resolved)
+	}
+}
+
+// TestInjectDependencyArtifacts_CanonicalAndAlias verifies both the
+// canonical and back-compat alias paths get populated, and that
+// {{ artifacts.<dep>.<name> }} resolves through the context.
+func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
+	tmp := t.TempDir()
+	src := writeArtifactFile(t, filepath.Join(tmp, "src"), "pr-context.json", `{"pr":1441}`)
+	workspace := filepath.Join(tmp, "consume-ws")
+
+	exec := fixtureExecution(t, []ArtifactDef{
+		{Name: "pr-context", Type: "json", Required: true},
+	})
+	exec.ArtifactPaths["fetch:pr-context"] = src
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	if err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[1], workspace); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	canonical := filepath.Join(workspace, ".agents", "artifacts", "fetch", "pr-context")
+	if _, err := os.Stat(canonical); err != nil {
+		t.Errorf("canonical missing: %v", err)
+	}
+	alias := filepath.Join(workspace, ".agents", "output", "pr-context")
+	if _, err := os.Stat(alias); err != nil {
+		t.Errorf("alias missing: %v", err)
+	}
+
+	// Template resolution.
+	got := exec.Context.ResolvePlaceholders("{{ artifacts.fetch.pr-context }}")
+	if got != canonical {
+		t.Errorf("template resolved to %q, want %q", got, canonical)
+	}
+}
+
+// TestInjectDependencyArtifacts_NoDepsNoOp verifies a step with no
+// dependencies makes no filesystem changes.
+func TestInjectDependencyArtifacts_NoDepsNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	exec := &PipelineExecution{
+		Pipeline:       &Pipeline{Steps: []Step{{ID: "solo"}}},
+		ArtifactPaths:  map[string]string{},
+		WorkspacePaths: map[string]string{},
+		Status:         &PipelineStatus{ID: "test"},
+		Context:        NewPipelineContext("test", "t", "solo"),
+	}
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	if err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[0], tmp); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, ".agents")); err == nil {
+		t.Errorf(".agents created for step with no deps")
+	}
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1498,6 +1498,14 @@ func (e *DefaultPipelineExecutor) executeCommandStep(ctx context.Context, execut
 	execution.WorkspacePaths[step.ID] = workspacePath
 	execution.mu.Unlock()
 
+	// Auto-inject declared dependency artifacts (issue #1452). Command
+	// scripts can read upstream outputs at .agents/artifacts/<dep>/<name>
+	// or the back-compat alias .agents/output/<name> without any
+	// workspace.mount or memory.inject_artifacts boilerplate.
+	if err := e.injectDependencyArtifacts(execution, step, workspacePath); err != nil {
+		return nil, fmt.Errorf("failed to auto-inject dep artifacts for step %q: %w", step.ID, err)
+	}
+
 	// Resolve the working directory for the command. For mount-based
 	// workspaces the project files live under the mount target (e.g.
 	// workspacePath/project/), so we set CWD to the project mount
@@ -3223,7 +3231,15 @@ func (e *DefaultPipelineExecutor) resolveStepResources(ctx context.Context, exec
 		)
 	}
 
-	// Inject artifacts from dependencies
+	// Auto-inject every declared dependency's output artifacts into the
+	// canonical .agents/artifacts/<dep>/<name> layout (issue #1452). Runs
+	// BEFORE legacy injectArtifacts so manual `as:` renames can still
+	// overwrite the canonical copy when desired.
+	if err := e.injectDependencyArtifacts(execution, step, workspacePath); err != nil {
+		return nil, fmt.Errorf("failed to auto-inject dep artifacts: %w", err)
+	}
+
+	// Inject artifacts from dependencies (legacy explicit inject_artifacts).
 	artifactInjectStart := time.Now()
 	if err := e.injectArtifacts(execution, step, workspacePath); err != nil {
 		return nil, fmt.Errorf("failed to inject artifacts: %w", err)

--- a/internal/pipeline/matrix.go
+++ b/internal/pipeline/matrix.go
@@ -417,6 +417,14 @@ func (m *MatrixExecutor) executeWorker(ctx context.Context, execution *PipelineE
 	// Create a modified step with the task template variable replaced
 	workerStep := m.createWorkerStep(step, item)
 
+	// Auto-inject declared dep artifacts (issue #1452) before the legacy
+	// explicit inject_artifacts pass so {{ artifacts.<dep>.<name> }} and
+	// .agents/artifacts/<dep>/<name> resolve transparently in the worker.
+	if err := m.executor.injectDependencyArtifacts(execution, workerStep, workspacePath); err != nil {
+		result.Error = fmt.Errorf("failed to auto-inject dep artifacts: %w", err)
+		return result
+	}
+
 	// Inject artifacts from dependencies into worker workspace
 	if err := m.executor.injectArtifacts(execution, workerStep, workspacePath); err != nil {
 		result.Error = fmt.Errorf("failed to inject artifacts: %w", err)


### PR DESCRIPTION
## Summary

First of three PRs implementing #1452. Replaces the three orthogonal manual handoff mechanisms (`memory.inject_artifacts`, `config.inject`, `workspace.mount`) with a single resolver + injector that runs natively on every step.

- New `internal/pipeline/depinject.go` with `ResolveDependencyArtifacts` (read-only) and `injectDependencyArtifacts` (write).
- Wired at the three convergence points where workspaces get created: persona steps (`runStepExecution`), command steps (`executeCommandStep`), and matrix workers (`matrix.go`).
- Legacy `inject_artifacts` and `config.inject` keep working — they run AFTER the auto-injector, so `as:` renames still overwrite the canonical copy.
- No pipeline YAML edits ship here. Per-pipeline cleanup follows in PR4..N.

## How it works

For every dep declared in `step.Dependencies`, the resolver loads the dep step, reads its `OutputArtifacts`, and locates each one in this order:

1. `execution.ArtifactPaths[<dep>:<name>]` (in-memory).
2. `store.GetArtifacts(runID, dep)` (DB, resume-safe).
3. `execution.Context.ArtifactPaths[<dep>.<name>]` (composition namespaced).
4. `<dep_workspace>/.agents/artifacts/{<dep>/,}<name>` filesystem walk.

The injector copies (symlink first, hard copy fallback) into `<workspace>/.agents/artifacts/<dep>/<name>` and a back-compat alias at `<workspace>/.agents/output/<name>`. Collisions on the alias path emit a `step_progress` warning naming both deps; canonical paths remain unambiguous.

## Test plan

- [x] `go test ./internal/pipeline/` — 7 new resolver/injector tests pass
- [x] `go test -race ./internal/pipeline/` — clean
- [x] `go test ./...` — all packages green
- [x] `golangci-lint run ./internal/pipeline/` — 0 issues
- [ ] Validation runs deferred to PR3 (live `wave run ops-pr-respond` against PR 1441 reaching `filter-scope` without ENOENT)

## Follow-ups

- PR2: Phase 3 surface — `{{ deps.<dep>.<name> }}` template + `WAVE_DEP_<DEP>_<NAME>` env vars + `WAVE_DEPS_DIR`
- PR3: validation runs documented + `wave validate` warns on now-redundant manual injection blocks
- PR4..N: per-pipeline cleanup, starting with `ops-pr-respond.yaml` (drops the filter-scope `workspace.mount` band-aid)

Closes the architectural half of #1452.