### PR TITLE
feat(pipeline): deps.* template + WAVE_DEP_* env (#1452 PR2)

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/recinq/wave/internal/event"
@@ -136,17 +137,22 @@ func (e *DefaultPipelineExecutor) locateDepArtifact(execution *PipelineExecution
 //
 // Failures on optional artifacts are warnings; required artifacts that
 // cannot be linked or copied propagate as errors.
-func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineExecution, step *Step, workspacePath string) error {
+//
+// The returned map is keyed "<dep>:<name>" with Path rewritten to the
+// canonical post-injection path (.agents/artifacts/<dep>/<name>) so
+// callers can build env-var or template surfaces from it without
+// re-resolving. Returns nil for steps with no dependencies.
+func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineExecution, step *Step, workspacePath string) (map[string]ResolvedArtifact, error) {
 	if execution == nil || step == nil || workspacePath == "" {
-		return nil
+		return nil, nil
 	}
 
 	resolved, err := e.ResolveDependencyArtifacts(execution, step)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(resolved) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	pipelineID := ""
@@ -157,20 +163,21 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 	artifactsRoot := filepath.Join(workspacePath, ".agents", "artifacts")
 	outputRoot := filepath.Join(workspacePath, ".agents", "output")
 	if err := os.MkdirAll(artifactsRoot, 0755); err != nil {
-		return fmt.Errorf("failed to create artifacts dir: %w", err)
+		return nil, fmt.Errorf("failed to create artifacts dir: %w", err)
 	}
 	if err := os.MkdirAll(outputRoot, 0755); err != nil {
-		return fmt.Errorf("failed to create output dir: %w", err)
+		return nil, fmt.Errorf("failed to create output dir: %w", err)
 	}
 
 	// Track collisions on the back-compat alias path so we can warn but
 	// not fail when two deps both produce the same bare artifact name.
 	aliasOwners := make(map[string]string)
+	canonical := make(map[string]ResolvedArtifact, len(resolved))
 
 	for _, art := range resolved {
 		canonicalDir := filepath.Join(artifactsRoot, art.DepStep)
 		if err := os.MkdirAll(canonicalDir, 0755); err != nil {
-			return fmt.Errorf("failed to create canonical dir %q: %w", canonicalDir, err)
+			return nil, fmt.Errorf("failed to create canonical dir %q: %w", canonicalDir, err)
 		}
 		canonicalPath := filepath.Join(canonicalDir, art.Name)
 
@@ -185,7 +192,7 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 				})
 				continue
 			}
-			return fmt.Errorf("failed to inject %s/%s: %w", art.DepStep, art.Name, err)
+			return nil, fmt.Errorf("failed to inject %s/%s: %w", art.DepStep, art.Name, err)
 		}
 
 		// Back-compat alias at .agents/output/<name>. Warn on collision.
@@ -213,13 +220,59 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 			aliasOwners[art.Name] = art.DepStep
 		}
 
-		// Register canonical path under {{ artifacts.<dep>.<name> }}.
+		// Register canonical path under both {{ artifacts.<dep>.<name> }}
+		// (existing namespace) and {{ deps.<dep>.<name> }} (new, dep-scoped
+		// namespace introduced by issue #1452 phase 3).
 		if execution.Context != nil {
 			execution.Context.SetArtifactPath(art.DepStep+"."+art.Name, canonicalPath)
+			execution.Context.SetCustomVariable("deps."+art.DepStep+"."+art.Name, canonicalPath)
+		}
+
+		canonical[art.DepStep+":"+art.Name] = ResolvedArtifact{
+			DepStep:  art.DepStep,
+			Name:     art.Name,
+			Path:     canonicalPath,
+			Type:     art.Type,
+			Optional: art.Optional,
 		}
 	}
 
-	return nil
+	return canonical, nil
+}
+
+// BuildDepEnvVars returns the WAVE_DEP_<DEP>_<NAME> + WAVE_DEPS_DIR env
+// entries (KEY=VALUE strings) for the given resolved-dep map and
+// workspace. Names are uppercased; non-alphanumerics become underscores.
+// Empty map / empty workspace returns an empty slice.
+func BuildDepEnvVars(resolved map[string]ResolvedArtifact, workspacePath string) []string {
+	if workspacePath == "" {
+		return nil
+	}
+	out := make([]string, 0, len(resolved)+1)
+	out = append(out, "WAVE_DEPS_DIR="+filepath.Join(workspacePath, ".agents", "artifacts"))
+	for _, art := range resolved {
+		out = append(out, "WAVE_DEP_"+envSlug(art.DepStep)+"_"+envSlug(art.Name)+"="+art.Path)
+	}
+	return out
+}
+
+// envSlug uppercases s and replaces every non-alphanumeric byte with `_`,
+// producing a token safe for use in environment-variable names.
+func envSlug(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			b.WriteByte(c)
+		case c >= 'a' && c <= 'z':
+			b.WriteByte(c - 32)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // findStepByID returns the step in p whose ID matches id, or nil.

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -177,7 +177,8 @@ func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
 	exec.ArtifactPaths["fetch:pr-context"] = src
 
 	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
-	if err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[1], workspace); err != nil {
+	canonicalMap, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[1], workspace)
+	if err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 
@@ -190,10 +191,24 @@ func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
 		t.Errorf("alias missing: %v", err)
 	}
 
-	// Template resolution.
+	// Template resolution under the existing artifacts namespace.
 	got := exec.Context.ResolvePlaceholders("{{ artifacts.fetch.pr-context }}")
 	if got != canonical {
-		t.Errorf("template resolved to %q, want %q", got, canonical)
+		t.Errorf("artifacts template resolved to %q, want %q", got, canonical)
+	}
+	// Template resolution under the new dep-scoped namespace (issue #1452 phase 3).
+	gotDeps := exec.Context.ResolvePlaceholders("{{ deps.fetch.pr-context }}")
+	if gotDeps != canonical {
+		t.Errorf("deps template resolved to %q, want %q", gotDeps, canonical)
+	}
+
+	// Returned canonical map should reflect post-injection paths.
+	got2, ok := canonicalMap["fetch:pr-context"]
+	if !ok {
+		t.Fatalf("canonical map missing fetch:pr-context entry; got %v", canonicalMap)
+	}
+	if got2.Path != canonical {
+		t.Errorf("canonical map path = %q, want %q", got2.Path, canonical)
 	}
 }
 
@@ -209,10 +224,52 @@ func TestInjectDependencyArtifacts_NoDepsNoOp(t *testing.T) {
 		Context:        NewPipelineContext("test", "t", "solo"),
 	}
 	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
-	if err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[0], tmp); err != nil {
+	if _, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[0], tmp); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(tmp, ".agents")); err == nil {
 		t.Errorf(".agents created for step with no deps")
+	}
+}
+
+// TestBuildDepEnvVars verifies the env-name slug rule and that
+// WAVE_DEPS_DIR is always emitted alongside per-artifact entries.
+func TestBuildDepEnvVars(t *testing.T) {
+	resolved := map[string]ResolvedArtifact{
+		"fetch-pr:pr-context":     {DepStep: "fetch-pr", Name: "pr-context", Path: "/ws/.agents/artifacts/fetch-pr/pr-context"},
+		"merge-findings:findings": {DepStep: "merge-findings", Name: "findings", Path: "/ws/.agents/artifacts/merge-findings/findings"},
+	}
+	got := BuildDepEnvVars(resolved, "/ws")
+
+	want := map[string]string{
+		"WAVE_DEPS_DIR":                "/ws/.agents/artifacts",
+		"WAVE_DEP_FETCH_PR_PR_CONTEXT": "/ws/.agents/artifacts/fetch-pr/pr-context",
+		"WAVE_DEP_MERGE_FINDINGS_FINDINGS": "/ws/.agents/artifacts/merge-findings/findings",
+	}
+	gotMap := make(map[string]string, len(got))
+	for _, kv := range got {
+		idx := -1
+		for i, c := range kv {
+			if c == '=' {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			t.Fatalf("malformed env entry %q", kv)
+		}
+		gotMap[kv[:idx]] = kv[idx+1:]
+	}
+	for k, v := range want {
+		if gotMap[k] != v {
+			t.Errorf("%s = %q, want %q (full env: %v)", k, gotMap[k], v, gotMap)
+		}
+	}
+}
+
+// TestBuildDepEnvVars_EmptyWorkspace returns nil when no workspace path.
+func TestBuildDepEnvVars_EmptyWorkspace(t *testing.T) {
+	if got := BuildDepEnvVars(map[string]ResolvedArtifact{"x:y": {}}, ""); got != nil {
+		t.Errorf("expected nil, got %v", got)
 	}
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1502,7 +1502,8 @@ func (e *DefaultPipelineExecutor) executeCommandStep(ctx context.Context, execut
 	// scripts can read upstream outputs at .agents/artifacts/<dep>/<name>
 	// or the back-compat alias .agents/output/<name> without any
 	// workspace.mount or memory.inject_artifacts boilerplate.
-	if err := e.injectDependencyArtifacts(execution, step, workspacePath); err != nil {
+	depArtifacts, err := e.injectDependencyArtifacts(execution, step, workspacePath)
+	if err != nil {
 		return nil, fmt.Errorf("failed to auto-inject dep artifacts for step %q: %w", step.ID, err)
 	}
 
@@ -1521,6 +1522,10 @@ func (e *DefaultPipelineExecutor) executeCommandStep(ctx context.Context, execut
 	// Prevents leaking secrets, API keys, or other sensitive environment
 	// variables into the command subprocess.
 	cmd.Env = filterEnvPassthrough(execution.Manifest.Runtime.Sandbox.EnvPassthrough)
+
+	// Append WAVE_DEP_<DEP>_<NAME>=<canonical path> + WAVE_DEPS_DIR for
+	// every auto-injected upstream artifact. Issue #1452 phase 3.
+	cmd.Env = append(cmd.Env, BuildDepEnvVars(depArtifacts, workspacePath)...)
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -3235,7 +3240,7 @@ func (e *DefaultPipelineExecutor) resolveStepResources(ctx context.Context, exec
 	// canonical .agents/artifacts/<dep>/<name> layout (issue #1452). Runs
 	// BEFORE legacy injectArtifacts so manual `as:` renames can still
 	// overwrite the canonical copy when desired.
-	if err := e.injectDependencyArtifacts(execution, step, workspacePath); err != nil {
+	if _, err := e.injectDependencyArtifacts(execution, step, workspacePath); err != nil {
 		return nil, fmt.Errorf("failed to auto-inject dep artifacts: %w", err)
 	}
 

--- a/internal/pipeline/matrix.go
+++ b/internal/pipeline/matrix.go
@@ -420,7 +420,7 @@ func (m *MatrixExecutor) executeWorker(ctx context.Context, execution *PipelineE
 	// Auto-inject declared dep artifacts (issue #1452) before the legacy
 	// explicit inject_artifacts pass so {{ artifacts.<dep>.<name> }} and
 	// .agents/artifacts/<dep>/<name> resolve transparently in the worker.
-	if err := m.executor.injectDependencyArtifacts(execution, workerStep, workspacePath); err != nil {
+	if _, err := m.executor.injectDependencyArtifacts(execution, workerStep, workspacePath); err != nil {
 		result.Error = fmt.Errorf("failed to auto-inject dep artifacts: %w", err)
 		return result
 	}


### PR DESCRIPTION
## Summary

Phase 3 of #1452. Builds on the auto-injector landed in #1454.

- `injectDependencyArtifacts` now returns the canonical-path map (post-injection paths) so callers can build env/template surfaces without re-resolving.
- Each resolved artifact is registered under two template namespaces:
  - `{{ artifacts.<dep>.<name> }}` — existing
  - `{{ deps.<dep>.<name> }}` — new, dep-scoped
- Command steps receive `WAVE_DEP_<DEP>_<NAME>=<canonical path>` for every resolved artifact, plus a single `WAVE_DEPS_DIR` pointing at `<workspace>/.agents/artifacts`.
- Slug rule: uppercase, non-alphanumerics become underscore.
- `BuildDepEnvVars` is exported so adapters that need per-worker env on top of the auto-injector can reuse the slug rule.

## Why two template namespaces

`{{ artifacts.<dep>.<name> }}` is the established surface; existing pipelines and personas already use it for sub-pipeline outputs via `MergeFrom`. Reclaiming `deps.*` gives prompt authors a clearer, dep-scoped name without colliding with cross-pipeline / sub-pipeline artifact registrations. Both resolve to the same canonical path.

## Test plan

- [x] `go test ./internal/pipeline/` — 9 dep tests pass (resolver tiers, injector, env-var slug, empty-workspace guard)
- [x] `go test -race ./internal/pipeline/` — clean
- [x] `go test ./...` — all packages green
- [x] `golangci-lint run ./internal/pipeline/` — 0 issues
- [ ] Real-pipeline validation deferred to PR#3 (per the plan)

## Follow-ups

- PR3: validation runs (ops-pr-respond on PR 1441 + audit-issue on #1450) + `wave validate` warns on now-redundant manual injection blocks
- PR4..N: per-pipeline cleanup, starting with `ops-pr-respond.yaml` (drops the filter-scope `workspace.mount` band-aid)

Refs #1452.