### PR TITLE
fix(pipeline): resolve implicit aggregate/iterate dep artifacts

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -48,7 +48,10 @@ func (e *DefaultPipelineExecutor) ResolveDependencyArtifacts(execution *Pipeline
 			continue
 		}
 
+		// Walk declared OutputArtifacts first.
+		declared := make(map[string]struct{}, len(depStep.OutputArtifacts))
 		for _, art := range depStep.OutputArtifacts {
+			declared[art.Name] = struct{}{}
 			required := art.Required
 			path, found := e.locateDepArtifact(execution, depID, art.Name)
 			if !found {
@@ -64,6 +67,39 @@ func (e *DefaultPipelineExecutor) ResolveDependencyArtifacts(execution *Pipeline
 				Path:     path,
 				Type:     art.Type,
 				Optional: !required,
+			}
+		}
+
+		// Implicit fallback: aggregate / iterate / sub_pipeline steps do
+		// not declare OutputArtifacts but register their outputs in
+		// execution.ArtifactPaths under "<dep>:<name>" or in the DB.
+		// Treat anything registered there but not already declared as an
+		// optional dep artifact so downstream steps see it via the same
+		// canonical injection path.
+		depPrefix := depID + ":"
+		execution.mu.Lock()
+		var implicit []string
+		for k := range execution.ArtifactPaths {
+			if !strings.HasPrefix(k, depPrefix) {
+				continue
+			}
+			name := k[len(depPrefix):]
+			if _, ok := declared[name]; ok {
+				continue
+			}
+			implicit = append(implicit, name)
+		}
+		execution.mu.Unlock()
+		for _, name := range implicit {
+			path, found := e.locateDepArtifact(execution, depID, name)
+			if !found {
+				continue
+			}
+			resolved[depID+":"+name] = ResolvedArtifact{
+				DepStep:  depID,
+				Name:     name,
+				Path:     path,
+				Optional: true,
 			}
 		}
 	}

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -267,6 +267,37 @@ func TestBuildDepEnvVars(t *testing.T) {
 	}
 }
 
+// TestResolveDependencyArtifacts_ImplicitAggregateFallback covers the
+// case where the dep step did NOT declare OutputArtifacts (aggregate /
+// iterate / sub_pipeline) but registered its output via
+// executeAggregateInDAG into execution.ArtifactPaths[<dep>:<name>].
+func TestResolveDependencyArtifacts_ImplicitAggregateFallback(t *testing.T) {
+	tmp := t.TempDir()
+	src := writeArtifactFile(t, tmp, "merged-findings.json", `[]`)
+
+	// fetch declares no output_artifacts, but registers
+	// "fetch:merged-findings" in ArtifactPaths the same way an aggregate
+	// step would after it writes the file.
+	exec := fixtureExecution(t, nil)
+	exec.ArtifactPaths["fetch:merged-findings"] = src
+
+	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, ok := resolved["fetch:merged-findings"]
+	if !ok {
+		t.Fatalf("missing implicit fetch:merged-findings entry; got %v", resolved)
+	}
+	if got.Path != src {
+		t.Errorf("path = %q, want %q", got.Path, src)
+	}
+	if !got.Optional {
+		t.Error("implicit fallback artifacts should be Optional")
+	}
+}
+
 // TestBuildDepEnvVars_EmptyWorkspace returns nil when no workspace path.
 func TestBuildDepEnvVars_EmptyWorkspace(t *testing.T) {
 	if got := BuildDepEnvVars(map[string]ResolvedArtifact{"x:y": {}}, ""); got != nil {


### PR DESCRIPTION
## Summary

Closes a gap in #1454 surfaced when running auto-injection against ops-pr-respond:

`ResolveDependencyArtifacts` walks `dep.OutputArtifacts` to know what to look up. But aggregate, iterate, and bare sub_pipeline steps register their outputs in `execution.ArtifactPaths` under `"<dep>:<name>"` without declaring `OutputArtifacts` in YAML. The auto-injector therefore silently skipped them.

Concrete failure: `ops-pr-respond.filter-scope` depends on `merge-findings` (aggregate). With the gap, `WAVE_DEP_MERGE_FINDINGS_MERGED_FINDINGS` and the canonical `.agents/artifacts/merge-findings/merged-findings` path were never produced.

## Fix

After walking declared `OutputArtifacts`, scan `execution.ArtifactPaths` for any `"<dep>:*"` key not already declared and treat it as an **optional** dep artifact. Implicit entries are flagged optional so a registration race doesn't fail required-artifact checks.

## Test plan

- [x] `TestResolveDependencyArtifacts_ImplicitAggregateFallback` — new regression test
- [x] `go test ./internal/pipeline/` — green
- [x] `golangci-lint run ./internal/pipeline/` — 0 issues

Refs #1452.