### PR TITLE
fix(pipeline): preserve source basename + drop ops-pr-respond mount

### DIFF
--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -224,19 +224,11 @@ steps:
   - id: filter-scope
     type: command
     dependencies: [merge-findings, fetch-pr]
-    # Bind the project's `.agents/output/` into the command workspace so the
-    # script can read upstream artifacts (`merged-findings.json` from the
-    # aggregate step, `pr-context.json` from fetch-pr — both written at the
-    # project root) AND write its own outputs (`scoped-findings.json`,
-    # `scope-filter-stats.json`) where downstream steps expect them. Command
-    # steps run in an isolated workspace dir by default and have no
-    # `memory.inject_artifacts` plumbing, so a workspace mount is the
-    # natural way to share a directory.
-    workspace:
-      mount:
-        - source: .agents/output
-          target: .agents/output
-          mode: readwrite
+    # Wave's native dep auto-injection (#1452) now copies every declared
+    # upstream artifact into <workspace>/.agents/output/<basename> and
+    # <workspace>/.agents/artifacts/<dep>/<basename> before the script
+    # runs, so this step reads `merged-findings.json` and `pr-context.json`
+    # at the same paths it always did — no workspace.mount required.
     script: |
       set -o pipefail
       mkdir -p .agents/output

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -65,7 +65,7 @@ func (a *ClaudeAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapter
 		return nil, fmt.Errorf("failed to prepare workspace: %w", err)
 	}
 
-	args := a.buildArgs(cfg)
+	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.claudePath, args...)
 	cmd.Dir = workspacePath
 	if cfg.Prompt != "" {
@@ -409,7 +409,7 @@ func getenvDefault(key, fallback string) string {
 	return fallback
 }
 
-func (a *ClaudeAdapter) buildArgs(cfg AdapterRunConfig) []string {
+func (a *ClaudeAdapter) buildArgs() []string {
 	args := []string{"-p"}
 
 	// Agent mode: pass --agent pointing to the compiled persona .md file.

--- a/internal/adapter/claude_test.go
+++ b/internal/adapter/claude_test.go
@@ -2051,14 +2051,7 @@ func TestPrepareWorkspaceAgentMode(t *testing.T) {
 // T028: Verify buildArgs produces --agent, no legacy flags
 func TestBuildArgsAgentMode(t *testing.T) {
 	adapter := NewClaudeAdapter()
-	cfg := AdapterRunConfig{
-		AllowedTools: []string{"Read", "Write", "Edit", "Bash"},
-		DenyTools:    []string{"Bash(rm *)"},
-		Model:        "opus",
-		Prompt:       "test prompt",
-	}
-
-	args := adapter.buildArgs(cfg)
+	args := adapter.buildArgs()
 
 	// --agent must be present
 	hasAgent := false

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -224,19 +224,11 @@ steps:
   - id: filter-scope
     type: command
     dependencies: [merge-findings, fetch-pr]
-    # Bind the project's `.agents/output/` into the command workspace so the
-    # script can read upstream artifacts (`merged-findings.json` from the
-    # aggregate step, `pr-context.json` from fetch-pr — both written at the
-    # project root) AND write its own outputs (`scoped-findings.json`,
-    # `scope-filter-stats.json`) where downstream steps expect them. Command
-    # steps run in an isolated workspace dir by default and have no
-    # `memory.inject_artifacts` plumbing, so a workspace mount is the
-    # natural way to share a directory.
-    workspace:
-      mount:
-        - source: .agents/output
-          target: .agents/output
-          mode: readwrite
+    # Wave's native dep auto-injection (#1452) now copies every declared
+    # upstream artifact into <workspace>/.agents/output/<basename> and
+    # <workspace>/.agents/artifacts/<dep>/<basename> before the script
+    # runs, so this step reads `merged-findings.json` and `pr-context.json`
+    # at the same paths it always did — no workspace.mount required.
     script: |
       set -o pipefail
       mkdir -p .agents/output

--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -215,7 +215,15 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 		if err := os.MkdirAll(canonicalDir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create canonical dir %q: %w", canonicalDir, err)
 		}
-		canonicalPath := filepath.Join(canonicalDir, art.Name)
+		// Filename on disk preserves the source basename (e.g.
+		// `pr-context.json`) so scripts that reference the original
+		// extension keep working transparently. Logical artifact name
+		// (`pr-context`) remains the key for env vars and templates.
+		filename := filepath.Base(art.Path)
+		if filename == "" || filename == "." || filename == "/" {
+			filename = art.Name
+		}
+		canonicalPath := filepath.Join(canonicalDir, filename)
 
 		if err := linkOrCopy(art.Path, canonicalPath); err != nil {
 			if art.Optional {
@@ -231,15 +239,15 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 			return nil, fmt.Errorf("failed to inject %s/%s: %w", art.DepStep, art.Name, err)
 		}
 
-		// Back-compat alias at .agents/output/<name>. Warn on collision.
-		aliasPath := filepath.Join(outputRoot, art.Name)
-		if prev, exists := aliasOwners[art.Name]; exists && prev != art.DepStep {
+		// Back-compat alias at .agents/output/<filename>. Warn on collision.
+		aliasPath := filepath.Join(outputRoot, filename)
+		if prev, exists := aliasOwners[filename]; exists && prev != art.DepStep {
 			e.emit(event.Event{
 				Timestamp:  time.Now(),
 				PipelineID: pipelineID,
 				StepID:     step.ID,
 				State:      "step_progress",
-				Message:    fmt.Sprintf("dep artifact name collision on %q: %s vs %s — alias .agents/output/%s won by %s; canonical paths remain unambiguous", art.Name, prev, art.DepStep, art.Name, art.DepStep),
+				Message:    fmt.Sprintf("dep artifact name collision on %q: %s vs %s — alias .agents/output/%s won by %s; canonical paths remain unambiguous", filename, prev, art.DepStep, filename, art.DepStep),
 			})
 		}
 		_ = os.Remove(aliasPath)
@@ -250,10 +258,10 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 				PipelineID: pipelineID,
 				StepID:     step.ID,
 				State:      "step_progress",
-				Message:    fmt.Sprintf("alias .agents/output/%s could not be created: %v", art.Name, err),
+				Message:    fmt.Sprintf("alias .agents/output/%s could not be created: %v", filename, err),
 			})
 		} else {
-			aliasOwners[art.Name] = art.DepStep
+			aliasOwners[filename] = art.DepStep
 		}
 
 		// Register canonical path under both {{ artifacts.<dep>.<name> }}

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -182,11 +182,11 @@ func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
 		t.Fatalf("inject: %v", err)
 	}
 
-	canonical := filepath.Join(workspace, ".agents", "artifacts", "fetch", "pr-context")
+	canonical := filepath.Join(workspace, ".agents", "artifacts", "fetch", "pr-context.json")
 	if _, err := os.Stat(canonical); err != nil {
 		t.Errorf("canonical missing: %v", err)
 	}
-	alias := filepath.Join(workspace, ".agents", "output", "pr-context")
+	alias := filepath.Join(workspace, ".agents", "output", "pr-context.json")
 	if _, err := os.Stat(alias); err != nil {
 		t.Errorf("alias missing: %v", err)
 	}


### PR DESCRIPTION
## Summary

Two related changes that make the auto-injector landed in #1454 actually replace the band-aid in ops-pr-respond.

1. **Preserve source basename in injector.** Files now land at `.agents/output/pr-context.json` (not `.agents/output/pr-context`). The logical artifact name (`pr-context`) still keys `{{ deps.<dep>.<name> }}` and `WAVE_DEP_FETCH_PR_PR_CONTEXT`, but the on-disk filename matches what producer steps wrote, so scripts referencing the original extension keep working with zero translation.

2. **Drop the filter-scope `workspace.mount` band-aid in ops-pr-respond.** The auto-injector now copies both `merged-findings.json` (from the `merge-findings` aggregate) and `pr-context.json` (from `fetch-pr`) into the filter-scope workspace at the exact paths the script reads. No mount needed.

## Drive-by

`buildArgs(cfg AdapterRunConfig)` on the Claude adapter became dead-arg after the #1449 stdin fix; golangci-lint started flagging it. Dropped the parameter and the corresponding test fixture.

## Test plan

- [x] `go test ./internal/pipeline/ ./internal/defaults/ ./internal/adapter/` — green
- [x] `go test -race ./internal/pipeline/` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Live `wave run ops-pr-respond -- "re-cinq/wave 1441" --adapter claude --model balanced` validation pending

Refs #1452.