### PR TITLE
chore(pipelines): drop redundant config.inject in parallel-review/evidence

### DIFF
--- a/.agents/pipelines/audit-issue.yaml
+++ b/.agents/pipelines/audit-issue.yaml
@@ -218,8 +218,9 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-issue]
     input: "Audit the references in issue {{ input }}. Read .agents/artifacts/issue-context for cited routes / files / run id."
-    config:
-      inject: ["issue-context"]
+    # `issue-context` reaches every audit-* child via auto-derived parent
+    # artifact paths (#1452 / #1458) — the fetch-issue dependency already
+    # tells Wave to forward its declared output_artifacts to the child.
     iterate:
       over: '["audit-webui-shots", "audit-code-walk", "audit-db-trace", "audit-event-trace"]'
       mode: parallel

--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -185,13 +185,12 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-pr]
     input: "Audit the changes in PR {{ input }}. Focus on files listed in .agents/output/pr-context.json (changed_files). Treat .agents/output/pr.diff as the authoritative scope."
-    # Inject pr-context into every audit-* child so each one receives
-    # `.agents/artifacts/pr-context` and can scope its scan to changed_files
-    # instead of walking the whole repo. Standalone audit-* runs (no parent
-    # injection) keep their whole-repo behaviour — the audit prompts guard
-    # the scope-narrowing on the artifact's existence.
-    config:
-      inject: ["pr-context"]
+    # `pr-context` reaches every audit-* child via auto-derived parent
+    # artifact paths (#1452 / #1458): the dependency on fetch-pr already
+    # tells Wave to forward its declared output_artifacts. Standalone
+    # audit-* runs (no parent injection) keep their whole-repo behaviour —
+    # the audit prompts guard the scope-narrowing on the artifact's
+    # existence.
     iterate:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel

--- a/internal/defaults/pipelines/audit-issue.yaml
+++ b/internal/defaults/pipelines/audit-issue.yaml
@@ -218,8 +218,9 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-issue]
     input: "Audit the references in issue {{ input }}. Read .agents/artifacts/issue-context for cited routes / files / run id."
-    config:
-      inject: ["issue-context"]
+    # `issue-context` reaches every audit-* child via auto-derived parent
+    # artifact paths (#1452 / #1458) — the fetch-issue dependency already
+    # tells Wave to forward its declared output_artifacts to the child.
     iterate:
       over: '["audit-webui-shots", "audit-code-walk", "audit-db-trace", "audit-event-trace"]'
       mode: parallel

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -185,13 +185,12 @@ steps:
     pipeline: "{{ item }}"
     dependencies: [fetch-pr]
     input: "Audit the changes in PR {{ input }}. Focus on files listed in .agents/output/pr-context.json (changed_files). Treat .agents/output/pr.diff as the authoritative scope."
-    # Inject pr-context into every audit-* child so each one receives
-    # `.agents/artifacts/pr-context` and can scope its scan to changed_files
-    # instead of walking the whole repo. Standalone audit-* runs (no parent
-    # injection) keep their whole-repo behaviour — the audit prompts guard
-    # the scope-narrowing on the artifact's existence.
-    config:
-      inject: ["pr-context"]
+    # `pr-context` reaches every audit-* child via auto-derived parent
+    # artifact paths (#1452 / #1458): the dependency on fetch-pr already
+    # tells Wave to forward its declared output_artifacts. Standalone
+    # audit-* runs (no parent injection) keep their whole-repo behaviour —
+    # the audit prompts guard the scope-narrowing on the artifact's
+    # existence.
     iterate:
       over: '["audit-security", "audit-architecture", "audit-tests", "audit-duplicates", "audit-doc-scan", "audit-dead-code-scan"]'
       mode: parallel


### PR DESCRIPTION
## Summary

Two `config.inject` entries are made redundant by the auto-derived parent artifact paths added in #1458.

- `ops-pr-respond.parallel-review` already depends on `fetch-pr`. Since fetch-pr declares `pr-context` as an output_artifact, every audit-* child sub-pipeline now receives it without an explicit inject list.
- `audit-issue.parallel-evidence` is the same shape: depends on `fetch-issue`, which declares `issue-context`.

Behavior is unchanged — only the YAML noise goes away.

## What is NOT in this PR

- `audit-issue.per-gap-deepdive` injects `issue-context` but only depends on `enumerate-gaps` (transitive, not direct). Will follow up by adding `fetch-issue` to its dependency list.
- `ops-pr-respond.resolve-each` is nested in a `loop.steps` block and has no `dependencies:` of its own, so the auto-derive path does not apply. Kept as-is.

## Test plan

- [x] `go test ./internal/defaults/ ./internal/pipeline/` — green
- [ ] Live `wave run ops-pr-respond` validation already in flight on the prior commit; this PR should land before the merge so the run exercises the new code path

Refs #1452.