### PR TITLE
fix(pipeline): keep CWD on workspace when auto-inject populated it

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -4063,6 +4063,20 @@ func resolveCommandWorkDir(workspacePath string, step *Step) string {
 			break
 		}
 	}
+
+	// Auto-injected dep artifacts (#1452) populate .agents/artifacts and
+	// .agents/output before the command runs. Treat their presence as a
+	// "this workspace is real" signal so commands keep CWD here and find
+	// the auto-injected files at relative paths.
+	if !hasMarker {
+		for _, d := range []string{".agents/artifacts", ".agents/output"} {
+			if info, err := os.Stat(filepath.Join(workspacePath, d)); err == nil && info.IsDir() {
+				hasMarker = true
+				break
+			}
+		}
+	}
+
 	if !hasMarker {
 		if cwd, err := os.Getwd(); err == nil {
 			// Only fall back if CWD has a project marker

--- a/internal/pipeline/graph_test.go
+++ b/internal/pipeline/graph_test.go
@@ -1203,6 +1203,23 @@ func TestResolveCommandWorkDir_BareWorkspaceFallback(t *testing.T) {
 			t.Errorf("expected workspace root %q, got %q", wsRoot, got)
 		}
 	})
+
+	t.Run("auto-injected .agents/output keeps CWD on workspace", func(t *testing.T) {
+		// Issue #1452: command steps with auto-injected dep artifacts
+		// must NOT fall back to project root, otherwise the script
+		// reads CWD-relative paths that bypass the injected files.
+		wsRoot := t.TempDir()
+		// Simulate auto-injector having populated the workspace.
+		if err := os.MkdirAll(filepath.Join(wsRoot, ".agents", "output"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		step := &Step{ID: "test-step"}
+		got := resolveCommandWorkDir(wsRoot, step)
+		if got != wsRoot {
+			t.Errorf("expected workspace root %q (auto-injected dir treated as marker), got %q", wsRoot, got)
+		}
+	})
 }
 
 // --- Unit test: filterEnvPassthrough ---


### PR DESCRIPTION
## Summary

Surfaced in a real `ops-pr-respond` run against PR 1441: filter-scope exited 1 with `missing input (.agents/output/merged-findings.json or .agents/output/pr-context.json)` even though the auto-injector had successfully placed both files.

Root cause: `resolveCommandWorkDir` falls back to the project root when the workspace has no project markers (go.mod, package.json, ...). After #1452, auto-injected dep artifacts populate `<workspace>/.agents/output` and `<workspace>/.agents/artifacts` but the workspace remains "bare" by the old marker rules — so CWD got moved to the project root, and command scripts reading relative paths like `.agents/output/pr-context.json` looked at the project's output dir instead of the injected one.

## Fix

Treat the presence of an auto-injected `.agents/artifacts` or `.agents/output` directory as a "this workspace is real" signal so CWD stays on the workspace and the script finds the injected files.

## Test plan

- [x] New regression test: `TestResolveCommandWorkDir_BareWorkspaceFallback/auto-injected_.agents/output_keeps_CWD_on_workspace`
- [x] Existing fallback / mount / worktree subtests still pass
- [ ] Re-run ops-pr-respond against PR 1441 once merged + binary rebuilt to confirm filter-scope reaches `triage`

Refs #1452.