### PR TITLE
fix(resume): load every prior-run artifact from DB, not just declared

### DIFF
--- a/internal/pipeline/resume.go
+++ b/internal/pipeline/resume.go
@@ -373,6 +373,25 @@ func (r *ResumeManager) loadResumeState(p *Pipeline, fromStep string, priorRunID
 		}
 	}
 
+	// Load every artifact registered for the prior run from the DB.
+	// Workspace-derived registration above only covers steps that declare
+	// OutputArtifacts; aggregate / iterate / sub_pipeline outputs land in
+	// the DB without a YAML declaration and would otherwise be invisible
+	// to the auto-injector after resume (#1452).
+	if resolvedRunID != "" && r.executor.store != nil {
+		if records, err := r.executor.store.GetArtifacts(resolvedRunID, ""); err == nil {
+			for _, rec := range records {
+				key := rec.StepID + ":" + rec.Name
+				if _, ok := state.ArtifactPaths[key]; ok {
+					// Workspace-derived path takes precedence (it points at
+					// the live workspace location, not the archived copy).
+					continue
+				}
+				state.ArtifactPaths[key] = rec.Path
+			}
+		}
+	}
+
 	// Load failure context from the prior run's step attempts so retry prompts have context
 	if resolvedRunID != "" && r.executor.store != nil {
 		// Query step attempts for the step being resumed


### PR DESCRIPTION
## Summary

`loadResumeState` walked `step.OutputArtifacts` to seed `ArtifactPaths`, missing aggregate / iterate / sub_pipeline outputs that have no YAML declaration but ARE recorded in the DB at runtime.

## Concrete failure

Real ops-pr-respond run resumed at filter-scope from prior run id failed identically to the original: \"missing input (.agents/output/merged-findings.json or .agents/output/pr-context.json)\". The auto-injector landed in #1454 had nothing to inject because:

- `merge-findings` is an aggregate step, no `OutputArtifacts:` block.
- Resume registered only `fetch-pr:pr-context` (the only declared output of a prior step).
- `merge-findings:merged-findings` was in the DB but never made it into the resumed `execution.ArtifactPaths` map.

## Fix

After workspace-derived registration, query `store.GetArtifacts(priorRunID, \"\")` and merge every record into `ResumeState.ArtifactPaths`. Workspace-derived paths still win on conflict, since they point at the live workspace location instead of the archived copy.

## Test plan

- [x] `go test ./internal/pipeline/ -run TestResume` — green
- [ ] `wave run ops-pr-respond --run <prior> --from-step filter-scope --force ...` should now reach `triage` once binary rebuilt

Refs #1452.