### PR TITLE
fix(resume): preserve pre-resume Dependencies for auto-injector

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -36,37 +36,57 @@ type ResolvedArtifact struct {
 // artifacts that cannot be located return an error naming both dep and name.
 func (e *DefaultPipelineExecutor) ResolveDependencyArtifacts(execution *PipelineExecution, step *Step) (map[string]ResolvedArtifact, error) {
 	resolved := make(map[string]ResolvedArtifact)
-	if execution == nil || step == nil || len(step.Dependencies) == 0 || execution.Pipeline == nil {
+	if execution == nil || step == nil || execution.Pipeline == nil {
 		return resolved, nil
 	}
 
-	for _, depID := range step.Dependencies {
-		depStep := findStepByID(execution.Pipeline, depID)
-		if depStep == nil {
-			// Dependency not declared in pipeline — skip silently.
-			// DAG validation already errors on undeclared deps.
-			continue
-		}
-
-		// Walk declared OutputArtifacts first.
-		declared := make(map[string]struct{}, len(depStep.OutputArtifacts))
-		for _, art := range depStep.OutputArtifacts {
-			declared[art.Name] = struct{}{}
-			required := art.Required
-			path, found := e.locateDepArtifact(execution, depID, art.Name)
-			if !found {
-				if required {
-					return nil, fmt.Errorf("dependency %q output artifact %q not found", depID, art.Name)
-				}
-				continue
+	// Walk both the live deps and any deps stripped by the resume
+	// subpipeline rewriter so artifacts from already-completed steps
+	// still get auto-injected on a resumed run.
+	depList := step.Dependencies
+	for _, dep := range step.ResumeOriginalDeps {
+		seen := false
+		for _, d := range depList {
+			if d == dep {
+				seen = true
+				break
 			}
-			key := depID + ":" + art.Name
-			resolved[key] = ResolvedArtifact{
-				DepStep:  depID,
-				Name:     art.Name,
-				Path:     path,
-				Type:     art.Type,
-				Optional: !required,
+		}
+		if !seen {
+			depList = append(depList, dep)
+		}
+	}
+	if len(depList) == 0 {
+		return resolved, nil
+	}
+
+	for _, depID := range depList {
+		depStep := findStepByID(execution.Pipeline, depID)
+		// depStep may be nil after resume — the resume subpipeline only
+		// contains steps from fromStep onwards. Fall through to the
+		// implicit-ArtifactPaths scan with an empty declared set so every
+		// "<dep>:*" registration still resolves.
+		declared := make(map[string]struct{})
+		if depStep != nil {
+			declared = make(map[string]struct{}, len(depStep.OutputArtifacts))
+			for _, art := range depStep.OutputArtifacts {
+				declared[art.Name] = struct{}{}
+				required := art.Required
+				path, found := e.locateDepArtifact(execution, depID, art.Name)
+				if !found {
+					if required {
+						return nil, fmt.Errorf("dependency %q output artifact %q not found", depID, art.Name)
+					}
+					continue
+				}
+				key := depID + ":" + art.Name
+				resolved[key] = ResolvedArtifact{
+					DepStep:  depID,
+					Name:     art.Name,
+					Path:     path,
+					Type:     art.Type,
+					Optional: !required,
+				}
 			}
 		}
 

--- a/internal/pipeline/resume.go
+++ b/internal/pipeline/resume.go
@@ -453,6 +453,16 @@ func (r *ResumeManager) createResumeSubpipeline(p *Pipeline, fromStep string) *P
 	subSteps := make([]Step, len(p.Steps[startIndex:]))
 	copy(subSteps, p.Steps[startIndex:])
 	for i := range subSteps {
+		// Preserve the pre-strip dependency list so the auto-injector
+		// (#1452) can still walk upstream OutputArtifacts after resume.
+		// Without this, deps that point at already-completed steps get
+		// stripped to satisfy DAGValidator and the resolver sees an
+		// empty Dependencies slice, leaving the workspace empty.
+		if len(subSteps[i].Dependencies) > 0 && len(subSteps[i].ResumeOriginalDeps) == 0 {
+			orig := make([]string, len(subSteps[i].Dependencies))
+			copy(orig, subSteps[i].Dependencies)
+			subSteps[i].ResumeOriginalDeps = orig
+		}
 		var kept []string
 		for _, dep := range subSteps[i].Dependencies {
 			if includedSteps[dep] {

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -303,6 +303,12 @@ type Step struct {
 	Adapter             string           `yaml:"adapter,omitempty"` // Step-level adapter override (e.g., "codex", "gemini")
 	Model               string           `yaml:"model,omitempty"`   // Step-level model override: tier name (cheapest, balanced, strongest) or literal model ID
 	Dependencies        []string         `yaml:"dependencies,omitempty"`
+	// ResumeOriginalDeps preserves the pre-resume Dependencies list when
+	// createResumeSubpipeline strips deps that point at already-completed
+	// steps (needed to satisfy DAGValidator). The auto-injector reads
+	// this list as a fallback so it can still resolve upstream artifacts
+	// after resume. Not serialized.
+	ResumeOriginalDeps []string `yaml:"-" json:"-"`
 	TimeoutMinutes      int              `yaml:"timeout_minutes,omitempty"`
 	Optional            bool             `yaml:"optional,omitempty"`
 	Memory              MemoryConfig     `yaml:"memory"`


### PR DESCRIPTION
## Summary

Concrete failure observed mid-#1452 validation: ops-pr-respond resumed at filter-scope still hit `missing input` even after #1462 loaded the DB artifacts. Reason: filter-scope's deps `[merge-findings, fetch-pr]` were stripped by `createResumeSubpipeline` (to satisfy `DAGValidator`), so `ResolveDependencyArtifacts` saw an empty `Dependencies` list and the auto-injector did nothing.

## Fix

- New `Step.ResumeOriginalDeps` field (in-memory only, not serialized) preserves the pre-strip dependency list.
- `createResumeSubpipeline` populates it before stripping.
- `ResolveDependencyArtifacts` walks both the live deps and `ResumeOriginalDeps`, deduped.
- `findStepByID == nil` is now tolerated (the dep is no longer in the resume subpipeline) — falls through to the implicit-ArtifactPaths scan so every `"<dep>:*"` entry seeded by `loadResumeState` still resolves.

## Test plan

- [x] `go test ./internal/pipeline/` — green
- [ ] Live `wave run ops-pr-respond --run <prior> --from-step filter-scope --force` should now reach `triage` once binary rebuilt — pending merge

Refs #1452.