### PR TITLE
fix(detach): preserve --run id during --from-step + --detach resume

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -779,21 +779,33 @@ func runDetached(opts RunOptions, p *pipeline.Pipeline, m *manifest.Manifest) er
 	}
 
 	var runID string
-	notified := false
-	for {
-		var createErr error
-		runID, createErr = store.CreateRunWithLimit(p.Metadata.Name, opts.Input, maxWorkers)
-		if createErr == nil {
-			break
+	// Resume-in-place: when the user passes --run <prior> alongside
+	// --from-step, reuse that run id instead of creating a fresh one.
+	// Otherwise the detached subprocess loses the prior-run reference and
+	// loadResumeState queries the empty new run, leaving the auto-injector
+	// (#1452) with nothing to inject.
+	if opts.RunID != "" && opts.FromStep != "" {
+		if _, err := store.GetRun(opts.RunID); err == nil {
+			runID = opts.RunID
 		}
-		if !errors.Is(createErr, state.ErrConcurrencyLimit) {
-			return fmt.Errorf("failed to create run record: %w", createErr)
+	}
+	if runID == "" {
+		notified := false
+		for {
+			var createErr error
+			runID, createErr = store.CreateRunWithLimit(p.Metadata.Name, opts.Input, maxWorkers)
+			if createErr == nil {
+				break
+			}
+			if !errors.Is(createErr, state.ErrConcurrencyLimit) {
+				return fmt.Errorf("failed to create run record: %w", createErr)
+			}
+			if !notified {
+				fmt.Fprintf(os.Stderr, "  Queued: %d/%d workers busy, waiting for a slot...\n", maxWorkers, maxWorkers)
+				notified = true
+			}
+			time.Sleep(5 * time.Second)
 		}
-		if !notified {
-			fmt.Fprintf(os.Stderr, "  Queued: %d/%d workers busy, waiting for a slot...\n", maxWorkers, maxWorkers)
-			notified = true
-		}
-		time.Sleep(5 * time.Second)
 	}
 	// Mark as running so wave status picks it up immediately.
 	_ = store.UpdateRunStatus(runID, "running", "", 0)


### PR DESCRIPTION
## Summary

`runDetached` unconditionally called `CreateRunWithLimit`, generating a fresh run id and re-execing the subprocess with `--run <NEW_ID>`. That silently overwrote the user's `wave run --run <prior> --from-step <step> --detach` invocation — the subprocess never saw the prior-run reference, `loadResumeState` queried the empty new run, and the auto-injector (#1452) had nothing to inject.

## Concrete failure

Every detached resume of `ops-pr-respond` at `filter-scope` exited with `missing input (.agents/output/merged-findings.json or .agents/output/pr-context.json)` because fetch-pr's `pr-context` and merge-findings's `merged-findings` were never carried over.

## Fix

When `--run` + `--from-step` are both set, reuse the prior run id instead of creating a new one. Falls back to the new-run path when the prior id can't be loaded (defensive — keeps old behavior for malformed input).

## Test plan

- [x] `go test ./cmd/wave/commands/ ./internal/pipeline/` — green
- [ ] Live `wave run ops-pr-respond --run <prior> --from-step filter-scope --force --detach` should resume into the prior run and find the seeded artifacts — pending merge

Refs #1452.