### PR TITLE
fix(audit-issue): drop redundant config.inject after adding fetch-issue dep

### DIFF
--- a/.agents/pipelines/audit-issue.yaml
+++ b/.agents/pipelines/audit-issue.yaml
@@ -345,10 +345,11 @@ steps:
   # followup-spec. iterate.parallel max=3 keeps the LLM cost bounded.
   - id: per-gap-deepdive
     pipeline: gap-analyze
-    dependencies: [enumerate-gaps]
+    dependencies: [enumerate-gaps, fetch-issue]
     input: "{{ item }}"
-    config:
-      inject: ["issue-context"]
+    # `issue-context` reaches every gap-analyze child via auto-derived
+    # parent artifact paths (#1452 / #1458) — fetch-issue is now a direct
+    # dependency so its declared output_artifacts forward automatically.
     iterate:
       over: "{{ enumerate-gaps.out.gap-set.gaps }}"
       mode: parallel

--- a/internal/defaults/pipelines/audit-issue.yaml
+++ b/internal/defaults/pipelines/audit-issue.yaml
@@ -345,10 +345,11 @@ steps:
   # followup-spec. iterate.parallel max=3 keeps the LLM cost bounded.
   - id: per-gap-deepdive
     pipeline: gap-analyze
-    dependencies: [enumerate-gaps]
+    dependencies: [enumerate-gaps, fetch-issue]
     input: "{{ item }}"
-    config:
-      inject: ["issue-context"]
+    # `issue-context` reaches every gap-analyze child via auto-derived
+    # parent artifact paths (#1452 / #1458) — fetch-issue is now a direct
+    # dependency so its declared output_artifacts forward automatically.
     iterate:
       over: "{{ enumerate-gaps.out.gap-set.gaps }}"
       mode: parallel


### PR DESCRIPTION
## Summary

Surfaced in the live audit-issue validation against #1450:
\`per-gap-deepdive artifact "issue-context" not found in parent context for sub-pipeline injection\`.

The auto-derive added in #1458 walks DIRECT deps only. \`per-gap-deepdive\` declared only \`enumerate-gaps\`, so fetch-issue's output_artifacts (issue-context) were invisible to the resolver. The legacy \`config.inject\` mechanism still ran and failed because the artifact was no longer registered in the bare-name namespace it expected after #1459 dropped the inject.

Add fetch-issue to per-gap-deepdive dependencies (transitively already required, so DAG order is unchanged). Auto-derive now forwards issue-context to every gap-analyze child without explicit inject.

Refs #1452.