### PR TITLE
fix(audit-issue): drop readonly project mount on file-each-followup

### DIFF
--- a/.agents/pipelines/audit-issue.yaml
+++ b/.agents/pipelines/audit-issue.yaml
@@ -539,11 +539,11 @@ steps:
   - id: file-each-followup
     type: command
     dependencies: [synthesize, aggregate-followups, fetch-issue]
-    workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readonly
+    # No workspace.mount needed — auto-injection (#1452) puts
+    # followup-specs.json + issue-context.json in
+    # <workspace>/.agents/output/, and `gh issue create --repo $OWNER/$REPO`
+    # uses owner/repo harvested from issue-context, not the local git
+    # remote, so the project tree is not required.
     script: |
       set -o pipefail
       mkdir -p .agents/output

--- a/internal/defaults/pipelines/audit-issue.yaml
+++ b/internal/defaults/pipelines/audit-issue.yaml
@@ -539,11 +539,11 @@ steps:
   - id: file-each-followup
     type: command
     dependencies: [synthesize, aggregate-followups, fetch-issue]
-    workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readonly
+    # No workspace.mount needed — auto-injection (#1452) puts
+    # followup-specs.json + issue-context.json in
+    # <workspace>/.agents/output/, and `gh issue create --repo $OWNER/$REPO`
+    # uses owner/repo harvested from issue-context, not the local git
+    # remote, so the project tree is not required.
     script: |
       set -o pipefail
       mkdir -p .agents/output


### PR DESCRIPTION
## Summary

Surfaced in the live audit-issue validation against #1450:

\`\`\`
file-each-followup command failed: exit status 1
stderr: mkdir: cannot create directory '.agents': Permission denied
file-each-followup: missing input (.agents/output/followup-specs.json or .agents/output/issue-context.json)
\`\`\`

The readonly \`workspace.mount\` aliased the project root at \`<workspace>/project\`, then \`resolveCommandWorkDir\` routed the command CWD into that readonly mount. \`mkdir -p .agents/output\` failed there, and the auto-injected inputs under \`<workspace>/.agents/output/\` were unreachable from the readonly project path.

## Fix

Drop the mount. The script never needs the project tree — it harvests \`owner/repo\` from \`issue-context.json\` and passes \`--repo $OWNER/$REPO\` to \`gh issue create\`. With the mount gone, the auto-injector (#1452) puts inputs where the script reads them and the workspace stays writable.

Refs #1452.