### PR TITLE
fix(pipeline): skip auto-inject symlink when src and dest resolve same

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -382,6 +382,19 @@ func linkOrCopy(src, dest string) error {
 			absSrc = a
 		}
 	}
+	absDest := dest
+	if !filepath.IsAbs(absDest) {
+		if a, err := filepath.Abs(absDest); err == nil {
+			absDest = a
+		}
+	}
+	// Same target after absolutization (e.g. archive path inside a
+	// shared worktree equals the canonical injection path). Skip — any
+	// symlink we create here would form a loop because os.Remove(dest)
+	// would delete the file we are trying to link to.
+	if absSrc == absDest {
+		return nil
+	}
 	// If dest already exists pointing to absSrc, leave it.
 	if existing, err := os.Readlink(dest); err == nil && existing == absSrc {
 		return nil


### PR DESCRIPTION
## Summary

Surfaced in audit-issue validation against #1450 at the create-pr step:
\`\`\`
failed to read required artifact 'audit-doc': open .../audit-doc.json: too many levels of symbolic links
\`\`\`

\`linkOrCopy\` compared input src/dest as strings, missing the case where they pointed at the same file via different relative/absolute forms. When the synthesize step's archive path (recorded in the DB as absolute) equalled the create-pr canonical injection path (computed via relative \`workspacePath\`) — both inside the same shared worktree because they share \`branch: pipeline_id\` — the function deleted the real file with \`os.Remove\`, created a dangling symlink \`dest -> src\`, and the next pass replaced the alias with a symlink back to the canonical. Result: \`canonical -> alias -> canonical\` ELOOP.

## Fix

Absolutize both src and dest, compare those, skip when equal. Falls back to the original behavior when \`filepath.Abs\` fails.

## Test plan

- [x] \`go test ./internal/pipeline/ -run "TestInjectDependency|TestResolveDependency|TestBuildDepEnv"\` — green
- [ ] Live audit-issue validation will resume past create-pr once binary rebuilt

Refs #1452.