### PR TITLE
chore(audit-issue): tolerate per-axis evidence failures

### DIFF
--- a/.agents/pipelines/audit-issue.yaml
+++ b/.agents/pipelines/audit-issue.yaml
@@ -225,6 +225,12 @@ steps:
       over: '["audit-webui-shots", "audit-code-walk", "audit-db-trace", "audit-event-trace"]'
       mode: parallel
       max_concurrent: 4
+      # Per-axis failures are tolerated — same pattern as
+      # ops-pr-respond.parallel-review (#1446). If 1-2 evidence axes time
+      # out, hit a contract failure, or get canceled by an external event
+      # (host sleep, sandbox cycle), aggregate-evidence still has the
+      # successful axes' output to feed enumerate-gaps.
+      on_failure: continue
 
   # ─── Phase 3: aggregate evidence into a single evidence set ──────────────
   - id: aggregate-evidence

--- a/internal/defaults/pipelines/audit-issue.yaml
+++ b/internal/defaults/pipelines/audit-issue.yaml
@@ -225,6 +225,12 @@ steps:
       over: '["audit-webui-shots", "audit-code-walk", "audit-db-trace", "audit-event-trace"]'
       mode: parallel
       max_concurrent: 4
+      # Per-axis failures are tolerated — same pattern as
+      # ops-pr-respond.parallel-review (#1446). If 1-2 evidence axes time
+      # out, hit a contract failure, or get canceled by an external event
+      # (host sleep, sandbox cycle), aggregate-evidence still has the
+      # successful axes' output to feed enumerate-gaps.
+      on_failure: continue
 
   # ─── Phase 3: aggregate evidence into a single evidence set ──────────────
   - id: aggregate-evidence


### PR DESCRIPTION
## Summary

\`parallel-evidence\` iterate had no \`on_failure\` setting, so a single audit-* axis failure (timeout, contract miss, external cancel) killed the whole run and discarded the successful axes' work.

Mirror \`ops-pr-respond.parallel-review\` (#1446): set \`on_failure: continue\`. \`aggregate-evidence\` still receives the successful axes' output and the run reaches enumerate-gaps.

## Trigger

Live audit-issue validation against #1450: audit-code-walk + audit-event-trace canceled at 12:25:25 by an external host event even though db-trace + webui-shots completed normally. Iterate fail-fast tossed all evidence.

Refs #1452.