### PR TITLE
fix(pipeline): skip auto-inject when source already inside workspace

### DIFF
--- a/internal/pipeline/depinject.go
+++ b/internal/pipeline/depinject.go
@@ -230,7 +230,49 @@ func (e *DefaultPipelineExecutor) injectDependencyArtifacts(execution *PipelineE
 	aliasOwners := make(map[string]string)
 	canonical := make(map[string]ResolvedArtifact, len(resolved))
 
+	// Absolutize workspacePath once for "is the src already inside this
+	// workspace?" comparisons below. Worktree workspaces are reused
+	// across steps on the same branch so the upstream archive often
+	// lives inside the same workspace tree, in which case we'd create a
+	// no-op self-symlink (worse: a symlink loop with the alias pass).
+	absWorkspace := workspacePath
+	if !filepath.IsAbs(absWorkspace) {
+		if a, err := filepath.Abs(absWorkspace); err == nil {
+			absWorkspace = a
+		}
+	}
+
 	for _, art := range resolved {
+		// If the upstream archive is already inside this step's workspace
+		// (shared worktree case — synthesize, create-pr both run on the
+		// same `branch: pipeline_id`), the file is reachable at its
+		// recorded path. Skip both canonical and alias creation; legacy
+		// injectArtifacts and direct path references still work because
+		// the file already exists where it was archived.
+		absArt := art.Path
+		if !filepath.IsAbs(absArt) {
+			if a, err := filepath.Abs(absArt); err == nil {
+				absArt = a
+			}
+		}
+		if strings.HasPrefix(absArt, absWorkspace+string(filepath.Separator)) {
+			// Still register canonical-name templates so prompts using
+			// {{ artifacts.<dep>.<name> }} or {{ deps.<dep>.<name> }}
+			// resolve to the existing path.
+			if execution.Context != nil {
+				execution.Context.SetArtifactPath(art.DepStep+"."+art.Name, absArt)
+				execution.Context.SetCustomVariable("deps."+art.DepStep+"."+art.Name, absArt)
+			}
+			canonical[art.DepStep+":"+art.Name] = ResolvedArtifact{
+				DepStep:  art.DepStep,
+				Name:     art.Name,
+				Path:     absArt,
+				Type:     art.Type,
+				Optional: art.Optional,
+			}
+			continue
+		}
+
 		canonicalDir := filepath.Join(artifactsRoot, art.DepStep)
 		if err := os.MkdirAll(canonicalDir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create canonical dir %q: %w", canonicalDir, err)


### PR DESCRIPTION
## Summary

Surfaced repeatedly in audit-issue validation against #1450:
\`\`\`
failed to read required artifact 'audit-doc': open .../audit-doc.json: too many levels of symbolic links
\`\`\`

Worktree workspaces are reused across steps that share a branch (audit-issue's synthesize, file-each-followup, create-pr all run on \`branch: {{ pipeline_id }}\`). When create-pr's auto-inject resolves synthesize:audit-doc, the DB-recorded archive path already lives inside create-pr's own worktree.

#1470 skipped only the canonical pass when paths matched. The alias pass then ran with src=canonical and dest=alias both inside the same worktree. \`os.Remove(alias)\` deleted synthesize's primary regular output, and the surviving symlinks formed a loop on subsequent reads.

## Fix

Skip both canonical and alias creation when the resolved source is already inside the step's workspace tree. Still register the \`{{ artifacts.<dep>.<name> }}\` and \`{{ deps.<dep>.<name> }}\` template variables so prompts resolve, and still return the path in the canonical map so command-step env builders see the file.

## Test plan

- [x] \`go test ./internal/pipeline/\` — green
- [ ] Resume audit-issue from create-pr after binary rebuild — pending merge

Refs #1452.