### PR TITLE
feat(state): #1450 sub-PR 1 — schema migration #27 + parent linkage

### DIFF
--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -83,6 +83,29 @@ func (c *CompositionExecutor) SetRunID(id string) {
 	c.runID = id
 }
 
+// recordParentLinkage writes parent_run_id / parent_step_id and
+// run_kind / sub_pipeline_ref onto every child run that just finished.
+// Best-effort: failures are swallowed because they only affect WebUI
+// rendering, not pipeline correctness. Issue #1450.
+func (c *CompositionExecutor) recordParentLinkage(result *SequenceResult, parentStepID, pipelineName string) {
+	if c.store == nil || c.runID == "" || result == nil {
+		return
+	}
+	for _, pr := range result.PipelineResults {
+		if pr.RunID == "" || pr.RunID == c.runID {
+			continue
+		}
+		if parentStepID != "" {
+			_ = c.store.SetParentRun(pr.RunID, c.runID, parentStepID)
+		}
+		// Default kind for composition-launched children. Iterate /
+		// branch / loop sites can refine this in a follow-up by
+		// calling SetRunComposition with a more specific kind +
+		// iterate index/total.
+		_ = c.store.SetRunComposition(pr.RunID, "sub_pipeline_child", pipelineName, "", nil, nil)
+	}
+}
+
 // registerArtifact records an aggregate/iterate output in the artifact table
 // when the wired store implements RegisterArtifact and a runID has been set.
 // Best-effort: failures are swallowed to avoid masking step success.
@@ -621,8 +644,12 @@ func (c *CompositionExecutor) runSubPipeline(ctx context.Context, stepID, pipeli
 
 	result, err := c.seqExecutor.Execute(ctx, []*Pipeline{p}, c.manifest, input)
 	if err != nil {
+		// Even on failure, record parent linkage so the WebUI can render the
+		// child under its parent in the run tree (issue #1450).
+		c.recordParentLinkage(result, stepID, pipelineName)
 		return err
 	}
+	c.recordParentLinkage(result, stepID, pipelineName)
 
 	key := stepID
 	if key == "" {

--- a/internal/state/migration_definitions.go
+++ b/internal/state/migration_definitions.go
@@ -547,5 +547,21 @@ CREATE INDEX IF NOT EXISTS idx_run_heartbeat ON pipeline_run(last_heartbeat) WHE
 			Down: `DROP INDEX IF EXISTS idx_run_heartbeat;
 ALTER TABLE pipeline_run DROP COLUMN last_heartbeat;`,
 		},
+		{
+			Version:     27,
+			Description: "Add iterate metadata + run_kind + sub_pipeline_ref to pipeline_run for composition tree rendering (issue #1450)",
+			Up: `ALTER TABLE pipeline_run ADD COLUMN iterate_index INTEGER;
+ALTER TABLE pipeline_run ADD COLUMN iterate_total INTEGER;
+ALTER TABLE pipeline_run ADD COLUMN iterate_mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_run ADD COLUMN run_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE pipeline_run ADD COLUMN sub_pipeline_ref TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_run_kind ON pipeline_run(run_kind) WHERE run_kind != '';`,
+			Down: `DROP INDEX IF EXISTS idx_run_kind;
+ALTER TABLE pipeline_run DROP COLUMN sub_pipeline_ref;
+ALTER TABLE pipeline_run DROP COLUMN run_kind;
+ALTER TABLE pipeline_run DROP COLUMN iterate_mode;
+ALTER TABLE pipeline_run DROP COLUMN iterate_total;
+ALTER TABLE pipeline_run DROP COLUMN iterate_index;`,
+		},
 	}
 }

--- a/internal/state/migrations_test.go
+++ b/internal/state/migrations_test.go
@@ -465,7 +465,7 @@ func TestInitializeWithMigrations_ExistingDatabase(t *testing.T) {
 	manager := NewMigrationManager(db)
 	applied, err := manager.GetAppliedMigrations()
 	assert.NoError(t, err)
-	assert.Len(t, applied, 26) // All 26 defined migrations
+	assert.Len(t, applied, 27) // All 27 defined migrations
 }
 
 func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
@@ -496,11 +496,11 @@ func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
 func TestMigrationDefinitions(t *testing.T) {
 	migrations := GetAllMigrations()
 
-	// Should have 26 migrations based on our definition
-	assert.Len(t, migrations, 26)
+	// Should have 27 migrations based on our definition
+	assert.Len(t, migrations, 27)
 
 	// Check version sequence
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}
 	for i, migration := range migrations {
 		assert.Equal(t, expectedVersions[i], migration.Version)
 		assert.NotEmpty(t, migration.Description)

--- a/internal/state/runstore.go
+++ b/internal/state/runstore.go
@@ -49,6 +49,7 @@ type RunStore interface {
 
 	// Parent/child run linkage
 	SetParentRun(childRunID, parentRunID, stepID string) error
+	SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error
 	GetChildRuns(parentRunID string) ([]RunRecord, error)
 
 	// Checkpoints (fork/rewind)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -149,6 +149,7 @@ type StateStore interface {
 
 	// Parent-child run linkage
 	SetParentRun(childRunID, parentRunID, stepID string) error
+	SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error
 	GetChildRuns(parentRunID string) ([]RunRecord, error)
 
 	// Retrospective tracking
@@ -704,7 +705,8 @@ func (s *stateStore) UpdateRunHeartbeat(runID string) error {
 func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat,
+	                 iterate_index, iterate_total, iterate_mode, run_kind, sub_pipeline_ref
 	          FROM pipeline_run
 	          WHERE run_id = ?`
 
@@ -715,6 +717,8 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	var pid sql.NullInt64
 	var parentRunID, parentStepID, forkedFromRunID sql.NullString
 	var lastHeartbeat int64
+	var iterateIndex, iterateTotal sql.NullInt64
+	var iterateMode, runKind, subPipelineRef sql.NullString
 
 	err := s.db.QueryRow(query, runID).Scan(
 		&record.RunID,
@@ -734,6 +738,11 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 		&parentStepID,
 		&forkedFromRunID,
 		&lastHeartbeat,
+		&iterateIndex,
+		&iterateTotal,
+		&iterateMode,
+		&runKind,
+		&subPipelineRef,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -784,6 +793,23 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 	if lastHeartbeat > 0 {
 		record.LastHeartbeat = time.Unix(lastHeartbeat, 0)
 	}
+	if iterateIndex.Valid {
+		v := int(iterateIndex.Int64)
+		record.IterateIndex = &v
+	}
+	if iterateTotal.Valid {
+		v := int(iterateTotal.Int64)
+		record.IterateTotal = &v
+	}
+	if iterateMode.Valid {
+		record.IterateMode = iterateMode.String
+	}
+	if runKind.Valid {
+		record.RunKind = runKind.String
+	}
+	if subPipelineRef.Valid {
+		record.SubPipelineRef = subPipelineRef.String
+	}
 
 	return &record, nil
 }
@@ -792,7 +818,8 @@ func (s *stateStore) GetRun(runID string) (*RunRecord, error) {
 func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat,
+	                 iterate_index, iterate_total, iterate_mode, run_kind, sub_pipeline_ref
 	          FROM pipeline_run
 	          WHERE (status = 'running' OR (status = 'pending' AND started_at > unixepoch() - 300))
 	          ORDER BY started_at DESC`
@@ -804,7 +831,8 @@ func (s *stateStore) GetRunningRuns() ([]RunRecord, error) {
 func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat,
+	                 iterate_index, iterate_total, iterate_mode, run_kind, sub_pipeline_ref
 	          FROM pipeline_run
 	          WHERE 1=1`
 	args := []any{}
@@ -1406,6 +1434,8 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		var pid sql.NullInt64
 		var parentRunID, parentStepID, forkedFromRunID sql.NullString
 		var lastHeartbeat int64
+		var iterateIndex, iterateTotal sql.NullInt64
+		var iterateMode, runKind, subPipelineRef sql.NullString
 
 		err := rows.Scan(
 			&record.RunID,
@@ -1425,6 +1455,11 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 			&parentStepID,
 			&forkedFromRunID,
 			&lastHeartbeat,
+			&iterateIndex,
+			&iterateTotal,
+			&iterateMode,
+			&runKind,
+			&subPipelineRef,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan run: %w", err)
@@ -1471,6 +1506,23 @@ func (s *stateStore) queryRunsWithArgs(query string, args ...any) ([]RunRecord, 
 		}
 		if lastHeartbeat > 0 {
 			record.LastHeartbeat = time.Unix(lastHeartbeat, 0)
+		}
+		if iterateIndex.Valid {
+			v := int(iterateIndex.Int64)
+			record.IterateIndex = &v
+		}
+		if iterateTotal.Valid {
+			v := int(iterateTotal.Int64)
+			record.IterateTotal = &v
+		}
+		if iterateMode.Valid {
+			record.IterateMode = iterateMode.String
+		}
+		if runKind.Valid {
+			record.RunKind = runKind.String
+		}
+		if subPipelineRef.Valid {
+			record.SubPipelineRef = subPipelineRef.String
 		}
 
 		records = append(records, record)
@@ -2623,15 +2675,57 @@ func (s *stateStore) SetParentRun(childRunID, parentRunID, stepID string) error 
 	return nil
 }
 
+// SetRunComposition records the composition metadata for a child run —
+// run kind, sub-pipeline reference, and per-iterate-item index/total/mode.
+// Issue #1450 — used by the WebUI to render parent → step → item-N
+// breadcrumbs and run-kind chips without re-deriving from event_log.
+//
+// Pass nil for iterateIndex / iterateTotal when the launch was not an
+// iterate item. Empty strings for iterateMode / subPipelineRef are valid
+// for non-iterate / non-sub-pipeline launches respectively.
+func (s *stateStore) SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error {
+	query := `UPDATE pipeline_run
+	          SET run_kind = ?, sub_pipeline_ref = ?, iterate_mode = ?,
+	              iterate_index = ?, iterate_total = ?
+	          WHERE run_id = ?`
+
+	var idxArg, totalArg any
+	if iterateIndex != nil {
+		idxArg = *iterateIndex
+	}
+	if iterateTotal != nil {
+		totalArg = *iterateTotal
+	}
+
+	result, err := s.db.Exec(query, runKind, subPipelineRef, iterateMode, idxArg, totalArg, childRunID)
+	if err != nil {
+		return fmt.Errorf("failed to set run composition metadata: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("run not found: %s", childRunID)
+	}
+
+	return nil
+}
+
 // GetChildRuns returns all runs that are children of the specified parent run,
 // ordered by started_at.
 func (s *stateStore) GetChildRuns(parentRunID string) ([]RunRecord, error) {
+	// Sort by iterate_index (NULLS LAST handled by COALESCE), then started_at,
+	// so iterate-children render in their YAML-defined order rather than
+	// goroutine-launch order. Issue #1450.
 	query := `SELECT run_id, pipeline_name, status, input, current_step, total_tokens,
 	                 started_at, completed_at, cancelled_at, error_message, tags_json, branch_name, pid,
-	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat
+	                 parent_run_id, parent_step_id, forked_from_run_id, last_heartbeat,
+	                 iterate_index, iterate_total, iterate_mode, run_kind, sub_pipeline_ref
 	          FROM pipeline_run
 	          WHERE parent_run_id = ?
-	          ORDER BY started_at ASC`
+	          ORDER BY COALESCE(iterate_index, 1<<30) ASC, started_at ASC`
 
 	return s.queryRunsWithArgs(query, parentRunID)
 }

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -23,6 +23,16 @@ type RunRecord struct {
 	ParentRunID     string   // Parent pipeline run ID (empty for top-level runs)
 	ParentStepID    string   // Step ID in parent pipeline that launched this child run
 	ForkedFromRunID string   // Run ID this was forked from (empty if not a fork)
+
+	// Composition metadata (issue #1450). Set when a parent composition
+	// step (iterate, aggregate, sub_pipeline, branch, loop) launches
+	// this run; lets the WebUI render iterate progress, sub-pipeline
+	// breadcrumbs, and run-kind chips without re-deriving from event_log.
+	IterateIndex   *int   // 0-based index within an iterate step's items array (nil for non-iterate launches)
+	IterateTotal   *int   // total items in the parent iterate step (nil for non-iterate launches)
+	IterateMode    string // "parallel" or "serial" (empty for non-iterate launches)
+	RunKind        string // "top_level" | "iterate_child" | "sub_pipeline_child" | "loop_iteration" | "branch_arm" (empty defaults to top_level for legacy rows)
+	SubPipelineRef string // Sub-pipeline name as referenced in YAML (e.g. "audit-security"); empty for top-level runs
 }
 
 // CheckpointRecord holds checkpoint data at a step boundary for fork/rewind.

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -518,6 +518,10 @@ func (m *MockStateStore) SetParentRun(childRunID, parentRunID, stepID string) er
 	return nil
 }
 
+func (m *MockStateStore) SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error {
+	return nil
+}
+
 func (m *MockStateStore) GetChildRuns(parentRunID string) ([]state.RunRecord, error) {
 	if m.getChildRuns != nil {
 		return m.getChildRuns(parentRunID)

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -133,7 +133,10 @@ func (b baseStateStore) GetCheckpoints(string) ([]state.CheckpointRecord, error)
 func (b baseStateStore) CreateRunWithFork(string, string, string) (string, error) {
 	return "", nil
 }
-func (b baseStateStore) SetParentRun(string, string, string) error          { return nil }
+func (b baseStateStore) SetParentRun(string, string, string) error { return nil }
+func (b baseStateStore) SetRunComposition(string, string, string, string, *int, *int) error {
+	return nil
+}
 func (b baseStateStore) GetChildRuns(string) ([]state.RunRecord, error)     { return nil, nil }
 func (b baseStateStore) SaveRetrospective(*state.RetrospectiveRecord) error { return nil }
 func (b baseStateStore) GetRetrospective(string) (*state.RetrospectiveRecord, error) {


### PR DESCRIPTION
## Summary

First sub-PR for #1450 (webui composition tree rendering). Backend-only data layer; rendering follows in sub-PRs 3-5.

- Migration 27 adds \`iterate_index\`, \`iterate_total\`, \`iterate_mode\`, \`run_kind\`, \`sub_pipeline_ref\` columns + \`idx_run_kind\` partial index.
- \`RunRecord\` gains the same five fields. \`GetRun\`, \`GetRunningRuns\`, \`ListRuns\`, \`GetChildRuns\` now select + scan them. \`GetChildRuns\` sorts by \`iterate_index\` first so iterate-children render in YAML order rather than goroutine-launch order.
- New \`SetRunComposition(runID, kind, ref, mode, idx, total)\` on \`StateStore\` + \`RunStore\` + \`MockStateStore\`. Pass nil for \`iterateIndex\`/\`iterateTotal\` on non-iterate launches.
- \`composition.CompositionExecutor.runSubPipeline\` now records \`parent_run_id\` + \`parent_step_id\` + \`sub_pipeline_ref\` for every child run via a new \`recordParentLinkage\` helper that fires on both success and error paths.

## What is NOT in this PR

- Per-call-site iterate index / mode wiring (sub-PR 2)
- \`/api/runs/{id}/children\` endpoint + \`GetSubtreeTokens\` query (sub-PR 2)
- Composition step renderer + run-kind chip (sub-PR 3)
- Tree-view child cards + breadcrumb (sub-PR 4)
- ReviewVerdict pill repositioning + pipeline detail filter (sub-PR 5)

## Test plan

- [x] \`go test ./internal/state/ ./internal/pipeline/ ./internal/webui/\` — green
- [x] \`TestMigrationDefinitions\` + \`TestInitializeWithMigrations_ExistingDatabase\` updated for migration 27

Refs #1450.