### PR TITLE
feat(webui): #1450 sub-PR 2 — children API + subtree tokens

### DIFF
--- a/internal/state/runstore.go
+++ b/internal/state/runstore.go
@@ -50,6 +50,7 @@ type RunStore interface {
 	// Parent/child run linkage
 	SetParentRun(childRunID, parentRunID, stepID string) error
 	SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error
+	GetSubtreeTokens(rootRunID string) (int64, error)
 	GetChildRuns(parentRunID string) ([]RunRecord, error)
 
 	// Checkpoints (fork/rewind)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -151,6 +151,7 @@ type StateStore interface {
 	SetParentRun(childRunID, parentRunID, stepID string) error
 	SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error
 	GetChildRuns(parentRunID string) ([]RunRecord, error)
+	GetSubtreeTokens(rootRunID string) (int64, error)
 
 	// Retrospective tracking
 	SaveRetrospective(record *RetrospectiveRecord) error
@@ -2711,6 +2712,33 @@ func (s *stateStore) SetRunComposition(childRunID, runKind, subPipelineRef, iter
 	}
 
 	return nil
+}
+
+// GetSubtreeTokens walks parent_run_id recursively from rootRunID and
+// sums total_tokens across the root + every descendant. Used by the
+// WebUI to display subtree-rolled-up cost on parent runs (issue #1450).
+//
+// Returns 0 with no error when the run has no children — a single-row
+// rollup equals the root's own total_tokens.
+func (s *stateStore) GetSubtreeTokens(rootRunID string) (int64, error) {
+	query := `WITH RECURSIVE subtree(run_id) AS (
+	    SELECT run_id FROM pipeline_run WHERE run_id = ?
+	  UNION ALL
+	    SELECT pr.run_id FROM pipeline_run pr
+	    JOIN subtree s ON pr.parent_run_id = s.run_id
+	)
+	SELECT COALESCE(SUM(pr.total_tokens), 0)
+	FROM pipeline_run pr
+	JOIN subtree s ON pr.run_id = s.run_id`
+
+	var total sql.NullInt64
+	if err := s.db.QueryRow(query, rootRunID).Scan(&total); err != nil {
+		return 0, fmt.Errorf("failed to compute subtree tokens: %w", err)
+	}
+	if total.Valid {
+		return total.Int64, nil
+	}
+	return 0, nil
 }
 
 // GetChildRuns returns all runs that are children of the specified parent run,

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2710,6 +2710,44 @@ func TestGetChildRuns(t *testing.T) {
 	}
 }
 
+// TestGetSubtreeTokens tests the recursive subtree token rollup.
+func TestGetSubtreeTokens(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	rootID, err := store.CreateRun("root-pipeline", "input")
+	require.NoError(t, err)
+	childID, err := store.CreateRun("child-pipeline", "input")
+	require.NoError(t, err)
+	grandchildID, err := store.CreateRun("grandchild-pipeline", "input")
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetParentRun(childID, rootID, "step-a"))
+	require.NoError(t, store.SetParentRun(grandchildID, childID, "step-b"))
+
+	// Set token totals so the rollup has something to sum.
+	require.NoError(t, store.UpdateRunStatus(rootID, "completed", "", 100))
+	require.NoError(t, store.UpdateRunStatus(childID, "completed", "", 250))
+	require.NoError(t, store.UpdateRunStatus(grandchildID, "completed", "", 75))
+
+	total, err := store.GetSubtreeTokens(rootID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100+250+75), total, "subtree tokens must include root + descendants recursively")
+
+	// Childless run rollup equals the run's own tokens.
+	loneID, err := store.CreateRun("lone-pipeline", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(loneID, "completed", "", 42))
+	loneTotal, err := store.GetSubtreeTokens(loneID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), loneTotal)
+
+	// Nonexistent run rollup is 0, not error.
+	missingTotal, err := store.GetSubtreeTokens("does-not-exist")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), missingTotal)
+}
+
 // TestGetChildRuns_Empty tests GetChildRuns with no children.
 func TestGetChildRuns_Empty(t *testing.T) {
 	store, cleanup := setupTestStore(t)

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -522,6 +522,10 @@ func (m *MockStateStore) SetRunComposition(childRunID, runKind, subPipelineRef, 
 	return nil
 }
 
+func (m *MockStateStore) GetSubtreeTokens(rootRunID string) (int64, error) {
+	return 0, nil
+}
+
 func (m *MockStateStore) GetChildRuns(parentRunID string) ([]state.RunRecord, error) {
 	if m.getChildRuns != nil {
 		return m.getChildRuns(parentRunID)

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -137,6 +137,7 @@ func (b baseStateStore) SetParentRun(string, string, string) error { return nil 
 func (b baseStateStore) SetRunComposition(string, string, string, string, *int, *int) error {
 	return nil
 }
+func (b baseStateStore) GetSubtreeTokens(string) (int64, error) { return 0, nil }
 func (b baseStateStore) GetChildRuns(string) ([]state.RunRecord, error)     { return nil, nil }
 func (b baseStateStore) SaveRetrospective(*state.RetrospectiveRecord) error { return nil }
 func (b baseStateStore) GetRetrospective(string) (*state.RetrospectiveRecord, error) {

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -102,6 +102,51 @@ func (s *Server) handleAPIRuns(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handleAPIRunChildren handles GET /api/runs/{id}/children — returns
+// the immediate child runs of a parent run, plus the rolled-up subtree
+// token total. Used by the WebUI to render iterate / sub-pipeline
+// children inline on the parent run page (issue #1450).
+func (s *Server) handleAPIRunChildren(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("id")
+	if runID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing run ID")
+		return
+	}
+
+	if _, err := s.store.GetRun(runID); err != nil {
+		writeJSONError(w, http.StatusNotFound, "run not found")
+		return
+	}
+
+	children, err := s.store.GetChildRuns(runID)
+	if err != nil {
+		log.Printf("[webui] failed to get children for run %s: %v", runID, err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to query children")
+		return
+	}
+	summaries := make([]RunSummary, len(children))
+	for i, c := range children {
+		summaries[i] = runToSummary(c)
+	}
+
+	subtreeTokens, err := s.store.GetSubtreeTokens(runID)
+	if err != nil {
+		log.Printf("[webui] failed to compute subtree tokens for run %s: %v", runID, err)
+		// Soft-fail: still return children, just without the rollup.
+	}
+
+	resp := struct {
+		ParentRunID   string       `json:"parent_run_id"`
+		Children      []RunSummary `json:"children"`
+		SubtreeTokens int64        `json:"subtree_tokens"`
+	}{
+		ParentRunID:   runID,
+		Children:      summaries,
+		SubtreeTokens: subtreeTokens,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // handleAPIRunDetail handles GET /api/runs/{id} - returns run detail as JSON.
 func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 	runID := r.PathValue("id")
@@ -136,8 +181,13 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	artSummaries := deduplicateArtifacts(allArts)
 
+	runSummary := runToSummary(*run)
+	if subtree, err := s.store.GetSubtreeTokens(runID); err == nil {
+		runSummary.SubtreeTokens = subtree
+	}
+
 	resp := RunDetailResponse{
-		Run:       runToSummary(*run),
+		Run:       runSummary,
 		Steps:     stepDetails,
 		Events:    eventSummaries,
 		Artifacts: artSummaries,
@@ -615,6 +665,11 @@ func runToSummary(r state.RunRecord) RunSummary {
 	summary.BranchName = r.BranchName
 	summary.ParentRunID = r.ParentRunID
 	summary.ParentStepID = r.ParentStepID
+	summary.IterateIndex = r.IterateIndex
+	summary.IterateTotal = r.IterateTotal
+	summary.IterateMode = r.IterateMode
+	summary.RunKind = r.RunKind
+	summary.SubPipelineRef = r.SubPipelineRef
 
 	// Full input and truncated preview
 	if r.Input != "" {

--- a/internal/webui/handlers_runs_test.go
+++ b/internal/webui/handlers_runs_test.go
@@ -293,6 +293,81 @@ func TestHandleAPIRunDetail_WithEvents(t *testing.T) {
 	}
 }
 
+// TestHandleAPIRunChildren tests the children endpoint introduced for #1450.
+func TestHandleAPIRunChildren(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("parent-pipeline", "test input")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	childA, err := rwStore.CreateRun("audit-security", "test input")
+	if err != nil {
+		t.Fatalf("create child A: %v", err)
+	}
+	childB, err := rwStore.CreateRun("audit-architecture", "test input")
+	if err != nil {
+		t.Fatalf("create child B: %v", err)
+	}
+	if err := rwStore.SetParentRun(childA, parentID, "parallel-review"); err != nil {
+		t.Fatalf("set parent A: %v", err)
+	}
+	if err := rwStore.SetParentRun(childB, parentID, "parallel-review"); err != nil {
+		t.Fatalf("set parent B: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(parentID, "running", "", 1000); err != nil {
+		t.Fatalf("update parent tokens: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(childA, "completed", "", 2500); err != nil {
+		t.Fatalf("update child A tokens: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(childB, "completed", "", 3300); err != nil {
+		t.Fatalf("update child B tokens: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/runs/"+parentID+"/children", nil)
+	req.SetPathValue("id", parentID)
+	rec := httptest.NewRecorder()
+	srv.handleAPIRunChildren(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		ParentRunID   string       `json:"parent_run_id"`
+		Children      []RunSummary `json:"children"`
+		SubtreeTokens int64        `json:"subtree_tokens"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ParentRunID != parentID {
+		t.Errorf("parent_run_id = %q, want %q", resp.ParentRunID, parentID)
+	}
+	if len(resp.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(resp.Children))
+	}
+	wantSubtree := int64(1000 + 2500 + 3300)
+	if resp.SubtreeTokens != wantSubtree {
+		t.Errorf("subtree_tokens = %d, want %d", resp.SubtreeTokens, wantSubtree)
+	}
+}
+
+// TestHandleAPIRunChildren_Missing returns 404 for unknown run IDs.
+func TestHandleAPIRunChildren_Missing(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequest("GET", "/api/runs/missing/children", nil)
+	req.SetPathValue("id", "missing")
+	rec := httptest.NewRecorder()
+	srv.handleAPIRunChildren(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
 // TestRunToSummary_CompletedRun tests duration calculation for completed runs.
 func TestRunToSummary_CompletedRun(t *testing.T) {
 	start := time.Now().Add(-5 * time.Minute)

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -45,6 +45,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/adapters", s.handleAPIAdapters)
 	mux.HandleFunc("GET /api/models", s.handleAPIModels)
 	mux.HandleFunc("GET /api/runs/{id}", s.handleAPIRunDetail)
+	mux.HandleFunc("GET /api/runs/{id}/children", s.handleAPIRunChildren)
 	mux.HandleFunc("GET /api/runs/{id}/logs", s.handleRunLogs)
 	mux.HandleFunc("POST /api/pipelines/{name}/start", s.handleStartPipeline)
 	mux.HandleFunc("POST /api/runs/{id}/cancel", s.handleCancelRun)

--- a/internal/webui/types.go
+++ b/internal/webui/types.go
@@ -39,6 +39,16 @@ type RunSummary struct {
 	ChildRuns            []RunSummary `json:"child_runs,omitempty"`
 	Adapters             []string     `json:"adapters,omitempty"`
 	Models               []string     `json:"models,omitempty"`
+
+	// Composition metadata (issue #1450). Populated when the run was
+	// launched by a parent composition step (iterate / aggregate /
+	// sub_pipeline / branch / loop).
+	IterateIndex    *int   `json:"iterate_index,omitempty"`
+	IterateTotal    *int   `json:"iterate_total,omitempty"`
+	IterateMode     string `json:"iterate_mode,omitempty"`
+	RunKind         string `json:"run_kind,omitempty"`
+	SubPipelineRef  string `json:"sub_pipeline_ref,omitempty"`
+	SubtreeTokens   int64  `json:"subtree_tokens,omitempty"`
 }
 
 // RunDetailResponse is the JSON response for the run detail API.


### PR DESCRIPTION
## Summary

Backend half of #1450 webui composition tree-rendering. Builds on #1475.

- New \`StateStore.GetSubtreeTokens(rootRunID)\` walks \`parent_run_id\` recursively and sums \`total_tokens\` across the root + every descendant. Returns 0 for unknown / childless runs (no error). \`RunStore\` + \`MockStateStore\` mirror the surface.
- New \`GET /api/runs/{id}/children\` endpoint returns immediate child runs as \`RunSummary\` (ordered by \`iterate_index\` ASC then \`started_at\`) + the rolled-up subtree token total. 404s when the parent does not exist.
- Existing \`GET /api/runs/{id}\` now reports \`subtree_tokens\` on \`RunSummary\` so list views can show the rollup without a second round trip.
- \`runToSummary\` forwards \`iterate_index\`/\`total\`/\`mode\` + \`run_kind\` + \`sub_pipeline_ref\` to JSON for every consumer.

## Test plan

- [x] \`TestGetSubtreeTokens\` — root + descendants, lone, missing
- [x] \`TestHandleAPIRunChildren\`, \`TestHandleAPIRunChildren_Missing\`
- [x] \`go test ./internal/state/ ./internal/webui/ ./internal/tui/\` — green

## What is NOT in this PR

- Per-call-site iterate index/mode population (sub-PR 3 — wires into composition.go's iterate / branch / loop entry points)
- Composition step renderer + run-kind chip (sub-PR 3)
- Tree-view child cards + breadcrumb (sub-PR 4)
- ReviewVerdict pill repositioning + pipeline detail filter (sub-PR 5)

Refs #1450.