### PR TITLE
fix(webui): clear stale step error_message on later completed event

### DIFF
--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -762,6 +762,11 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 			t := ev.Timestamp
 			si.completedAt = &t
 			si.state = "completed"
+			// Clear any error message left over from a prior failed
+			// attempt — a later "completed" event for the same step
+			// means the step succeeded on retry / resume and the stale
+			// error must not bleed into the final UI row (#1450 follow-up).
+			si.errMsg = ""
 		case "failed":
 			t := ev.Timestamp
 			si.completedAt = &t


### PR DESCRIPTION
## Summary

\`buildStepDetails\` walks \`event_log\` sequentially. On \`failed\` it sets \`si.errMsg\` from the event message. On a later \`completed\` event for the same step (resume / retry succeeded), it set \`state=completed\` but NEVER cleared \`si.errMsg\` — so the run-detail page kept showing the prior failure text on a step that actually succeeded.

## Concrete trigger

\`audit-issue-20260428-121221-a580\` (the validation run from #1450 sub-PR 1): \`parallel-evidence\` and \`create-pr\` showed red error banners despite the run completing successfully. The audit-code-walk \"context canceled\" message and the symlink-loop error were from prior failed attempts; the resumed attempts succeeded but the UI never caught up.

## Fix

Clear \`si.errMsg\` when a \`completed\` event arrives for the same step.

## Test plan

- [x] \`go test ./internal/webui/\` — green
- [ ] Live: refreshing /runs/audit-issue-20260428-121221-a580 should show clean step rows after rebuild

Refs #1450.