### PR TITLE
feat(pipeline+webui): #1450 sub-PR 3 — iterate metadata + run-kind chip

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -5436,7 +5436,7 @@ func (e *DefaultPipelineExecutor) executeCompositionStep(ctx context.Context, ex
 
 	// Fall through: bare sub-pipeline step
 	input := e.resolveSubPipelineInput(execution, step)
-	return e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input)
+	return e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input, compositionLaunchInfo{kind: "sub_pipeline_child"})
 }
 
 // resolveSubPipelineInput resolves the input string for a composition step,
@@ -5458,10 +5458,29 @@ func (e *DefaultPipelineExecutor) resolveSubPipelineInput(execution *PipelineExe
 	return input
 }
 
+// compositionLaunchInfo carries the metadata needed to populate the
+// run_kind / iterate_index / iterate_total / iterate_mode columns
+// (issue #1450) for a child run launched by a composition primitive.
+// Zero-value defaults to "sub_pipeline_child" with no iterate metadata,
+// matching bare sub-pipeline launches.
+type compositionLaunchInfo struct {
+	kind          string // "sub_pipeline_child" | "iterate_child" | "branch_arm" | "loop_iteration"
+	iterateIndex  *int   // 0-based index within iterate.over (nil for non-iterate launches)
+	iterateTotal  *int   // total items in iterate.over (nil for non-iterate launches)
+	iterateMode   string // "parallel" or "serial"; empty for non-iterate launches
+}
+
+func (info compositionLaunchInfo) effectiveKind() string {
+	if info.kind != "" {
+		return info.kind
+	}
+	return "sub_pipeline_child"
+}
+
 // runNamedSubPipeline loads a pipeline by name from disk and executes it as a
 // child of the current execution. It handles timeout, artifact injection/extraction,
 // context merging, and parent-child state linking.
-func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execution *PipelineExecution, step *Step, pipelineName, input string) error {
+func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execution *PipelineExecution, step *Step, pipelineName, input string, info compositionLaunchInfo) error {
 	pipelineID := execution.Status.ID
 
 	// Apply lifecycle timeout from sub-pipeline config
@@ -5614,6 +5633,9 @@ func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execu
 		childRunID := e.createRunID(pipelineName, 4, input)
 		childOpts = append(childOpts, WithRunID(childRunID))
 		_ = e.store.SetParentRun(childRunID, pipelineID, step.ID)
+		// Issue #1450 — record composition metadata so iterate progress
+		// + run-kind chips render without re-deriving from event_log.
+		_ = e.store.SetRunComposition(childRunID, info.effectiveKind(), pipelineName, info.iterateMode, info.iterateIndex, info.iterateTotal)
 	}
 
 	childOpts = append(childOpts, WithRegistry(e.registry))
@@ -5824,7 +5846,15 @@ func (e *DefaultPipelineExecutor) executeIterateInDAG(ctx context.Context, execu
 			CompletedSteps: i,
 		})
 
-		if err := e.runNamedSubPipeline(ctx, execution, step, resolvedName, input); err != nil {
+		idx := i
+		total := len(items)
+		info := compositionLaunchInfo{
+			kind:         "iterate_child",
+			iterateIndex: &idx,
+			iterateTotal: &total,
+			iterateMode:  "serial",
+		}
+		if err := e.runNamedSubPipeline(ctx, execution, step, resolvedName, input, info); err != nil {
 			return fmt.Errorf("iterate item %d (%s): %w", i, resolvedName, err)
 		}
 	}
@@ -5898,8 +5928,16 @@ func (e *DefaultPipelineExecutor) executeIterateParallelInDAG(ctx context.Contex
 			Message:    fmt.Sprintf("iterate parallel item %d/%d: %s", i+1, len(items), resolvedName),
 		})
 
+		idx := i
+		total := len(items)
+		info := compositionLaunchInfo{
+			kind:         "iterate_child",
+			iterateIndex: &idx,
+			iterateTotal: &total,
+			iterateMode:  "parallel",
+		}
 		g.Go(func() error {
-			return e.runNamedSubPipeline(gctx, execution, step, resolvedName, input)
+			return e.runNamedSubPipeline(gctx, execution, step, resolvedName, input, info)
 		})
 	}
 
@@ -6132,7 +6170,7 @@ func (e *DefaultPipelineExecutor) executeBranchInDAG(ctx context.Context, execut
 	}
 
 	input := e.resolveSubPipelineInput(execution, step)
-	return e.runNamedSubPipeline(ctx, execution, step, pipelineName, input)
+	return e.runNamedSubPipeline(ctx, execution, step, pipelineName, input, compositionLaunchInfo{kind: "branch_arm"})
 }
 
 // executeLoopInDAG runs sub-steps/sub-pipelines repeatedly until a condition is
@@ -6162,7 +6200,14 @@ func (e *DefaultPipelineExecutor) executeLoopInDAG(ctx context.Context, executio
 		// Execute sub-pipeline if specified at the loop step level
 		if step.SubPipeline != "" {
 			input := e.resolveSubPipelineInput(execution, step)
-			if err := e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input); err != nil {
+			idx := i
+			total := step.Loop.MaxIterations
+			info := compositionLaunchInfo{
+				kind:         "loop_iteration",
+				iterateIndex: &idx,
+				iterateTotal: &total,
+			}
+			if err := e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input, info); err != nil {
 				return fmt.Errorf("loop iteration %d: %w", i, err)
 			}
 		}

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -113,6 +113,14 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 		"forgeIcon":      forgeIcon,
 		"modelTierClass":   modelTierClass,
 		"modelTierTooltip": modelTierTooltip,
+		"runKindLabel":     runKindLabel,
+		"addInt":           func(a, b int) int { return a + b },
+		"deref": func(p *int) int {
+			if p == nil {
+				return 0
+			}
+			return *p
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular

--- a/internal/webui/icons.go
+++ b/internal/webui/icons.go
@@ -12,6 +12,26 @@ func adapterIcon(name string) template.HTML {
 	return template.HTML(svg)
 }
 
+// runKindLabel maps the run_kind enum to a short human-readable label.
+// Unknown values return the raw value so the UI is forward-compatible
+// with future kinds without a panic. Issue #1450.
+func runKindLabel(kind string) string {
+	switch kind {
+	case "iterate_child":
+		return "iterate"
+	case "sub_pipeline_child":
+		return "sub-pipeline"
+	case "branch_arm":
+		return "branch"
+	case "loop_iteration":
+		return "loop"
+	case "top_level", "":
+		return ""
+	default:
+		return kind
+	}
+}
+
 // forgeIcon returns an inline SVG icon for a known forge name.
 // Unknown names return empty string (text-only fallback).
 func forgeIcon(name string) template.HTML {

--- a/internal/webui/templates/partials/run_row.html
+++ b/internal/webui/templates/partials/run_row.html
@@ -12,7 +12,10 @@
         <span class="badge {{statusClass .Status}}">{{.Status}}</span>
     </td>
     <td class="wrap">
-        <div class="run-pipeline-name">{{.PipelineName}}</div>
+        <div class="run-pipeline-name">
+            {{.PipelineName}}
+            {{if .RunKind}}{{if ne .RunKind "top_level"}}<span class="badge badge-runkind badge-runkind-{{.RunKind}}" title="Launched by parent composition step">{{runKindLabel .RunKind}}{{if and (eq .RunKind "iterate_child") .IterateIndex .IterateTotal}} {{addInt (deref .IterateIndex) 1}}/{{deref .IterateTotal}}{{end}}</span>{{end}}{{end}}
+        </div>
         {{if .BranchName}}<div class="run-branch"><span class="branch-icon">&#9741;</span> {{.BranchName}}</div>{{end}}
         {{if .InputPreview}}<div class="run-input-preview" title="{{.InputPreview}}">{{.InputPreview}}</div>{{end}}
     </td>


### PR DESCRIPTION
## Summary

Closes the data-flow loop opened in #1475 + #1476: composition primitives now write \`run_kind\` + \`iterate_index/total/mode\` per child run, and the WebUI shows a chip on iterate / sub-pipeline / branch / loop children.

- \`runNamedSubPipeline\` now takes a \`compositionLaunchInfo\` struct (kind / iterateIndex / iterateTotal / iterateMode). Every call site passes the right values: bare sub-pipeline, iterate (serial + parallel), branch, loop.
- New \`runKindLabel\` + \`addInt\` + \`deref\` template helpers.
- \`partials/run_row.html\` renders \`iterate 3/6\` / \`sub-pipeline\` / \`branch\` / \`loop\` chip next to pipeline name when the row is a composition child. Top-level runs unchanged.

## Test plan

- [x] \`go test ./internal/state/ ./internal/pipeline/ ./internal/webui/\` — green
- [ ] Visual verification: refresh /runs after a fresh ops-pr-respond / audit-issue run; iterate children carry chips with index/total

## What is NOT in this PR

- Tree-view child cards + breadcrumb (sub-PR 4)
- ReviewVerdict pill repositioning + pipeline detail filter (sub-PR 5)

Refs #1450.