### PR TITLE
feat(webui): #1450 sub-PR 4 — iterate breadcrumb + child chip + subtree tokens

### DIFF
--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -121,6 +121,9 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 			}
 			return *p
 		},
+		"subtreeIsLarger": func(r RunSummary) bool {
+			return r.SubtreeTokens > int64(r.TotalTokens)
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular

--- a/internal/webui/templates/partials/child_run_row.html
+++ b/internal/webui/templates/partials/child_run_row.html
@@ -12,7 +12,10 @@
         <span class="badge {{statusClass .Status}}">{{.Status}}</span>
     </td>
     <td class="wrap">
-        <div class="run-pipeline-name"><span class="child-indent">&#x2514;</span> {{.PipelineName}}</div>
+        <div class="run-pipeline-name">
+            <span class="child-indent">&#x2514;</span> {{.PipelineName}}
+            {{if .RunKind}}{{if ne .RunKind "top_level"}}<span class="badge badge-runkind badge-runkind-{{.RunKind}}" title="Launched by parent composition step">{{runKindLabel .RunKind}}{{if and (eq .RunKind "iterate_child") .IterateIndex .IterateTotal}} {{addInt (deref .IterateIndex) 1}}/{{deref .IterateTotal}}{{end}}</span>{{end}}{{end}}
+        </div>
         {{if .BranchName}}<div class="run-branch"><span class="branch-icon">&#9741;</span> {{.BranchName}}</div>{{end}}
         {{if .InputPreview}}<div class="run-input-preview" title="{{.InputPreview}}">{{.InputPreview}}</div>{{end}}
     </td>

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -6,7 +6,19 @@
 <div class="w-head">
     <div>
         <a href="/runs" class="back-link">&larr; Runs</a>
-        {{if .Run.ParentRunID}}<a href="/runs/{{.Run.ParentRunID}}" class="back-link" style="font-size:0.72rem;">&larr; parent: {{.Run.ParentRunID}}</a>{{end}}
+        {{if .Run.ParentRunID}}
+        <a href="/runs/{{.Run.ParentRunID}}" class="back-link" style="font-size:0.72rem;" title="{{.Run.ParentRunID}}">
+            &larr; parent
+            {{- with .Run.ParentStepID}}<span style="color:var(--color-text-muted);"> &rsaquo; </span><code style="font-size:0.7rem;background:var(--color-bg-tertiary);padding:0 0.25rem;border-radius:2px;">{{.}}</code>{{end}}
+            {{- if and (eq .Run.RunKind "iterate_child") .Run.IterateIndex .Run.IterateTotal}}
+            <span style="color:var(--color-text-muted);"> &rsaquo; </span>
+            <span class="badge badge-runkind badge-runkind-iterate_child">item {{addInt (deref .Run.IterateIndex) 1}}/{{deref .Run.IterateTotal}}</span>
+            {{- else if .Run.RunKind}}
+            <span style="color:var(--color-text-muted);"> &rsaquo; </span>
+            <span class="badge badge-runkind badge-runkind-{{.Run.RunKind}}">{{runKindLabel .Run.RunKind}}</span>
+            {{- end}}
+        </a>
+        {{end}}
         <h1>
             <a href="/pipelines/{{.Run.PipelineName}}">{{.Run.PipelineName}}</a>
             <span class="badge {{statusClass .Run.Status}}">{{statusLabel .Run.Status}}</span>
@@ -30,7 +42,7 @@
     <span style="color:var(--color-text-muted);">·</span>
     <span><b>{{.Run.StepsCompleted}}/{{.Run.StepsTotal}}</b> steps</span>
     <span style="color:var(--color-text-muted);">·</span>
-    <span><b>{{formatTokens .Run.TotalTokens}}</b> tok</span>
+    <span><b>{{formatTokens .Run.TotalTokens}}</b> tok{{if subtreeIsLarger .Run}} <span style="color:var(--color-text-muted);" title="Total tokens across this run + every descendant child run">(subtree {{formatTokens .Run.SubtreeTokens}})</span>{{end}}</span>
     {{range .Adapters}}<span class="badge badge-adapter">{{adapterIcon .}}{{friendlyModel .}}</span>{{end}}
     {{range .Models}}<span class="badge badge-model {{modelTierClass .}}"{{if modelTierTooltip .}} title="{{modelTierTooltip .}}" style="cursor:help"{{end}}>{{friendlyModel .}}</span>{{end}}
     {{if .Run.BranchName}}<span class="badge badge-branch">&#9741; {{.Run.BranchName}}</span>{{end}}


### PR DESCRIPTION
## Summary

UX-side surface for the data added in sub-PRs 1-3.

- **Run-detail breadcrumb**: 'parent > step > item N/M' header on iterate / sub-pipeline / branch / loop children, sourced from \`RunKind\` + \`IterateIndex\` + \`IterateTotal\` populated in #1478.
- **Child row chip**: \`partials/child_run_row.html\` shows the run-kind chip with iterate index/total next to the child pipeline name (parity with top-level row chip from #1478).
- **Subtree token rollup**: stats bar shows \`(subtree N tok)\` next to per-run total when \`SubtreeTokens\` (#1476) exceeds the run's own — i.e. when child runs consumed additional tokens.
- New template helper \`subtreeIsLarger\` handles the int64 vs int comparison.

## Test plan

- [x] \`go test ./internal/webui/\` — green
- [ ] Visual: refresh /runs/&lt;parent&gt; for a multi-level run and confirm breadcrumb + chips + subtree rollup render

## What is NOT in this PR

- Composition step renderer for iterate/aggregate/branch/loop step kinds inside step_card.html (sub-PR 4.1)
- Multi-level recursive nesting (currently child_run_row only renders one level)
- ReviewVerdict pill repositioning + pipeline detail filter (sub-PR 5)

Refs #1450.