### PR TITLE
feat(webui): #1450 sub-PR 5 — review pill move + pipeline detail filter

### DIFF
--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -870,6 +870,10 @@ func (s *stateStore) ListRuns(opts ListRunsOptions) ([]RunRecord, error) {
 		args = append(args, opts.SinceUnix)
 	}
 
+	if opts.TopLevelOnly {
+		query += " AND (parent_run_id IS NULL OR parent_run_id = '')"
+	}
+
 	// Cursor-based pagination: return runs before the cursor position
 	if opts.BeforeUnix > 0 {
 		if opts.BeforeRunID != "" {

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -57,6 +57,7 @@ type ListRunsOptions struct {
 	BeforeUnix   int64    // Cursor: only return runs started before this unix timestamp
 	BeforeRunID  string   // Cursor: tie-break for runs at the same timestamp
 	SinceUnix    int64    // Only return runs started after this unix timestamp
+	TopLevelOnly bool     // Only return top-level runs (parent_run_id IS NULL OR ''). Issue #1450 — keeps composition children out of pipeline detail recent-runs lists.
 }
 
 // LogRecord holds an event log entry.

--- a/internal/webui/handlers_pipelines.go
+++ b/internal/webui/handlers_pipelines.go
@@ -448,6 +448,10 @@ func (s *Server) handlePipelineDetailPage(w http.ResponseWriter, r *http.Request
 		runs, err := s.store.ListRuns(state.ListRunsOptions{
 			PipelineName: name,
 			Limit:        1000,
+			// Filter out composition children (issue #1450) — sub-pipeline
+			// runs spawned by ops-pr-respond / audit-issue / impl-issue
+			// otherwise flood the recent-runs table for audit-* etc.
+			TopLevelOnly: true,
 		})
 		if err == nil {
 			runCount = len(runs)

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -204,9 +204,9 @@
             <div class="ws-io">
                 <span class="ws-io-lbl ws-io-click" onclick="toggleIn(this)" title="Show prompt">IN</span>
                 {{if $step.InputArtifacts}}{{range $ia := $step.InputArtifacts}}<a href="#" class="w-tab" data-run-id="{{$step.RunID}}" data-step-id="{{$ia.Step}}" data-artifact-name="{{$ia.Name}}" onclick="toggleArt(this);return false;" title="Show injected artifact content">{{$ia.Step}}/{{$ia.Name}}</a>{{end}}{{else}}<span class="ws-io-val ws-io-click" onclick="toggleIn(this)" title="Show prompt">{{if and $step.Action (not (hasPrefix $step.Action "{{"))}}{{if gt (len $step.Action) 80}}{{slice $step.Action 0 80}}…{{else}}{{$step.Action}}{{end}}{{else if eq $i 0}}pipeline input{{else if $step.Dependencies}}{{joinStrings $step.Dependencies " + "}}{{else}}prev step{{end}}</span>{{end}}
-                {{if $step.ReviewVerdict}}<span class="w-ctr {{if eq $step.ReviewVerdict "pass"}}w-ctr-pass{{else}}w-ctr-fail{{end}}">{{$step.ReviewVerdict}}</span>{{end}}
                 <span class="ws-io-sep"></span>
                 <span class="ws-io-lbl">OUT</span>
+                {{if $step.ReviewVerdict}}<span class="w-ctr w-ctr-review {{if eq $step.ReviewVerdict "pass"}}w-ctr-pass{{else}}w-ctr-fail{{end}}" title="Agent review verdict for this step">review: {{$step.ReviewVerdict}}</span>{{end}}
                 {{if $step.Artifacts}}{{range $a := $step.Artifacts}}<a href="#" class="w-tab" data-run-id="{{$step.RunID}}" data-step-id="{{$step.StepID}}" data-artifact-name="{{$a.Name}}" onclick="toggleArt(this);return false;">{{$a.Name}} <span class="art-size">{{formatBytes $a.SizeBytes}}</span></a>{{end}}{{end}}
                 <a href="#" class="w-tab" onclick="toggleLogs(this);return false;" data-step-id="{{$step.StepID}}">logs</a>
                 {{if $step.Duration}}<span class="ws-dur">{{$step.Duration}}</span>{{end}}


### PR DESCRIPTION
## Summary

- **Review verdict pill** moved out of the IN row (where it visually adjudicated the input refs) into a slot above the OUT row, with a 'review:' prefix so the meaning is unambiguous.
- **Pipeline detail recent-runs filter**: new \`ListRunsOptions.TopLevelOnly\` filter; the pipeline detail page passes it for the recent-runs table so composition children (audit-* spawned by ops-pr-respond, impl-finding spawned by resolve-and-verify, etc.) don't flood the parent pipeline's recent runs.

## Test plan

- [x] \`go test ./internal/state/ ./internal/webui/\` — green

## Closes the #1450 sub-PR series

Together with #1475, #1476, #1477, #1478, #1479: backend schema + API + composition wiring + UX surface for the WebUI composition tree-rendering work.

Refs #1450.