### PR TITLE
fix(webui): show run-kind chip + render children for all composition kinds

### DIFF
--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -809,6 +809,16 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 		if stepType == "" && step.SubPipeline != "" {
 			stepType = "pipeline"
 		}
+		// Composition primitives (#1450): treat iterate/aggregate/branch/loop
+		// as "pipeline" so the inline child-runs block under each step renders
+		// for them too. Without this, only bare sub_pipeline steps got the
+		// inline list; iterate steps that fan out children showed nothing.
+		if stepType == "" {
+			switch {
+			case step.Iterate != nil, step.Aggregate != nil, step.Branch != nil, step.Loop != nil:
+				stepType = "pipeline"
+			}
+		}
 
 		// Collect gate info
 		var gatePrompt, gateChoices string

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -249,6 +249,7 @@
                 {{range .}}
                 <a href="/runs/{{.RunID}}" style="display:flex;align-items:center;gap:0.4rem;padding:0.2rem 0.4rem;margin-bottom:0.15rem;background:var(--color-bg-tertiary);border-radius:4px;border-left:3px solid {{if eq .Status "completed"}}var(--color-completed){{else if eq .Status "failed"}}var(--color-failed){{else if eq .Status "running"}}var(--color-running){{else}}var(--color-border){{end}};text-decoration:none;color:inherit;font-size:0.72rem;">
                     <span style="font-weight:600;color:var(--color-text);">{{.PipelineName}}</span>
+                    {{if .RunKind}}{{if ne .RunKind "top_level"}}<span class="badge badge-runkind badge-runkind-{{.RunKind}}" style="font-size:0.62rem;" title="Launched by parent composition step">{{runKindLabel .RunKind}}{{if and (eq .RunKind "iterate_child") .IterateIndex .IterateTotal}} {{addInt (deref .IterateIndex) 1}}/{{deref .IterateTotal}}{{end}}</span>{{end}}{{end}}
                     <span class="badge {{statusClass .Status}}" style="font-size:0.65rem;">{{.Status}}</span>
                     {{if .Duration}}<span style="color:var(--color-text-muted);">{{.Duration}}</span>{{end}}
                     {{if .TotalTokens}}<span style="color:var(--color-text-muted);">{{formatTokens .TotalTokens}} tok</span>{{end}}


### PR DESCRIPTION
## Summary

Two follow-ups to #1450 sub-PRs 3-4 surfaced on a live ops-parallel-audit demo run.

- Inline child-run block under each step only rendered when \`StepType == \"pipeline\"\`, which was set only for bare \`sub_pipeline\` steps. Iterate / aggregate / branch / loop steps that fan out children showed nothing inline. Treat all four as \"pipeline\" so children render under the step card.
- Inline child anchor row had no run-kind chip. Add same chip + iterate index/total used by run_row / child_run_row partials (#1478, #1479).

## Test plan

- [x] \`go test ./internal/webui/\` — green
- [ ] Live: refresh /runs/&lt;parent-with-iterate-step&gt; and confirm chips on inline children

Refs #1450.