### PR TITLE
feat(state): orphan reaper for stale running runs (#1467)

### DIFF
--- a/internal/state/runstore.go
+++ b/internal/state/runstore.go
@@ -31,6 +31,7 @@ type RunStore interface {
 	UpdateRunBranch(runID string, branch string) error
 	UpdateRunPID(runID string, pid int) error
 	UpdateRunHeartbeat(runID string) error
+	ReapOrphans(staleAfter time.Duration) (int, error)
 	GetRun(runID string) (*RunRecord, error)
 	GetRunningRuns() ([]RunRecord, error)
 	ListRuns(opts ListRunsOptions) ([]RunRecord, error)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -123,6 +123,7 @@ type StateStore interface {
 	// reconciler can flag zombies whose owning process died without
 	// updating the DB.
 	UpdateRunHeartbeat(runID string) error
+	ReapOrphans(staleAfter time.Duration) (int, error)
 
 	// Step attempt tracking (retry/recovery)
 	RecordStepAttempt(record *StepAttemptRecord) error
@@ -700,6 +701,38 @@ func (s *stateStore) UpdateRunHeartbeat(runID string) error {
 		return fmt.Errorf("failed to update run heartbeat: %w", err)
 	}
 	return nil
+}
+
+// ReapOrphans marks every "running" pipeline whose last_heartbeat is older
+// than staleAfter (or has never reported a heartbeat AND started more than
+// staleAfter ago) as failed with reason "orphaned (no heartbeat)". Returns
+// the number of rows transitioned. Issue #1467 — fixes the dead-process /
+// stale-DB-row leak where host sleep / sandbox cycle / SIGKILL skipped the
+// deferred UpdateRunStatus and left max_concurrent_workers wedged.
+func (s *stateStore) ReapOrphans(staleAfter time.Duration) (int, error) {
+	now := s.now().Unix()
+	cutoff := now - int64(staleAfter.Seconds())
+
+	query := `UPDATE pipeline_run
+	          SET status = 'failed',
+	              error_message = COALESCE(NULLIF(error_message, ''), 'orphaned (no heartbeat for ' || ? || 's)'),
+	              completed_at = ?
+	          WHERE status = 'running'
+	            AND started_at < ?
+	            AND (
+	                  (last_heartbeat IS NOT NULL AND last_heartbeat > 0 AND last_heartbeat < ?)
+	               OR (last_heartbeat IS NULL OR last_heartbeat = 0)
+	            )`
+
+	result, err := s.db.Exec(query, int64(staleAfter.Seconds()), now, cutoff, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reap orphans: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	return int(rows), nil
 }
 
 // GetRun retrieves a single run record by ID.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2710,6 +2710,73 @@ func TestGetChildRuns(t *testing.T) {
 	}
 }
 
+// TestReapOrphans tests the orphaned-run reaper for issue #1467.
+func TestReapOrphans(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Backdate started_at via direct SQL so the cutoff check fires.
+	internalStore := store.(*stateStore)
+	pastTime := time.Now().Add(-30 * time.Minute).Unix()
+
+	// Stale: running, no heartbeat, started long ago — should be reaped.
+	staleNoHeartbeat, err := store.CreateRun("stale-no-heartbeat", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(staleNoHeartbeat, "running", "step-a", 0))
+	_, err = internalStore.db.Exec(`UPDATE pipeline_run SET started_at = ? WHERE run_id = ?`, pastTime, staleNoHeartbeat)
+	require.NoError(t, err)
+
+	// Stale: running, last heartbeat older than threshold.
+	staleHeartbeat, err := store.CreateRun("stale-heartbeat", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(staleHeartbeat, "running", "step-b", 0))
+	_, err = internalStore.db.Exec(`UPDATE pipeline_run SET started_at = ?, last_heartbeat = ? WHERE run_id = ?`, pastTime, pastTime, staleHeartbeat)
+	require.NoError(t, err)
+
+	// Live: recent heartbeat — must NOT be reaped.
+	liveHeartbeat, err := store.CreateRun("live-heartbeat", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(liveHeartbeat, "running", "step-c", 0))
+	require.NoError(t, store.UpdateRunHeartbeat(liveHeartbeat))
+
+	// Young: just started, no heartbeat yet — must NOT be reaped (grace).
+	youngRun, err := store.CreateRun("young-run", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(youngRun, "running", "step-d", 0))
+
+	// Already-completed: must be unchanged.
+	completedRun, err := store.CreateRun("completed-run", "input")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(completedRun, "completed", "step-e", 100))
+	_, err = internalStore.db.Exec(`UPDATE pipeline_run SET started_at = ? WHERE run_id = ?`, pastTime, completedRun)
+	require.NoError(t, err)
+
+	reaped, err := store.ReapOrphans(5 * time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, reaped, "should reap two stale running runs")
+
+	r, err := store.GetRun(staleNoHeartbeat)
+	require.NoError(t, err)
+	assert.Equal(t, "failed", r.Status)
+	assert.Contains(t, r.ErrorMessage, "orphaned")
+
+	r, err = store.GetRun(staleHeartbeat)
+	require.NoError(t, err)
+	assert.Equal(t, "failed", r.Status)
+
+	r, err = store.GetRun(liveHeartbeat)
+	require.NoError(t, err)
+	assert.Equal(t, "running", r.Status, "live runs must not be reaped")
+
+	r, err = store.GetRun(youngRun)
+	require.NoError(t, err)
+	assert.Equal(t, "running", r.Status, "young runs must not be reaped")
+
+	r, err = store.GetRun(completedRun)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", r.Status, "completed runs must be unchanged")
+}
+
 // TestGetSubtreeTokens tests the recursive subtree token rollup.
 func TestGetSubtreeTokens(t *testing.T) {
 	store, cleanup := setupTestStore(t)

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -406,6 +406,10 @@ func (m *MockStateStore) UpdateRunHeartbeat(runID string) error {
 	return nil
 }
 
+func (m *MockStateStore) ReapOrphans(staleAfter time.Duration) (int, error) {
+	return 0, nil
+}
+
 func (m *MockStateStore) RecordStepAttempt(record *state.StepAttemptRecord) error {
 	if m.recordStepAttempt != nil {
 		return m.recordStepAttempt(record)

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -103,7 +103,8 @@ func (b baseStateStore) GetRunTags(string) ([]string, error) { return nil, nil }
 func (b baseStateStore) AddRunTag(string, string) error      { return nil }
 func (b baseStateStore) RemoveRunTag(string, string) error   { return nil }
 func (b baseStateStore) UpdateRunPID(string, int) error      { return nil }
-func (b baseStateStore) UpdateRunHeartbeat(string) error      { return nil }
+func (b baseStateStore) UpdateRunHeartbeat(string) error                { return nil }
+func (b baseStateStore) ReapOrphans(time.Duration) (int, error)         { return 0, nil }
 func (b baseStateStore) RecordStepAttempt(*state.StepAttemptRecord) error {
 	return nil
 }

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -353,6 +353,18 @@ func (s *Server) Start() error {
 		fmt.Fprintf(os.Stderr, "Dashboard token: %s\n", s.token)
 	}
 
+	// Issue #1467 — reap any "running" rows whose owning process died
+	// without writing the deferred UpdateRunStatus (host sleep, sandbox
+	// cycle, SIGKILL). Heartbeats fire every 30s; treat anything stale
+	// for > 5 minutes as orphaned.
+	if s.store != nil {
+		if reaped, err := s.store.ReapOrphans(5 * time.Minute); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: orphan reap failed: %v\n", err)
+		} else if reaped > 0 {
+			fmt.Fprintf(os.Stderr, "Reaped %d orphaned run(s) on startup\n", reaped)
+		}
+	}
+
 	// Graceful shutdown on interrupt
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()


### PR DESCRIPTION
## Summary

Closes #1467.

When the host sleeps / sandbox cycles / a wave subprocess gets SIGKILL, the deferred \`UpdateRunStatus\` never fires and the \`pipeline_run\` row sits at \`status='running'\` forever. \`wave list runs\` shows ghost workers and \`CreateRunWithLimit\`'s \`max_concurrent_workers\` gate gets wedged.

- New \`ReapOrphans(staleAfter time.Duration) (int, error)\` on \`StateStore\` + \`RunStore\`: marks every \`running\` row started > \`staleAfter\` ago and \`last_heartbeat\` older than the cutoff (or NULL/0) as \`failed\` with reason \`orphaned (no heartbeat for Ns)\`. Returns count.
- \`wave serve\` startup runs \`ReapOrphans(5*time.Minute)\` once and logs the number reaped. Heartbeats fire every 30s so 5min is well outside the live-run window.
- Mock + tui base store get no-op stubs.

## Test plan

- [x] \`TestReapOrphans\` — stale-no-heartbeat (reaped), stale-heartbeat (reaped), live-heartbeat (kept), young-no-grace (kept), completed (unchanged)
- [x] \`go test ./internal/state/ ./internal/webui/ ./internal/tui/\` — green

## What is NOT in this PR

- \`wave reap\` CLI command for manual cleanup (follow-up)
- PID-based liveness check (follow-up)
- Periodic in-server reap (currently startup-only — restart \`wave serve\` to flush)

Refs #1467.