### PR TITLE
feat(pipeline): subset_from mount mode for #1453 layer 1

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -3993,7 +3993,7 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 			if resolvedMounts[i].SubsetFrom == "" {
 				continue
 			}
-			subsetSrc, err := e.materialiseMountSubset(execution, resolvedMounts[i])
+			subsetSrc, err := e.materialiseMountSubset(execution, step.ID, i, resolvedMounts[i])
 			if err != nil {
 				return "", fmt.Errorf("step %q mount subset: %w", step.ID, err)
 			}
@@ -4038,7 +4038,7 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 // path navigated via ExtractJSONPath. The extracted value must be a
 // JSON array of strings, each interpreted as a path relative to the
 // original mount.Source.
-func (e *DefaultPipelineExecutor) materialiseMountSubset(execution *PipelineExecution, mount Mount) (string, error) {
+func (e *DefaultPipelineExecutor) materialiseMountSubset(execution *PipelineExecution, ownerStepID string, mountIdx int, mount Mount) (string, error) {
 	parts := strings.SplitN(mount.SubsetFrom, ".", 3)
 	if len(parts) < 3 {
 		return "", fmt.Errorf("subset_from %q: must be '<step>.<artifact>.<json-path>'", mount.SubsetFrom)
@@ -4066,17 +4066,25 @@ func (e *DefaultPipelineExecutor) materialiseMountSubset(execution *PipelineExec
 		return "", fmt.Errorf("subset_from %q: expected array of strings, got %s", mount.SubsetFrom, string(listJSON))
 	}
 
-	// Resolve original source path for relative copy.
+	// Resolve original source path for relative copy. EvalSymlinks
+	// gives us the canonical path so the security check below catches
+	// cases where the source itself is a symlink.
 	source := mount.Source
 	if !filepath.IsAbs(source) {
 		if abs, err := filepath.Abs(source); err == nil {
 			source = abs
 		}
 	}
+	canonicalSource, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return "", fmt.Errorf("resolve source: %w", err)
+	}
 
-	// Materialise into .agents/workspaces/_subsets/<runID>/<stepID>/<step-mount-idx>.
+	// Materialise into a path unique to (run, ownerStep, mountIdx) so two
+	// concurrent steps with the same SubsetFrom can't collide on the
+	// RemoveAll/MkdirAll race.
 	pipelineID := execution.Status.ID
-	subsetRoot := filepath.Join(".agents", "workspaces", "_subsets", pipelineID, fmt.Sprintf("%x", []byte(mount.SubsetFrom)))
+	subsetRoot := filepath.Join(".agents", "workspaces", "_subsets", pipelineID, ownerStepID, fmt.Sprintf("mount%d", mountIdx))
 	if err := os.RemoveAll(subsetRoot); err != nil {
 		return "", fmt.Errorf("clean subset dir: %w", err)
 	}
@@ -4100,13 +4108,29 @@ func (e *DefaultPipelineExecutor) materialiseMountSubset(execution *PipelineExec
 		if info.IsDir() {
 			continue
 		}
+		// Reject symlinks — even if the JSON path itself looks safe,
+		// a symlink in the source tree could point outside it. Belt
+		// and suspenders below.
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		// Belt and suspenders: resolve through any parent symlinks
+		// and confirm the canonical path is still under source.
+		canonicalSrc, err := filepath.EvalSymlinks(srcFile)
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(canonicalSrc, canonicalSource+string(filepath.Separator)) && canonicalSrc != canonicalSource {
+			// Canonical path escaped source — drop.
+			continue
+		}
 		dstFile := filepath.Join(subsetRoot, clean)
 		if err := os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
 			return "", fmt.Errorf("mkdir subset parent: %w", err)
 		}
 		// Copy rather than symlink — readonly mode chmods the tree
 		// later, which symlinks don't carry.
-		if err := copySubsetFile(srcFile, dstFile); err != nil {
+		if err := copySubsetFile(canonicalSrc, dstFile); err != nil {
 			return "", fmt.Errorf("copy %q: %w", clean, err)
 		}
 	}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -3982,9 +3982,27 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 		// Use pipeline context for template variables
 		templateVars := execution.Context.ToTemplateVars()
 
+		// Issue #1453 — resolve subset_from on each mount before passing
+		// to the workspace manager. When set, the materialised subset
+		// tree replaces the mount Source so the resulting workspace only
+		// contains files listed in the named artifact's JSON path.
+		mounts := step.Workspace.Mount
+		resolvedMounts := make([]Mount, len(mounts))
+		copy(resolvedMounts, mounts)
+		for i := range resolvedMounts {
+			if resolvedMounts[i].SubsetFrom == "" {
+				continue
+			}
+			subsetSrc, err := e.materialiseMountSubset(execution, resolvedMounts[i])
+			if err != nil {
+				return "", fmt.Errorf("step %q mount subset: %w", step.ID, err)
+			}
+			resolvedMounts[i].Source = subsetSrc
+		}
+
 		wsPath, err := e.wsManager.Create(workspace.WorkspaceConfig{
 			Root:  wsRoot,
-			Mount: toWorkspaceMounts(step.Workspace.Mount),
+			Mount: toWorkspaceMounts(resolvedMounts),
 		}, templateVars)
 		if err != nil {
 			return "", err
@@ -4007,6 +4025,116 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 	// Anchor Claude Code path resolution (see mount-based workspace above)
 	_ = exec.Command("git", "init", "-q", wsPath).Run()
 	return wsPath, nil
+}
+
+// materialiseMountSubset reads the artifact named in mount.SubsetFrom,
+// extracts the path list at the dotted JSON path, and copies only
+// those files (preserving directory structure) into a fresh temp dir
+// rooted under .agents/workspaces/_subsets/. Returns the temp-dir path
+// to be used as the mount source. Issue #1453.
+//
+// SubsetFrom format: "<step>.<artifact>.<json-path>".
+// The first two segments name the artifact; the remainder is a JSON
+// path navigated via ExtractJSONPath. The extracted value must be a
+// JSON array of strings, each interpreted as a path relative to the
+// original mount.Source.
+func (e *DefaultPipelineExecutor) materialiseMountSubset(execution *PipelineExecution, mount Mount) (string, error) {
+	parts := strings.SplitN(mount.SubsetFrom, ".", 3)
+	if len(parts) < 3 {
+		return "", fmt.Errorf("subset_from %q: must be '<step>.<artifact>.<json-path>'", mount.SubsetFrom)
+	}
+	stepID, artifactName, jsonPath := parts[0], parts[1], parts[2]
+
+	// Resolve artifact path via the same lookup tiers as the auto-injector.
+	path, ok := e.locateDepArtifact(execution, stepID, artifactName)
+	if !ok {
+		return "", fmt.Errorf("subset_from artifact %q:%q not found", stepID, artifactName)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read subset artifact: %w", err)
+	}
+
+	listJSON, err := ExtractJSONPath(data, "."+jsonPath)
+	if err != nil {
+		return "", fmt.Errorf("extract %q: %w", jsonPath, err)
+	}
+
+	var files []string
+	if err := json.Unmarshal([]byte(listJSON), &files); err != nil {
+		return "", fmt.Errorf("subset_from %q: expected array of strings, got %s", mount.SubsetFrom, string(listJSON))
+	}
+
+	// Resolve original source path for relative copy.
+	source := mount.Source
+	if !filepath.IsAbs(source) {
+		if abs, err := filepath.Abs(source); err == nil {
+			source = abs
+		}
+	}
+
+	// Materialise into .agents/workspaces/_subsets/<runID>/<stepID>/<step-mount-idx>.
+	pipelineID := execution.Status.ID
+	subsetRoot := filepath.Join(".agents", "workspaces", "_subsets", pipelineID, fmt.Sprintf("%x", []byte(mount.SubsetFrom)))
+	if err := os.RemoveAll(subsetRoot); err != nil {
+		return "", fmt.Errorf("clean subset dir: %w", err)
+	}
+	if err := os.MkdirAll(subsetRoot, 0755); err != nil {
+		return "", fmt.Errorf("create subset dir: %w", err)
+	}
+
+	for _, rel := range files {
+		// Reject path traversal — entries must be repo-relative.
+		clean := filepath.Clean(rel)
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
+			continue
+		}
+		srcFile := filepath.Join(source, clean)
+		info, err := os.Lstat(srcFile)
+		if err != nil {
+			// Listed but missing — skip silently. PR file lists may
+			// include deleted paths.
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		dstFile := filepath.Join(subsetRoot, clean)
+		if err := os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
+			return "", fmt.Errorf("mkdir subset parent: %w", err)
+		}
+		// Copy rather than symlink — readonly mode chmods the tree
+		// later, which symlinks don't carry.
+		if err := copySubsetFile(srcFile, dstFile); err != nil {
+			return "", fmt.Errorf("copy %q: %w", clean, err)
+		}
+	}
+
+	return subsetRoot, nil
+}
+
+// copySubsetFile copies a single file (regular or symlink target)
+// from src to dst, preserving mode bits.
+func copySubsetFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func toWorkspaceMounts(mounts []Mount) []workspace.Mount {

--- a/internal/pipeline/subset_mount_test.go
+++ b/internal/pipeline/subset_mount_test.go
@@ -1,0 +1,133 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/manifest"
+)
+
+// TestMaterialiseMountSubset covers the workspace subset mount mode
+// added for issue #1453.
+func TestMaterialiseMountSubset(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Project tree with three files; we'll subset to two of them.
+	source := filepath.Join(tmp, "project")
+	for _, p := range []string{"keep/a.go", "keep/b.go", "drop/c.go"} {
+		full := filepath.Join(source, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("package x\n// "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// pr-context.json artifact listing only the keep/* files.
+	artifact := filepath.Join(tmp, "pr-context.json")
+	body, _ := json.Marshal(map[string]any{
+		"changed_files": []string{"keep/a.go", "keep/b.go"},
+	})
+	if err := os.WriteFile(artifact, body, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// chdir into tmp so the subset root resolves under tmp/.agents/workspaces/_subsets/.
+	origWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	exec := &PipelineExecution{
+		Pipeline: &Pipeline{
+			Steps: []Step{{ID: "fetch-pr"}, {ID: "audit", Dependencies: []string{"fetch-pr"}}},
+		},
+		Manifest:       &manifest.Manifest{},
+		ArtifactPaths:  map[string]string{"fetch-pr:pr-context": artifact},
+		WorkspacePaths: map[string]string{},
+		Status:         &PipelineStatus{ID: "test-run"},
+		Context:        NewPipelineContext("test-run", "test", "audit"),
+	}
+
+	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+
+	mount := Mount{
+		Source:     source,
+		Target:     "/project",
+		Mode:       "readonly",
+		SubsetFrom: "fetch-pr.pr-context.changed_files",
+	}
+
+	subsetDir, err := executor.materialiseMountSubset(exec, mount)
+	if err != nil {
+		t.Fatalf("materialise: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(subsetDir, "keep/a.go")); err != nil {
+		t.Errorf("keep/a.go missing in subset: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subsetDir, "keep/b.go")); err != nil {
+		t.Errorf("keep/b.go missing in subset: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subsetDir, "drop/c.go")); err == nil {
+		t.Errorf("drop/c.go must NOT be in subset")
+	}
+}
+
+// TestMaterialiseMountSubset_PathTraversalRejected verifies that
+// listed paths escaping the source root are silently dropped.
+func TestMaterialiseMountSubset_PathTraversalRejected(t *testing.T) {
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "ok.go"), []byte("package x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	artifact := filepath.Join(tmp, "pr-context.json")
+	body, _ := json.Marshal(map[string]any{
+		"changed_files": []string{"ok.go", "../../etc/passwd", "/etc/passwd"},
+	})
+	if err := os.WriteFile(artifact, body, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	exec := &PipelineExecution{
+		Pipeline:       &Pipeline{Steps: []Step{{ID: "fetch-pr"}}},
+		Manifest:       &manifest.Manifest{},
+		ArtifactPaths:  map[string]string{"fetch-pr:pr-context": artifact},
+		WorkspacePaths: map[string]string{},
+		Status:         &PipelineStatus{ID: "test-run"},
+		Context:        NewPipelineContext("test-run", "test", "audit"),
+	}
+	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+
+	subsetDir, err := executor.materialiseMountSubset(exec, Mount{
+		Source:     source,
+		Target:     "/project",
+		SubsetFrom: "fetch-pr.pr-context.changed_files",
+	})
+	if err != nil {
+		t.Fatalf("materialise: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(subsetDir, "ok.go")); err != nil {
+		t.Errorf("ok.go missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subsetDir, "../../etc/passwd")); err == nil {
+		t.Errorf("path traversal entry must be dropped")
+	}
+}

--- a/internal/pipeline/subset_mount_test.go
+++ b/internal/pipeline/subset_mount_test.go
@@ -63,7 +63,7 @@ func TestMaterialiseMountSubset(t *testing.T) {
 		SubsetFrom: "fetch-pr.pr-context.changed_files",
 	}
 
-	subsetDir, err := executor.materialiseMountSubset(exec, mount)
+	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, mount)
 	if err != nil {
 		t.Fatalf("materialise: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestMaterialiseMountSubset_PathTraversalRejected(t *testing.T) {
 	}
 	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
 
-	subsetDir, err := executor.materialiseMountSubset(exec, Mount{
+	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
 		Source:     source,
 		Target:     "/project",
 		SubsetFrom: "fetch-pr.pr-context.changed_files",
@@ -129,5 +129,63 @@ func TestMaterialiseMountSubset_PathTraversalRejected(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(subsetDir, "../../etc/passwd")); err == nil {
 		t.Errorf("path traversal entry must be dropped")
+	}
+}
+
+// TestMaterialiseMountSubset_SymlinkRejected verifies that a symlink
+// inside Source pointing outside is dropped rather than dereferenced.
+func TestMaterialiseMountSubset_SymlinkRejected(t *testing.T) {
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "project")
+	secret := filepath.Join(tmp, "secret.txt")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte("CONFIDENTIAL"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(source, "leak")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "ok.go"), []byte("package x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	artifact := filepath.Join(tmp, "pr-context.json")
+	body, _ := json.Marshal(map[string]any{"changed_files": []string{"ok.go", "leak"}})
+	if err := os.WriteFile(artifact, body, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	exec := &PipelineExecution{
+		Pipeline:       &Pipeline{Steps: []Step{{ID: "fetch-pr"}}},
+		Manifest:       &manifest.Manifest{},
+		ArtifactPaths:  map[string]string{"fetch-pr:pr-context": artifact},
+		WorkspacePaths: map[string]string{},
+		Status:         &PipelineStatus{ID: "test-run"},
+		Context:        NewPipelineContext("test-run", "test", "audit"),
+	}
+	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+
+	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
+		Source:     source,
+		Target:     "/project",
+		SubsetFrom: "fetch-pr.pr-context.changed_files",
+	})
+	if err != nil {
+		t.Fatalf("materialise: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(subsetDir, "ok.go")); err != nil {
+		t.Errorf("ok.go missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subsetDir, "leak")); err == nil {
+		t.Errorf("symlink leaking outside source must be dropped")
 	}
 }

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -425,6 +425,15 @@ type Mount struct {
 	Source string `yaml:"source"`
 	Target string `yaml:"target"`
 	Mode   string `yaml:"mode,omitempty"`
+	// SubsetFrom narrows the mount to files listed in an upstream
+	// artifact. Form: "<step>.<artifact>.<json-path>" (e.g.
+	// "fetch-pr.pr-context.changed_files"). When set, the executor
+	// reads the artifact JSON, extracts the array at <json-path> (each
+	// entry being a path relative to Source), and materialises a
+	// symlink tree at a temp dir containing only those files. That
+	// temp dir replaces Source for the actual mount. Issue #1453 —
+	// keeps audit-* sub-pipelines from scanning the whole repo.
+	SubsetFrom string `yaml:"subset_from,omitempty"`
 }
 
 type ExecConfig struct {


### PR DESCRIPTION
## Summary

Layer 1 of #1453 (audit scope too broad). New \`Mount.SubsetFrom\` field \`<step>.<artifact>.<json-path>\` narrows a workspace mount to the file list extracted from an upstream artifact's JSON path.

Concrete use case: \`ops-pr-respond.parallel-review\` six audit-* sub-pipelines mount the project root readonly today and scan the entire repo even though only \`changed_files\` in \`pr-context\` are in scope. The LLM-only guard added in #1436 is consistently weakened at runtime.

## How it works

When \`SubsetFrom\` is set, \`createStepWorkspace\` materialises a fresh tree under \`.agents/workspaces/_subsets/<runID>/<hash>\` containing only the listed paths (relative to the original \`Source\`) before invoking \`wsManager.Create\`. The workspace manager is unchanged — it sees a regular \`Source\` pointing at the subset tree.

Tools inside the audit-* child physically cannot Read / Grep / Glob outside the diff scope.

## YAML usage

\`\`\`yaml
- id: parallel-review
  pipeline: \"{{ item }}\"
  workspace:
    mount:
      - source: ./
        target: /project
        mode: readonly
        subset_from: fetch-pr.pr-context.changed_files
\`\`\`

## Safety

- Path-traversal entries (absolute or \`..\`-prefixed) silently dropped.
- Listed-but-missing paths skipped (deleted-file diff entries).

## Test plan

- [x] \`TestMaterialiseMountSubset\` — keep+drop subset
- [x] \`TestMaterialiseMountSubset_PathTraversalRejected\`
- [x] \`go test ./internal/pipeline/\` — green

## What is NOT in this PR

- Pipeline YAML edits to actually apply \`subset_from\` to ops-pr-respond / audit-issue (follow-up)
- Layer 2 persona path-prefix allowlist (separate PR)
- Layer 3 schema-pattern enforcement (redundant with filter-scope; deferred)

Refs #1453.