### PR TITLE
feat(pipelines): apply subset_from to all six audit-* pipelines

### DIFF
--- a/.agents/pipelines/audit-architecture.yaml
+++ b/.agents/pipelines/audit-architecture.yaml
@@ -44,6 +44,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source_path: .agents/prompts/audit/architecture-scan.md

--- a/.agents/pipelines/audit-dead-code-scan.yaml
+++ b/.agents/pipelines/audit-dead-code-scan.yaml
@@ -43,6 +43,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/.agents/pipelines/audit-doc-scan.yaml
+++ b/.agents/pipelines/audit-doc-scan.yaml
@@ -43,6 +43,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/.agents/pipelines/audit-duplicates.yaml
+++ b/.agents/pipelines/audit-duplicates.yaml
@@ -44,6 +44,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -46,6 +46,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/.agents/pipelines/audit-tests.yaml
+++ b/.agents/pipelines/audit-tests.yaml
@@ -43,6 +43,7 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source_path: .agents/prompts/audit/tests-scan.md

--- a/internal/defaults/pipelines/audit-architecture.yaml
+++ b/internal/defaults/pipelines/audit-architecture.yaml
@@ -43,6 +43,9 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # Narrow mount to PR scope when invoked from ops-pr-respond
+          # (#1453). Soft-fallback to full tree on standalone runs.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source_path: .agents/prompts/audit/architecture-scan.md

--- a/internal/defaults/pipelines/audit-dead-code-scan.yaml
+++ b/internal/defaults/pipelines/audit-dead-code-scan.yaml
@@ -42,6 +42,9 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # Narrow mount to PR scope when invoked from ops-pr-respond
+          # (#1453). Soft-fallback to full tree on standalone runs.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/audit-doc-scan.yaml
+++ b/internal/defaults/pipelines/audit-doc-scan.yaml
@@ -42,6 +42,9 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # Narrow mount to PR scope when invoked from ops-pr-respond
+          # (#1453). Soft-fallback to full tree on standalone runs.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/audit-duplicates.yaml
+++ b/internal/defaults/pipelines/audit-duplicates.yaml
@@ -43,6 +43,9 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # Narrow mount to PR scope when invoked from ops-pr-respond
+          # (#1453). Soft-fallback to full tree on standalone runs.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/audit-security.yaml
+++ b/internal/defaults/pipelines/audit-security.yaml
@@ -45,6 +45,11 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # When invoked from ops-pr-respond.parallel-review, narrow the
+          # mount to the PR's changed_files only so audits cannot scan
+          # out-of-scope code (#1453). Standalone runs without
+          # pr-context fall back to the full tree.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source: |

--- a/internal/defaults/pipelines/audit-tests.yaml
+++ b/internal/defaults/pipelines/audit-tests.yaml
@@ -42,6 +42,9 @@ steps:
         - source: ./
           target: /project
           mode: readonly
+          # Narrow mount to PR scope when invoked from ops-pr-respond
+          # (#1453). Soft-fallback to full tree on standalone runs.
+          subset_from: fetch-pr.pr-context.changed_files
     exec:
       type: prompt
       source_path: .agents/prompts/audit/tests-scan.md


### PR DESCRIPTION
## Summary

Closes the user-facing half of #1453. With #1486 + #1487 landed, every \`audit-*\` pipeline can now opt into the diff-scoped mount.

Each scan step's \`workspace.mount\` gains \`subset_from: fetch-pr.pr-context.changed_files\`. When invoked from \`ops-pr-respond.parallel-review\`, the mount only contains the PR's changed files. Standalone runs degrade gracefully to the full project tree via #1487's soft-fallback.

## Pipelines updated

audit-security, audit-architecture, audit-tests, audit-duplicates, audit-doc-scan, audit-dead-code-scan — both \`internal/defaults/\` and \`.agents/\` mirrors.

## Test plan

- [x] \`go test ./internal/defaults/ ./internal/pipeline/\` — green
- [ ] Live ops-pr-respond run on a small PR to verify auditors no longer flag out-of-scope files (acceptance criterion in #1453)

Refs #1453.