### PR TITLE
fix(ops-pr-respond): strip mount-target prefix in filter-scope

### DIFF
--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -260,6 +260,14 @@ steps:
       # Build a JSON array of the PR scope.
       jq -c '.changed_files // []' "$CONTEXT" > .agents/output/_changed-files.json
 
+      # Normalise finding paths: strip mount-target prefixes (e.g.
+      # `project/`, `/project/`) that auditors record when reading via
+      # the workspace mount target. Findings emitted with bare
+      # repo-relative paths pass through unchanged.
+      jq '[ .[] | .file = ((.file // "") | sub("^/?project/"; "")) ]' \
+        .agents/output/_flat-findings.json > .agents/output/_flat-findings.normalised.json
+      mv .agents/output/_flat-findings.normalised.json .agents/output/_flat-findings.json
+
       # Drop findings whose `file` is not in changed_files.
       jq --slurpfile scope .agents/output/_changed-files.json \
         '[ .[] | select(.file as $f | $scope[0] | index($f)) ]' \

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -260,6 +260,14 @@ steps:
       # Build a JSON array of the PR scope.
       jq -c '.changed_files // []' "$CONTEXT" > .agents/output/_changed-files.json
 
+      # Normalise finding paths: strip mount-target prefixes (e.g.
+      # `project/`, `/project/`) that auditors record when reading via
+      # the workspace mount target. Findings emitted with bare
+      # repo-relative paths pass through unchanged.
+      jq '[ .[] | .file = ((.file // "") | sub("^/?project/"; "")) ]' \
+        .agents/output/_flat-findings.json > .agents/output/_flat-findings.normalised.json
+      mv .agents/output/_flat-findings.normalised.json .agents/output/_flat-findings.json
+
       # Drop findings whose `file` is not in changed_files.
       jq --slurpfile scope .agents/output/_changed-files.json \
         '[ .[] | select(.file as $f | $scope[0] | index($f)) ]' \


### PR DESCRIPTION
## Summary

`filter-scope` was dropping every finding from auditors using `subset_from` mounts. Findings come back with paths like `project/cmd/wave/commands/run.go` (because the audit step mounts `./` at `/project`), but `pr-context.changed_files` lists bare repo-relative paths. Index lookup mismatched 1:1, so the upstream auto-injection PR #1486 + audit-yaml application PR #1488 looked like they were filtering findings out at the wrong layer.

## Trigger

Live `ops-pr-respond 1472` (4 changed files) just now: 33 findings produced across 6 audits, 33 dropped, comment-back posted "no findings" despite all 33 sample entries referencing files actually in `changed_files`. See `dropped_sample` paths in `.agents/workspaces/ops-pr-respond-20260428-180120-2073/filter-scope/.agents/output/scope-filter-stats.json`.

## Fix

Normalise `finding.file` with `sub("^/?project/"; "")` before the scope-set lookup. Bare-path findings pass through unchanged.

## Why this works

Subset materialisation was correct — `_subsets/audit-*-.../scan/mount0/` had exactly the 4 changed files. The audit prompts also ran on the right scope. The bug was purely in path normalisation between auditor output and changed_files comparison.

## Test plan

- [ ] Re-run `wave run ops-pr-respond 1472` after merge — expect non-zero `total_kept` in scope-filter-stats and a substantive PR comment
- [x] Diff inspection: only the jq pipeline and a comment block changed