### PR TITLE
fix(retro): give narrator a tmp workspace so adapter call succeeds

### DIFF
--- a/internal/retro/narrator.go
+++ b/internal/retro/narrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -32,10 +33,20 @@ func NewNarrator(runner adapter.AdapterRunner, model string) *Narrator {
 func (n *Narrator) Narrate(ctx context.Context, runID string, pipeline string, quant *QuantitativeData) (*Narrative, error) {
 	prompt := n.buildPrompt(runID, pipeline, quant)
 
+	// Adapters require a non-empty WorkspacePath to avoid accidentally
+	// rooting an LLM call in the project directory. The narrator is a
+	// one-shot prompt with no file I/O, so an ephemeral tmpdir suffices.
+	workspace, err := os.MkdirTemp("", "wave-narrator-")
+	if err != nil {
+		return nil, fmt.Errorf("narrator workspace: %w", err)
+	}
+	defer os.RemoveAll(workspace)
+
 	cfg := adapter.AdapterRunConfig{
-		Prompt:  prompt,
-		Model:   n.model,
-		Timeout: n.timeout,
+		Prompt:        prompt,
+		Model:         n.model,
+		Timeout:       n.timeout,
+		WorkspacePath: workspace,
 	}
 
 	result, err := n.runner.Run(ctx, cfg)


### PR DESCRIPTION
## Problem

Adapters reject `Run()` when `WorkspacePath` is empty (security: refuse to root an LLM call in the project directory by default — see internal/adapter/{claude,codex,gemini,opencode}.go:40). The narrator was constructing AdapterRunConfig with only Prompt/Model/Timeout, so every retrospective narrative generation failed:

\`\`\`
[retro] narrative generation failed for run <id>:
  narrator adapter failed: WorkspacePath is required —
  refusing to use project root as workspace
\`\`\`

Visible in the log of every successful pipeline run today. `Narrative` field on retrospective records was never populated.

## Fix

Create an ephemeral tmpdir per `Narrate()` call, defer-clean it, pass it as WorkspacePath. Narrator only sends a single prompt with no file I/O — throwaway dir is sufficient.

## Test plan

- [x] `go test ./internal/retro/` — green (existing tests mock the runner; the bug is only observable against a real adapter, which the existing harness doesn't exercise)
- [ ] Next pipeline run: `[retro] narrative retrospective completed for run ...` instead of the failure line