### PR TITLE
chore(pipelines): remove agent_review token budget restrictions

### DIFF
--- a/.agents/pipelines/audit-architecture.yaml
+++ b/.agents/pipelines/audit-architecture.yaml
@@ -117,6 +117,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/architecture-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/.agents/pipelines/audit-issue.yaml
+++ b/.agents/pipelines/audit-issue.yaml
@@ -532,7 +532,7 @@ steps:
           criteria_path: .agents/contracts/audit-doc-criteria.md
           source: .agents/output/audit-doc.json
           model: balanced
-          token_budget: 12000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 

--- a/.agents/pipelines/audit-security.yaml
+++ b/.agents/pipelines/audit-security.yaml
@@ -380,6 +380,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/security-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/.agents/pipelines/audit-tests.yaml
+++ b/.agents/pipelines/audit-tests.yaml
@@ -117,6 +117,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/tests-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/.agents/pipelines/impl-issue-core.yaml
+++ b/.agents/pipelines/impl-issue-core.yaml
@@ -107,7 +107,7 @@ steps:
           criteria_path: .agents/contracts/plan-review-criteria.md
           source: .agents/output/impl-plan.json
           model: balanced
-          token_budget: 16000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 

--- a/.agents/pipelines/impl-issue.yaml
+++ b/.agents/pipelines/impl-issue.yaml
@@ -110,7 +110,7 @@ steps:
           criteria_path: .agents/contracts/plan-review-criteria.md
           source: .agents/output/impl-plan.json
           model: balanced
-          token_budget: 16000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 
@@ -242,7 +242,7 @@ steps:
           persona: navigator
           criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 90s
           context:
             - source: git_diff

--- a/.agents/pipelines/impl-speckit.yaml
+++ b/.agents/pipelines/impl-speckit.yaml
@@ -258,7 +258,7 @@ steps:
           persona: navigator
           criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 5m
           context:
             - source: git_diff

--- a/.agents/pipelines/ops-pr-respond.yaml
+++ b/.agents/pipelines/ops-pr-respond.yaml
@@ -462,7 +462,7 @@ steps:
           persona: auditor
           source: .agents/output/triaged-findings.json
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 90s
           criteria:
             - "Every actionable item has a non-empty remediation that names a concrete edit."
@@ -736,7 +736,7 @@ steps:
           persona: reviewer
           source: .agents/output/comment-result.json
           model: cheapest
-          token_budget: 6000
+          token_budget: 0
           timeout: 60s
           criteria:
             - "The posted comment maps every actionable finding id to either a commit SHA or a clear skipped/failed status."

--- a/.agents/pipelines/ops-pr-review.yaml
+++ b/.agents/pipelines/ops-pr-review.yaml
@@ -379,7 +379,7 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/quality-review.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: continue
 

--- a/internal/defaults/pipelines/audit-architecture.yaml
+++ b/internal/defaults/pipelines/audit-architecture.yaml
@@ -117,6 +117,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/architecture-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/internal/defaults/pipelines/audit-issue.yaml
+++ b/internal/defaults/pipelines/audit-issue.yaml
@@ -532,7 +532,7 @@ steps:
           criteria_path: .agents/contracts/audit-doc-criteria.md
           source: .agents/output/audit-doc.json
           model: balanced
-          token_budget: 12000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 

--- a/internal/defaults/pipelines/audit-security.yaml
+++ b/internal/defaults/pipelines/audit-security.yaml
@@ -381,6 +381,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/security-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/internal/defaults/pipelines/audit-tests.yaml
+++ b/internal/defaults/pipelines/audit-tests.yaml
@@ -117,6 +117,6 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/tests-report.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: warn

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -106,7 +106,7 @@ steps:
           criteria_path: .agents/contracts/plan-review-criteria.md
           source: .agents/output/impl-plan.json
           model: balanced
-          token_budget: 16000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 

--- a/internal/defaults/pipelines/impl-issue.yaml
+++ b/internal/defaults/pipelines/impl-issue.yaml
@@ -106,7 +106,7 @@ steps:
           criteria_path: .agents/contracts/plan-review-criteria.md
           source: .agents/output/impl-plan.json
           model: balanced
-          token_budget: 16000
+          token_budget: 0
           timeout: 120s
           on_failure: warn
 
@@ -237,7 +237,7 @@ steps:
           persona: navigator
           criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 90s
           context:
             - source: git_diff

--- a/internal/defaults/pipelines/impl-speckit.yaml
+++ b/internal/defaults/pipelines/impl-speckit.yaml
@@ -258,7 +258,7 @@ steps:
           persona: navigator
           criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 5m
           context:
             - source: git_diff

--- a/internal/defaults/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/pipelines/ops-pr-respond.yaml
@@ -462,7 +462,7 @@ steps:
           persona: auditor
           source: .agents/output/triaged-findings.json
           model: cheapest
-          token_budget: 8000
+          token_budget: 0
           timeout: 90s
           criteria:
             - "Every actionable item has a non-empty remediation that names a concrete edit."
@@ -736,7 +736,7 @@ steps:
           persona: reviewer
           source: .agents/output/comment-result.json
           model: cheapest
-          token_budget: 6000
+          token_budget: 0
           timeout: 60s
           criteria:
             - "The posted comment maps every actionable finding id to either a commit SHA or a clear skipped/failed status."

--- a/internal/defaults/pipelines/ops-pr-review.yaml
+++ b/internal/defaults/pipelines/ops-pr-review.yaml
@@ -379,7 +379,7 @@ steps:
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/quality-review.md
         model: cheapest
-        token_budget: 8000
+        token_budget: 0
         timeout: 90s
         on_failure: continue
 


### PR DESCRIPTION
## Summary

- Set `token_budget: 0` (unlimited per schema) on every shipped `agent_review` step in `internal/defaults/pipelines/` and the matching project-local mirrors under `.agents/pipelines/`.
- Real reviewer token usage is consistently 22-33k while the shipped caps were 6k-16k, so every run logged an advisory `[agent_review] reviewer used X tokens, exceeding budget of Y` warning. The check is advisory-only (`internal/contract/agent_review.go:137-140`), so flipping the value to 0 silences the noise without any behavioural change.
- The schema (`internal/defaults/schemas/wave-pipeline.schema.json`) already documents `0 = unlimited`, so no Go or schema change is required.
- 18 files changed, 22 lines flipped (11 in `internal/defaults/pipelines/` plus 11 mirrors in `.agents/pipelines/`). No new comments added — schema docs the semantics.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/contract/... ./internal/manifest/... ./internal/pipeline/...` — all green
- [ ] On next run of any audit/impl/ops review pipeline, expect zero `reviewer used X tokens, exceeding budget of Y` warnings
- [ ] No schema validation regressions on pipeline load