### PR TITLE
fix(pipeline): wave resume validator skip composition + worktree priors

### DIFF
--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -99,6 +99,25 @@ func (v *PhaseSkipValidator) validateGenericStepSequence(p *Pipeline, fromStep s
 			break
 		}
 
+		// Composition steps (iterate, sub_pipeline, branch, loop, aggregate)
+		// don't create their own workspace dir — their state lives in child
+		// run rows + the registered aggregate artifact. Their existence is
+		// validated by the artifact-based resume preflight, not the
+		// workspace-on-disk heuristic. See #1434.
+		if step.IsCompositionStep() {
+			continue
+		}
+
+		// Worktree steps prune their worktree on success, so a completed
+		// step leaves no `step.ID` directory behind. The DB step_state +
+		// registered artifacts are the authoritative record. Skipping the
+		// workspace heuristic for worktree steps keeps resume working for
+		// composition pipelines that mix worktree personas with later
+		// command/aggregate steps. See #1434.
+		if step.Workspace.Type == "worktree" {
+			continue
+		}
+
 		if v.hasWorkspaceInAnyRun(step, runDirs) {
 			continue
 		}

--- a/internal/pipeline/validation_test.go
+++ b/internal/pipeline/validation_test.go
@@ -588,3 +588,38 @@ func TestValidateThreadFields(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateGenericStepSequence_CompositionAndWorktree is a regression test
+// for #1434. Composition steps (iterate, sub_pipeline, etc.) and worktree
+// steps don't leave a step-named directory under the run workspace —
+// composition steps put their state in child runs + registered artifacts;
+// worktree steps prune the worktree on success. The validator must not
+// reject resume just because there's no on-disk dir for those step kinds.
+func TestValidateGenericStepSequence_CompositionAndWorktree(t *testing.T) {
+	tmpDir := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	pipeline := &Pipeline{
+		Metadata: PipelineMetadata{Name: "audit-issue"},
+		Steps: []Step{
+			{ID: "fetch-issue"},
+			{ID: "parallel-evidence", Iterate: &IterateConfig{Over: "{{ axes }}", Mode: "parallel"}},
+			{ID: "synthesize", Workspace: WorkspaceConfig{Type: "worktree"}},
+			{ID: "create-pr"},
+		},
+	}
+
+	// Create only the fetch-issue workspace — none for composition or worktree
+	// steps, mirroring the real audit-issue failure shape.
+	runDir := filepath.Join(tmpDir, ".agents/workspaces/audit-issue-20260428-111246-6a7d")
+	_ = os.MkdirAll(filepath.Join(runDir, "fetch-issue"), 0755)
+
+	v := NewPhaseSkipValidator()
+	if err := v.ValidatePhaseSequence(pipeline, "create-pr"); err != nil {
+		t.Fatalf("expected resume to validate (composition + worktree priors should be skipped), got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1434.

## Symptom

\`wave resume <audit-issue-run-id>\` failed:

\`\`\`
Phase 'create-pr' failed: cannot resume from 'create-pr':
  prior step 'parallel-evidence' has no workspace artifacts
\`\`\`

After unblocking that, the next step in line failed too:

\`\`\`
prior step 'synthesize' has no workspace artifacts
\`\`\`

## Root cause

\`PhaseSkipValidator.validateGenericStepSequence\` proves prior steps ran by looking for \`<runDir>/<step.ID>/\` directories on disk. Two step kinds break this assumption:

1. **Composition steps** (\`iterate\`, \`sub_pipeline\`, \`branch\`, \`loop\`, \`aggregate\`) don't create their own workspace dir — they spawn child run rows and register an aggregate artifact in the artifact table. Their existence is proved by the DB, not the filesystem. \`parallel-evidence\` is \`iterate.parallel\` over four audit child pipelines.
2. **Worktree steps** (\`workspace.type: worktree\`) prune the worktree on success. A completed step leaves no dir behind. The DB step_state row is the authoritative record. \`synthesize\` is a worktree step.

PR #1441 fixed the artifact-registration half of #1434 (aggregate / iterate now register their \`Into\` / \`collected-output\`). The validator half remained broken, so even with artifacts present, resume preflight still rejected the run.

## Fix

Skip the on-disk workspace heuristic for composition steps and worktree steps. Other step kinds keep the heuristic — it still catches the common case of \"user tries to resume a pipeline that never ran at all\".

## Verified end-to-end

\`wave resume audit-issue-20260428-111246-6a7d\` now passes the validator and reaches the actual step executor (auto-detected failed step \`create-pr\`).

## Test plan

- [x] Regression test \`TestValidateGenericStepSequence_CompositionAndWorktree\` builds the exact audit-issue failure shape and asserts the validator passes
- [x] Full \`go test ./internal/pipeline/\` — green (29s)
- [x] Manual: \`wave resume audit-issue-20260428-111246-6a7d --model cheapest\` proceeds past validator