### PR TITLE
ci(workflow): cache + split validate job to halve PR turnaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  validate:
+  test:
     if: "!startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
@@ -21,9 +21,34 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
 
-      - name: Run tests
-        run: go test -race ./...
+      - name: Cache go-build
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Run race tests on hot packages
+        run: go test -race -timeout 5m ./internal/pipeline/... ./internal/contract/... ./internal/state/...
+
+      - name: Run remaining tests without race
+        run: go test -timeout 5m $(go list ./... | grep -v -E '/(internal/pipeline|internal/contract|internal/state)(/|$)')
+
+  goreleaser-check:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Install GoReleaser
         run: go install github.com/goreleaser/goreleaser/v2@latest
@@ -33,6 +58,13 @@ jobs:
 
       - name: Test build
         run: goreleaser release --snapshot --clean
+
+  validate:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    needs: [test, goreleaser-check]
+    steps:
+      - run: echo "all validation jobs passed"
 
   auto-tag:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Closes #1461.

Splits the monolithic `validate` job into two parallel jobs that each
land in 3-4 minutes instead of one 7-8 minute job:

- `test` — runs `go test -race` on hot packages (pipeline, contract,
  state) and `go test` (no race) on everything else. Race detector was
  the long tail; restricting it to packages that actually exercise
  goroutines drops the suite cost without losing race coverage where
  it matters.
- `goreleaser-check` — runs goreleaser install/check/snapshot in
  parallel with the test job.
- `validate` — kept as a fan-in gate so existing required-status-check
  configuration (and `auto-tag`'s `needs: validate`) still works
  without UI changes.

Caching:
- `actions/setup-go@v5` with `cache: true` reuses module cache keyed
  on go.sum (built-in).
- `actions/cache@v4` for `~/.cache/go-build` keyed on go.sum so
  unchanged packages compile from cache.

Test timeouts capped at 5m so a hung test fails the job rather than
hitting the GitHub Actions 6h limit.
