### PR TITLE
refactor: dedupe sanitizeBranch into pipeline pkg (#1503 partial 8.1)

### DIFF
--- a/internal/pipeline/context.go
+++ b/internal/pipeline/context.go
@@ -293,7 +293,7 @@ func (ctx *PipelineContext) GetSpeckitPath(filename string) string {
 		// Check if branch indicates Speckit workflow
 		if strings.Contains(ctx.BranchName, "-") {
 			// This looks like it might be Speckit, but let's generate a path anyway
-			featureDir := "999-" + sanitizeBranchName(ctx.BranchName)
+			featureDir := "999-" + SanitizeBranchName(ctx.BranchName)
 			return "specs/" + featureDir + "/" + filename
 		}
 		return filename
@@ -307,7 +307,7 @@ func (ctx *PipelineContext) GetSpeckitPath(filename string) string {
 			featureDir = num
 		} else if ctx.SpeckitMode {
 			// Generate a simple numeric prefix for non-standard branch names when in Speckit mode
-			featureDir = "999-" + sanitizeBranchName(ctx.BranchName)
+			featureDir = "999-" + SanitizeBranchName(ctx.BranchName)
 		}
 	}
 
@@ -379,8 +379,10 @@ func extractFeatureNumber(branchName string) string {
 	return ""
 }
 
-// sanitizeBranchName removes invalid characters from branch names for use in paths
-func sanitizeBranchName(branchName string) string {
+// SanitizeBranchName removes invalid characters from branch names for use in paths.
+// It replaces any character outside [a-zA-Z0-9_-] with a dash, collapses consecutive
+// dashes, trims leading/trailing dashes, and caps the result at 50 characters.
+func SanitizeBranchName(branchName string) string {
 	// Replace invalid path characters
 	sanitized := invalidPathCharRe.ReplaceAllString(branchName, "-")
 

--- a/internal/pipeline/context_test.go
+++ b/internal/pipeline/context_test.go
@@ -331,7 +331,7 @@ func TestSanitizeBranchName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeBranchName(tt.branchName)
+			result := SanitizeBranchName(tt.branchName)
 			if result != tt.expected {
 				t.Errorf("Expected %s but got %s", tt.expected, result)
 			}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -3916,7 +3916,7 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 		// workspace run ID override so resume reuses the original run's
 		// worktree dir instead of creating an empty one at the resume
 		// timestamp; falls back to pipelineID for fresh runs.
-		sanitized := sanitizeBranchName(branch)
+		sanitized := SanitizeBranchName(branch)
 		wtKey := "__wt_" + sanitized
 		wsPath := filepath.Join(wsRoot, e.workspaceRunIDFor(pipelineID), wtKey)
 

--- a/internal/tui/pipeline_detail_provider.go
+++ b/internal/tui/pipeline_detail_provider.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/recinq/wave/internal/pipeline"
@@ -110,18 +108,6 @@ type DefaultDetailDataProvider struct {
 // NewDefaultDetailDataProvider creates a new provider.
 func NewDefaultDetailDataProvider(store detailStore, pipelinesDir string) *DefaultDetailDataProvider {
 	return &DefaultDetailDataProvider{store: store, pipelinesDir: pipelinesDir}
-}
-
-// sanitizeBranch sanitizes a branch name for use in filesystem paths.
-// Mirrors the logic in internal/pipeline/context.go:sanitizeBranchName().
-func sanitizeBranch(branchName string) string {
-	sanitized := regexp.MustCompile(`[^a-zA-Z0-9\-_]`).ReplaceAllString(branchName, "-")
-	sanitized = regexp.MustCompile(`-+`).ReplaceAllString(sanitized, "-")
-	sanitized = strings.Trim(sanitized, "-")
-	if len(sanitized) > 50 {
-		sanitized = sanitized[:50]
-	}
-	return sanitized
 }
 
 // FetchAvailableDetail reads all YAML files from pipelinesDir, finds the pipeline with the
@@ -286,7 +272,7 @@ func (d *DefaultDetailDataProvider) FetchFinishedDetail(runID string) (*Finished
 
 	// Derive workspace path from RunID and BranchName.
 	if run.BranchName != "" {
-		sanitized := sanitizeBranch(run.BranchName)
+		sanitized := pipeline.SanitizeBranchName(run.BranchName)
 		wsPath := filepath.Join(".agents", "workspaces", run.RunID, "__wt_"+sanitized)
 		if _, err := os.Stat(wsPath); err == nil {
 			detail.WorkspacePath = wsPath

--- a/internal/tui/pipeline_detail_provider_test.go
+++ b/internal/tui/pipeline_detail_provider_test.go
@@ -343,6 +343,32 @@ func TestDefaultDetailDataProvider_FetchFinishedDetail_EmptyBranchGlob(t *testin
 	assert.Equal(t, wsDir, got.WorkspacePath)
 }
 
+// TestSanitizeBranchName_TUIParity locks in the branch-sanitization output the
+// TUI workspace-path derivation depends on. Before the dedup, this lived as a
+// local sanitizeBranch() mirror in pipeline_detail_provider.go; the cases here
+// match what that mirror would have produced so any drift is caught.
+func TestSanitizeBranchName_TUIParity(t *testing.T) {
+	tests := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{name: "feature_slash", branch: "feat/my-feature", expected: "feat-my-feature"},
+		{name: "colon_in_branch", branch: "feature/branch:name", expected: "feature-branch-name"},
+		{name: "consecutive_dashes_collapsed", branch: "feat//my--branch", expected: "feat-my-branch"},
+		{name: "leading_trailing_trimmed", branch: "/feat/x/", expected: "feat-x"},
+		{name: "fifty_char_cap", branch: "this-is-a-very-long-branch-name-that-should-be-truncated-to-fifty-characters-maximum", expected: "this-is-a-very-long-branch-name-that-should-be-tru"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pipeline.SanitizeBranchName(tt.branch)
+			assert.Equal(t, tt.expected, got)
+			assert.LessOrEqual(t, len(got), 50)
+		})
+	}
+}
+
 func TestStepTypeLabel(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Export `pipeline.SanitizeBranchName` (was unexported `sanitizeBranchName`).
- Delete `internal/tui/pipeline_detail_provider.go` mirror that admitted drift hazard in its own comment.
- TUI parity test locks the previously-produced output values.

## Byte-equivalence verified before merge

Both implementations produced identical output:
- canonical regex `[^a-zA-Z0-9\-_]` == tui inline `[^a-zA-Z0-9\-_]`
- canonical regex `-+` == tui inline `-+`
- both `strings.Trim(sanitized, "-")`
- both 50-char cap

Only difference: canonical pre-compiles regex; mirror inlined `regexp.MustCompile` per call (worse perf, same behaviour).

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/pipeline/...` 54s pass
- `go test -race ./internal/tui/...` 5s pass

## Out of scope (deferred)

- 8.2 pipeline-YAML loader centralization
- 8.3 HTTP client centralize
- 8.4 credential redaction consolidate
- 8.5 formatDuration verification (likely already done by #1408)

## Test plan

- [ ] CI green
- [ ] Spot-check tui pipeline detail panel renders branch names correctly

Partial of #1503 (subset 8.1). Parent: #1494.