### PR TITLE
refactor(adapter,contract): mock to test pkg, no init panics (#1504 partial)

### DIFF
--- a/cmd/wave/commands/compose.go
+++ b/cmd/wave/commands/compose.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/pipeline"
@@ -276,8 +277,8 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 
 	var runner adapter.AdapterRunner
 	if mock {
-		runner = adapter.NewMockAdapter(
-			adapter.WithSimulatedDelay(5 * time.Second),
+		runner = adaptertest.NewMockAdapter(
+			adaptertest.WithSimulatedDelay(5 * time.Second),
 		)
 	} else {
 		var adapterName string
@@ -397,8 +398,8 @@ func runCompose(seq tui.Sequence, input string, manifestPath string, mock bool, 
 	// Resolve adapter
 	var runner adapter.AdapterRunner
 	if mock {
-		runner = adapter.NewMockAdapter(
-			adapter.WithSimulatedDelay(5 * time.Second),
+		runner = adaptertest.NewMockAdapter(
+			adaptertest.WithSimulatedDelay(5 * time.Second),
 		)
 	} else {
 		var adapterName string

--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/classify"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
@@ -170,7 +171,7 @@ func runDo(input string, opts DoOptions) error {
 
 	var runner adapter.AdapterRunner
 	if opts.Mock {
-		runner = adapter.NewMockAdapter()
+		runner = adaptertest.NewMockAdapter()
 	} else {
 		adapterName := opts.Adapter
 		if adapterName == "" {

--- a/cmd/wave/commands/meta.go
+++ b/cmd/wave/commands/meta.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/recinq/wave/internal/skill"
@@ -87,7 +88,7 @@ func runMeta(input string, opts MetaOptions) error {
 	// Resolve adapter
 	var runner adapter.AdapterRunner
 	if opts.Mock {
-		runner = adapter.NewMockAdapter()
+		runner = adaptertest.NewMockAdapter()
 	} else {
 		var adapterName string
 		for name := range m.Adapters {

--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/audit"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
@@ -154,8 +155,8 @@ func runResume(opts ResumeOptions, debug bool) error {
 	// Resolve adapter.
 	var runner adapter.AdapterRunner
 	if opts.Mock {
-		runner = adapter.NewMockAdapter(
-			adapter.WithSimulatedDelay(5 * time.Second),
+		runner = adaptertest.NewMockAdapter(
+			adaptertest.WithSimulatedDelay(5 * time.Second),
 		)
 	} else {
 		var adapterName string

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/audit"
 	"github.com/recinq/wave/internal/continuous"
 	"github.com/recinq/wave/internal/display"
@@ -333,8 +334,8 @@ func runRun(opts RunOptions, debug bool) error {
 	// Resolve adapter — use mock if --mock or if no adapter binary found
 	var runner adapter.AdapterRunner
 	if opts.Mock {
-		runner = adapter.NewMockAdapter(
-			adapter.WithSimulatedDelay(5 * time.Second),
+		runner = adaptertest.NewMockAdapter(
+			adaptertest.WithSimulatedDelay(5 * time.Second),
 		)
 	} else {
 		runner = adapter.ResolveAdapter("claude")

--- a/cmd/wave/commands/run_phantom_test.go
+++ b/cmd/wave/commands/run_phantom_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
@@ -97,7 +98,7 @@ runtime:
 
 	// Create executor with the run ID
 	executor := pipeline.NewDefaultPipelineExecutor(
-		adapter.NewMockAdapter(),
+		adaptertest.NewMockAdapter(),
 		pipeline.WithRunID(runID),
 		pipeline.WithStateStore(store),
 	)

--- a/cmd/wave/commands/run_test.go
+++ b/cmd/wave/commands/run_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
@@ -81,10 +82,10 @@ func loadTestPipeline(t *testing.T, name string) *pipeline.Pipeline {
 }
 
 // createTestExecutor creates an executor with mock adapter and event collector
-func createTestExecutor(collector *testEventCollector) (*pipeline.DefaultPipelineExecutor, *adapter.MockAdapter) {
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success", "result": "test output"}`),
-		adapter.WithTokensUsed(1000),
+func createTestExecutor(collector *testEventCollector) (*pipeline.DefaultPipelineExecutor, *adaptertest.MockAdapter) {
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success", "result": "test output"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	opts := []pipeline.ExecutorOption{

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -283,41 +283,6 @@ func TestMockAdapterRegistry_CreateRunner(t *testing.T) {
 	}
 }
 
-func TestSlowReader_Read(t *testing.T) {
-	data := "hello world"
-	reader := NewSlowReader(data, 5, 10*time.Millisecond)
-
-	buf := make([]byte, 1024)
-	n, err := reader.Read(buf)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	if n != 5 {
-		t.Errorf("expected 5 bytes, got: %d", n)
-	}
-
-	if string(buf[:5]) != "hello" {
-		t.Errorf("expected 'hello', got: %s", string(buf[:5]))
-	}
-
-	n, err = reader.Read(buf)
-	if n != 5 {
-		t.Errorf("expected 5 bytes, got: %d", n)
-	}
-	if string(buf[:n]) != " worl" {
-		t.Errorf("expected ' worl', got: %s", string(buf[:n]))
-	}
-
-	n, err = reader.Read(buf)
-	if n != 1 {
-		t.Errorf("expected 1 byte, got: %d", n)
-	}
-	if err != io.EOF {
-		t.Errorf("expected EOF, got: %v", err)
-	}
-}
-
 func TestEstimateTokens(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/adapter/adaptertest/mock.go
+++ b/internal/adapter/adaptertest/mock.go
@@ -1,4 +1,15 @@
-package adapter
+// Package adaptertest provides test doubles for the adapter package.
+//
+// MockAdapter is a configurable AdapterRunner that emits realistic,
+// schema-compliant stdout for the Wave pipelines. It is used by tests
+// across the codebase as well as by the `--mock` flag on CLI commands
+// such as `wave run` for offline / dry-run development.
+//
+// Keeping these helpers in a dedicated package (rather than in the
+// production adapter package) prevents accidental wiring of test doubles
+// into a release build and respects AGENTS.md's "test doubles in a
+// dedicated test package" rule.
+package adaptertest
 
 import (
 	"bytes"
@@ -10,6 +21,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/recinq/wave/internal/adapter"
 )
 
 type MockAdapter struct {
@@ -72,7 +85,7 @@ func NewMockAdapter(opts ...MockOption) *MockAdapter {
 	return &MockAdapter{Config: cfg}
 }
 
-func (m *MockAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*AdapterResult, error) {
+func (m *MockAdapter) Run(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
 	if m.Config.SimulatedDelay > 0 {
 		select {
 		case <-time.After(m.Config.SimulatedDelay):
@@ -97,7 +110,7 @@ func (m *MockAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*AdapterRe
 
 	artifacts := append([]string(nil), extractArtifactNames(stdout)...)
 
-	return &AdapterResult{
+	return &adapter.AdapterResult{
 		ExitCode:      m.Config.ExitCode,
 		Stdout:        bytes.NewReader([]byte(stdout)),
 		TokensUsed:    tokens,
@@ -109,7 +122,7 @@ func (m *MockAdapter) Run(ctx context.Context, cfg AdapterRunConfig) (*AdapterRe
 // generateRealisticOutput produces phase-aware, schema-compliant mock output.
 // It first checks the workspace path for a known prototype phase name, then
 // falls back to persona-based output generation.
-func generateRealisticOutput(cfg AdapterRunConfig) string {
+func generateRealisticOutput(cfg adapter.AdapterRunConfig) string {
 	// Check for pipeline-specific step generators first
 	// (workspace path contains pipeline name, e.g., ".agents/workspaces/implement/fetch-assess/")
 	// implement-epic must be checked before implement to avoid false match
@@ -165,7 +178,7 @@ func generateRealisticOutput(cfg AdapterRunConfig) string {
 	}
 }
 
-func generateNavigatorOutput(_ AdapterRunConfig) string {
+func generateNavigatorOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"files": []map[string]string{
 			{"path": "internal/pipeline/executor.go", "purpose": "Core pipeline execution engine with DAG traversal and step orchestration"},
@@ -199,7 +212,7 @@ func generateNavigatorOutput(_ AdapterRunConfig) string {
 }
 
 // generateSpecPhaseOutput returns spec-phase.schema.json compliant output
-func generateSpecPhaseOutput(cfg AdapterRunConfig) string {
+func generateSpecPhaseOutput(cfg adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"phase": "spec",
 		"artifacts": map[string]interface{}{
@@ -231,7 +244,7 @@ func generateSpecPhaseOutput(cfg AdapterRunConfig) string {
 }
 
 // generateDocsPhaseOutput returns docs-phase.schema.json compliant output
-func generateDocsPhaseOutput(_ AdapterRunConfig) string {
+func generateDocsPhaseOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"phase": "docs",
 		"artifacts": map[string]interface{}{
@@ -261,7 +274,7 @@ func generateDocsPhaseOutput(_ AdapterRunConfig) string {
 }
 
 // generateDummyPhaseOutput returns dummy-phase.schema.json compliant output
-func generateDummyPhaseOutput(_ AdapterRunConfig) string {
+func generateDummyPhaseOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"phase": "dummy",
 		"artifacts": map[string]interface{}{
@@ -291,7 +304,7 @@ func generateDummyPhaseOutput(_ AdapterRunConfig) string {
 }
 
 // generateImplementPhaseOutput returns implement-phase.schema.json compliant output
-func generateImplementPhaseOutput(_ AdapterRunConfig) string {
+func generateImplementPhaseOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"phase": "implement",
 		"artifacts": map[string]interface{}{
@@ -325,7 +338,7 @@ func generateImplementPhaseOutput(_ AdapterRunConfig) string {
 	return string(out)
 }
 
-func generateAuditorOutput(cfg AdapterRunConfig) string {
+func generateAuditorOutput(_ adapter.AdapterRunConfig) string {
 	return `## Security & Quality Review
 
 ### Summary
@@ -360,7 +373,7 @@ No critical or high-severity issues found.
 `
 }
 
-func generateSummarizerOutput(cfg AdapterRunConfig) string {
+func generateSummarizerOutput(_ adapter.AdapterRunConfig) string {
 	return `# Checkpoint Summary
 
 ## Objective
@@ -387,7 +400,7 @@ Contract validation passed where configured.
 `
 }
 
-func generateGenericOutput(cfg AdapterRunConfig) string {
+func generateGenericOutput(cfg adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"adapter":     cfg.Adapter,
 		"persona":     cfg.Persona,
@@ -401,7 +414,7 @@ func generateGenericOutput(cfg AdapterRunConfig) string {
 }
 
 // generateIssueAssessmentOutput returns issue-assessment.schema.json compliant output
-func generateIssueAssessmentOutput(_ AdapterRunConfig) string {
+func generateIssueAssessmentOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"implementable": true,
 		"issue": map[string]interface{}{
@@ -429,7 +442,7 @@ func generateIssueAssessmentOutput(_ AdapterRunConfig) string {
 }
 
 // generateIssuePlanOutput returns issue-impl-plan.schema.json compliant output
-func generateIssuePlanOutput(_ AdapterRunConfig) string {
+func generateIssuePlanOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"issue_number": 50,
 		"branch_name":  "050-mock-issue",
@@ -462,7 +475,7 @@ func generateIssuePlanOutput(_ AdapterRunConfig) string {
 }
 
 // generateIssuePROutput returns PR result output for gh-implement create-pr step
-func generateIssuePROutput(_ AdapterRunConfig) string {
+func generateIssuePROutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"pr_url":                   "https://github.com/re-cinq/wave/pull/51",
 		"pr_number":                51,
@@ -476,7 +489,7 @@ func generateIssuePROutput(_ AdapterRunConfig) string {
 }
 
 // generateEpicScopePlanOutput returns epic-scope-plan.schema.json compliant output
-func generateEpicScopePlanOutput(_ AdapterRunConfig) string {
+func generateEpicScopePlanOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"parent_issue": map[string]interface{}{
 			"owner":  "re-cinq",
@@ -527,7 +540,7 @@ func generateEpicScopePlanOutput(_ AdapterRunConfig) string {
 }
 
 // generateEpicReportOutput returns epic-report.schema.json compliant output
-func generateEpicReportOutput(_ AdapterRunConfig) string {
+func generateEpicReportOutput(_ adapter.AdapterRunConfig) string {
 	data := map[string]interface{}{
 		"parent_issue": map[string]interface{}{
 			"owner":  "re-cinq",
@@ -596,10 +609,10 @@ func NewMockAdapterRegistry() *MockAdapterRegistry {
 	}
 }
 
-func (r *MockAdapterRegistry) Register(name string, adapter *MockAdapter) {
+func (r *MockAdapterRegistry) Register(name string, mockAdapter *MockAdapter) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.adapters[name] = adapter
+	r.adapters[name] = mockAdapter
 }
 
 func (r *MockAdapterRegistry) Get(name string) *MockAdapter {
@@ -608,7 +621,7 @@ func (r *MockAdapterRegistry) Get(name string) *MockAdapter {
 	return r.adapters[name]
 }
 
-func (r *MockAdapterRegistry) CreateRunner(name string) AdapterRunner {
+func (r *MockAdapterRegistry) CreateRunner(name string) adapter.AdapterRunner {
 	_ = r.Get(name)
 	return &registeredRunner{
 		registry: r,
@@ -621,13 +634,13 @@ type registeredRunner struct {
 	name     string
 }
 
-func (r *registeredRunner) Run(ctx context.Context, cfg AdapterRunConfig) (*AdapterResult, error) {
-	adapter := r.registry.Get(r.name)
-	if adapter == nil {
-		adapter = NewMockAdapter()
+func (r *registeredRunner) Run(ctx context.Context, cfg adapter.AdapterRunConfig) (*adapter.AdapterResult, error) {
+	mockAdapter := r.registry.Get(r.name)
+	if mockAdapter == nil {
+		mockAdapter = NewMockAdapter()
 	}
 	cfg.Adapter = r.name
-	return adapter.Run(ctx, cfg)
+	return mockAdapter.Run(ctx, cfg)
 }
 
 type SlowReader struct {

--- a/internal/adapter/adaptertest/slowreader_test.go
+++ b/internal/adapter/adaptertest/slowreader_test.go
@@ -1,0 +1,42 @@
+package adaptertest
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestSlowReader_Read(t *testing.T) {
+	data := "hello world"
+	reader := NewSlowReader(data, 5, 10*time.Millisecond)
+
+	buf := make([]byte, 1024)
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if n != 5 {
+		t.Errorf("expected 5 bytes, got: %d", n)
+	}
+
+	if string(buf[:5]) != "hello" {
+		t.Errorf("expected 'hello', got: %s", string(buf[:5]))
+	}
+
+	n, _ = reader.Read(buf)
+	if n != 5 {
+		t.Errorf("expected 5 bytes, got: %d", n)
+	}
+	if string(buf[:n]) != " worl" {
+		t.Errorf("expected ' worl', got: %s", string(buf[:n]))
+	}
+
+	n, err = reader.Read(buf)
+	if n != 1 {
+		t.Errorf("expected 1 byte, got: %d", n)
+	}
+	if err != io.EOF {
+		t.Errorf("expected EOF, got: %v", err)
+	}
+}

--- a/internal/adapter/errors.go
+++ b/internal/adapter/errors.go
@@ -2,9 +2,18 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrUnknownAdapter is returned when a registry is asked to strictly resolve
+// an adapter name that has no override registered and is not a built-in
+// adapter (claude, codex, gemini, opencode, browser). It allows callers
+// such as FallbackRunner to surface a typed error rather than silently
+// falling back to a generic ProcessGroupRunner — which would attempt to
+// exec the adapter name as a binary.
+var ErrUnknownAdapter = errors.New("unknown adapter")
 
 // Failure reason constants for error classification.
 const (

--- a/internal/adapter/fallback.go
+++ b/internal/adapter/fallback.go
@@ -60,7 +60,18 @@ func (f *FallbackRunner) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapte
 		default:
 		}
 
-		runner := f.registry.Resolve(fallbackName)
+		if f.registry == nil {
+			return lastResult, fmt.Errorf("fallback registry is nil; cannot resolve %q", fallbackName)
+		}
+		runner, resolveErr := f.registry.ResolveStrict(fallbackName)
+		if resolveErr != nil {
+			lastErr = resolveErr
+			continue
+		}
+		if runner == nil {
+			lastErr = fmt.Errorf("%w: %q (registry returned nil)", ErrUnknownAdapter, fallbackName)
+			continue
+		}
 		result, err = runner.Run(ctx, cfg)
 		if err == nil && !isFallbackTrigger(result) {
 			return result, nil

--- a/internal/adapter/fallback_test.go
+++ b/internal/adapter/fallback_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -179,6 +180,48 @@ func TestFallbackRunner_ContextCancelledDuringFallback(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cancel")
+}
+
+func TestFallbackRunner_UnknownFallbackNameSurfacesTypedError(t *testing.T) {
+	// Primary fails with rate_limit so the runner walks the fallback chain.
+	primary := &failingRunner{failureReason: "rate_limit"}
+
+	// Registry has no override and no default runner. The fallback name
+	// "definitely-not-a-real-adapter" is not a built-in adapter, so
+	// ResolveStrict must return ErrUnknownAdapter and the FallbackRunner
+	// must surface it without panicking.
+	registry := NewAdapterRegistry(nil)
+
+	fr := NewFallbackRunner(primary, []string{"definitely-not-a-real-adapter"}, registry)
+	result, err := fr.Run(context.Background(), AdapterRunConfig{})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnknownAdapter),
+		"expected wrapped ErrUnknownAdapter, got: %v", err)
+	assert.Contains(t, err.Error(), "all fallback adapters exhausted")
+	// The last seen result from the primary is propagated through.
+	assert.NotNil(t, result)
+	assert.Equal(t, "rate_limit", result.FailureReason)
+	assert.Equal(t, 1, primary.callCount)
+}
+
+func TestFallbackRunner_UnknownFallbackThenSuccessSecondAttempt(t *testing.T) {
+	// Primary rate-limits; first fallback name is unknown (must not crash);
+	// second fallback succeeds and the chain unwinds normally.
+	primary := &failingRunner{failureReason: "rate_limit"}
+	good := &successRunner{}
+
+	registry := NewAdapterRegistry(nil)
+	registry.RegisterOverride("good", good)
+
+	fr := NewFallbackRunner(primary, []string{"unknown-typo", "good"}, registry)
+	result, err := fr.Run(context.Background(), AdapterRunConfig{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "success", result.ResultContent)
+	assert.Equal(t, 1, primary.callCount)
+	assert.Equal(t, 1, good.callCount)
 }
 
 func TestIsFallbackTrigger(t *testing.T) {

--- a/internal/adapter/integration_test.go
+++ b/internal/adapter/integration_test.go
@@ -3,6 +3,7 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,6 +14,51 @@ import (
 	"testing"
 	"time"
 )
+
+// concurrentMockRunner is an inline test double used by
+// TestAdapterIntegration_ConcurrentAccess. Living inside the adapter
+// package avoids importing the adaptertest helper package — which would
+// create an import cycle with this file's `package adapter` declaration.
+type concurrentMockRunner struct {
+	stdoutJSON string
+	tokensUsed int
+}
+
+func (m *concurrentMockRunner) Run(_ context.Context, cfg AdapterRunConfig) (*AdapterResult, error) {
+	_ = cfg
+	return &AdapterResult{
+		ExitCode:      0,
+		Stdout:        bytes.NewReader([]byte(m.stdoutJSON)),
+		TokensUsed:    m.tokensUsed,
+		ResultContent: m.stdoutJSON,
+	}, nil
+}
+
+// concurrentMockRegistry is a minimal registry that hands out
+// concurrentMockRunner instances by name.
+type concurrentMockRegistry struct {
+	mu       sync.RWMutex
+	adapters map[string]*concurrentMockRunner
+}
+
+func newConcurrentMockRegistry() *concurrentMockRegistry {
+	return &concurrentMockRegistry{adapters: make(map[string]*concurrentMockRunner)}
+}
+
+func (r *concurrentMockRegistry) Register(name string, m *concurrentMockRunner) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters[name] = m
+}
+
+func (r *concurrentMockRegistry) CreateRunner(name string) AdapterRunner {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if m, ok := r.adapters[name]; ok {
+		return m
+	}
+	return &concurrentMockRunner{}
+}
 
 // =============================================================================
 // Integration Tests for Adapter Package
@@ -128,16 +174,15 @@ func TestAdapterIntegration_ConcurrentAccess(t *testing.T) {
 	const numWorkers = 10
 	const opsPerWorker = 5
 
-	registry := NewMockAdapterRegistry()
+	registry := newConcurrentMockRegistry()
 
 	// Register different adapters for each worker
 	for i := 0; i < numWorkers; i++ {
 		name := fmt.Sprintf("worker-%d", i)
-		adapter := NewMockAdapter(
-			WithStdoutJSON(fmt.Sprintf(`{"worker": %d, "timestamp": "%d"}`, i, time.Now().Unix())),
-			WithTokensUsed(100+i*10),
-		)
-		registry.Register(name, adapter)
+		registry.Register(name, &concurrentMockRunner{
+			stdoutJSON: fmt.Sprintf(`{"worker": %d, "timestamp": "%d"}`, i, time.Now().Unix()),
+			tokensUsed: 100 + i*10,
+		})
 	}
 
 	var wg sync.WaitGroup

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -1,8 +1,30 @@
 package adapter
 
 import (
+	"fmt"
 	"strings"
 )
+
+// builtinAdapterNames lists the adapter names that ResolveAdapterWithBinary
+// recognises (anything outside this set falls through to ProcessGroupRunner,
+// which is rarely what callers want for fallback chains).
+var builtinAdapterNames = map[string]struct{}{
+	"claude":   {},
+	"codex":    {},
+	"gemini":   {},
+	"opencode": {},
+	"browser":  {},
+}
+
+// isKnownAdapterName reports whether the given name corresponds to a built-in
+// adapter or an opencode fork (opencode-*).
+func isKnownAdapterName(name string) bool {
+	lc := strings.ToLower(name)
+	if _, ok := builtinAdapterNames[lc]; ok {
+		return true
+	}
+	return strings.HasPrefix(lc, "opencode-")
+}
 
 // AdapterRegistry resolves adapter names to AdapterRunner implementations.
 // It replaces the single-runner model with per-step adapter resolution,
@@ -44,6 +66,10 @@ func NewSingleRunnerRegistry(runner AdapterRunner) *AdapterRegistry {
 
 // Resolve returns the AdapterRunner for the given adapter name.
 // Resolution order: overrides → defaultRunner → built-in adapter mapping.
+//
+// Resolve never returns nil: unknown adapter names fall through to a
+// ProcessGroupRunner that exec's the name as a binary. Callers that want
+// to distinguish "registered" from "unknown" should use ResolveStrict.
 func (r *AdapterRegistry) Resolve(adapterName string) AdapterRunner {
 	if runner, ok := r.overrides[adapterName]; ok {
 		return runner
@@ -56,6 +82,38 @@ func (r *AdapterRegistry) Resolve(adapterName string) AdapterRunner {
 		binary = r.binaries[adapterName]
 	}
 	return ResolveAdapterWithBinary(adapterName, binary)
+}
+
+// ResolveStrict is like Resolve but returns ErrUnknownAdapter wrapped with
+// the adapter name when the name has no override registered, no default
+// runner is configured, and the name is not a built-in adapter. This is
+// the preferred API for callers (e.g. FallbackRunner) that should refuse
+// silently exec'ing an arbitrary binary on a typo'd fallback chain entry.
+func (r *AdapterRegistry) ResolveStrict(adapterName string) (AdapterRunner, error) {
+	if r == nil {
+		return nil, fmt.Errorf("%w: nil registry", ErrUnknownAdapter)
+	}
+	if runner, ok := r.overrides[adapterName]; ok {
+		if runner == nil {
+			return nil, fmt.Errorf("%w: %q (override registered as nil)", ErrUnknownAdapter, adapterName)
+		}
+		return runner, nil
+	}
+	if r.defaultRunner != nil {
+		return r.defaultRunner, nil
+	}
+	if !isKnownAdapterName(adapterName) {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownAdapter, adapterName)
+	}
+	binary := ""
+	if r.binaries != nil {
+		binary = r.binaries[adapterName]
+	}
+	runner := ResolveAdapterWithBinary(adapterName, binary)
+	if runner == nil {
+		return nil, fmt.Errorf("%w: %q (resolver returned nil)", ErrUnknownAdapter, adapterName)
+	}
+	return runner, nil
 }
 
 // ResolveWithFallback returns the primary runner wrapped in a FallbackRunner

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubRunner is a minimal AdapterRunner used by registry tests where we
+// only need a recognisable identity. Living inside the adapter package
+// avoids importing the dedicated test-double package (adaptertest) which
+// would create an import cycle.
+type stubRunner struct {
+	exitCode int
+}
+
+func (r *stubRunner) Run(_ context.Context, _ AdapterRunConfig) (*AdapterResult, error) {
+	return &AdapterResult{ExitCode: r.exitCode}, nil
+}
+
 func TestAdapterRegistry_ResolveKnownAdapters(t *testing.T) {
 	registry := NewAdapterRegistry(nil)
 
@@ -63,7 +75,7 @@ func TestAdapterRegistry_ResolveUnknownReturnsProcessGroupRunner(t *testing.T) {
 
 func TestAdapterRegistry_OverrideTakesPrecedence(t *testing.T) {
 	registry := NewAdapterRegistry(nil)
-	mock := NewMockAdapter()
+	mock := &stubRunner{}
 	registry.RegisterOverride("claude", mock)
 
 	runner := registry.Resolve("claude")
@@ -71,7 +83,7 @@ func TestAdapterRegistry_OverrideTakesPrecedence(t *testing.T) {
 }
 
 func TestSingleRunnerRegistry_AlwaysReturnsSameRunner(t *testing.T) {
-	mock := NewMockAdapter()
+	mock := &stubRunner{}
 	registry := NewSingleRunnerRegistry(mock)
 
 	// Any name should return the same runner
@@ -123,10 +135,10 @@ func TestAdapterRegistry_NilFallbacks(t *testing.T) {
 }
 
 func TestSingleRunnerRegistry_OverrideStillWorks(t *testing.T) {
-	defaultMock := NewMockAdapter()
+	defaultMock := &stubRunner{}
 	registry := NewSingleRunnerRegistry(defaultMock)
 
-	overrideMock := NewMockAdapter(WithExitCode(42))
+	overrideMock := &stubRunner{exitCode: 42}
 	registry.RegisterOverride("special", overrideMock)
 
 	// Override should take precedence
@@ -154,7 +166,7 @@ func TestAdapterRegistry_ResolveDoesNotReturnNil(t *testing.T) {
 }
 
 func TestSingleRunnerRegistry_RunDelegates(t *testing.T) {
-	mock := NewMockAdapter(WithExitCode(0))
+	mock := &stubRunner{exitCode: 0}
 	registry := NewSingleRunnerRegistry(mock)
 	runner := registry.Resolve("anything")
 

--- a/internal/contract/schemas/shared/registry.go
+++ b/internal/contract/schemas/shared/registry.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"sync"
 )
 
 //go:embed *.json
@@ -22,14 +23,47 @@ var schemasFS embed.FS
 // Pipelines with no typed schema default to "string".
 const TypeString = "string"
 
-// registry is populated at init time from the embedded *.json files.
-// Keys are the filename sans extension (e.g. "issue_ref").
-var registry = func() map[string][]byte {
+// registry holds the parsed schema bytes keyed by short type name (e.g.
+// "issue_ref"). It is populated lazily on the first call to one of the
+// public lookup helpers via loadOnce.
+//
+// Loading is intentionally lazy — and not done in init() — so that an
+// embed-FS read failure surfaces as a structured error rather than a
+// process-wide panic. Callers that want to fail fast at startup can
+// invoke LoadSchemas() once during binary wiring.
+var (
+	registry  map[string][]byte
+	loadOnce  sync.Once
+	loadError error
+)
+
+// LoadSchemas eagerly populates the in-memory registry from the embedded
+// FS. It is safe to call concurrently and idempotent: subsequent calls
+// reuse the first result. The returned error (if any) is also surfaced
+// from Lookup, Exists, and Names via LoadError after the first call.
+//
+// Callers that prefer fail-fast semantics should invoke LoadSchemas
+// during binary wiring (e.g. from a manifest constructor) and abort on
+// non-nil. Callers that prefer best-effort semantics can rely on the
+// implicit lazy load performed by Lookup/Exists/Names.
+func LoadSchemas() error {
+	loadOnce.Do(func() {
+		registry, loadError = loadSchemasFromFS()
+	})
+	return loadError
+}
+
+// LoadError returns the error encountered the first time the registry was
+// populated, or nil if loading has not been attempted or succeeded.
+func LoadError() error {
+	return loadError
+}
+
+func loadSchemasFromFS() (map[string][]byte, error) {
 	out := make(map[string][]byte)
 	entries, err := fs.ReadDir(schemasFS, ".")
 	if err != nil {
-		//nolint:forbidigo // package-init guard, embedded FS read cannot fail at runtime
-		panic(fmt.Sprintf("shared schemas: failed to read embedded FS: %v", err))
+		return out, fmt.Errorf("shared schemas: failed to read embedded FS: %w", err)
 	}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
@@ -37,40 +71,59 @@ var registry = func() map[string][]byte {
 		}
 		data, err := schemasFS.ReadFile(e.Name())
 		if err != nil {
-			//nolint:forbidigo // package-init guard, embedded FS read cannot fail at runtime
-			panic(fmt.Sprintf("shared schemas: failed to read %s: %v", e.Name(), err))
+			return out, fmt.Errorf("shared schemas: failed to read %s: %w", e.Name(), err)
 		}
 		name := strings.TrimSuffix(e.Name(), ".json")
 		out[name] = data
 	}
-	return out
-}()
+	return out, nil
+}
+
+// ensureLoaded triggers the lazy load on first call. Subsequent calls
+// are no-ops thanks to sync.Once.
+func ensureLoaded() {
+	_ = LoadSchemas()
+}
 
 // Lookup returns the raw JSON schema bytes for a named type.
 // The special name "string" resolves to (nil, true) — callers treat it as
 // free-text with no schema validation.
-// Returns (nil, false) if the type is unknown.
+// Returns (nil, false) if the type is unknown OR if the embedded FS
+// failed to load (see LoadError).
 func Lookup(name string) ([]byte, bool) {
 	if name == "" || name == TypeString {
 		return nil, true
+	}
+	ensureLoaded()
+	if registry == nil {
+		return nil, false
 	}
 	data, ok := registry[name]
 	return data, ok
 }
 
 // Exists reports whether the given type name is registered (or is the
-// "string" sentinel).
+// "string" sentinel). Returns false if the registry failed to load.
 func Exists(name string) bool {
 	if name == "" || name == TypeString {
 		return true
+	}
+	ensureLoaded()
+	if registry == nil {
+		return false
 	}
 	_, ok := registry[name]
 	return ok
 }
 
 // Names returns the sorted list of registered typed schema names.
-// The "string" sentinel is not included.
+// The "string" sentinel is not included. Returns an empty slice if the
+// registry failed to load.
 func Names() []string {
+	ensureLoaded()
+	if registry == nil {
+		return nil
+	}
 	names := make([]string, 0, len(registry))
 	for n := range registry {
 		names = append(names, n)

--- a/internal/pipeline/concurrency_test.go
+++ b/internal/pipeline/concurrency_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -17,9 +18,9 @@ import (
 func TestConcurrencyExecutor_BasicExecution(t *testing.T) {
 	var callCount atomic.Int32
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	// Wrap to count calls
@@ -161,9 +162,9 @@ func TestConcurrencyExecutor_MaxConcurrencyCap(t *testing.T) {
 
 func TestConcurrencyExecutor_SingleAgent(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -197,9 +198,9 @@ func TestConcurrencyExecutor_SingleAgent(t *testing.T) {
 
 func TestConcurrencyExecutor_ZeroConcurrency(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -233,9 +234,9 @@ func TestConcurrencyExecutor_ZeroConcurrency(t *testing.T) {
 
 func TestConcurrencyExecutor_ResultAggregation(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -290,9 +291,9 @@ func TestConcurrencyExecutor_ResultAggregation(t *testing.T) {
 
 func TestConcurrencyExecutor_WorkspaceIsolation(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -345,7 +346,7 @@ func TestConcurrencyExecutor_WorkspaceIsolation(t *testing.T) {
 
 // concurrencyCountingAdapter wraps MockAdapter and counts calls.
 type concurrencyCountingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	callCount *atomic.Int32
 }
 
@@ -365,9 +366,9 @@ func (a *concurrencyFailAdapter) Run(ctx context.Context, cfg adapter.AdapterRun
 	if n == a.failOnCall {
 		return nil, errors.New("simulated agent failure")
 	}
-	return adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	return adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	).Run(ctx, cfg)
 }
 
@@ -390,9 +391,9 @@ func (a *concurrencyConcurrentTracker) Run(ctx context.Context, cfg adapter.Adap
 	time.Sleep(10 * time.Millisecond)
 	a.currentConcurrent.Add(-1)
 
-	return adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	return adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	).Run(ctx, cfg)
 }
 

--- a/internal/pipeline/contract_integration_test.go
+++ b/internal/pipeline/contract_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
@@ -31,15 +32,15 @@ import (
 
 // contractTestPromptCapturingAdapter captures prompts sent to the adapter for inspection
 type contractTestPromptCapturingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	mu              sync.Mutex
 	capturedPrompts []string
 	capturedConfigs []adapter.AdapterRunConfig
 }
 
-func newContractTestPromptCapturingAdapter(opts ...adapter.MockOption) *contractTestPromptCapturingAdapter {
+func newContractTestPromptCapturingAdapter(opts ...adaptertest.MockOption) *contractTestPromptCapturingAdapter {
 	return &contractTestPromptCapturingAdapter{
-		MockAdapter:     adapter.NewMockAdapter(opts...),
+		MockAdapter:     adaptertest.NewMockAdapter(opts...),
 		capturedPrompts: make([]string, 0),
 		capturedConfigs: make([]adapter.AdapterRunConfig, 0),
 	}
@@ -302,8 +303,8 @@ func TestContractIntegration_SchemaInjectedIntoPrompt(t *testing.T) {
 
 	// Create capturing adapter to verify prompt contents
 	capturingAdapter := newContractTestPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"result": "success", "confidence": 0.95}`),
-		adapter.WithTokensUsed(1000),
+		adaptertest.WithStdoutJSON(`{"result": "success", "confidence": 0.95}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	// Also write the valid artifact
@@ -378,8 +379,8 @@ func TestContractIntegration_InlineSchemaInjectedIntoPrompt(t *testing.T) {
 	inlineSchema := `{"type": "object", "properties": {"status": {"type": "string"}}, "required": ["status"]}`
 
 	capturingAdapter := newContractTestPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"status": "complete"}`),
-		adapter.WithTokensUsed(500),
+		adaptertest.WithStdoutJSON(`{"status": "complete"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(capturingAdapter)
@@ -929,8 +930,8 @@ func TestContractIntegration_InputTemplateReplacement(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	capturingAdapter := newContractTestPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"result": "done"}`),
-		adapter.WithTokensUsed(500),
+		adaptertest.WithStdoutJSON(`{"result": "done"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(capturingAdapter)

--- a/internal/pipeline/create_workspace_test.go
+++ b/internal/pipeline/create_workspace_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -13,7 +13,7 @@ import (
 // error paths in createStepWorkspace.
 func TestCreateStepWorkspace_TemplateResolution(t *testing.T) {
 	newExecutor := func() *DefaultPipelineExecutor {
-		return NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	}
 
 	newExecution := func() *PipelineExecution {

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -58,7 +58,7 @@ func TestResolveDependencyArtifacts_InMemoryArtifactPaths(t *testing.T) {
 	})
 	exec.ArtifactPaths["fetch:pr-context"] = src
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -86,7 +86,7 @@ func TestResolveDependencyArtifacts_ContextNamespacedFallback(t *testing.T) {
 	})
 	exec.Context.SetArtifactPath("fetch.merged-findings", src)
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -114,7 +114,7 @@ func TestResolveDependencyArtifacts_FilesystemFallback(t *testing.T) {
 	})
 	exec.WorkspacePaths["fetch"] = depWorkspace
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -135,7 +135,7 @@ func TestResolveDependencyArtifacts_RequiredMissingErrors(t *testing.T) {
 		{Name: "pr-context", Type: "json", Required: true},
 	})
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	_, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err == nil {
 		t.Fatal("expected error for missing required artifact")
@@ -153,7 +153,7 @@ func TestResolveDependencyArtifacts_OptionalMissingNoError(t *testing.T) {
 		{Name: "pr-context", Type: "json", Required: false},
 	})
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("optional missing should not error; got: %v", err)
@@ -176,7 +176,7 @@ func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
 	})
 	exec.ArtifactPaths["fetch:pr-context"] = src
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	canonicalMap, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[1], workspace)
 	if err != nil {
 		t.Fatalf("inject: %v", err)
@@ -223,7 +223,7 @@ func TestInjectDependencyArtifacts_NoDepsNoOp(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test"},
 		Context:        NewPipelineContext("test", "t", "solo"),
 	}
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	if _, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[0], tmp); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
@@ -242,8 +242,8 @@ func TestBuildDepEnvVars(t *testing.T) {
 	got := BuildDepEnvVars(resolved, "/ws")
 
 	want := map[string]string{
-		"WAVE_DEPS_DIR":                "/ws/.agents/artifacts",
-		"WAVE_DEP_FETCH_PR_PR_CONTEXT": "/ws/.agents/artifacts/fetch-pr/pr-context",
+		"WAVE_DEPS_DIR":                    "/ws/.agents/artifacts",
+		"WAVE_DEP_FETCH_PR_PR_CONTEXT":     "/ws/.agents/artifacts/fetch-pr/pr-context",
 		"WAVE_DEP_MERGE_FINDINGS_FINDINGS": "/ws/.agents/artifacts/merge-findings/findings",
 	}
 	gotMap := make(map[string]string, len(got))
@@ -281,7 +281,7 @@ func TestResolveDependencyArtifacts_ImplicitAggregateFallback(t *testing.T) {
 	exec := fixtureExecution(t, nil)
 	exec.ArtifactPaths["fetch:merged-findings"] = src
 
-	ex := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)

--- a/internal/pipeline/executor_schema_test.go
+++ b/internal/pipeline/executor_schema_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -428,8 +428,8 @@ func TestContractPrompt_EndToEndExecution(t *testing.T) {
 	collector := testutil.NewEventCollector()
 
 	mockAdapter := newContractTestPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"result": "success"}`),
-		adapter.WithTokensUsed(100),
+		adaptertest.WithStdoutJSON(`{"result": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	securityConfig := security.DefaultSecurityConfig()

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/skill"
@@ -26,9 +27,9 @@ import (
 // TestStepOrdering verifies steps execute in topological order (T047)
 func TestStepOrdering(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -70,9 +71,9 @@ func TestStepOrdering(t *testing.T) {
 // TestComplexDAGOrdering tests a more complex DAG structure
 func TestComplexDAGOrdering(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -135,10 +136,10 @@ func TestParallelStepExecution(t *testing.T) {
 	// sporadic max-concurrent=1 false negatives. 500ms gives a 10x
 	// margin against scheduler jitter while keeping wall time under 2s.
 	concurrentAdapter := &concurrencyTrackingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(500),
-			adapter.WithSimulatedDelay(500*time.Millisecond),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(500),
+			adaptertest.WithSimulatedDelay(500*time.Millisecond),
 		),
 		onStart: func() {
 			current := atomic.AddInt32(&currentConcurrent, 1)
@@ -217,14 +218,14 @@ func TestConcurrentStepFailure(t *testing.T) {
 
 	// Create an adapter that fails for step-b but succeeds (slowly) for step-c
 	failingConcurrentAdapter := &stepAwareAdapter{
-		defaultAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(500),
-			adapter.WithSimulatedDelay(200*time.Millisecond),
+		defaultAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(500),
+			adaptertest.WithSimulatedDelay(200*time.Millisecond),
 		),
 		stepAdapters: map[string]adapter.AdapterRunner{
-			"step-b": adapter.NewMockAdapter(
-				adapter.WithFailure(errors.New("step-b intentional failure")),
+			"step-b": adaptertest.NewMockAdapter(
+				adaptertest.WithFailure(errors.New("step-b intentional failure")),
 			),
 		},
 		onStart: func(stepID string) {
@@ -269,9 +270,9 @@ func TestConcurrentStepFailure(t *testing.T) {
 // dependencies run through the single-step fast path (no goroutine overhead).
 func TestSingleStepBatchNoOverhead(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -313,8 +314,8 @@ func TestSingleStepBatchNoOverhead(t *testing.T) {
 // even when the step fails on a single-step batch (no concurrency).
 func TestFailedStepAlwaysHasID(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	failingAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("simulated timeout")),
+	failingAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("simulated timeout")),
 	)
 
 	_ = NewDefaultPipelineExecutor(failingAdapter,
@@ -335,9 +336,9 @@ func TestFailedStepAlwaysHasID(t *testing.T) {
 
 	// Make step-a succeed, step-b fail
 	stepAdapter := &stepAwareAdapter{
-		defaultAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		defaultAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		stepAdapters: map[string]adapter.AdapterRunner{
 			"step-b": failingAdapter,
@@ -365,10 +366,10 @@ func TestConcurrentStepWideFanOut(t *testing.T) {
 	var currentConcurrent int32
 
 	concurrentAdapter := &concurrencyTrackingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
-			adapter.WithSimulatedDelay(200*time.Millisecond),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
+			adaptertest.WithSimulatedDelay(200*time.Millisecond),
 		),
 		onStart: func() {
 			current := atomic.AddInt32(&currentConcurrent, 1)
@@ -457,12 +458,12 @@ func TestContractFailureRetry(t *testing.T) {
 	retryAdapter := &retryTrackingAdapter{
 		attempts:  &attemptCount,
 		failUntil: 2,
-		successAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(1000),
+		successAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(1000),
 		),
-		failAdapter: adapter.NewMockAdapter(
-			adapter.WithFailure(errors.New("contract validation failed")),
+		failAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithFailure(errors.New("contract validation failed")),
 		),
 	}
 
@@ -506,8 +507,8 @@ func TestContractFailureExhaustsRetries(t *testing.T) {
 	collector := testutil.NewEventCollector()
 
 	// Create an adapter that always fails
-	failingAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("persistent failure")),
+	failingAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("persistent failure")),
 	)
 
 	executor := NewDefaultPipelineExecutor(failingAdapter,
@@ -611,9 +612,9 @@ func TestBuildContractPrompt_NoContract(t *testing.T) {
 // TestProgressEventEmission tests that progress events are emitted during execution (T052)
 func TestProgressEventEmission(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(2500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(2500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -686,9 +687,9 @@ func TestProgressEventEmission(t *testing.T) {
 // TestProgressEventFields tests that progress events have correct field values
 func TestProgressEventFields(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(3000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(3000),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -732,8 +733,8 @@ func TestProgressEventFields(t *testing.T) {
 
 // TestExecutorWithoutEmitter tests executor works without an emitter configured
 func TestExecutorWithoutEmitter(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	// Create executor without emitter
@@ -761,8 +762,8 @@ func TestExecutorWithoutEmitter(t *testing.T) {
 func TestGetStatus(t *testing.T) {
 	mockStore := testutil.NewMockStateStore()
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -806,7 +807,7 @@ func TestGetStatus(t *testing.T) {
 // TestDAGCycleDetection tests that cycles are detected and rejected
 func TestDAGCycleDetection(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
@@ -836,7 +837,7 @@ func TestDAGCycleDetection(t *testing.T) {
 // TestMissingDependency tests that missing dependencies are caught
 func TestMissingDependency(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
@@ -863,8 +864,8 @@ func TestMissingDependency(t *testing.T) {
 // TestWorkspaceCreation tests that workspaces are created for each step
 func TestWorkspaceCreation(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -911,9 +912,9 @@ func TestEmptyResultContentDoesNotOverwriteArtifacts(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mock adapter that returns empty ResultContent (simulating parsing failure or compaction effect)
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"type": "result", "result": ""}`), // Empty result in JSON
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"type": "result", "result": ""}`), // Empty result in JSON
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	collector := testutil.NewEventCollector()
@@ -961,7 +962,7 @@ func indexOfInSlice(slice []string, item string) int {
 
 // concurrencyTrackingAdapter wraps MockAdapter to track concurrent executions
 type concurrencyTrackingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	onStart func()
 	onEnd   func()
 }
@@ -1000,8 +1001,8 @@ func TestMemoryCleanupAfterCompletion(t *testing.T) {
 	// Use a mock state store to test persistent storage fallback
 	mockStore := testutil.NewMockStateStore()
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1048,8 +1049,8 @@ func TestMemoryCleanupAfterFailure(t *testing.T) {
 	mockStore := testutil.NewMockStateStore()
 	collector := testutil.NewEventCollector()
 	// Use a failing adapter
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("step failure")),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("step failure")),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1097,8 +1098,8 @@ func TestRegressionProductionIssues(t *testing.T) {
 	t.Run("EmptyInputDoesNotCauseIssues", func(t *testing.T) {
 		mockStore := testutil.NewMockStateStore()
 		collector := testutil.NewEventCollector()
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		)
 
 		executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1142,8 +1143,8 @@ func TestRegressionProductionIssues(t *testing.T) {
 
 	t.Run("NilContextIsHandledDefensively", func(t *testing.T) {
 		// Create a pipeline execution with nil context to test defensive handling
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		)
 
 		executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -1181,8 +1182,8 @@ func TestRegressionProductionIssues(t *testing.T) {
 
 	t.Run("MatrixExecutorContextPropagation", func(t *testing.T) {
 		// Test that matrix executor properly propagates context to worker executions
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		)
 
 		executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -1238,8 +1239,8 @@ func TestRegressionProductionIssues(t *testing.T) {
 // This is a regression test for a bug where test code didn't check for nil status
 // after GetStatus returned an error, causing a panic when accessing status.CompletedSteps.
 func TestNilStatusHandlingInTests(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("simulated failure")),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("simulated failure")),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -1291,9 +1292,9 @@ func TestWriteOutputArtifactsPreservesExistingFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mock adapter returns non-empty ResultContent (conversational prose)
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"type": "result", "result": "I analyzed the issue and wrote the file."}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"type": "result", "result": "I analyzed the issue and wrote the file."}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	collector := testutil.NewEventCollector()
@@ -1337,9 +1338,9 @@ func TestWriteOutputArtifactsPreservesExistingFiles(t *testing.T) {
 func TestCommandStepOutputArtifactsRegisteredForInjection(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"type": "result", "result": "ok"}`),
-		adapter.WithTokensUsed(10),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"type": "result", "result": "ok"}`),
+		adaptertest.WithTokensUsed(10),
 	)
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
@@ -1407,7 +1408,7 @@ func TestCommandStepOutputArtifactsRegisteredForInjection(t *testing.T) {
 
 // configCapturingAdapter wraps MockAdapter and captures the AdapterRunConfig passed to Run
 type configCapturingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	mu         sync.Mutex
 	lastConfig adapter.AdapterRunConfig
 }
@@ -1429,9 +1430,9 @@ func (a *configCapturingAdapter) getLastConfig() adapter.AdapterRunConfig {
 // emits a warning event but still allows the step to complete (work may have been done).
 func TestExecuteStep_NonZeroExitCode_EmitsWarning(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithExitCode(1),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithExitCode(1),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1474,9 +1475,9 @@ func TestExecuteStep_NonZeroExitCode_EmitsWarning(t *testing.T) {
 // exits with a non-zero code, subsequent steps still execute (work may have been done).
 func TestExecuteStep_NonZeroExitCode_ContinuesSubsequentSteps(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithExitCode(1),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithExitCode(1),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1526,7 +1527,7 @@ func TestExecuteStep_NonZeroExitCode_ContinuesSubsequentSteps(t *testing.T) {
 // streamEventAdapter wraps MockAdapter and fires OnStreamEvent callbacks before delegating Run.
 // This lets us test the stream-activity event bridge in the executor.
 type streamEventAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	streamEvents []adapter.StreamEvent
 }
 
@@ -1551,9 +1552,9 @@ func TestStreamActivityEventBridge(t *testing.T) {
 	// 2. Non-tool_use event (type "text") -> should NOT emit stream_activity
 	// 3. tool_use with empty ToolName -> should NOT emit stream_activity
 	streamAdapter := &streamEventAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(500),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(500),
 		),
 		streamEvents: []adapter.StreamEvent{
 			{
@@ -1625,7 +1626,7 @@ func TestStreamActivityEventBridge(t *testing.T) {
 }
 
 func TestCreateStepWorkspace_Ref(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 	m := &manifest.Manifest{}
 	tmpDir := t.TempDir()
 
@@ -1650,7 +1651,7 @@ func TestCreateStepWorkspace_Ref(t *testing.T) {
 }
 
 func TestCreateStepWorkspace_RefMissing(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 	m := &manifest.Manifest{}
 
 	execution := &PipelineExecution{
@@ -1673,8 +1674,8 @@ func TestCreateStepWorkspace_RefMissing(t *testing.T) {
 
 func TestCreateStepWorkspace_SharedWorktree(t *testing.T) {
 	// Test that two steps with the same branch reuse the same worktree path
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 
@@ -1738,8 +1739,8 @@ func TestCreateStepWorkspace_SharedWorktree(t *testing.T) {
 
 func TestCreateStepWorkspace_DifferentBranches(t *testing.T) {
 	// Test that two steps with different branches get separate worktree entries
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 
@@ -1800,8 +1801,8 @@ func TestCreateStepWorkspace_DifferentBranches(t *testing.T) {
 
 func TestCleanupWorktrees_Dedup(t *testing.T) {
 	// Test that shared worktree paths are only cleaned up once
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 
@@ -1849,9 +1850,9 @@ func getExecutorPipeline(executor PipelineExecutor, pipelineID string) (*Pipelin
 func TestStdoutArtifactCapture(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	stdoutContent := `{"analysis": "test analysis data", "score": 42}`
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(stdoutContent),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(stdoutContent),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1903,9 +1904,9 @@ func TestStdoutArtifactSizeLimitEnforced(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	// Create a large stdout (over 10MB would be too slow, so we'll configure a smaller limit)
 	largeContent := strings.Repeat("x", 1000)
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(largeContent),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(largeContent),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1944,9 +1945,9 @@ func TestStdoutArtifactSizeLimitEnforced(t *testing.T) {
 func TestStdoutArtifactWrittenToCorrectLocation(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	expectedContent := "test content for stdout artifact"
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(expectedContent),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(expectedContent),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -1990,9 +1991,9 @@ func TestStdoutArtifactWrittenToCorrectLocation(t *testing.T) {
 // TestMissingRequiredArtifactFailsBeforeStep tests that missing required artifacts fail before step execution
 func TestMissingRequiredArtifactFailsBeforeStep(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -2038,9 +2039,9 @@ func TestMissingRequiredArtifactFailsBeforeStep(t *testing.T) {
 // TestOptionalMissingArtifactProceeds tests that optional missing artifacts don't fail the step
 func TestOptionalMissingArtifactProceeds(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -2095,9 +2096,9 @@ func TestOptionalMissingArtifactProceeds(t *testing.T) {
 // TestTypeMismatchFailsWithClearError tests that type mismatch produces a clear error
 func TestTypeMismatchFailsWithClearError(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -2146,9 +2147,9 @@ func TestTypeMismatchFailsWithClearError(t *testing.T) {
 // TestTypeNotDeclaredSkipsValidation tests that missing type declaration skips validation
 func TestTypeNotDeclaredSkipsValidation(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -2199,9 +2200,9 @@ func TestOutcomeExtractionRegistersDeliverables(t *testing.T) {
 
 	artifactJSON := `{"comment_url": "https://github.com/re-cinq/wave/pull/42#issuecomment-999", "pr": "42"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: artifactJSON,
 	}
@@ -2267,9 +2268,9 @@ func TestOutcomeExtractionRegistersDeliverables(t *testing.T) {
 // warnings but don't fail the step.
 func TestOutcomeExtractionMissingFileWarns(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -2323,9 +2324,9 @@ func TestOutcomeExtractionPRType(t *testing.T) {
 
 	prJSON := `{"pr_url": "https://github.com/re-cinq/wave/pull/99", "title": "feat: add feature"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: prJSON,
 	}
@@ -2378,9 +2379,9 @@ func TestOutcomeExtractionIssueType(t *testing.T) {
 
 	issueJSON := `{"issue_url": "https://github.com/re-cinq/wave/issues/55"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: issueJSON,
 	}
@@ -2420,9 +2421,9 @@ func TestOutcomeExtractionDeploymentType(t *testing.T) {
 
 	deployJSON := `{"deploy_url": "https://staging.example.com"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: deployJSON,
 	}
@@ -2463,9 +2464,9 @@ func TestOutcomeExtractionUnknownTypeFallsBackToURL(t *testing.T) {
 
 	artifactJSON := `{"link": "https://example.com/report"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: artifactJSON,
 	}
@@ -2502,9 +2503,9 @@ func TestOutcomeExtractionUnknownTypeFallsBackToURL(t *testing.T) {
 // workspace are rejected with a warning.
 func TestOutcomeExtractionPathTraversal(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
@@ -2546,9 +2547,9 @@ func TestOutcomeExtractionInvalidJSONPath(t *testing.T) {
 
 	artifactJSON := `{"url": "https://example.com"}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: artifactJSON,
 	}
@@ -2620,7 +2621,7 @@ func TestOutcomeDefValidation(t *testing.T) {
 // outcomeTestAdapter wraps MockAdapter and writes an artifact JSON file during execution
 // so that outcome extraction can find it afterward.
 type outcomeTestAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	artifactJSON string
 }
 
@@ -2655,9 +2656,9 @@ func TestOutcomeExtractionEmptyArrayFriendlyMessage(t *testing.T) {
 	// Artifact contains an empty array — a valid "no results" condition
 	artifactJSON := `{"enhanced_issues": []}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: artifactJSON,
 	}
@@ -2727,9 +2728,9 @@ func TestOutcomeExtractionNonEmptyArrayOOBStillEmitsWarning(t *testing.T) {
 	// Array has 1 element but the outcome path asks for index 5
 	artifactJSON := `{"items": [{"url": "https://example.com"}]}`
 	outcomeAdapter := &outcomeTestAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		artifactJSON: artifactJSON,
 	}
@@ -2801,9 +2802,9 @@ type modelCapturingAdapter struct {
 func newModelCapturingAdapter() *modelCapturingAdapter {
 	return &modelCapturingAdapter{
 		models: make(map[string]string),
-		inner: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		inner: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 }
@@ -2824,14 +2825,14 @@ func (a *modelCapturingAdapter) getModel(stepID string) string {
 
 // TestWithModelOverrideOption verifies that the WithModelOverride option sets the field
 func TestWithModelOverrideOption(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"))
 	assert.Equal(t, "haiku", executor.modelOverride)
 }
 
 // TestWithModelOverrideEmpty verifies that empty string override is not set
 func TestWithModelOverrideEmpty(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride(""))
 	assert.Equal(t, "", executor.modelOverride)
 }
@@ -2924,7 +2925,7 @@ func TestModelOverridePrecedence(t *testing.T) {
 
 // TestModelOverrideInChildExecutor verifies that NewChildExecutor inherits modelOverride
 func TestModelOverrideInChildExecutor(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	parent := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"))
 
 	child := parent.NewChildExecutor()
@@ -3297,7 +3298,7 @@ type countingFailAdapter struct {
 	failCount   int // how many calls should fail
 	callCount   int
 	failError   error
-	successMock *adapter.MockAdapter
+	successMock *adaptertest.MockAdapter
 	lastConfigs []adapter.AdapterRunConfig
 }
 
@@ -3305,7 +3306,7 @@ func newCountingFailAdapter(failCount int, failErr error) *countingFailAdapter {
 	return &countingFailAdapter{
 		failCount:   failCount,
 		failError:   failErr,
-		successMock: adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status":"ok"}`)),
+		successMock: adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`)),
 	}
 }
 
@@ -3559,9 +3560,9 @@ func TestExecuteStep_AdaptPrompt_InjectsFailureContext(t *testing.T) {
 // takes precedence over runtime.default_timeout_minutes from the manifest.
 func TestStepTimeoutMinutes_OverridesManifestDefault(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3598,9 +3599,9 @@ func TestStepTimeoutMinutes_OverridesManifestDefault(t *testing.T) {
 // takes precedence over the CLI --timeout flag.
 func TestStepTimeoutMinutes_OverridesCLITimeout(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3639,9 +3640,9 @@ func TestStepTimeoutMinutes_OverridesCLITimeout(t *testing.T) {
 // timeout is configured, the CLI --timeout flag is used.
 func TestStepTimeoutMinutes_FallsBackToCLIWhenUnset(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3680,9 +3681,9 @@ func TestStepTimeoutMinutes_FallsBackToCLIWhenUnset(t *testing.T) {
 // step-level timeout nor CLI --timeout is set, the manifest default is used.
 func TestStepTimeoutMinutes_FallsBackToManifestWhenNoCLI(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3719,9 +3720,9 @@ func TestStepTimeoutMinutes_FallsBackToManifestWhenNoCLI(t *testing.T) {
 // set on a pipeline step is correctly passed through to the AdapterRunConfig.
 func TestMaxConcurrentAgents_FlowsToAdapterConfig(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3757,9 +3758,9 @@ func TestMaxConcurrentAgents_FlowsToAdapterConfig(t *testing.T) {
 // to 0 in AdapterRunConfig when not set on the step.
 func TestMaxConcurrentAgents_ZeroWhenUnset(t *testing.T) {
 	capturingAdapter := &configCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -3796,9 +3797,9 @@ func TestStepTimeoutMinutes_PerStepDifferentTimeouts(t *testing.T) {
 	var mu sync.Mutex
 	configs := make(map[string]adapter.AdapterRunConfig)
 
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	// Custom adapter that captures configs per step
@@ -3858,7 +3859,7 @@ func TestStepTimeoutMinutes_PerStepDifferentTimeouts(t *testing.T) {
 
 // perStepCapturingAdapter captures AdapterRunConfig per step based on prompt content.
 type perStepCapturingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	mu      *sync.Mutex
 	configs map[string]adapter.AdapterRunConfig
 }
@@ -3885,11 +3886,11 @@ func (a *perStepCapturingAdapter) Run(ctx context.Context, cfg adapter.AdapterRu
 // the pipeline continues to the next independent step and completes successfully.
 func TestOptionalStep_FailsPipelineContinues(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional step failed")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional step failed")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -3939,8 +3940,8 @@ func TestOptionalStep_FailsPipelineContinues(t *testing.T) {
 // behaves identically to a required step.
 func TestOptionalStep_SucceedsNormally(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
@@ -3975,8 +3976,8 @@ func TestOptionalStep_SucceedsNormally(t *testing.T) {
 // field still halts the pipeline on failure (regression test).
 func TestOptionalStep_DefaultBehaviorPreserved(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("required step failed")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("required step failed")),
 	)
 
 	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector))
@@ -4054,11 +4055,11 @@ func TestOptionalStep_WithRetries(t *testing.T) {
 // optional step is skipped.
 func TestOptionalStep_DependentSkipped(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional failure")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional failure")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -4107,11 +4108,11 @@ func TestOptionalStep_DependentSkipped(t *testing.T) {
 // optional A — when A fails, both B and C are skipped.
 func TestOptionalStep_TransitiveDependencySkip(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional failure")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional failure")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -4162,8 +4163,8 @@ func TestOptionalStep_TransitiveDependencySkip(t *testing.T) {
 // retry.on_failure: "fail" results in pipeline halt (explicit wins).
 func TestOptionalStep_ExplicitOnFailurePrecedence(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("step failed")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("step failed")),
 	)
 
 	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector))
@@ -4201,11 +4202,11 @@ func TestOptionalStep_ExplicitOnFailurePrecedence(t *testing.T) {
 func TestOptionalStep_PipelineStatusCompleted(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	stateStore := testutil.NewMockStateStore()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional failure")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional failure")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -4268,8 +4269,8 @@ func TestPreserveWorkspaceKeepsExistingContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(markerFile, []byte("preserved"), 0644))
 
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -4321,8 +4322,8 @@ func TestDefaultBehaviorCleansWorkspace(t *testing.T) {
 	require.NoError(t, os.WriteFile(markerFile, []byte("should-be-removed"), 0644))
 
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -4353,9 +4354,9 @@ func TestDefaultBehaviorCleansWorkspace(t *testing.T) {
 // TestExecuteWithIncludeFilter verifies that --steps filter runs only the named steps
 func TestExecuteWithIncludeFilter(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	filter := &StepFilter{Include: []string{"step-a", "step-c"}}
@@ -4389,9 +4390,9 @@ func TestExecuteWithIncludeFilter(t *testing.T) {
 // TestExecuteWithExcludeFilter verifies that --exclude filter skips the named steps
 func TestExecuteWithExcludeFilter(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	filter := &StepFilter{Exclude: []string{"step-b"}}
@@ -4424,7 +4425,7 @@ func TestExecuteWithExcludeFilter(t *testing.T) {
 
 // TestExecuteWithInvalidStepFilter verifies that invalid step names in filter produce errors
 func TestExecuteWithInvalidStepFilter(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	filter := &StepFilter{Include: []string{"nonexistent"}}
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithStepFilter(filter),
@@ -4451,9 +4452,9 @@ func TestExecuteWithInvalidStepFilter(t *testing.T) {
 // TestExecuteWithNilFilter verifies that nil filter runs all steps (no-op)
 func TestExecuteWithNilFilter(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -4491,7 +4492,7 @@ type promptFailAdapter struct {
 	mu          sync.Mutex
 	failPrompt  string // fail if prompt contains this substring
 	failError   error
-	successMock *adapter.MockAdapter
+	successMock *adaptertest.MockAdapter
 	lastConfigs []adapter.AdapterRunConfig
 }
 
@@ -4499,7 +4500,7 @@ func newPromptFailAdapter(failPrompt string, failErr error) *promptFailAdapter {
 	return &promptFailAdapter{
 		failPrompt:  failPrompt,
 		failError:   failErr,
-		successMock: adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status":"ok"}`)),
+		successMock: adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`)),
 	}
 }
 
@@ -4837,7 +4838,7 @@ func TestExecuteStep_OnFailureRework_DownstreamStepsRun(t *testing.T) {
 // are not scheduled in the normal DAG pass.
 func TestExecuteStep_OnFailureRework_ReworkOnlyNotScheduled(t *testing.T) {
 	// Adapter succeeds for everything — step-1 should NOT fail, so rework step should never run.
-	mockAdapter := adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status":"ok"}`))
+	mockAdapter := adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`))
 	collector := testutil.NewEventCollector()
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -4888,9 +4889,9 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 		// should execute without errors and without needing a skill store.
 		// The check command uses "true" which always succeeds on Linux.
 		collector := testutil.NewEventCollector()
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		)
 
 		// No withSkillStore option — executor has nil skillStore
@@ -4936,7 +4937,7 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 	t.Run("validateSkillRefs_nil_store_returns_nil", func(t *testing.T) {
 		// When the executor has no skill store, validateSkillRefs should
 		// return nil regardless of what skill references exist.
-		mockAdapter := adapter.NewMockAdapter()
+		mockAdapter := adaptertest.NewMockAdapter()
 		executor := NewDefaultPipelineExecutor(mockAdapter)
 
 		// Pipeline with skills references at all scopes
@@ -4963,9 +4964,9 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 		// A pipeline with zero skill references anywhere should behave
 		// identically to pre-skill-hierarchy pipelines.
 		collector := testutil.NewEventCollector()
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"result": "ok"}`),
-			adapter.WithTokensUsed(200),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"result": "ok"}`),
+			adaptertest.WithTokensUsed(200),
 		)
 		executor := NewDefaultPipelineExecutor(mockAdapter,
 			WithEmitter(collector),
@@ -5024,9 +5025,9 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 		store := skill.NewDirectoryStore(skill.SkillSource{Root: storeDir, Precedence: 0})
 
 		capturingAdapter := &configCapturingAdapter{
-			MockAdapter: adapter.NewMockAdapter(
-				adapter.WithStdoutJSON(`{"status": "success"}`),
-				adapter.WithTokensUsed(100),
+			MockAdapter: adaptertest.NewMockAdapter(
+				adaptertest.WithStdoutJSON(`{"status": "success"}`),
+				adaptertest.WithTokensUsed(100),
 			),
 		}
 
@@ -5067,9 +5068,9 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 		store := skill.NewDirectoryStore(skill.SkillSource{Root: storeDir, Precedence: 0})
 
 		capturingAdapter := &configCapturingAdapter{
-			MockAdapter: adapter.NewMockAdapter(
-				adapter.WithStdoutJSON(`{"status": "success"}`),
-				adapter.WithTokensUsed(100),
+			MockAdapter: adaptertest.NewMockAdapter(
+				adaptertest.WithStdoutJSON(`{"status": "success"}`),
+				adaptertest.WithTokensUsed(100),
 			),
 		}
 
@@ -5105,9 +5106,9 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 		storeDir := t.TempDir()
 		store := skill.NewDirectoryStore(skill.SkillSource{Root: storeDir, Precedence: 0})
 
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		)
 		executor := NewDefaultPipelineExecutor(mockAdapter, withSkillStore(store))
 
@@ -5138,9 +5139,9 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 		storeDir := t.TempDir()
 		store := skill.NewDirectoryStore(skill.SkillSource{Root: storeDir, Precedence: 0})
 
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		)
 
 		executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -5179,11 +5180,11 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 // All of B, C, D should be skipped. Pipeline should succeed because A is optional.
 func TestTransitiveSkip_DiamondDependency(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional failure")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional failure")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -5241,11 +5242,11 @@ func TestTransitiveSkip_DiamondDependency(t *testing.T) {
 //	B (skipped)            F (should execute)
 func TestTransitiveSkip_IndependentPathsExecute(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	successAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	successAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("optional failure")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("optional failure")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -5335,8 +5336,8 @@ func TestConcurrentBatchCancellation(t *testing.T) {
 		TokensUsed: 100,
 	}
 
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("step-b exploded")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("step-b exploded")),
 	)
 
 	sa := &stepAwareAdapter{
@@ -5382,14 +5383,14 @@ func TestConcurrentBatchCancellation(t *testing.T) {
 
 // promptCapturingAdapter captures prompt from each step's AdapterRunConfig.
 type promptCapturingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	mu      sync.Mutex
 	prompts map[string]string // stepID (from workspace path) -> prompt
 }
 
-func newPromptCapturingAdapter(opts ...adapter.MockOption) *promptCapturingAdapter {
+func newPromptCapturingAdapter(opts ...adaptertest.MockOption) *promptCapturingAdapter {
 	return &promptCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(opts...),
+		MockAdapter: adaptertest.NewMockAdapter(opts...),
 		prompts:     make(map[string]string),
 	}
 }
@@ -5414,8 +5415,8 @@ func (a *promptCapturingAdapter) getPrompt(stepID string) string {
 // as step A receives step A's output in its prompt via THREAD CONTEXT header.
 func TestThreadSharing_TwoStepsSameThread(t *testing.T) {
 	capturing := newPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"status":"ok"}`),
-		adapter.WithTokensUsed(100),
+		adaptertest.WithStdoutJSON(`{"status":"ok"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(capturing)
@@ -5458,8 +5459,8 @@ func TestThreadSharing_TwoStepsSameThread(t *testing.T) {
 // do NOT share transcripts.
 func TestThreadIsolation_DifferentThreads(t *testing.T) {
 	capturing := newPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"status":"ok"}`),
-		adapter.WithTokensUsed(100),
+		adaptertest.WithStdoutJSON(`{"status":"ok"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(capturing)
@@ -5503,8 +5504,8 @@ func TestThreadIsolation_DifferentThreads(t *testing.T) {
 // do NOT receive any thread context (fresh memory behavior).
 func TestNoThread_FreshMemory(t *testing.T) {
 	capturing := newPromptCapturingAdapter(
-		adapter.WithStdoutJSON(`{"status":"ok"}`),
-		adapter.WithTokensUsed(100),
+		adaptertest.WithStdoutJSON(`{"status":"ok"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(capturing)
@@ -5544,9 +5545,9 @@ func TestNoThread_FreshMemory(t *testing.T) {
 
 // TestThreadValidation_InvalidFidelity verifies the executor rejects invalid fidelity values.
 func TestThreadValidation_InvalidFidelity(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status":"ok"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status":"ok"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -5580,9 +5581,9 @@ func TestThreadValidation_InvalidFidelity(t *testing.T) {
 // with a default, and auto-approve selects the default (approve -> implement).
 func TestExecutor_GateStep_AutoApprove(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -5649,9 +5650,9 @@ func TestExecutor_GateStep_AutoApprove(t *testing.T) {
 // returns a choice targeting _fail. The pipeline should fail with a gateAbortError.
 func TestExecutor_GateStep_Abort(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	// Custom handler that always selects "abort" (the _fail target)
@@ -5744,9 +5745,9 @@ func TestExecutor_GateStep_ChoiceRouting_Revise(t *testing.T) {
 	var implCount int32
 
 	countingAdapter := &stepAwareAdapter{
-		defaultAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(500),
+		defaultAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(500),
 		),
 		onStart: func(stepID string) {
 			switch stepID {
@@ -5812,9 +5813,9 @@ func TestExecutor_GateStep_ChoiceRouting_Revise(t *testing.T) {
 // in the PipelineContext after a gate step completes with auto-approve.
 func TestExecutor_GateStep_TemplateVars(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -6049,8 +6050,8 @@ func TestExecuteStep_FailureClassification_Canceled(t *testing.T) {
 	store := newAttemptTrackingStore()
 
 	// Use a mock adapter with a simulated delay so that it respects ctx.Done()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithSimulatedDelay(10 * time.Second),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithSimulatedDelay(10 * time.Second),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
@@ -6098,9 +6099,9 @@ func TestExecuteStep_FailureClassification_Canceled(t *testing.T) {
 // TestThreadedSteps_FreshFidelity verifies that fidelity: fresh suppresses transcript injection.
 func TestThreadedSteps_FreshFidelity(t *testing.T) {
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6145,7 +6146,7 @@ func TestThreadedSteps_FreshFidelity(t *testing.T) {
 
 // allConfigCapturingAdapter captures AdapterRunConfig for every call, keyed by step workspace path.
 type allConfigCapturingAdapter struct {
-	*adapter.MockAdapter
+	*adaptertest.MockAdapter
 	mu      sync.Mutex
 	configs []adapter.AdapterRunConfig
 }
@@ -6170,9 +6171,9 @@ func (a *allConfigCapturingAdapter) getConfigs() []adapter.AdapterRunConfig {
 func TestIterateInDAG_Sequential(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"findings": []}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"findings": []}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6236,9 +6237,9 @@ steps:
 func TestIterateInDAG_Parallel(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"findings": []}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"findings": []}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6301,9 +6302,9 @@ steps:
 func TestIterateInDAG_CollectsOutputs(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"findings": ["issue-1"]}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"findings": ["issue-1"]}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6387,9 +6388,9 @@ steps:
 func TestIterateInDAG_Parallel_CollectsOutputs(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "done"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "done"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6463,9 +6464,9 @@ steps:
 func TestIterateInDAG_OutputResolvesInAggregate(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"findings": ["f1"]}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"findings": ["f1"]}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6544,8 +6545,8 @@ steps:
 // TestAggregateInDAG verifies the aggregate primitive merges output to a file.
 func TestAggregateInDAG(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "ok"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
@@ -6588,9 +6589,9 @@ func TestAggregateInDAG(t *testing.T) {
 func TestBranchInDAG(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "ok"}`),
-			adapter.WithTokensUsed(100),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "ok"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -6646,8 +6647,8 @@ steps:
 func TestBranchInDAG_Skip(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	capAdapter := &allConfigCapturingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "ok"}`),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 		),
 	}
 
@@ -6688,7 +6689,7 @@ func TestRetryInjectsContractFailureContext(t *testing.T) {
 	// succeed at the adapter level — the failure comes from the contract.
 	capAdapter := &countingFailAdapter{
 		failCount:   0, // adapter always succeeds
-		successMock: adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status":"ok"}`)),
+		successMock: adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`)),
 	}
 
 	collector := testutil.NewEventCollector()
@@ -6768,7 +6769,7 @@ fi
 // {{ steps.STEP_ID.artifacts.ARTIFACT_NAME.JSON_PATH }} is resolved from
 // execution.ArtifactPaths at workspace creation time.
 func TestResolveWorkspaceStepRefs_ArtifactsNamedField(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	tmpDir := t.TempDir()
 
@@ -6797,7 +6798,7 @@ func TestResolveWorkspaceStepRefs_ArtifactsNamedField(t *testing.T) {
 // TestResolveWorkspaceStepRefs_Output verifies that
 // {{ steps.STEP_ID.output.JSON_FIELD }} is resolved from the first artifact.
 func TestResolveWorkspaceStepRefs_Output(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	tmpDir := t.TempDir()
 	artFile := filepath.Join(tmpDir, "step-output.json")
@@ -6823,7 +6824,7 @@ func TestResolveWorkspaceStepRefs_Output(t *testing.T) {
 // TestResolveWorkspaceStepRefs_MissingStep verifies a clear error when the
 // referenced step artifact does not exist.
 func TestResolveWorkspaceStepRefs_MissingStep(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "ws-missing-test"}},
@@ -6844,7 +6845,7 @@ func TestResolveWorkspaceStepRefs_MissingStep(t *testing.T) {
 // TestResolveWorkspaceStepRefs_NoStepsRef verifies that non-steps templates
 // are passed through unchanged (they are resolved by ResolvePlaceholders later).
 func TestResolveWorkspaceStepRefs_NoStepsRef(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "ws-passthrough-test"}},
@@ -6870,7 +6871,7 @@ func TestResolveWorkspaceStepRefs_NoStepsRef(t *testing.T) {
 // the WorktreePaths cache (pre-populated to simulate a worktree that was
 // already created on the resolved branch).
 func TestCreateStepWorkspace_DeferredBranch(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	tmpDir := t.TempDir()
 
@@ -6941,17 +6942,17 @@ func newCapturingArtifactStore(cap *artifactCapture) *testutil.MockStateStore {
 // step-workspace paths pointed at the original run's tree.
 func TestWorkspaceRunIDFor(t *testing.T) {
 	t.Run("falls back to pipelineID when no override", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 		assert.Equal(t, "runtime-id", executor.workspaceRunIDFor("runtime-id"))
 	})
 	t.Run("override wins when set", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 			WithWorkspaceRunID("original-run"),
 		)
 		assert.Equal(t, "original-run", executor.workspaceRunIDFor("resume-run"))
 	})
 	t.Run("empty override defers to pipelineID", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 			WithWorkspaceRunID(""),
 		)
 		assert.Equal(t, "fresh-run", executor.workspaceRunIDFor("fresh-run"))
@@ -6968,7 +6969,7 @@ func TestExecuteAggregateInDAG_RegistersArtifact(t *testing.T) {
 	cap := &artifactCapture{}
 	store := newCapturingArtifactStore(cap)
 
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithStateStore(store),
 		WithRunID("test-run-1"),
 	)
@@ -7014,7 +7015,7 @@ func TestExecuteAggregateInDAG_NoStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "out.json")
 
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "p"}},
@@ -7055,7 +7056,7 @@ func TestCollectIterateOutputs_RegistersArtifact(t *testing.T) {
 	cap := &artifactCapture{}
 	store := newCapturingArtifactStore(cap)
 
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithStateStore(store),
 		WithRunID("iterate-run"),
 	)
@@ -7100,7 +7101,7 @@ func TestCreateStepWorkspace_UsesEffectiveWorkspaceRunID(t *testing.T) {
 	tmpDir := t.TempDir()
 	wsRoot := filepath.Join(tmpDir, "workspaces")
 
-	executor := NewDefaultPipelineExecutor(&adapter.MockAdapter{},
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithRunID("resume-run-2"),
 		WithWorkspaceRunID("original-run-1"),
 	)

--- a/internal/pipeline/failure_modes_test.go
+++ b/internal/pipeline/failure_modes_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
@@ -90,9 +91,9 @@ func TestFailureMode_ContractSchemaMismatch(t *testing.T) {
 	// Schema requires "name" (string) and "version" (string).
 	// Adapter returns {"bad": true} which lacks required fields.
 	badOutput := `{"bad": true}`
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(badOutput),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(badOutput),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter)
@@ -152,9 +153,9 @@ func TestFailureMode_ContractSchemaMismatch(t *testing.T) {
 func TestFailureMode_StepTimeout(t *testing.T) {
 	// Adapter simulates a long-running step (5 seconds).
 	// Context has a short timeout (200ms) so the step should be cancelled.
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithSimulatedDelay(5*time.Second),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithSimulatedDelay(5*time.Second),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter)
@@ -190,9 +191,9 @@ func TestFailureMode_MissingArtifact(t *testing.T) {
 	// executed ("nonexistent-step"). The DAG validator only checks
 	// Dependencies, not inject_artifacts step references, so the pipeline
 	// starts but fails at artifact injection time.
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter)
@@ -243,9 +244,9 @@ func TestFailureMode_MalformedArtifact(t *testing.T) {
 	// Step produces malformed JSON (truncated) as stdout.
 	// Contract validation with json_schema should reject it.
 	malformedJSON := `{"name": "test", "version": `
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(malformedJSON),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(malformedJSON),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter)
@@ -316,9 +317,9 @@ func (f *failingWorkspaceManager) CleanAll(root string) error {
 func TestFailureMode_WorkspaceCorruption(t *testing.T) {
 	// Workspace manager returns an error on Create().
 	// The step uses mount-based workspace to trigger wsManager.Create().
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter,
@@ -359,10 +360,10 @@ func TestFailureMode_NonZeroExitCode(t *testing.T) {
 		// Adapter returns exit code 1 but no error.
 		// Output doesn't match schema, and contract has MustPass: true.
 		// Pipeline should fail because contract validation fails (not because of exit code).
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithExitCode(1),
-			adapter.WithStdoutJSON(`{"bad": true}`),
-			adapter.WithTokensUsed(500),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithExitCode(1),
+			adaptertest.WithStdoutJSON(`{"bad": true}`),
+			adaptertest.WithTokensUsed(500),
 		)
 
 		tc := setupFailureModeTest(t, mockAdapter)
@@ -409,10 +410,10 @@ func TestFailureMode_NonZeroExitCode(t *testing.T) {
 	t.Run("without_contract_completes_successfully", func(t *testing.T) {
 		// Adapter returns exit code 1 but no error, and no contract is configured.
 		// Pipeline should still complete since non-zero exit code alone is not fatal.
-		mockAdapter := adapter.NewMockAdapter(
-			adapter.WithExitCode(1),
-			adapter.WithStdoutJSON(`{"status": "done"}`),
-			adapter.WithTokensUsed(500),
+		mockAdapter := adaptertest.NewMockAdapter(
+			adaptertest.WithExitCode(1),
+			adaptertest.WithStdoutJSON(`{"status": "done"}`),
+			adaptertest.WithTokensUsed(500),
 		)
 
 		tc := setupFailureModeTest(t, mockAdapter)
@@ -460,8 +461,8 @@ func TestFailureMode_AdapterError(t *testing.T) {
 	// Adapter returns a direct error via WithFailure().
 	// Pipeline should propagate the error and emit a failed event.
 	adapterErr := fmt.Errorf("adapter crashed: out of memory")
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(adapterErr),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(adapterErr),
 	)
 
 	tc := setupFailureModeTest(t, mockAdapter)

--- a/internal/pipeline/graph_test.go
+++ b/internal/pipeline/graph_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/testutil"
 )
 
@@ -910,9 +910,9 @@ func TestExecuteGraphPipeline_CommandStepIntegration(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	collector := testutil.NewEventCollector()

--- a/internal/pipeline/hooks_integration_test.go
+++ b/internal/pipeline/hooks_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/hooks"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -45,9 +45,9 @@ func (m *mockHookRunner) getCalls() []hooks.HookEvent {
 // workspace_created, step_completed), and finally run_completed.
 func TestHooksFireAtCorrectLifecyclePoints(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	hr := &mockHookRunner{failOn: map[hooks.EventType]error{}}
@@ -133,9 +133,9 @@ func TestHooksFireAtCorrectLifecyclePoints(t *testing.T) {
 // on step_start causes the pipeline to fail.
 func TestBlockingStepStartHookAbortsPipeline(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	hookErr := errors.New("step_start hook rejected")
@@ -173,9 +173,9 @@ func TestBlockingStepStartHookAbortsPipeline(t *testing.T) {
 // (run_completed) does not cause the pipeline to fail.
 func TestNonBlockingHooksContinue(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	hr := &mockHookRunner{

--- a/internal/pipeline/iotypes.go
+++ b/internal/pipeline/iotypes.go
@@ -18,6 +18,14 @@ func ValidatePipelineIOTypes(p *Pipeline) error {
 		return nil
 	}
 
+	// Eagerly load the embedded shared-schema registry so that an FS read
+	// failure surfaces here as a structured error rather than a stale empty
+	// registry. LoadSchemas is idempotent (sync.Once) so repeated calls are
+	// cheap.
+	if err := shared.LoadSchemas(); err != nil {
+		return fmt.Errorf("pipeline %q: shared schema registry failed to load: %w", p.Metadata.Name, err)
+	}
+
 	if t := p.Input.EffectiveType(); !shared.Exists(t) {
 		return fmt.Errorf("pipeline %q: input.type %q is not a registered shared schema (known: %v, or use %q)",
 			p.Metadata.Name, t, shared.Names(), shared.TypeString)

--- a/internal/pipeline/matrix_test.go
+++ b/internal/pipeline/matrix_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -505,9 +506,9 @@ func TestMatrixExecutor_SpawnsCorrectWorkerCount(t *testing.T) {
 			// Create a tracking adapter
 			trackingAdapter := &workerTrackingAdapter{
 				tracker: workerSpawns,
-				baseAdapter: adapter.NewMockAdapter(
-					adapter.WithStdoutJSON(`{"status": "success"}`),
-					adapter.WithTokensUsed(100),
+				baseAdapter: adaptertest.NewMockAdapter(
+					adaptertest.WithStdoutJSON(`{"status": "success"}`),
+					adaptertest.WithTokensUsed(100),
 				),
 			}
 
@@ -649,10 +650,10 @@ func TestMatrixExecutor_MaxConcurrencyLimit(t *testing.T) {
 			// Create adapter that tracks concurrency
 			concurrencyAdapter := &concurrencyTrackingMatrixAdapter{
 				tracker: concurrencyTracker,
-				baseAdapter: adapter.NewMockAdapter(
-					adapter.WithStdoutJSON(`{"status": "success"}`),
-					adapter.WithTokensUsed(100),
-					adapter.WithSimulatedDelay(50*time.Millisecond), // Add delay to test concurrency
+				baseAdapter: adaptertest.NewMockAdapter(
+					adaptertest.WithStdoutJSON(`{"status": "success"}`),
+					adaptertest.WithTokensUsed(100),
+					adaptertest.WithSimulatedDelay(50*time.Millisecond), // Add delay to test concurrency
 				),
 			}
 
@@ -804,9 +805,9 @@ func TestMatrixExecutor_PartialFailureHandling(t *testing.T) {
 			partialFailAdapter := &partialFailureAdapter{
 				failingIndices: failingSet,
 				callCount:      0,
-				baseAdapter: adapter.NewMockAdapter(
-					adapter.WithStdoutJSON(`{"status": "success"}`),
-					adapter.WithTokensUsed(100),
+				baseAdapter: adaptertest.NewMockAdapter(
+					adaptertest.WithStdoutJSON(`{"status": "success"}`),
+					adaptertest.WithTokensUsed(100),
 				),
 			}
 
@@ -946,7 +947,7 @@ func TestMatrixExecutor_ZeroTasks(t *testing.T) {
 			eventCollector := testutil.NewEventCollector()
 
 			executor := NewDefaultPipelineExecutor(
-				adapter.NewMockAdapter(adapter.WithStdoutJSON(`{"status": "success"}`)),
+				adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status": "success"}`)),
 				WithEmitter(eventCollector),
 			)
 			matrixExecutor := NewMatrixExecutor(executor)
@@ -1044,7 +1045,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	t.Run("missing items_source file", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1076,7 +1077,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 		invalidJSONFile := filepath.Join(tmpDir, "invalid.json")
 		_ = os.WriteFile(invalidJSONFile, []byte("not valid json{"), 0644)
 
-		executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1108,7 +1109,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 		objectJSONFile := filepath.Join(tmpDir, "object.json")
 		_ = os.WriteFile(objectJSONFile, []byte(`{"key": "value"}`), 0644)
 
-		executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1280,9 +1281,9 @@ func TestMatrixExecutor_TieredExecution_IndependentItems(t *testing.T) {
 
 	trackAdapter := &orderTrackingAdapter{
 		tracker: orderTracker,
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -1351,9 +1352,9 @@ func TestMatrixExecutor_TieredExecution_LinearChain(t *testing.T) {
 	orderTracker := &executionOrderTracker{}
 	trackAdapter := &orderTrackingAdapter{
 		tracker: orderTracker,
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -1432,9 +1433,9 @@ func TestMatrixExecutor_TieredExecution_Diamond(t *testing.T) {
 
 	eventCollector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(
-		adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		WithEmitter(eventCollector),
 	)
@@ -1497,9 +1498,9 @@ func TestMatrixExecutor_TieredExecution_DependencyFailure(t *testing.T) {
 	// Fail item A (index 0) by matching workspace path
 	failAdapter := &tieredFailureAdapter{
 		failPatterns: []string{`"id":"A"`},
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -1572,7 +1573,7 @@ func TestMatrixExecutor_TieredExecution_CycleDetection(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-cycle")
@@ -1611,7 +1612,7 @@ func TestMatrixExecutor_TieredExecution_MissingDependency(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-missing-dep")
@@ -1753,9 +1754,9 @@ func TestMatrixExecutor_ChildPipeline_LoadsAndExecutes(t *testing.T) {
 
 	// Track adapter calls
 	counter := &childPipelineCallCounter{
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -1875,9 +1876,9 @@ func TestMatrixExecutor_ChildPipeline_WithTiers(t *testing.T) {
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
 	counter := &childPipelineCallCounter{
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -1955,9 +1956,9 @@ func TestMatrixExecutor_ChildPipeline_PartialFailure(t *testing.T) {
 	// Fail the 2nd adapter call (0-indexed: call #1)
 	failAdapter := &partialFailureAdapter{
 		failingIndices: map[int]bool{1: true},
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -2010,7 +2011,7 @@ func TestMatrixExecutor_ChildPipeline_NotFound(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "child-not-found")
@@ -2117,9 +2118,9 @@ func TestMatrixExecutor_Stacked_TwoTierLinearChain(t *testing.T) {
 	trackAdapter := &stackedBranchTrackingAdapter{
 		mu:             &mu,
 		branchCaptures: branchCaptures,
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -2187,9 +2188,9 @@ func TestMatrixExecutor_Stacked_WithoutDependencyKey(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	baseAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	baseAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	eventCollector := testutil.NewEventCollector()
@@ -2249,9 +2250,9 @@ func TestMatrixExecutor_Stacked_PartialTierFailure(t *testing.T) {
 
 	failAdapter := &tieredFailureAdapter{
 		failPatterns: []string{`"id":"C"`}, // Match item C by its JSON content in the prompt
-		baseAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		baseAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 	}
 
@@ -2324,9 +2325,9 @@ steps:
 	require.NoError(t, os.MkdirAll(childPipelineDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(childPipelineDir, "test-child.yaml"), []byte(childPipelineYAML), 0644))
 
-	baseAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	baseAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	executor := NewDefaultPipelineExecutor(baseAdapter)
@@ -2375,9 +2376,9 @@ func TestMatrixExecutor_Stacked_ParentNoOutputBranch(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	baseAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	baseAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	eventCollector := testutil.NewEventCollector()

--- a/internal/pipeline/resolve_steprefs_test.go
+++ b/internal/pipeline/resolve_steprefs_test.go
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 )
 
 // TestResolveWorkspaceStepRefs tests the template resolution for step artifact/output references.
 func TestResolveWorkspaceStepRefs(t *testing.T) {
 	newExecutor := func() *DefaultPipelineExecutor {
-		return NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	}
 
 	newExecution := func(artifacts map[string]string) *PipelineExecution {

--- a/internal/pipeline/resume_display_test.go
+++ b/internal/pipeline/resume_display_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 )
@@ -120,7 +120,7 @@ func TestResumeFromStep_SyntheticCompletionEvents(t *testing.T) {
 			tt.setupWorkspace(t, tempDir)
 
 			emitter := &capturingEmitter{}
-			mockAdapter := adapter.NewMockAdapter()
+			mockAdapter := adaptertest.NewMockAdapter()
 			executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(emitter))
 			manager := NewResumeManager(executor)
 
@@ -185,7 +185,7 @@ func TestResumeFromStep_SyntheticCompletionEvents(t *testing.T) {
 }
 
 func TestLookupStepPersona(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{

--- a/internal/pipeline/resume_test.go
+++ b/internal/pipeline/resume_test.go
@@ -12,14 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/testutil"
 )
 
 func TestResumeManager_ValidateResumePoint(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -125,7 +125,7 @@ func TestResumeManager_ValidateResumePoint(t *testing.T) {
 }
 
 func TestResumeManager_LoadResumeState(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -275,7 +275,7 @@ func TestResumeManager_LoadResumeState(t *testing.T) {
 }
 
 func TestResumeManager_LoadResumeState_HashSuffixedRunDirs(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -444,7 +444,7 @@ func TestResumeManager_LoadResumeState_HashSuffixedRunDirs(t *testing.T) {
 }
 
 func TestResumeManager_CreateResumeSubpipeline(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -515,7 +515,7 @@ func TestResumeManager_CreateResumeSubpipeline(t *testing.T) {
 }
 
 func TestResumeManager_GetRecommendedResumePoint(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -670,7 +670,7 @@ func TestResumeManager_GetRecommendedResumePoint(t *testing.T) {
 
 func TestResumeManager_IntegrationWithStaleDetection(t *testing.T) {
 	// Test integration between resume functionality and stale artifact detection
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -800,7 +800,7 @@ func TestResumeManager_IntegrationWithStaleDetection(t *testing.T) {
 }
 
 func TestCreateResumeSubpipelineStripsPriorDependencies(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -836,7 +836,7 @@ func TestCreateResumeSubpipelineStripsPriorDependencies(t *testing.T) {
 }
 
 func TestLoadResumeState_WithPriorRunID(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1033,7 +1033,7 @@ func TestLoadResumeState_WithPriorRunID(t *testing.T) {
 }
 
 func TestLoadResumeState_LoadsFailureContext(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 
 	// Wire a mock store with step attempt data
@@ -1098,7 +1098,7 @@ func TestLoadResumeState_LoadsFailureContext(t *testing.T) {
 }
 
 func TestLoadResumeState_NoFailureContextWithoutStore(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 	// No store set — executor.store is nil
 	manager := NewResumeManager(executor)
@@ -1127,7 +1127,7 @@ func TestLoadResumeState_NoFailureContextWithoutStore(t *testing.T) {
 }
 
 func TestLoadResumeState_NoFailureContextWhenStepSucceeded(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := NewDefaultPipelineExecutor(mockAdapter)
 
 	store := &resumeMockStore{
@@ -1185,9 +1185,9 @@ func TestResumeFromStepWithForceSkipsValidation(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -1240,9 +1240,9 @@ func TestResumeFromStepWithForceSkipsValidation(t *testing.T) {
 // TestResumeWithExcludeFilter verifies --from-step + -x combo works correctly.
 // When resuming from "step-b" with -x "step-c", only step-b should execute.
 func TestResumeWithExcludeFilter(t *testing.T) {
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	collector := testutil.NewEventCollector()
@@ -1304,8 +1304,8 @@ func TestExecuteResumedPipeline_ReturnsStepExecutionError(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	// Create a mock adapter that always fails
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(fmt.Errorf("adapter crashed")),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(fmt.Errorf("adapter crashed")),
 	)
 
 	collector := testutil.NewEventCollector()
@@ -1374,9 +1374,9 @@ func TestResumeNonPrototypePipeline(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	executor := NewDefaultPipelineExecutor(mockAdapter)
@@ -1425,7 +1425,7 @@ func TestResumeNonPrototype_NoRunStateFails(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1466,7 +1466,7 @@ func TestGetRecommendedResumePoint_NonPrototype(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1533,8 +1533,8 @@ func TestFailureClassRecordedOnStepAttempt(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 
 	// Use a failing adapter
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(fmt.Errorf("runtime failure: process exited with code 1")),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(fmt.Errorf("runtime failure: process exited with code 1")),
 	)
 
 	store := &capturingMockStore{MockStateStore: testutil.NewMockStateStore()}
@@ -1563,7 +1563,7 @@ func TestFailureClassRecordedOnStepAttempt(t *testing.T) {
 		t.Fatal("expected at least one recorded step attempt, got none")
 	}
 
-	// The adapter.WithFailure returns a generic error (not contract/security/preflight),
+	// The adaptertest.WithFailure returns a generic error (not contract/security/preflight),
 	// so it should be classified as "unknown" by recovery.ClassifyError()
 	lastAttempt := attempts[len(attempts)-1]
 	if lastAttempt.FailureClass == "" {
@@ -1602,9 +1602,9 @@ func TestResumeFromStep_ReusesExecutorRunID(t *testing.T) {
 	)
 
 	executor := NewDefaultPipelineExecutor(
-		adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithTokensUsed(100),
+		adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithTokensUsed(100),
 		),
 		WithRunID("preset-run-id"),
 		WithStateStore(store),
@@ -1643,7 +1643,6 @@ func TestResumeFromStep_ReusesExecutorRunID(t *testing.T) {
 	}
 }
 
-
 // initGitRepo initializes a minimal git repo with a GitHub remote for forge detection.
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
@@ -1660,7 +1659,7 @@ func initGitRepo(t *testing.T, dir string) {
 }
 
 func TestResumeFromStep_InjectsForgeVariables(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	tempDir := t.TempDir()
@@ -1717,7 +1716,7 @@ func TestResumeFromStep_InjectsForgeVariables(t *testing.T) {
 }
 
 func TestResumeFromStep_ReusesWorktree(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 	manager := NewResumeManager(executor)
 
 	tempDir := t.TempDir()

--- a/internal/pipeline/sequence_test.go
+++ b/internal/pipeline/sequence_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -44,9 +45,9 @@ func newMinimalPipeline(name string) *Pipeline {
 
 func TestSequenceExecutor_SinglePipeline(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(500),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(500),
 	)
 
 	tmpDir := t.TempDir()
@@ -83,9 +84,9 @@ func TestSequenceExecutor_SinglePipeline(t *testing.T) {
 
 func TestSequenceExecutor_MultiplePipelines(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(300),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(300),
 	)
 
 	tmpDir := t.TempDir()
@@ -129,8 +130,8 @@ func TestSequenceExecutor_FailureStopsSequence(t *testing.T) {
 	collector := testutil.NewEventCollector()
 
 	// This adapter always fails
-	failAdapter := adapter.NewMockAdapter(
-		adapter.WithFailure(errors.New("adapter explosion")),
+	failAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithFailure(errors.New("adapter explosion")),
 	)
 
 	tmpDir := t.TempDir()
@@ -173,7 +174,7 @@ func TestSequenceExecutor_FailureStopsSequence(t *testing.T) {
 
 func TestSequenceExecutor_EmptySequence(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -201,10 +202,10 @@ func TestSequenceExecutor_ContextCancellation(t *testing.T) {
 	collector := testutil.NewEventCollector()
 
 	// Use a delay so context cancellation can fire between pipelines
-	slowAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
-		adapter.WithSimulatedDelay(50*time.Millisecond),
+	slowAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
+		adaptertest.WithSimulatedDelay(50*time.Millisecond),
 	)
 
 	tmpDir := t.TempDir()
@@ -237,9 +238,9 @@ func TestSequenceExecutor_ContextCancellation(t *testing.T) {
 
 func TestSequenceExecutor_ResultTracksTokens(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(1000),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(1000),
 	)
 
 	tmpDir := t.TempDir()
@@ -275,9 +276,9 @@ func TestSequenceExecutor_ResultTracksTokens(t *testing.T) {
 
 func TestSequenceExecutor_ExecutePlan_Sequential(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(100),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(100),
 	)
 
 	tmpDir := t.TempDir()
@@ -311,9 +312,9 @@ func TestSequenceExecutor_ExecutePlan_Sequential(t *testing.T) {
 
 func TestSequenceExecutor_ExecutePlan_Parallel(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
-		adapter.WithTokensUsed(200),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
+		adaptertest.WithTokensUsed(200),
 	)
 
 	tmpDir := t.TempDir()
@@ -360,7 +361,7 @@ func TestSequenceExecutor_ExecutePlan_Parallel(t *testing.T) {
 
 func TestSequenceExecutor_ExecutePlan_Empty(t *testing.T) {
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -392,9 +393,9 @@ func TestSequenceExecutor_ExecutePlan_ParallelFailFastFalse(t *testing.T) {
 		callCount:  &callCount,
 		failOnCall: 2,
 		failErr:    errors.New("pipeline exploded"),
-		successAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithSimulatedDelay(10*time.Millisecond),
+		successAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithSimulatedDelay(10*time.Millisecond),
 		),
 	}
 
@@ -461,9 +462,9 @@ func TestSequenceExecutor_ExecutePlan_MaxConcurrent(t *testing.T) {
 	var maxConcurrent int32
 
 	trackingAdapter := &concurrencyTrackingAdapter{
-		MockAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
-			adapter.WithSimulatedDelay(50*time.Millisecond),
+		MockAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
+			adaptertest.WithSimulatedDelay(50*time.Millisecond),
 		),
 		onStart: func() {
 			current := atomic.AddInt32(&currentConcurrent, 1)
@@ -530,8 +531,8 @@ func TestSequenceExecutor_CrossPipelineArtifacts(t *testing.T) {
 	// Verify that pipelineOutputs are passed to downstream executors via
 	// WithCrossPipelineArtifacts option.
 	collector := testutil.NewEventCollector()
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 
 	tmpDir := t.TempDir()
@@ -587,8 +588,8 @@ func TestSequenceExecutor_ExecutePlan_SequentialFailFastFalse(t *testing.T) {
 		callCount:  &callCount,
 		failOnCall: 2,
 		failErr:    errors.New("sequential bad pipeline failed"),
-		successAdapter: adapter.NewMockAdapter(
-			adapter.WithStdoutJSON(`{"status": "success"}`),
+		successAdapter: adaptertest.NewMockAdapter(
+			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		),
 	}
 
@@ -696,7 +697,7 @@ func TestSequenceExecutor_RecordPipelineOutputs_ConcurrentRace(t *testing.T) {
 	}
 
 	seq := NewSequenceExecutor(
-		newSequenceTestExecutorFactory(adapter.NewMockAdapter()),
+		newSequenceTestExecutorFactory(adaptertest.NewMockAdapter()),
 		nil,
 		nil, // no emitter needed
 		nil,
@@ -735,8 +736,8 @@ func TestSequenceExecutor_CrossPipelineArtifacts_WrittenToDisk(t *testing.T) {
 	workspacePath := t.TempDir()
 
 	// Set up a DefaultPipelineExecutor with cross-pipeline artifacts.
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithStdoutJSON(`{"status": "success"}`),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
 	executor := NewDefaultPipelineExecutor(
 		mockAdapter,

--- a/internal/pipeline/subset_mount_test.go
+++ b/internal/pipeline/subset_mount_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -54,7 +54,7 @@ func TestMaterialiseMountSubset(t *testing.T) {
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
 
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 
 	mount := Mount{
 		Source:     source,
@@ -113,7 +113,7 @@ func TestMaterialiseMountSubset_PathTraversalRejected(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test-run"},
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 
 	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
 		Source:     source,
@@ -171,7 +171,7 @@ func TestMaterialiseMountSubset_SymlinkRejected(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test-run"},
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
-	executor := NewDefaultPipelineExecutor(adapter.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
 
 	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
 		Source:     source,

--- a/tests/preflight_recovery_test.go
+++ b/tests/preflight_recovery_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/preflight"
@@ -49,7 +49,7 @@ func TestPreflightRecovery_MissingSkill(t *testing.T) {
 	}
 
 	// Create executor with mock adapter
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
@@ -163,7 +163,7 @@ func TestPreflightRecovery_MissingTool(t *testing.T) {
 		},
 	}
 
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
@@ -280,7 +280,7 @@ func TestPreflightRecovery_MixedFailures(t *testing.T) {
 		},
 	}
 
-	mockAdapter := adapter.NewMockAdapter()
+	mockAdapter := adaptertest.NewMockAdapter()
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
@@ -458,7 +458,7 @@ func TestPreflightRecovery_NoRedundantErrorMessage(t *testing.T) {
 				},
 			}
 
-			mockAdapter := adapter.NewMockAdapter()
+			mockAdapter := adaptertest.NewMockAdapter()
 			executor := pipeline.NewDefaultPipelineExecutor(mockAdapter)
 
 			ctx := context.Background()
@@ -592,8 +592,8 @@ func TestPreflightRecovery_EndToEndFlow(t *testing.T) {
 	}
 
 	// Step 3: Execute pipeline
-	mockAdapter := adapter.NewMockAdapter(
-		adapter.WithSimulatedDelay(10 * time.Millisecond),
+	mockAdapter := adaptertest.NewMockAdapter(
+		adaptertest.WithSimulatedDelay(10 * time.Millisecond),
 	)
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,


### PR DESCRIPTION
## Summary

- Move `MockAdapter`/`MockAdapterRegistry` from `internal/adapter/mock.go` into new `internal/adapter/adaptertest` package. Production package no longer ships test doubles.
- Replace `internal/contract/schemas/shared/registry.go` `init()` panics (lines 32, 41) with `LoadSchemas() error` + `sync.Once` lazy load. Caller `internal/pipeline/iotypes.go` invokes and surfaces errors.
- Add `adapter.ErrUnknownAdapter` typed error + `AdapterRegistry.ResolveStrict`. `FallbackRunner` uses ResolveStrict + nil-guards — closes nil-deref bug at `fallback.go:63`.

## Pre-fix verification (per item)

- **9.1**: `grep -n "MockAdapter" internal/adapter/*.go | grep -v _test.go | grep -v adaptertest` was non-empty before, now empty.
- **9.2**: `grep -n "panic(" internal/contract/schemas/shared/registry.go` was non-empty before (lines 32, 41), now empty.
- **9.4**: New test `TestFallbackRunner_UnknownFallbackNameSurfacesTypedError` failed pre-fix with `"all fallback adapters exhausted"`; post-fix asserts `errors.Is(err, ErrUnknownAdapter) == true`.

## Out of scope (deferred to follow-up PRs)

- 9.3 `AdapterRegistry` → `Resolver` interface (broader test refactor needed)
- 9.5 silent `ontology.NoOp` default in `pipeline.NewExecutor` (touches executor.go, conflicts with planned #1495)

## Files touched

41 files, +966/-934 (large because mock.go consumer migrations + new doc comments + plumbing). Production code delta is ~+200 LOC; rest is test-call-site updates.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/adapter/... ./internal/contract/... ./internal/pipeline/... ./cmd/wave/commands/...` pass
- Pre-existing `internal/state` race-flake unrelated to this PR (does not import touched packages)

## Test plan

- [ ] CI green
- [ ] No production binary references `MockAdapter` (sanity grep)
- [ ] `wave run --mock <pipeline>` still works (mock adapter via `adaptertest`)

Partial of #1504. Parent: #1494.