### PR TITLE
refactor: invert defaults->pipeline import (#1497 partial 3.1)

### DIFF
--- a/internal/defaults/embed.go
+++ b/internal/defaults/embed.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/internal/manifest"
-	"github.com/recinq/wave/internal/pipeline"
 	"gopkg.in/yaml.v3"
 )
 
@@ -232,12 +231,12 @@ func GetReleasePipelines() (map[string]string, error) {
 
 	result := make(map[string]string)
 	for name, content := range all {
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+		var header manifest.PipelineHeader
+		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping pipeline %s: failed to unmarshal: %v\n", name, err)
 			continue
 		}
-		if p.Metadata.Release {
+		if header.Metadata.Release {
 			result[name] = content
 		}
 	}

--- a/internal/defaults/embed_test.go
+++ b/internal/defaults/embed_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/skill"
 	"gopkg.in/yaml.v3"
 )
@@ -62,12 +62,12 @@ func TestGetReleasePipelines_OnlyReleaseTrue(t *testing.T) {
 	}
 
 	for name, content := range release {
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+		var header manifest.PipelineHeader
+		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
 			t.Errorf("failed to unmarshal release pipeline %q: %v", name, err)
 			continue
 		}
-		if !p.Metadata.Release {
+		if !header.Metadata.Release {
 			t.Errorf("pipeline %q is in release set but metadata.release is false", name)
 		}
 	}
@@ -85,11 +85,11 @@ func TestGetReleasePipelines_ExcludesNonRelease(t *testing.T) {
 	}
 
 	for name, content := range all {
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+		var header manifest.PipelineHeader
+		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
 			continue // skip pipelines that fail to unmarshal
 		}
-		if !p.Metadata.Release {
+		if !header.Metadata.Release {
 			if _, ok := release[name]; ok {
 				t.Errorf("pipeline %q does not have release: true but is in the release set", name)
 			}
@@ -137,11 +137,11 @@ func TestGetReleasePipelines_DisabledAndReleaseIncluded(t *testing.T) {
 	}
 
 	for name, content := range all {
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+		var header manifest.PipelineHeader
+		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
 			continue
 		}
-		if p.Metadata.Release && p.Metadata.Disabled {
+		if header.Metadata.Release && header.Metadata.Disabled {
 			if _, ok := release[name]; !ok {
 				t.Errorf("pipeline %q has both release: true and disabled: true but is not in the release set", name)
 			}

--- a/internal/manifest/pipeline_metadata.go
+++ b/internal/manifest/pipeline_metadata.go
@@ -1,0 +1,27 @@
+package manifest
+
+// PipelineMetadata is the minimal subset of pipeline.PipelineMetadata that
+// non-orchestrator packages need in order to filter/select shipped pipelines
+// without depending on internal/pipeline.
+//
+// The full type lives in internal/pipeline.PipelineMetadata; the YAML tags
+// here intentionally mirror that type so any YAML pipeline definition can
+// be unmarshalled into a PipelineHeader without losing the metadata fields.
+type PipelineMetadata struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Release     bool   `yaml:"release,omitempty"`
+	Category    string `yaml:"category,omitempty"`
+	Disabled    bool   `yaml:"disabled,omitempty"`
+}
+
+// PipelineHeader is a partial view of a pipeline YAML file that exposes only
+// the metadata block. It is used by leaf-level packages (e.g. internal/defaults)
+// that need to inspect release/disabled flags on shipped pipelines without
+// pulling in the full orchestrator type tree from internal/pipeline.
+//
+// Consumers unmarshal pipeline YAML into this struct; unknown fields
+// (steps, hooks, etc.) are ignored by the YAML decoder.
+type PipelineHeader struct {
+	Metadata PipelineMetadata `yaml:"metadata"`
+}


### PR DESCRIPTION
## Summary

- New `internal/manifest.PipelineHeader` + `PipelineMetadata` (mirror of `pipeline.PipelineMetadata` YAML shape).
- `internal/defaults/embed.go` drops `import internal/pipeline`; uses `manifest.PipelineHeader` for release-flag filtering.
- `pipeline.Pipeline` type unchanged.

## Direction verified

```
$ go list -deps github.com/recinq/wave/internal/defaults | grep "internal/pipeline"
(empty)
```

`defaults` no longer pulls the orchestrator type tree transitively. `manifest` does not import `pipeline` (verified) so no cycle.

## Why option A (manifest type, not new schema leaf)

`internal/manifest` already owns config types and is a proven leaf. Adding `PipelineHeader` here introduces zero new packages and zero cycle risk. New schema sub-package (option B) was avoided to minimize churn.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/defaults/... ./internal/manifest/... ./internal/pipeline/...` all pass

## Out of scope (deferred)

- 3.2 event→state (in flight, separate PR)
- 3.3 webui→tui (internal/health extract)
- 3.4 onboarding→tui (internal/pipelinecatalog extract)

## Test plan

- [ ] CI green
- [ ] `wave init` lists release pipelines correctly

Partial of #1497 (subset 3.1). Parent: #1494.