### PR TITLE
refactor(event): invert event->state dep via lifecycle consts (#1497 partial 3.2)

### DIFF
--- a/internal/event/emitter.go
+++ b/internal/event/emitter.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"github.com/recinq/wave/internal/state"
 )
+
+// StepState represents the lifecycle state of a pipeline step. It is the
+// canonical type for step lifecycle observability and is consumed by
+// internal/state for persistence (state -> event, not the reverse).
+type StepState string
 
 type Event struct {
 	Timestamp  time.Time `json:"timestamp"`
@@ -93,18 +96,27 @@ type DeliverableJSON struct {
 	StepID      string `json:"step_id"`
 }
 
-// Event state constants for pipeline and step lifecycle
+// Event state constants for pipeline and step lifecycle.
+//
+// The step lifecycle constants below are the canonical lifecycle vocabulary
+// for the project. They are untyped string constants so they can be assigned
+// directly to both the `string` Event.State field and the typed StepState
+// alias re-exported by internal/state for persistence APIs.
 const (
 	// Event-specific states
 	StateStarted = "started"
 
-	// Step lifecycle states — canonical source: state.StepState
-	StateRunning   = string(state.StateRunning)
-	StateCompleted = string(state.StateCompleted)
-	StateFailed    = string(state.StateFailed)
-	StateRetrying  = string(state.StateRetrying)
-	StateSkipped   = string(state.StateSkipped)
-	StateReworking = string(state.StateReworking)
+	// Step lifecycle states (canonical). Untyped string constants — assignable
+	// to both string and StepState. See internal/state for the persistence
+	// alias (state.StepState = event.StepState).
+	StatePending        = "pending"
+	StateRunning        = "running"
+	StateCompleted      = "completed"
+	StateCompletedEmpty = "completed_empty" // Step completed but produced no meaningful changes (zero diff in worktree)
+	StateFailed         = "failed"
+	StateRetrying       = "retrying"
+	StateSkipped        = "skipped"
+	StateReworking      = "reworking"
 
 	// Progress tracking states
 	StateStepProgress       = "step_progress"       // Step is making progress (with percentage)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -10,21 +10,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/event"
+
 	_ "modernc.org/sqlite"
 )
 
-// StepState represents the state of a pipeline step.
-type StepState string
+// StepState represents the state of a pipeline step. It aliases event.StepState
+// — internal/event is the canonical owner of the lifecycle vocabulary, and
+// internal/state imports it (reversing the historical event -> state import).
+type StepState = event.StepState
 
+// Step lifecycle constants. These re-export the canonical untyped string
+// constants from internal/event so they are usable both as plain strings and
+// as StepState values (typed alias of event.StepState).
 const (
-	StatePending        StepState = "pending"
-	StateRunning        StepState = "running"
-	StateCompleted      StepState = "completed"
-	StateCompletedEmpty StepState = "completed_empty" // Step completed but produced no meaningful changes (zero diff in worktree)
-	StateFailed         StepState = "failed"
-	StateRetrying       StepState = "retrying"
-	StateSkipped        StepState = "skipped"
-	StateReworking      StepState = "reworking"
+	StatePending        StepState = event.StatePending
+	StateRunning        StepState = event.StateRunning
+	StateCompleted      StepState = event.StateCompleted
+	StateCompletedEmpty StepState = event.StateCompletedEmpty
+	StateFailed         StepState = event.StateFailed
+	StateRetrying       StepState = event.StateRetrying
+	StateSkipped        StepState = event.StateSkipped
+	StateReworking      StepState = event.StateReworking
 )
 
 // PipelineStateRecord holds persisted pipeline state.


### PR DESCRIPTION
## Summary

- Move `StepState` type + 8 lifecycle constants (`StatePending`, `StateRunning`, `StateCompleted`, `StateCompletedEmpty`, `StateFailed`, `StateRetrying`, `StateSkipped`, `StateReworking`) from `internal/state` to `internal/event/emitter.go`.
- `internal/state` re-exports `StepState` via type alias and re-exports constants as typed values backed by event consts.
- All existing call sites (`event.StateRunning`, `state.StateRunning`, `state.StepState`) compile unmodified.

## Direction reversed (verified)

```
$ go list -deps github.com/recinq/wave/internal/event | grep state
(empty)

$ go list -deps github.com/recinq/wave/internal/state | grep event
github.com/recinq/wave/internal/event
```

`event` is now a true leaf observability primitive. `state` consumes event.

## Why 8 constants, not 3

Audit said 3, actual emitter uses 6, full lifecycle vocabulary is 8. Kept as semantic group — `StatePending` and `StateCompletedEmpty` belong to same lifecycle owned by `state.SaveStepState`/`state.GetStepStates`. Splitting would require future cleanup; one move is cleaner.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/event/...` pass (4.8s)
- `go test -race ./internal/state/...` pass (470s)
- `go test -race ./internal/pipeline/...` pass (51s; full-suite saw a `TestSequenceExecutor_ExecutePlan_MaxConcurrent` flake unrelated to this refactor — passes on rerun)

## Out of scope (deferred)

- 3.1 defaults→pipeline (filed as PR #1516)
- 3.3 webui→tui (internal/health extract)
- 3.4 onboarding→tui (internal/pipelinecatalog extract)

## Test plan

- [ ] CI green
- [ ] Spot-check `wave run` lifecycle events stream correctly

Partial of #1497 (subset 3.2). Parent: #1494.