### PR TITLE
refactor: extract internal/pipelinecatalog from tui (#1497 partial 3.4)

### DIFF
--- a/cmd/wave/commands/compose.go
+++ b/cmd/wave/commands/compose.go
@@ -13,10 +13,11 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/pipelinecatalog"
+	"github.com/recinq/wave/internal/skill"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/recinq/wave/internal/workspace"
-	"github.com/recinq/wave/internal/skill"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +68,7 @@ Use --validate-only to check compatibility without executing.`,
 			// Load all pipelines from arguments
 			var seq tui.Sequence
 			for _, name := range args {
-				p, err := tui.LoadPipelineByName(pDir, name)
+				p, err := pipelinecatalog.LoadPipelineByName(pDir, name)
 				if err != nil {
 					return NewCLIError(CodePipelineNotFound,
 						fmt.Sprintf("pipeline not found: %s", name),

--- a/cmd/wave/commands/list.go
+++ b/cmd/wave/commands/list.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/display"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/state"
-	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -1499,7 +1499,7 @@ func listSkillsTable(skills map[string]pipelineSkillConfig) {
 
 // listCompositions lists composition pipelines with their sub-pipelines and step types.
 func listCompositions(pipelinesDir string, format string) error {
-	pipelines, err := tui.DiscoverPipelines(pipelinesDir)
+	pipelines, err := pipelinecatalog.DiscoverPipelines(pipelinesDir)
 	if err != nil {
 		return fmt.Errorf("failed to discover pipelines: %w", err)
 	}
@@ -1514,7 +1514,7 @@ func listCompositions(pipelinesDir string, format string) error {
 	var compositions []CompositionInfo
 	for _, info := range pipelines {
 		// Load full pipeline to check for composition steps
-		p, err := tui.LoadPipelineByName(pipelinesDir, info.Name)
+		p, err := pipelinecatalog.LoadPipelineByName(pipelinesDir, info.Name)
 		if err != nil {
 			continue
 		}

--- a/internal/onboarding/steps.go
+++ b/internal/onboarding/steps.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/tui"
 )
 
@@ -236,7 +237,7 @@ func (s *PipelineSelectionStep) Name() string { return "Pipeline Selection" }
 
 func (s *PipelineSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 	pipelinesDir := ".agents/pipelines"
-	pipelines, err := tui.DiscoverPipelines(pipelinesDir)
+	pipelines, err := pipelinecatalog.DiscoverPipelines(pipelinesDir)
 	if err != nil {
 		// No pipelines directory yet — not an error during init
 		return &StepResult{
@@ -255,7 +256,7 @@ func (s *PipelineSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 	}
 
 	// Build options grouped by category
-	groups := make(map[string][]tui.PipelineInfo)
+	groups := make(map[string][]pipelinecatalog.PipelineInfo)
 	for _, p := range pipelines {
 		cat := p.Category
 		if cat == "" {

--- a/internal/pipelinecatalog/catalog.go
+++ b/internal/pipelinecatalog/catalog.go
@@ -1,4 +1,5 @@
-package tui
+// Package pipelinecatalog discovers and loads pipeline metadata from YAML files.
+package pipelinecatalog
 
 import (
 	"fmt"

--- a/internal/pipelinecatalog/catalog_test.go
+++ b/internal/pipelinecatalog/catalog_test.go
@@ -1,4 +1,4 @@
-package tui
+package pipelinecatalog
 
 import (
 	"os"

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,7 +36,7 @@ func (m *mockPipelineDataProvider) FetchFinishedPipelines(limit int) ([]Finished
 	return nil, nil
 }
 
-func (m *mockPipelineDataProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+func (m *mockPipelineDataProvider) FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error) {
 	return nil, nil
 }
 

--- a/internal/tui/compose_list.go
+++ b/internal/tui/compose_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 // ComposeListModel is the Bubble Tea model for the sequence builder list
@@ -22,7 +23,7 @@ type ComposeListModel struct {
 	picking      bool
 	picker       *huh.Form
 	pickerTarget *string // heap-allocated target for huh form value binding
-	available    []PipelineInfo
+	available    []pipelinecatalog.PipelineInfo
 	validation   CompatibilityResult
 	confirming   bool         // T026: inline confirmation for incompatible sequences
 	parallel     bool         // When true, launch with --parallel flag
@@ -32,7 +33,7 @@ type ComposeListModel struct {
 // NewComposeListModel creates a new compose list model. The initial pipeline
 // is added as the first entry in the sequence, and available provides the
 // list of pipelines that can be appended via the picker.
-func NewComposeListModel(initial PipelineInfo, initialPipeline *pipeline.Pipeline, available []PipelineInfo) ComposeListModel {
+func NewComposeListModel(initial pipelinecatalog.PipelineInfo, initialPipeline *pipeline.Pipeline, available []pipelinecatalog.PipelineInfo) ComposeListModel {
 	m := ComposeListModel{
 		available: available,
 	}

--- a/internal/tui/compose_list_test.go
+++ b/internal/tui/compose_list_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,11 +27,11 @@ func composeStripAnsi(s string) string {
 // entries. The first entry is always "pipeline-1" (added by the constructor).
 // Additional entries are added via sequence.Add.
 func newTestComposeList(entries int) ComposeListModel {
-	initial := PipelineInfo{Name: "pipeline-1", Description: "First", StepCount: 2}
+	initial := pipelinecatalog.PipelineInfo{Name: "pipeline-1", Description: "First", StepCount: 2}
 	initialPipeline := testPipeline("pipeline-1",
 		[]pipeline.ArtifactDef{{Name: "output1"}}, nil)
 
-	available := []PipelineInfo{
+	available := []pipelinecatalog.PipelineInfo{
 		{Name: "pipeline-1", Description: "First", StepCount: 2},
 		{Name: "pipeline-2", Description: "Second", StepCount: 3},
 		{Name: "pipeline-3", Description: "Third", StepCount: 1},

--- a/internal/tui/content_pipelines.go
+++ b/internal/tui/content_pipelines.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/state"
 )
 
@@ -252,7 +253,7 @@ func (m ContentModel) handlePipelineKeyMsg(msg tea.KeyMsg) (ContentModel, tea.Cm
 			idx := m.list.availableIndexForName(item.pipelineName)
 			if item.kind == itemKindPipelineName && idx >= 0 {
 				selectedPipeline := m.list.available[idx]
-				loadedPipeline, err := LoadPipelineByName(m.launcher.deps.PipelinesDir, selectedPipeline.Name)
+				loadedPipeline, err := pipelinecatalog.LoadPipelineByName(m.launcher.deps.PipelinesDir, selectedPipeline.Name)
 				if err == nil {
 					cl := NewComposeListModel(selectedPipeline, loadedPipeline, m.list.available)
 					cd := NewComposeDetailModel()

--- a/internal/tui/content_suggest.go
+++ b/internal/tui/content_suggest.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 // ensureSuggestModels lazily creates the suggest list and detail models.
@@ -114,7 +115,7 @@ func (m ContentModel) updateSuggestMessage(msg tea.Msg) (ContentModel, tea.Cmd, 
 			// Build compose sequence from selected proposals
 			var seq Sequence
 			for _, p := range msg.Pipelines {
-				loaded, err := LoadPipelineByName(m.launcher.deps.PipelinesDir, p.Name)
+				loaded, err := pipelinecatalog.LoadPipelineByName(m.launcher.deps.PipelinesDir, p.Name)
 				if err == nil {
 					seq.Add(p.Name, loaded)
 				} else {

--- a/internal/tui/content_test.go
+++ b/internal/tui/content_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ func (m *contentTestPipelineProvider) FetchFinishedPipelines(limit int) ([]Finis
 	return nil, nil
 }
 
-func (m *contentTestPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+func (m *contentTestPipelineProvider) FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error) {
 	return nil, nil
 }
 
@@ -116,7 +117,7 @@ func TestContentModel_EnterOnAvailableItemTransitionsFocusRight(t *testing.T) {
 
 	// Inject data with an available pipeline
 	c.list, _ = c.list.Update(PipelineDataMsg{
-		Available: []PipelineInfo{{Name: "test-pipe", StepCount: 1}},
+		Available: []pipelinecatalog.PipelineInfo{{Name: "test-pipe", StepCount: 1}},
 	})
 
 	// Move cursor to the pipeline name node
@@ -164,7 +165,7 @@ func TestContentModel_EnterOnPipelineName_TransitionsRight(t *testing.T) {
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
-		Available: []PipelineInfo{{Name: "test"}},
+		Available: []pipelinecatalog.PipelineInfo{{Name: "test"}},
 	})
 
 	// Cursor starts on a pipeline name node
@@ -225,7 +226,7 @@ func TestContentModel_ArrowKeysInRightPaneDoNotMoveList(t *testing.T) {
 	c.SetSize(120, 40)
 
 	c.list, _ = c.list.Update(PipelineDataMsg{
-		Available: []PipelineInfo{{Name: "pipe1"}, {Name: "pipe2"}},
+		Available: []pipelinecatalog.PipelineInfo{{Name: "pipe1"}, {Name: "pipe2"}},
 	})
 
 	// Move cursor to first available item
@@ -261,7 +262,7 @@ func TestContentModel_EnterOnAvailable_EmitsConfigureFormMsg(t *testing.T) {
 
 	// Inject data with an available pipeline that has an input example
 	c.list, _ = c.list.Update(PipelineDataMsg{
-		Available: []PipelineInfo{{Name: "test-pipe", StepCount: 1, InputExample: "example input"}},
+		Available: []pipelinecatalog.PipelineInfo{{Name: "test-pipe", StepCount: 1, InputExample: "example input"}},
 	})
 
 	// Move cursor to the available item
@@ -352,7 +353,7 @@ func TestContentModel_CKey_OnNonRunningItem_IsNoOp(t *testing.T) {
 
 	// Inject data with an available pipeline
 	c.list, _ = c.list.Update(PipelineDataMsg{
-		Available: []PipelineInfo{{Name: "test-pipe", StepCount: 1}},
+		Available: []pipelinecatalog.PipelineInfo{{Name: "test-pipe", StepCount: 1}},
 	})
 
 	// Move cursor to the available item
@@ -529,7 +530,7 @@ steps:
 	m := NewContentModel(nil, nil, deps)
 
 	// Populate the list with pipeline data
-	m.list.available = []PipelineInfo{{
+	m.list.available = []pipelinecatalog.PipelineInfo{{
 		Name:        "test-pipeline",
 		Description: "A test pipeline",
 		StepCount:   1,

--- a/internal/tui/integration_test.go
+++ b/internal/tui/integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +56,7 @@ func (p *integrationMockProvider) FetchPipelineHealth() (HealthStatus, error) {
 
 // integrationPipelineProvider is a PipelineDataProvider returning stable pipeline data.
 type integrationPipelineProvider struct {
-	available []PipelineInfo
+	available []pipelinecatalog.PipelineInfo
 	running   []RunningPipeline
 	finished  []FinishedPipeline
 }
@@ -68,12 +69,12 @@ func (p *integrationPipelineProvider) FetchFinishedPipelines(limit int) ([]Finis
 	return p.finished, nil
 }
 
-func (p *integrationPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+func (p *integrationPipelineProvider) FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error) {
 	return p.available, nil
 }
 
 // newIntegrationApp creates an AppModel wired with integration-level mock providers.
-func newIntegrationApp(projectName string, pipelines []PipelineInfo) AppModel { //nolint:unparam // test helper
+func newIntegrationApp(projectName string, pipelines []pipelinecatalog.PipelineInfo) AppModel { //nolint:unparam // test helper
 	meta := &integrationMockProvider{projectName: projectName}
 	pipeProv := &integrationPipelineProvider{available: pipelines}
 	return NewAppModel(meta, pipeProv, nil, LaunchDependencies{})
@@ -306,7 +307,7 @@ func TestHeader_ShowsMetadata_ViaApp(t *testing.T) {
 func TestApp_ComposedLayout(t *testing.T) {
 	const projectName = "composed-layout-test"
 
-	pipelines := []PipelineInfo{
+	pipelines := []pipelinecatalog.PipelineInfo{
 		{Name: "impl-issue", Description: "Implement a GitHub issue", StepCount: 5},
 		{Name: "ops-pr-review", Description: "Review a pull request", StepCount: 3},
 	}

--- a/internal/tui/issue_detail.go
+++ b/internal/tui/issue_detail.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 // IssueDetailModel is the right pane model for the Issues view.
@@ -17,7 +18,7 @@ type IssueDetailModel struct {
 	focused       bool
 	viewport      viewport.Model
 	selected      *IssueData
-	pipelines     []PipelineInfo
+	pipelines     []pipelinecatalog.PipelineInfo
 	chooserActive bool
 	chooserCursor int
 }
@@ -61,7 +62,7 @@ func (m *IssueDetailModel) SetIssue(issue *IssueData) {
 }
 
 // SetPipelines sets the available pipelines for the chooser.
-func (m *IssueDetailModel) SetPipelines(pipelines []PipelineInfo) {
+func (m *IssueDetailModel) SetPipelines(pipelines []pipelinecatalog.PipelineInfo) {
 	m.pipelines = pipelines
 }
 
@@ -257,7 +258,7 @@ func (m *IssueDetailModel) sortPipelinesByRelevance() {
 }
 
 // pipelineRelevanceScore computes a simple keyword-overlap score between a pipeline and an issue.
-func pipelineRelevanceScore(p PipelineInfo, issue *IssueData) int {
+func pipelineRelevanceScore(p pipelinecatalog.PipelineInfo, issue *IssueData) int {
 	score := 0
 	titleLower := strings.ToLower(issue.Title)
 	nameLower := strings.ToLower(p.Name)

--- a/internal/tui/issue_detail_test.go
+++ b/internal/tui/issue_detail_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,7 +87,7 @@ func TestIssueDetailModel_PipelineChooser_Open(t *testing.T) {
 	m.SetSize(80, 40)
 	m.SetFocused(true)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-bugfix"},
 		{Name: "wave-review"},
@@ -111,7 +112,7 @@ func TestIssueDetailModel_PipelineChooser_Navigate(t *testing.T) {
 	m.SetSize(80, 40)
 	m.SetFocused(true)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-bugfix"},
 		{Name: "wave-review"},
@@ -149,7 +150,7 @@ func TestIssueDetailModel_PipelineChooser_Launch(t *testing.T) {
 	m.SetSize(80, 40)
 	m.SetFocused(true)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-bugfix"},
 	})
@@ -187,7 +188,7 @@ func TestIssueDetailModel_PipelineChooser_Cancel(t *testing.T) {
 	m.SetSize(80, 40)
 	m.SetFocused(true)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 	})
 
@@ -231,7 +232,7 @@ func TestIssueDetailModel_UnfocusedIgnoresKeys(t *testing.T) {
 	m.SetSize(80, 40)
 	m.SetFocused(false)
 
-	m.SetPipelines([]PipelineInfo{{Name: "speckit-flow"}})
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{{Name: "speckit-flow"}})
 
 	issue := &IssueData{
 		Number:  1,
@@ -250,7 +251,7 @@ func TestIssueDetailModel_ViewShowsPipelineChooser(t *testing.T) {
 	m := NewIssueDetailModel()
 	m.SetSize(80, 40)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-bugfix"},
 	})
@@ -269,7 +270,7 @@ func TestIssueDetailModel_ViewShowsPipelineChooser(t *testing.T) {
 }
 
 func TestPipelineRelevanceScore_NameMatchesTitle(t *testing.T) {
-	p := PipelineInfo{Name: "pr-review", Description: "Automated code review workflow"}
+	p := pipelinecatalog.PipelineInfo{Name: "pr-review", Description: "Automated code review workflow"}
 	issue := &IssueData{Title: "Review the PR for auth module", Labels: nil}
 
 	score := pipelineRelevanceScore(p, issue)
@@ -277,7 +278,7 @@ func TestPipelineRelevanceScore_NameMatchesTitle(t *testing.T) {
 }
 
 func TestPipelineRelevanceScore_LabelMatchesName(t *testing.T) {
-	p := PipelineInfo{Name: "wave-bugfix", Description: "Fix bugs", Category: "maintenance"}
+	p := pipelinecatalog.PipelineInfo{Name: "wave-bugfix", Description: "Fix bugs", Category: "maintenance"}
 	issue := &IssueData{Title: "Something unrelated", Labels: []string{"bugfix"}}
 
 	score := pipelineRelevanceScore(p, issue)
@@ -285,7 +286,7 @@ func TestPipelineRelevanceScore_LabelMatchesName(t *testing.T) {
 }
 
 func TestPipelineRelevanceScore_NoMatch(t *testing.T) {
-	p := PipelineInfo{Name: "deploy-prod", Description: "Deploy to production"}
+	p := pipelinecatalog.PipelineInfo{Name: "deploy-prod", Description: "Deploy to production"}
 	issue := &IssueData{Title: "Fix authentication bug", Labels: []string{"bug"}}
 
 	score := pipelineRelevanceScore(p, issue)
@@ -293,7 +294,7 @@ func TestPipelineRelevanceScore_NoMatch(t *testing.T) {
 }
 
 func TestPipelineRelevanceScore_CategoryMatchesLabel(t *testing.T) {
-	p := PipelineInfo{Name: "some-pipeline", Description: "A pipeline", Category: "security"}
+	p := pipelinecatalog.PipelineInfo{Name: "some-pipeline", Description: "A pipeline", Category: "security"}
 	issue := &IssueData{Title: "Unrelated title", Labels: []string{"security"}}
 
 	score := pipelineRelevanceScore(p, issue)
@@ -304,7 +305,7 @@ func TestIssueDetailModel_RelevanceSorting(t *testing.T) {
 	m := NewIssueDetailModel()
 	m.SetSize(80, 40)
 
-	m.SetPipelines([]PipelineInfo{
+	m.SetPipelines([]pipelinecatalog.PipelineInfo{
 		{Name: "deploy-prod", Description: "Deploy to production"},
 		{Name: "wave-bugfix", Description: "Fix bugs quickly"},
 		{Name: "speckit-flow", Description: "Feature development"},

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 // PipelineLauncher manages pipeline execution from the TUI.
@@ -41,7 +42,7 @@ func (l *PipelineLauncher) SetProgram(p *tea.Program) {
 // SQLite events, not in-memory buffers.
 func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 	// Load the full pipeline definition to validate it exists
-	p, err := LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
+	p, err := pipelinecatalog.LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
 	if err != nil {
 		pipelineName := config.PipelineName
 		return func() tea.Msg {

--- a/internal/tui/pipeline_list.go
+++ b/internal/tui/pipeline_list.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/recinq/wave/internal/humanize"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 const (
@@ -46,7 +47,7 @@ type PipelineListModel struct {
 	// Section data
 	running   []RunningPipeline
 	finished  []FinishedPipeline
-	available []PipelineInfo
+	available []pipelinecatalog.PipelineInfo
 
 	// Navigation state
 	cursor    int

--- a/internal/tui/pipeline_list_test.go
+++ b/internal/tui/pipeline_list_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +21,7 @@ import (
 type listTestPipelineProvider struct {
 	running   []RunningPipeline
 	finished  []FinishedPipeline
-	available []PipelineInfo
+	available []pipelinecatalog.PipelineInfo
 }
 
 func (m *listTestPipelineProvider) FetchRunningPipelines() ([]RunningPipeline, error) {
@@ -31,13 +32,13 @@ func (m *listTestPipelineProvider) FetchFinishedPipelines(limit int) ([]Finished
 	return m.finished, nil
 }
 
-func (m *listTestPipelineProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
+func (m *listTestPipelineProvider) FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error) {
 	return m.available, nil
 }
 
 // newTestListModel creates a PipelineListModel pre-loaded with the given data.
 // It bypasses async commands by directly injecting a PipelineDataMsg.
-func newTestListModel(running []RunningPipeline, finished []FinishedPipeline, available []PipelineInfo) PipelineListModel {
+func newTestListModel(running []RunningPipeline, finished []FinishedPipeline, available []pipelinecatalog.PipelineInfo) PipelineListModel {
 	provider := &listTestPipelineProvider{running: running, finished: finished, available: available}
 	m := NewPipelineListModel(provider)
 	m.SetSize(40, 20)
@@ -154,10 +155,10 @@ func sampleFinished(n int) []FinishedPipeline {
 	return out
 }
 
-func sampleAvailable(n int) []PipelineInfo {
-	out := make([]PipelineInfo, n)
+func sampleAvailable(n int) []pipelinecatalog.PipelineInfo {
+	out := make([]pipelinecatalog.PipelineInfo, n)
 	for i := range n {
-		out[i] = PipelineInfo{
+		out[i] = pipelinecatalog.PipelineInfo{
 			Name:        "avail-" + string(rune('a'+i)),
 			Description: "desc " + string(rune('a'+i)),
 			StepCount:   i + 1,
@@ -221,7 +222,7 @@ func TestPipelineListModel_View_FinishedItemsShowStatusAndDuration(t *testing.T)
 }
 
 func TestPipelineListModel_View_AvailableItemsShowNameOnly(t *testing.T) {
-	avail := []PipelineInfo{{Name: "speckit-flow", Description: "A pipeline"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "speckit-flow", Description: "A pipeline"}}
 	m := newTestListModel(nil, nil, avail)
 	view := listStripAnsi(m.View())
 
@@ -239,7 +240,7 @@ func TestPipelineListModel_View_EmptyList_ShowsEmptyMessage(t *testing.T) {
 }
 
 func TestPipelineListModel_View_NoMatchingPipelines_ShowsEmptyMessage(t *testing.T) {
-	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "speckit-flow"}}
 	m := newTestListModel(nil, nil, avail)
 
 	// Activate filter with a query that matches nothing
@@ -254,7 +255,7 @@ func TestPipelineListModel_View_NoMatchingPipelines_ShowsEmptyMessage(t *testing
 
 func TestPipelineListModel_View_LongNamesTruncated(t *testing.T) {
 	longName := strings.Repeat("x", 50)
-	avail := []PipelineInfo{{Name: longName}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: longName}}
 	m := newTestListModel(nil, nil, avail)
 	m.SetSize(40, 20)
 	// Re-inject data so View uses updated size
@@ -454,7 +455,7 @@ func TestPipelineListModel_Navigation_RunningItemIncludesRunID(t *testing.T) {
 }
 
 func TestPipelineListModel_Navigation_PipelineNameHasEmptyRunID(t *testing.T) {
-	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "speckit-flow"}}
 	m := newTestListModel(nil, nil, avail)
 
 	// Cursor starts on the pipeline name node
@@ -482,7 +483,7 @@ func TestPipelineListModel_Filter_SlashActivates(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_MatchesSubstring(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-evolve"},
 		{Name: "speckit-debug"},
@@ -511,7 +512,7 @@ func TestPipelineListModel_Filter_AcrossPipelines(t *testing.T) {
 	finished := []FinishedPipeline{
 		{RunID: "f1", Name: "speckit-done", Status: "completed", Duration: time.Minute},
 	}
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "wave-evolve"},
 	}
 	m := newTestListModel(running, finished, avail)
@@ -529,7 +530,7 @@ func TestPipelineListModel_Filter_AcrossPipelines(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_EscapeDismisses(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-evolve"},
 	}
@@ -553,7 +554,7 @@ func TestPipelineListModel_Filter_EscapeDismisses(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_ZeroMatchesMessage(t *testing.T) {
-	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "speckit-flow"}}
 	m := newTestListModel(nil, nil, avail)
 
 	m, _ = sendRune(m, '/')
@@ -566,7 +567,7 @@ func TestPipelineListModel_Filter_ZeroMatchesMessage(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_NavigationInFilteredResults(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "alpha-pipe"},
 		{Name: "alpha-debug"},
 		{Name: "beta-pipe"},
@@ -595,7 +596,7 @@ func TestPipelineListModel_Filter_NavigationInFilteredResults(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_CursorClampedAfterNarrow(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "alpha-pipeline"},
 		{Name: "beta-pipeline"},
 		{Name: "gamma-pipeline"},
@@ -623,7 +624,7 @@ func TestPipelineListModel_Filter_CursorClampedAfterNarrow(t *testing.T) {
 }
 
 func TestPipelineListModel_Filter_EnterWithZeroResults_StaysInFilterMode(t *testing.T) {
-	avail := []PipelineInfo{{Name: "speckit-flow"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "speckit-flow"}}
 	m := newTestListModel(nil, nil, avail)
 
 	// Activate filter and type a query that matches nothing
@@ -645,7 +646,7 @@ func TestPipelineListModel_Filter_EnterWithZeroResults_StaysInFilterMode(t *test
 }
 
 func TestPipelineListModel_Filter_SlashRestoresListAfterConfirmedFilter(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "speckit-flow"},
 		{Name: "wave-evolve"},
 	}
@@ -802,7 +803,7 @@ func TestPipelineListModel_Collapse_CursorSkipsHiddenItems(t *testing.T) {
 		{RunID: "f1", Name: "alpha-pipe", Status: "completed", Duration: time.Minute, StartedAt: time.Now()},
 		{RunID: "f2", Name: "alpha-pipe", Status: "failed", Duration: time.Minute, StartedAt: time.Now()},
 	}
-	avail := []PipelineInfo{{Name: "beta-pipe"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "beta-pipe"}}
 	m := newTestListModel(nil, finished, avail)
 
 	require.True(t, m.collapsed["alpha-pipe"], "alpha-pipe should start collapsed")
@@ -832,7 +833,7 @@ func TestPipelineListModel_Collapse_IndicatorRendering(t *testing.T) {
 
 func TestPipelineListModel_Collapse_NoIndicatorForLeafNodes(t *testing.T) {
 	// A pipeline with no runs should not show collapse indicators
-	avail := []PipelineInfo{{Name: "leaf-pipe"}}
+	avail := []pipelinecatalog.PipelineInfo{{Name: "leaf-pipe"}}
 	m := newTestListModel(nil, nil, avail)
 
 	view := listStripAnsi(m.View())
@@ -987,7 +988,7 @@ func TestPipelineListModel_PipelineLaunchedMsg_PreservesExistingRunning(t *testi
 // ===========================================================================
 
 func TestPipelineListModel_TreeLayout_AlphabeticalOrder(t *testing.T) {
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "zebra"},
 		{Name: "alpha"},
 		{Name: "middle"},
@@ -1006,7 +1007,7 @@ func TestPipelineListModel_TreeLayout_MergesAcrossDataSources(t *testing.T) {
 	running := []RunningPipeline{
 		{RunID: "r1", Name: "shared-pipe", StartedAt: time.Now()},
 	}
-	avail := []PipelineInfo{
+	avail := []pipelinecatalog.PipelineInfo{
 		{Name: "shared-pipe"},
 	}
 	m := newTestListModel(running, nil, avail)

--- a/internal/tui/pipeline_messages.go
+++ b/internal/tui/pipeline_messages.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/state"
 )
 
@@ -10,7 +11,7 @@ import (
 type PipelineDataMsg struct {
 	Running   []RunningPipeline
 	Finished  []FinishedPipeline
-	Available []PipelineInfo
+	Available []pipelinecatalog.PipelineInfo
 	Err       error
 }
 

--- a/internal/tui/pipeline_provider.go
+++ b/internal/tui/pipeline_provider.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/state"
 )
 
@@ -36,7 +37,7 @@ type FinishedPipeline struct {
 type PipelineDataProvider interface {
 	FetchRunningPipelines() ([]RunningPipeline, error)
 	FetchFinishedPipelines(limit int) ([]FinishedPipeline, error)
-	FetchAvailablePipelines() ([]PipelineInfo, error)
+	FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error)
 }
 
 // DefaultPipelineDataProvider implements PipelineDataProvider using a state store and pipeline discovery.
@@ -144,6 +145,6 @@ func (p *DefaultPipelineDataProvider) FetchFinishedPipelines(limit int) ([]Finis
 }
 
 // FetchAvailablePipelines returns all configured pipelines from the manifest directory.
-func (p *DefaultPipelineDataProvider) FetchAvailablePipelines() ([]PipelineInfo, error) {
-	return DiscoverPipelines(p.pipelinesDir)
+func (p *DefaultPipelineDataProvider) FetchAvailablePipelines() ([]pipelinecatalog.PipelineInfo, error) {
+	return pipelinecatalog.DiscoverPipelines(p.pipelinesDir)
 }

--- a/internal/tui/run_selector.go
+++ b/internal/tui/run_selector.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/pipelinecatalog"
 )
 
 // Selection holds the result of the interactive pipeline selection.
@@ -38,7 +39,7 @@ func DefaultFlags() []Flag {
 // preFilter narrows the initial pipeline list (e.g. from a partial name argument).
 // pipelinesDir is the directory to scan for pipeline YAML files.
 func RunPipelineSelector(pipelinesDir, preFilter string) (*Selection, error) {
-	pipelines, err := DiscoverPipelines(pipelinesDir)
+	pipelines, err := pipelinecatalog.DiscoverPipelines(pipelinesDir)
 	if err != nil {
 		return nil, fmt.Errorf("discovering pipelines: %w", err)
 	}
@@ -103,7 +104,7 @@ func RunPipelineSelector(pipelinesDir, preFilter string) (*Selection, error) {
 
 // runInputAndFlags runs the input prompt, flag selection, and confirmation
 // when the pipeline is already known (auto-selected via preFilter).
-func runInputAndFlags(selected PipelineInfo) (*Selection, error) {
+func runInputAndFlags(selected pipelinecatalog.PipelineInfo) (*Selection, error) {
 	var input string
 	var selectedFlags []string
 
@@ -172,7 +173,7 @@ func confirmAndReturn(pipeline, input string, selectedFlags []string) (*Selectio
 }
 
 // buildPipelineOptions creates huh options from pipeline info.
-func buildPipelineOptions(pipelines []PipelineInfo) []huh.Option[string] {
+func buildPipelineOptions(pipelines []pipelinecatalog.PipelineInfo) []huh.Option[string] {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
 	options := make([]huh.Option[string], len(pipelines))
 	for i, p := range pipelines {
@@ -197,9 +198,9 @@ func buildFlagOptions(flags []Flag) []huh.Option[string] {
 }
 
 // filterPipelines returns pipelines whose names contain the filter string (case-insensitive).
-func filterPipelines(pipelines []PipelineInfo, filter string) []PipelineInfo {
+func filterPipelines(pipelines []pipelinecatalog.PipelineInfo, filter string) []pipelinecatalog.PipelineInfo {
 	filter = strings.ToLower(filter)
-	var matched []PipelineInfo
+	var matched []pipelinecatalog.PipelineInfo
 	for _, p := range pipelines {
 		if strings.Contains(strings.ToLower(p.Name), filter) {
 			matched = append(matched, p)

--- a/internal/tui/run_selector_test.go
+++ b/internal/tui/run_selector_test.go
@@ -3,11 +3,12 @@ package tui
 import (
 	"testing"
 
+	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterPipelines(t *testing.T) {
-	pipelines := []PipelineInfo{
+	pipelines := []pipelinecatalog.PipelineInfo{
 		{Name: "feature", Description: "Plan and implement"},
 		{Name: "hotfix", Description: "Quick fix"},
 		{Name: "pr-review", Description: "Review PRs"},
@@ -119,7 +120,7 @@ func TestComposeCommand(t *testing.T) {
 }
 
 func TestBuildPipelineOptions(t *testing.T) {
-	pipelines := []PipelineInfo{
+	pipelines := []pipelinecatalog.PipelineInfo{
 		{Name: "feature", Description: "Plan and implement"},
 		{Name: "minimal"},
 	}


### PR DESCRIPTION
## Summary

- Move `PipelineInfo`, `DiscoverPipelines`, `LoadPipelineByName`, `parsePipelineFile` from `internal/tui/pipelines.go` to new `internal/pipelinecatalog/catalog.go`
- Symbol names unchanged
- 21 files touched: 2 new catalog files + 1 cmd file + 1 onboarding file + 17 tui consumers updated

## Inversion partially reversed

```
$ go list -deps github.com/recinq/wave/internal/onboarding | grep "internal/tui"
github.com/recinq/wave/internal/tui
```

**Residual onboarding→tui edge**: `tui.WaveTheme()` (huh.Theme builder) used by `internal/onboarding/{steps,ontology_step}.go` for interactive forms. Removing requires extracting theme into separate package (`internal/uitheme`) — outside strict scope of subset 3.4 (pipeline discovery). **Follow-up ticket needed.**

The pipeline-discovery coupling is eliminated. Onboarding can list pipelines without dragging Bubble Tea behaviour, only the theme widget remains.

## Validation

- `go build ./...` + `go vet ./...` clean
- `go test -race ./internal/pipelinecatalog/... ./internal/onboarding/... ./internal/tui/... ./cmd/wave/commands/...` all pass

## Out of scope (deferred)

- 3.3 webui→tui health (filed as PR #1519)
- 3.4 residual `tui.WaveTheme` extract → new ticket needed

## Test plan

- [ ] CI green
- [ ] `wave init` greenfield discovers pipelines correctly
- [ ] `wave compose` lists pipelines correctly
- [ ] `wave tui --guided` pipeline panel unchanged

Partial of #1497 (subset 3.4). Parent: #1494.