### PR TITLE
docs: add package doc comments to internal/* (#1507 partial 13.2)

### DIFF
--- a/internal/bench/doc.go
+++ b/internal/bench/doc.go
@@ -1,0 +1,3 @@
+// Package bench runs benchmark task suites against pipelines and compares
+// per-task pass/fail status across runs to detect regressions.
+package bench

--- a/internal/classify/doc.go
+++ b/internal/classify/doc.go
@@ -1,0 +1,3 @@
+// Package classify analyzes free-form user input to infer task domain,
+// complexity, and other signals used to route requests to the right pipeline.
+package classify

--- a/internal/doctor/doc.go
+++ b/internal/doctor/doc.go
@@ -1,0 +1,3 @@
+// Package doctor runs configuration, dependency, and infrastructure health
+// checks against a Wave manifest and reports actionable diagnostics.
+package doctor

--- a/internal/fileutil/doc.go
+++ b/internal/fileutil/doc.go
@@ -1,0 +1,3 @@
+// Package fileutil provides file and directory copy helpers that auto-create
+// parent directories and recurse into subdirectories.
+package fileutil

--- a/internal/forge/doc.go
+++ b/internal/forge/doc.go
@@ -1,0 +1,3 @@
+// Package forge abstracts Git hosting providers (GitHub, GitLab, Gitea) behind
+// a common Client interface for issue, pull request, and check operations.
+package forge

--- a/internal/github/doc.go
+++ b/internal/github/doc.go
@@ -1,0 +1,3 @@
+// Package github implements the GitHub-specific forge client and quality
+// analyzer that scores issues and suggests title, body, and label improvements.
+package github

--- a/internal/hooks/doc.go
+++ b/internal/hooks/doc.go
@@ -1,0 +1,3 @@
+// Package hooks executes user-defined lifecycle shell commands at pipeline
+// events, interpreting exit codes to allow, block, or fail the surrounding step.
+package hooks

--- a/internal/onboarding/doc.go
+++ b/internal/onboarding/doc.go
@@ -1,0 +1,3 @@
+// Package onboarding detects project flavour (language, build, test, lint
+// commands) and extracts manifest metadata for first-run wizard scaffolding.
+package onboarding

--- a/internal/pathfmt/doc.go
+++ b/internal/pathfmt/doc.go
@@ -1,0 +1,3 @@
+// Package pathfmt formats absolute filesystem paths as file:// URIs so modern
+// terminal emulators render them as clickable hyperlinks.
+package pathfmt

--- a/internal/preflight/doc.go
+++ b/internal/preflight/doc.go
@@ -1,0 +1,3 @@
+// Package preflight verifies that required CLI binaries, forge tokens, and
+// host capabilities are present before a pipeline run starts.
+package preflight

--- a/internal/recovery/doc.go
+++ b/internal/recovery/doc.go
@@ -1,0 +1,3 @@
+// Package recovery classifies pipeline step errors into recovery classes and
+// renders user-facing recovery hint blocks suggesting next actions.
+package recovery

--- a/internal/retro/doc.go
+++ b/internal/retro/doc.go
@@ -1,0 +1,3 @@
+// Package retro collects quantitative run metrics from the state store and
+// generates retrospective summaries of pipeline executions.
+package retro

--- a/internal/sandbox/doc.go
+++ b/internal/sandbox/doc.go
@@ -1,0 +1,3 @@
+// Package sandbox executes adapter subprocesses inside isolated environments
+// (bubblewrap or Docker) with configurable filesystem and network restrictions.
+package sandbox

--- a/internal/scope/doc.go
+++ b/internal/scope/doc.go
@@ -1,0 +1,3 @@
+// Package scope parses persona token scope expressions and introspects forge
+// tokens to validate that granted permissions cover declared requirements.
+package scope

--- a/internal/skill/doc.go
+++ b/internal/skill/doc.go
@@ -1,0 +1,3 @@
+// Package skill discovers Claude Code SKILL.md bundles, computes content
+// digests, and integrates them as reusable persona capabilities.
+package skill

--- a/internal/suggest/doc.go
+++ b/internal/suggest/doc.go
@@ -1,0 +1,3 @@
+// Package suggest proposes prioritized pipeline sequences for a given input
+// type and project context to drive the guided-mode and TUI orchestrators.
+package suggest

--- a/internal/tui/doc.go
+++ b/internal/tui/doc.go
@@ -1,0 +1,3 @@
+// Package tui implements Wave's Bubble Tea terminal UI, composing the
+// three-row layout (header, body, status) for runs, fleets, and proposals.
+package tui

--- a/internal/webui/doc.go
+++ b/internal/webui/doc.go
@@ -1,0 +1,3 @@
+// Package webui serves Wave's embedded web dashboard with token authentication,
+// security headers, and HTTP handlers for runs, pipelines, and live events.
+package webui

--- a/internal/worktree/doc.go
+++ b/internal/worktree/doc.go
@@ -1,0 +1,3 @@
+// Package worktree manages git worktree lifecycle (create, prune, remove) for
+// isolated per-step workspace execution in pipeline runs.
+package worktree


### PR DESCRIPTION
## Summary

- Add `doc.go` to 19 internal packages that lacked package-level documentation
- 22 priority-list packages already had package comments in other files (e.g. `attention.go`, `humanize.go`, `redact.go`, `health.go`, `ledger.go`, `embed.go`, `types.go`, `service.go`, `timeouts.go`, `check.go`) — left untouched to avoid duplicate-comment lint warnings
- Final state: **all 41 internal packages return a `Package <name> ...` summary from `go doc`**

## Sample summaries

- `bench`: Package bench runs benchmark task suites against pipelines and compares per-task pass/fail status across runs to detect regressions.
- `forge`: Package forge abstracts Git hosting providers (GitHub, GitLab, Gitea) behind a common Client interface for issue, pull request, and check operations.
- `pathfmt`: Package pathfmt formats absolute filesystem paths as file:// URIs so modern terminal emulators render them as clickable hyperlinks.
- `sandbox`: Package sandbox executes adapter subprocesses inside isolated environments (bubblewrap or Docker) with configurable filesystem and network restrictions.
- `tui`: Package tui implements Wave's Bubble Tea terminal UI, composing the three-row layout (header, body, status) for runs, fleets, and proposals.
- `webui`: Package webui serves Wave's embedded web dashboard with token authentication, security headers, and HTTP handlers for runs, pipelines, and live events.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `for d in internal/*/; do pkg=$(basename "$d"); doc=$(go doc "./internal/$pkg" 2>&1 | head -1); echo "$pkg: $doc"; done | grep -v "// "` returns empty

## Out of scope (deferred)

- 13.3 os.Getenv centralize
- 13.4 Config struct sprawl consolidate
- 13.5 internal/persona extract

## Test plan

- [ ] CI green
- [ ] `go doc ./internal/<pkg>` returns summary for every package

Partial of #1507 (subset 13.2). Parent: #1494.