### PR TITLE
refactor(cmd): thin init.go; move logic to internal/onboarding (#1502 partial)

### DIFF
--- a/cmd/wave/commands/forge_init_test.go
+++ b/cmd/wave/commands/forge_init_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/recinq/wave/internal/defaults"
 	"github.com/recinq/wave/internal/forge"
+	"github.com/recinq/wave/internal/onboarding"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,7 +145,7 @@ func TestCrossForgeInit(t *testing.T) {
 			personaConfigs, err := defaults.GetPersonaConfigs()
 			require.NoError(t, err, "loading persona configs")
 
-			filteredPersonas := filterPersonasByForge(personaConfigs, info.Type)
+			filteredPersonas := onboarding.FilterPersonasByForge(personaConfigs, info.Type)
 
 			if tt.wantPersonaPrefix != "" {
 				// For forges with a persona prefix, every forge-specific persona

--- a/cmd/wave/commands/init.go
+++ b/cmd/wave/commands/init.go
@@ -2,26 +2,20 @@ package commands
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
-	"github.com/recinq/wave/internal/defaults"
-	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/onboarding"
-	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
 
+// InitOptions captures the flag values for `wave init`.
 type InitOptions struct {
 	Force       bool
 	Merge       bool
@@ -29,10 +23,11 @@ type InitOptions struct {
 	Adapter     string
 	Workspace   string
 	OutputPath  string
-	Yes         bool // Skip confirmation prompts
-	Reconfigure bool // Re-run wizard with existing values as defaults
+	Yes         bool
+	Reconfigure bool
 }
 
+// NewInitCmd constructs the `wave init` cobra command.
 func NewInitCmd() *cobra.Command {
 	var opts InitOptions
 
@@ -64,242 +59,22 @@ preserving your custom settings.`,
 	return cmd
 }
 
-// initAssets holds the resolved asset maps for init/merge operations.
-type initAssets struct {
-	personas       map[string]string
-	personaConfigs map[string]manifest.Persona
-	pipelines      map[string]string
-	contracts      map[string]string
-	prompts        map[string]string
-}
-
-// FileStatus represents the status of a file in the merge change summary.
-type FileStatus string
-
-const (
-	FileStatusNew       FileStatus = "new"        // File does not exist, will be created
-	FileStatusPreserved FileStatus = "preserved"  // File exists, differs from default
-	FileStatusUpToDate  FileStatus = "up_to_date" // File exists, matches default byte-for-byte
-)
-
-// FileChangeEntry represents a single file's status in the change summary.
-type FileChangeEntry struct {
-	RelPath  string
-	Category string
-	Status   FileStatus
-}
-
-// ManifestAction represents the type of change to a manifest key.
-type ManifestAction string
-
-const (
-	ManifestActionAdded     ManifestAction = "added"
-	ManifestActionPreserved ManifestAction = "preserved"
-)
-
-// ManifestChangeEntry represents a change to a manifest key.
-type ManifestChangeEntry struct {
-	KeyPath string
-	Action  ManifestAction
-}
-
-// ChangeSummary holds the complete pre-mutation change report.
-type ChangeSummary struct {
-	Files           []FileChangeEntry
-	ManifestChanges []ManifestChangeEntry
-	MergedManifest  map[string]interface{}
-	Assets          *initAssets
-	AlreadyUpToDate bool
-}
-
-// getFilteredAssets returns the asset maps for init, applying release filtering
-// unless opts.All is true.
-func getFilteredAssets(cmd *cobra.Command, opts InitOptions) (*initAssets, error) {
-	personas, err := defaults.GetPersonas()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default personas: %w", err)
-	}
-
-	allPersonaConfigs, err := defaults.GetPersonaConfigs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get persona configs: %w", err)
-	}
-
-	if opts.All {
-		pipelines, err := defaults.GetPipelines()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default pipelines: %w", err)
-		}
-		contracts, err := defaults.GetContracts()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default contracts: %w", err)
-		}
-		prompts, err := defaults.GetPrompts()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default prompts: %w", err)
-		}
-		return &initAssets{
-			personas:       personas,
-			personaConfigs: allPersonaConfigs,
-			pipelines:      pipelines,
-			contracts:      contracts,
-			prompts:        prompts,
-		}, nil
-	}
-
-	// Release-filtered mode
-	pipelines, err := defaults.GetReleasePipelines()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get release pipelines: %w", err)
-	}
-
-	if len(pipelines) == 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(), "warning: no pipelines are marked with release: true\n")
-	}
-
-	allContracts, err := defaults.GetContracts()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default contracts: %w", err)
-	}
-	allPrompts, err := defaults.GetPrompts()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default prompts: %w", err)
-	}
-
-	contracts, prompts, personaConfigs := filterTransitiveDeps(cmd, pipelines, allContracts, allPrompts, allPersonaConfigs)
-
-	return &initAssets{
-		personas:       personas,
-		personaConfigs: personaConfigs,
-		pipelines:      pipelines,
-		contracts:      contracts,
-		prompts:        prompts,
-	}, nil
-}
-
-// systemPersonas are always included in the manifest regardless of pipeline references.
-// These are used by relay compaction, meta-pipelines, and adhoc operations.
-var systemPersonas = map[string]bool{
-	"summarizer":  true,
-	"navigator":   true,
-	"philosopher": true,
-}
-
-// filterTransitiveDeps filters contracts, prompts, and persona configs to only
-// those referenced by the given pipeline set. System personas are always included.
-func filterTransitiveDeps(cmd *cobra.Command, pipelines, allContracts, allPrompts map[string]string, allPersonaConfigs map[string]manifest.Persona) (contracts, prompts map[string]string, personaConfigs map[string]manifest.Persona) {
-	contractRefs := make(map[string]bool)
-	promptRefs := make(map[string]bool)
-	personaRefs := make(map[string]bool)
-
-	for name, content := range pipelines {
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to parse pipeline %s for dependency resolution: %v\n", name, err)
-			continue
-		}
-
-		for _, step := range p.Steps {
-			// Extract persona references
-			if step.Persona != "" {
-				personaRefs[step.Persona] = true
-			}
-
-			// Extract compaction persona references
-			if step.Handover.Compaction.Persona != "" {
-				personaRefs[step.Handover.Compaction.Persona] = true
-			}
-
-			// Extract contract references from schema_path
-			if sp := step.Handover.Contract.SchemaPath; sp != "" {
-				normalized := strings.TrimPrefix(sp, ".agents/contracts/")
-				contractRefs[normalized] = true
-			}
-
-			// Extract prompt references from source_path
-			if sp := step.Exec.SourcePath; sp != "" {
-				if strings.HasPrefix(sp, ".agents/prompts/") {
-					normalized := strings.TrimPrefix(sp, ".agents/prompts/")
-					promptRefs[normalized] = true
-				}
-			}
-		}
-	}
-
-	// Always include system personas
-	for name := range systemPersonas {
-		personaRefs[name] = true
-	}
-
-	// Expand forge-templated persona refs (e.g. "{{ forge.type }}-analyst") into
-	// all 4 forge variants so they survive filtering. filterPersonasByForge (called
-	// later) trims to only the detected forge.
-	expandedRefs := make(map[string]bool)
-	for ref := range personaRefs {
-		if strings.Contains(ref, "{{ forge.type }}") || strings.Contains(ref, "{{forge.type}}") {
-			for _, forgeType := range []string{"github", "gitlab", "gitea", "bitbucket"} {
-				expanded := strings.ReplaceAll(ref, "{{ forge.type }}", forgeType)
-				expanded = strings.ReplaceAll(expanded, "{{forge.type}}", forgeType)
-				expandedRefs[expanded] = true
-			}
-		} else {
-			expandedRefs[ref] = true
-		}
-	}
-	personaRefs = expandedRefs
-
-	// Filter persona configs to only referenced ones
-	personaConfigs = make(map[string]manifest.Persona)
-	for name, cfg := range allPersonaConfigs {
-		if personaRefs[name] {
-			personaConfigs[name] = cfg
-		}
-	}
-
-	// Filter contracts to only referenced ones
-	contracts = make(map[string]string)
-	for key, content := range allContracts {
-		if contractRefs[key] {
-			contracts[key] = content
-		}
-	}
-
-	// Warn about referenced but missing contracts
-	for ref := range contractRefs {
-		if _, ok := allContracts[ref]; !ok {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: pipeline references contract %s which is not in embedded defaults\n", ref)
-		}
-	}
-
-	// Filter prompts to only referenced ones
-	prompts = make(map[string]string)
-	for key, content := range allPrompts {
-		if promptRefs[key] {
-			prompts[key] = content
-		}
-	}
-
-	return contracts, prompts, personaConfigs
-}
+// --- Orchestration ---
 
 func runInit(cmd *cobra.Command, opts InitOptions) error {
-	// Handle --reconfigure: clear onboarding state and re-run wizard
 	if opts.Reconfigure {
 		return runReconfigure(cmd, opts)
 	}
 
-	// Determine if we should run the interactive wizard
-	interactive := !opts.Yes && isInitInteractive()
+	interactive := !opts.Yes && onboarding.IsInteractive()
 	if interactive && !opts.Force && !opts.Merge {
 		return runWizardInit(cmd, opts)
 	}
 
-	// Cold-start: ensure git repo exists
-	if err := ensureGitRepo(cmd.ErrOrStderr()); err != nil {
+	if err := onboarding.EnsureGitRepo(cmd.ErrOrStderr()); err != nil {
 		return err
 	}
 
-	// Get absolute path for clearer error messages
 	absOutputPath, err := filepath.Abs(opts.OutputPath)
 	if err != nil {
 		absOutputPath = opts.OutputPath
@@ -310,7 +85,6 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 
 	if fileExists {
 		if opts.Force && !opts.Merge {
-			// --force (without --merge): warn and require confirmation before destructive overwrite
 			if !opts.Yes {
 				confirmed, err := confirmForceOverwrite(cmd, absOutputPath)
 				if err != nil {
@@ -320,105 +94,22 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 					return fmt.Errorf("aborted: force overwrite cancelled (use --merge to preserve custom settings)")
 				}
 			}
-			// Check file permissions before overwriting
 			if existingFile.Mode().Perm()&0200 == 0 {
 				return fmt.Errorf("cannot overwrite %s: file is read-only", absOutputPath)
 			}
 		} else {
-			// Default behavior when wave.yaml exists: merge
-			// Explicit --merge flag, --merge --force combo, or implicit default all route here.
-			// When --force is combined with --merge, it acts as a prompt-skip modifier
-			// (handled by confirmMerge which checks opts.Force).
 			return runMerge(cmd, opts, absOutputPath)
 		}
 	}
 
-	// Create .wave directory structure
-	waveDirs := []string{
-		".agents/personas",
-		".agents/pipelines",
-		".agents/contracts",
-		".agents/prompts",
-		".agents/traces",
-		".agents/workspaces",
-	}
-	for _, dir := range waveDirs {
-		absDir, _ := filepath.Abs(dir)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("failed to create directory %s: %w", absDir, err)
-		}
-	}
-
-	// Detect project flavour
-	cwd, _ := os.Getwd()
-	flavour := onboarding.DetectFlavour(cwd)
-	project := flavourToProjectMap(flavour)
-
-	// Get filtered assets based on --all flag (needed for persona configs in manifest)
-	assets, err := getFilteredAssets(cmd, opts)
+	assets, flavour, err := onboarding.Greenfield(onboarding.GreenfieldOpts{
+		Adapter:    opts.Adapter,
+		Workspace:  opts.Workspace,
+		OutputPath: opts.OutputPath,
+		All:        opts.All,
+		Stderr:     cmd.ErrOrStderr(),
+	})
 	if err != nil {
-		return err
-	}
-
-	// Filter personas by detected forge
-	forgeInfo, _ := forge.DetectFromGitRemotes()
-	assets.personaConfigs = filterPersonasByForge(assets.personaConfigs, forgeInfo.Type)
-
-	// Extract project metadata for manifest name/description
-	meta := onboarding.ExtractProjectMetadata(cwd)
-
-	manifest := createDefaultManifest(opts.Adapter, opts.Workspace, project, assets.personaConfigs)
-
-	// Override default metadata with extracted values
-	if metaMap, ok := manifest["metadata"].(map[string]interface{}); ok {
-		if meta.Name != "" {
-			metaMap["name"] = meta.Name
-		}
-		if meta.Description != "" {
-			metaMap["description"] = meta.Description
-		}
-	}
-
-	manifestData, err := yaml.Marshal(manifest)
-	if err != nil {
-		return fmt.Errorf("failed to marshal manifest: %w", err)
-	}
-
-	// Ensure parent directory exists for custom output path
-	outputDir := filepath.Dir(opts.OutputPath)
-	if outputDir != "." && outputDir != "" {
-		absOutputDir, _ := filepath.Abs(outputDir)
-		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return fmt.Errorf("failed to create output directory %s: %w", absOutputDir, err)
-		}
-	}
-
-	if err := os.WriteFile(opts.OutputPath, manifestData, 0644); err != nil {
-		return fmt.Errorf("failed to write manifest to %s: %w", absOutputPath, err)
-	}
-
-	if err := createExamplePersonas(assets.personas); err != nil {
-		return fmt.Errorf("failed to create example personas in .agents/personas/: %w", err)
-	}
-
-	if err := createExamplePipelines(assets.pipelines); err != nil {
-		return fmt.Errorf("failed to create example pipelines in .agents/pipelines/: %w", err)
-	}
-
-	if err := createExampleContracts(assets.contracts); err != nil {
-		return fmt.Errorf("failed to create example contracts in .agents/contracts/: %w", err)
-	}
-
-	if err := createExamplePrompts(assets.prompts); err != nil {
-		return fmt.Errorf("failed to create example prompts in .agents/prompts/: %w", err)
-	}
-
-	if err := createProjectInstructionFiles(); err != nil {
-		return fmt.Errorf("failed to create project instruction files: %w", err)
-	}
-
-	// Cold-start: create initial commit if no commits exist
-	if err := createInitialCommit(cmd.ErrOrStderr(), opts.OutputPath); err != nil {
 		return err
 	}
 
@@ -428,42 +119,35 @@ func runInit(cmd *cobra.Command, opts InitOptions) error {
 }
 
 func runMerge(cmd *cobra.Command, opts InitOptions, absOutputPath string) error {
-	// Read existing manifest
 	existingData, err := os.ReadFile(opts.OutputPath)
 	if err != nil {
 		return fmt.Errorf("failed to read existing manifest %s: %w", absOutputPath, err)
 	}
 
-	// Parse existing manifest — abort on parse failure (FR-013)
 	var existingManifest map[string]interface{}
 	if err := yaml.Unmarshal(existingData, &existingManifest); err != nil {
 		return fmt.Errorf("failed to parse existing manifest %s: %w", absOutputPath, err)
 	}
 
-	// Get filtered assets
 	cwd, _ := os.Getwd()
 	flavour := onboarding.DetectFlavour(cwd)
-	project := flavourToProjectMap(flavour)
-	assets, err := getFilteredAssets(cmd, opts)
+	project := onboarding.FlavourToProjectMap(flavour)
+	assets, err := onboarding.LoadAssets(cmd.ErrOrStderr(), onboarding.AssetOptions{All: opts.All})
 	if err != nil {
 		return err
 	}
 
-	defaultManifest := createDefaultManifest(opts.Adapter, opts.Workspace, project, assets.personaConfigs)
+	defaultManifest := onboarding.BuildDefaultManifest(opts.Adapter, opts.Workspace, project, assets.PersonaConfigs)
 
-	// Pre-mutation: compute all changes
-	summary := computeChangeSummary(assets, existingManifest, defaultManifest)
+	summary := onboarding.ComputeChangeSummary(assets, existingManifest, defaultManifest)
 
-	// Check if already up to date (US1-AS4)
 	if summary.AlreadyUpToDate {
 		fmt.Fprintf(cmd.ErrOrStderr(), "\n  Already up to date — no changes needed.\n\n")
 		return nil
 	}
 
-	// Display change summary to stderr (FR-001, FR-006)
-	displayChangeSummary(cmd.ErrOrStderr(), summary)
+	onboarding.DisplayChangeSummary(cmd.ErrOrStderr(), summary)
 
-	// Confirm merge (FR-002, FR-007, FR-008, FR-014)
 	confirmed, err := confirmMerge(cmd, opts)
 	if err != nil {
 		return err
@@ -472,8 +156,7 @@ func runMerge(cmd *cobra.Command, opts InitOptions, absOutputPath string) error 
 		return fmt.Errorf("aborted: merge cancelled by user")
 	}
 
-	// Apply changes (FR-003, FR-004, FR-005)
-	if err := applyChanges(summary, opts.OutputPath); err != nil {
+	if err := onboarding.ApplyChanges(summary, opts.OutputPath); err != nil {
 		return err
 	}
 
@@ -481,8 +164,9 @@ func runMerge(cmd *cobra.Command, opts InitOptions, absOutputPath string) error 
 	return nil
 }
 
+// --- Interactive prompts (stay in cmd: they touch cobra streams) ---
+
 func confirmOverwrite(cmd *cobra.Command, path string) (bool, error) {
-	// If not running interactively, don't prompt
 	if cmd.InOrStdin() == nil {
 		return false, nil
 	}
@@ -499,9 +183,6 @@ func confirmOverwrite(cmd *cobra.Command, path string) (bool, error) {
 	return response == "y" || response == "yes", nil
 }
 
-// confirmForceOverwrite prints a warning about data loss and asks for confirmation.
-// This is used when --force is specified to ensure the user understands that custom
-// personas, adapter configurations, and ontology settings will be lost.
 func confirmForceOverwrite(cmd *cobra.Command, path string) (bool, error) {
 	if cmd.InOrStdin() == nil {
 		return false, nil
@@ -525,377 +206,12 @@ func confirmForceOverwrite(cmd *cobra.Command, path string) (bool, error) {
 	return response == "y" || response == "yes", nil
 }
 
-func mergeManifests(defaults, existing map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	// Copy all default values first
-	for k, v := range defaults {
-		result[k] = v
-	}
-
-	// Override with existing values, merging nested maps
-	for k, v := range existing {
-		if existingMap, isMap := v.(map[string]interface{}); isMap {
-			if defaultMap, isDefaultMap := result[k].(map[string]interface{}); isDefaultMap {
-				// Deep merge for maps
-				result[k] = mergeMaps(defaultMap, existingMap)
-			} else {
-				result[k] = v
-			}
-		} else {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
-func mergeMaps(defaults, existing map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	// Copy all default values
-	for k, v := range defaults {
-		result[k] = v
-	}
-
-	// Override/add existing values
-	for k, v := range existing {
-		if existingMap, isMap := v.(map[string]interface{}); isMap {
-			if defaultMap, isDefaultMap := result[k].(map[string]interface{}); isDefaultMap {
-				result[k] = mergeMaps(defaultMap, existingMap)
-			} else {
-				result[k] = v
-			}
-		} else {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
-// mergeTypedManifests merges a generated manifest into an existing one,
-// preserving custom settings from the existing manifest while updating
-// infrastructure defaults from the generated manifest.
-//
-// Preservation rules:
-//   - Custom personas (not in generated) are preserved
-//   - Custom adapter configurations are preserved
-//   - Ontology section is preserved entirely from existing
-//   - Metadata.Name is preserved if already set
-//   - Metadata.Description is preserved if already set
-//   - apiVersion, kind, and runtime settings are updated from generated
-func mergeTypedManifests(existing, generated *manifest.Manifest) *manifest.Manifest {
-	result := &manifest.Manifest{}
-
-	// Update infrastructure defaults from generated
-	result.APIVersion = generated.APIVersion
-	result.Kind = generated.Kind
-
-	// Preserve metadata from existing if set, otherwise use generated
-	result.Metadata = generated.Metadata
-	if existing.Metadata.Name != "" {
-		result.Metadata.Name = existing.Metadata.Name
-	}
-	if existing.Metadata.Description != "" {
-		result.Metadata.Description = existing.Metadata.Description
-	}
-	if existing.Metadata.Repo != "" {
-		result.Metadata.Repo = existing.Metadata.Repo
-	}
-	if existing.Metadata.Forge != "" {
-		result.Metadata.Forge = existing.Metadata.Forge
-	}
-
-	// Merge adapters: generated as base, existing overrides/adds
-	result.Adapters = make(map[string]manifest.Adapter)
-	for name, adapter := range generated.Adapters {
-		result.Adapters[name] = adapter
-	}
-	for name, adapter := range existing.Adapters {
-		result.Adapters[name] = adapter
-	}
-
-	// Merge personas: generated as base, existing overrides/adds
-	// Custom personas (not in generated) are preserved
-	result.Personas = make(map[string]manifest.Persona)
-	for name, persona := range generated.Personas {
-		result.Personas[name] = persona
-	}
-	for name, persona := range existing.Personas {
-		result.Personas[name] = persona
-	}
-
-	// Preserve ontology section entirely from existing if present
-	if existing.Ontology != nil {
-		result.Ontology = existing.Ontology
-	} else {
-		result.Ontology = generated.Ontology
-	}
-
-	// Preserve project section from existing if present
-	if existing.Project != nil {
-		result.Project = existing.Project
-	} else {
-		result.Project = generated.Project
-	}
-
-	// Update runtime settings from generated
-	result.Runtime = generated.Runtime
-
-	// Preserve server config from existing if set
-	if existing.Server != nil {
-		result.Server = existing.Server
-	} else {
-		result.Server = generated.Server
-	}
-
-	// Merge skills: combine both sets, deduplicate
-	skillSet := make(map[string]bool)
-	for _, s := range generated.Skills {
-		skillSet[s] = true
-	}
-	for _, s := range existing.Skills {
-		skillSet[s] = true
-	}
-	if len(skillSet) > 0 {
-		result.Skills = make([]string, 0, len(skillSet))
-		for s := range skillSet {
-			result.Skills = append(result.Skills, s)
-		}
-		sort.Strings(result.Skills)
-	}
-
-	// Preserve hooks from existing if set
-	if len(existing.Hooks) > 0 {
-		result.Hooks = existing.Hooks
-	} else {
-		result.Hooks = generated.Hooks
-	}
-
-	return result
-}
-
-// computeChangeSummary builds a pre-mutation change report by comparing on-disk
-// files with embedded defaults and computing the manifest diff.
-func computeChangeSummary(assets *initAssets, existingManifest, defaultManifest map[string]interface{}) *ChangeSummary {
-	var files []FileChangeEntry
-
-	// Helper to classify a file
-	classifyFile := func(path, category, defaultContent string) FileChangeEntry {
-		entry := FileChangeEntry{
-			RelPath:  path,
-			Category: category,
-		}
-		existing, err := os.ReadFile(path)
-		switch {
-		case err != nil:
-			entry.Status = FileStatusNew
-		case bytes.Equal(existing, []byte(defaultContent)):
-			entry.Status = FileStatusUpToDate
-		default:
-			entry.Status = FileStatusPreserved
-		}
-		return entry
-	}
-
-	// Check personas
-	for filename, content := range assets.personas {
-		path := filepath.Join(".agents", "personas", filename)
-		files = append(files, classifyFile(path, "persona", content))
-	}
-
-	// Check pipelines
-	for filename, content := range assets.pipelines {
-		path := filepath.Join(".agents", "pipelines", filename)
-		files = append(files, classifyFile(path, "pipeline", content))
-	}
-
-	// Check contracts
-	for filename, content := range assets.contracts {
-		path := filepath.Join(".agents", "contracts", filename)
-		files = append(files, classifyFile(path, "contract", content))
-	}
-
-	// Check prompts
-	for relPath, content := range assets.prompts {
-		path := filepath.Join(".agents", "prompts", relPath)
-		files = append(files, classifyFile(path, "prompt", content))
-	}
-
-	// Sort for deterministic output
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].RelPath < files[j].RelPath
-	})
-
-	// Compute manifest diff
-	merged, manifestChanges := computeManifestDiff(defaultManifest, existingManifest)
-
-	// Determine if already up to date: no new files AND no added manifest keys
-	alreadyUpToDate := true
-	for _, f := range files {
-		if f.Status == FileStatusNew {
-			alreadyUpToDate = false
-			break
-		}
-	}
-	if alreadyUpToDate {
-		for _, mc := range manifestChanges {
-			if mc.Action == ManifestActionAdded {
-				alreadyUpToDate = false
-				break
-			}
-		}
-	}
-
-	return &ChangeSummary{
-		Files:           files,
-		ManifestChanges: manifestChanges,
-		MergedManifest:  merged,
-		Assets:          assets,
-		AlreadyUpToDate: alreadyUpToDate,
-	}
-}
-
-// computeManifestDiff performs the manifest merge and tracks what changed.
-func computeManifestDiff(defaults, existing map[string]interface{}) (map[string]interface{}, []ManifestChangeEntry) {
-	merged := mergeManifests(defaults, existing)
-	var changes []ManifestChangeEntry
-	collectManifestDiff("", defaults, existing, &changes)
-
-	sort.Slice(changes, func(i, j int) bool {
-		return changes[i].KeyPath < changes[j].KeyPath
-	})
-	return merged, changes
-}
-
-// collectManifestDiff recursively walks default and existing manifests, recording
-// keys that were added (from defaults) or preserved (user value kept).
-func collectManifestDiff(prefix string, defaults, existing map[string]interface{}, entries *[]ManifestChangeEntry) {
-	for key, defaultVal := range defaults {
-		path := key
-		if prefix != "" {
-			path = prefix + "." + key
-		}
-
-		existingVal, exists := existing[key]
-		if !exists {
-			// Key in defaults but not in existing → added
-			*entries = append(*entries, ManifestChangeEntry{
-				KeyPath: path,
-				Action:  ManifestActionAdded,
-			})
-			continue
-		}
-
-		// Key exists in both — recurse if both are maps
-		defaultMap, defaultIsMap := defaultVal.(map[string]interface{})
-		existingMap, existingIsMap := existingVal.(map[string]interface{})
-
-		if defaultIsMap && existingIsMap {
-			collectManifestDiff(path, defaultMap, existingMap, entries)
-		} else if fmt.Sprintf("%v", defaultVal) != fmt.Sprintf("%v", existingVal) {
-			// Values differ → user value is preserved
-			*entries = append(*entries, ManifestChangeEntry{
-				KeyPath: path,
-				Action:  ManifestActionPreserved,
-			})
-		}
-	}
-
-	// User-only keys (not in defaults) are preserved
-	for key := range existing {
-		if _, inDefaults := defaults[key]; !inDefaults {
-			path := key
-			if prefix != "" {
-				path = prefix + "." + key
-			}
-			*entries = append(*entries, ManifestChangeEntry{
-				KeyPath: path,
-				Action:  ManifestActionPreserved,
-			})
-		}
-	}
-}
-
-// displayChangeSummary renders the ChangeSummary as a categorized table to the
-// given writer (typically stderr).
-func displayChangeSummary(w io.Writer, summary *ChangeSummary) {
-	fmt.Fprintf(w, "\n  Change Summary:\n\n")
-
-	categories := []struct {
-		name  string
-		label string
-	}{
-		{"persona", "Personas"},
-		{"pipeline", "Pipelines"},
-		{"contract", "Contracts"},
-		{"prompt", "Prompts"},
-	}
-
-	for _, cat := range categories {
-		var catFiles []FileChangeEntry
-		for _, f := range summary.Files {
-			if f.Category == cat.name {
-				catFiles = append(catFiles, f)
-			}
-		}
-		if len(catFiles) == 0 {
-			continue
-		}
-
-		fmt.Fprintf(w, "  %s:\n", cat.label)
-		for _, f := range catFiles {
-			var status string
-			switch f.Status {
-			case FileStatusNew:
-				status = "+ new"
-			case FileStatusPreserved:
-				status = "~ preserved"
-			case FileStatusUpToDate:
-				status = "= up to date"
-			}
-			fmt.Fprintf(w, "    %-14s %s\n", status, f.RelPath)
-		}
-		fmt.Fprintf(w, "\n")
-	}
-
-	// Show manifest changes
-	added := 0
-	preserved := 0
-	for _, mc := range summary.ManifestChanges {
-		if mc.Action == ManifestActionAdded {
-			added++
-		} else {
-			preserved++
-		}
-	}
-
-	if len(summary.ManifestChanges) > 0 {
-		fmt.Fprintf(w, "  Manifest (wave.yaml):\n")
-		for _, mc := range summary.ManifestChanges {
-			var action string
-			switch mc.Action {
-			case ManifestActionAdded:
-				action = "+ added"
-			case ManifestActionPreserved:
-				action = "~ preserved"
-			}
-			fmt.Fprintf(w, "    %-14s %s\n", action, mc.KeyPath)
-		}
-		fmt.Fprintf(w, "\n")
-	}
-}
-
-// confirmMerge prompts the user for confirmation before applying merge changes.
-// Skips the prompt when --yes or --force is specified. Requires --yes or --force
-// in non-interactive terminals (FR-002, FR-014).
 func confirmMerge(cmd *cobra.Command, opts InitOptions) (bool, error) {
 	if opts.Yes || opts.Force {
 		return true, nil
 	}
 
-	if !isInitInteractive() {
+	if !onboarding.IsInteractive() {
 		return false, fmt.Errorf("non-interactive terminal detected: use --yes or --force to proceed without confirmation")
 	}
 
@@ -911,477 +227,15 @@ func confirmMerge(cmd *cobra.Command, opts InitOptions) (bool, error) {
 	return response == "y" || response == "yes", nil
 }
 
-// applyChanges writes only "new" files from the ChangeSummary and writes the
-// merged manifest. Files with status "preserved" or "up_to_date" are not touched.
-func applyChanges(summary *ChangeSummary, outputPath string) error {
-	// Ensure directories exist
-	waveDirs := []string{
-		".agents/personas",
-		".agents/pipelines",
-		".agents/contracts",
-		".agents/prompts",
-		".agents/traces",
-		".agents/workspaces",
-	}
-	for _, dir := range waveDirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			absDir, _ := filepath.Abs(dir)
-			return fmt.Errorf("failed to create directory %s: %w", absDir, err)
-		}
-	}
+// --- Wizard / reconfigure orchestration ---
 
-	// Write only "new" files
-	for _, f := range summary.Files {
-		if f.Status != FileStatusNew {
-			continue
-		}
-
-		var content string
-		switch f.Category {
-		case "persona":
-			content = summary.Assets.personas[filepath.Base(f.RelPath)]
-		case "pipeline":
-			content = summary.Assets.pipelines[filepath.Base(f.RelPath)]
-		case "contract":
-			content = summary.Assets.contracts[filepath.Base(f.RelPath)]
-		case "prompt":
-			promptPrefix := filepath.Join(".agents", "prompts") + string(filepath.Separator)
-			relPath := strings.TrimPrefix(f.RelPath, promptPrefix)
-			content = summary.Assets.prompts[relPath]
-		}
-
-		// Ensure parent directory exists (for prompts with subdirs)
-		if err := os.MkdirAll(filepath.Dir(f.RelPath), 0755); err != nil {
-			absPath, _ := filepath.Abs(f.RelPath)
-			return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
-		}
-
-		if err := os.WriteFile(f.RelPath, []byte(content), 0644); err != nil {
-			absPath, _ := filepath.Abs(f.RelPath)
-			return fmt.Errorf("failed to write %s: %w", absPath, err)
-		}
-	}
-
-	// Write merged manifest
-	mergedData, err := yaml.Marshal(summary.MergedManifest)
-	if err != nil {
-		return fmt.Errorf("failed to marshal merged manifest: %w", err)
-	}
-
-	if err := os.WriteFile(outputPath, mergedData, 0644); err != nil {
-		absPath, _ := filepath.Abs(outputPath)
-		return fmt.Errorf("failed to write manifest to %s: %w", absPath, err)
-	}
-
-	return nil
-}
-
-func printInitSuccess(cmd *cobra.Command, outputPath string, assets *initAssets) {
-	out := cmd.OutOrStdout()
-
-	// Get sorted pipeline names for display
-	pipelineNames := make([]string, 0, len(assets.pipelines))
-	for name := range assets.pipelines {
-		pipelineNames = append(pipelineNames, strings.TrimSuffix(name, ".yaml"))
-	}
-	sort.Strings(pipelineNames)
-
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  ╦ ╦╔═╗╦  ╦╔═╗\n")
-	fmt.Fprintf(out, "  ║║║╠═╣╚╗╔╝║╣ \n")
-	fmt.Fprintf(out, "  ╚╩╝╩ ╩ ╚╝ ╚═╝\n")
-	fmt.Fprintf(out, "  Multi-Agent Pipeline Orchestrator\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Project initialized successfully!\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Created:\n")
-	fmt.Fprintf(out, "    %-24s Main manifest\n", outputPath)
-	fmt.Fprintf(out, "    .agents/personas/          %d persona archetypes\n", len(assets.personas))
-	fmt.Fprintf(out, "    .agents/pipelines/         %d pipelines\n", len(assets.pipelines))
-	fmt.Fprintf(out, "    .agents/contracts/         %d JSON schema validators\n", len(assets.contracts))
-	fmt.Fprintf(out, "    .agents/prompts/           %d prompt templates\n", len(assets.prompts))
-	fmt.Fprintf(out, "    .agents/workspaces/        Ephemeral workspace root\n")
-	fmt.Fprintf(out, "    .agents/traces/            Audit log directory\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Pipelines: %s\n", strings.Join(pipelineNames, ", "))
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Next steps:\n")
-	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
-	fmt.Fprintf(out, "    2. Run 'wave run ops-hello-world \"test\"' to verify setup\n")
-	fmt.Fprintf(out, "    3. Run 'wave run plan-task \"your feature\"' to plan a task\n")
-	fmt.Fprintf(out, "\n")
-}
-
-func printMergeSuccess(cmd *cobra.Command, outputPath string) {
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  ╦ ╦╔═╗╦  ╦╔═╗\n")
-	fmt.Fprintf(out, "  ║║║╠═╣╚╗╔╝║╣ \n")
-	fmt.Fprintf(out, "  ╚╩╝╩ ╩ ╚╝ ╚═╝\n")
-	fmt.Fprintf(out, "  Multi-Agent Pipeline Orchestrator\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Configuration merged successfully!\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Updated:\n")
-	fmt.Fprintf(out, "    %s       Preserved your settings\n", outputPath)
-	fmt.Fprintf(out, "    Added missing default adapters and personas\n")
-	fmt.Fprintf(out, "    Created missing .agents/ directories and files\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Next steps:\n")
-	fmt.Fprintf(out, "    1. Run 'wave migrate up' to apply pending migrations\n")
-	fmt.Fprintf(out, "    2. Run 'wave validate' to check configuration\n")
-	fmt.Fprintf(out, "\n")
-}
-
-func buildPersonaManifest(configs map[string]manifest.Persona, adapter string) map[string]interface{} {
-	result := make(map[string]interface{})
-	for name, cfg := range configs {
-		entry := map[string]interface{}{
-			"adapter":            adapter,
-			"description":        cfg.Description,
-			"system_prompt_file": fmt.Sprintf(".agents/personas/%s.md", name),
-			"temperature":        cfg.Temperature,
-			"permissions": map[string]interface{}{
-				"allowed_tools": cfg.Permissions.AllowedTools,
-				"deny":          cfg.Permissions.Deny,
-			},
-		}
-		if cfg.Model != "" {
-			entry["model"] = cfg.Model
-		}
-		result[name] = entry
-	}
-	return result
-}
-
-func createDefaultManifest(adapter string, workspace string, project map[string]interface{}, personaConfigs map[string]manifest.Persona) map[string]interface{} {
-	adapterProjectFiles := map[string][]string{
-		"claude":   {"AGENTS.md"},
-		"opencode": {"AGENTS.md"},
-		"gemini":   {"AGENTS.md"},
-		"codex":    {"AGENTS.md"},
-	}
-
-	adapterDefaults := map[string]string{
-		"claude":   "sonnet",
-		"opencode": "zai-coding-plan/glm-5-turbo",
-		"gemini":   "gemini-2.5-flash-lite",
-		"codex":    "o3",
-	}
-
-	adapters := map[string]interface{}{}
-	for name, projectFiles := range adapterProjectFiles {
-		entry := map[string]interface{}{
-			"binary":        name,
-			"default_model": adapterDefaults[name],
-			"mode":          "headless",
-			"output_format": "json",
-			"project_files": projectFiles,
-			"default_permissions": map[string]interface{}{
-				"allowed_tools": []string{"Read", "Write", "Edit", "Bash"},
-				"deny":          []string{},
-			},
-		}
-		adapters[name] = entry
-	}
-
-	manifest := map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "WaveManifest",
-		"metadata": map[string]interface{}{
-			"name":        "wave-project",
-			"description": "A Wave multi-agent project",
-		},
-		"adapters": adapters,
-		"personas": buildPersonaManifest(personaConfigs, adapter),
-		"runtime": map[string]interface{}{
-			"workspace_root":          workspace,
-			"max_concurrent_workers":  5,
-			"default_timeout_minutes": 30,
-			"relay": map[string]interface{}{
-				"token_threshold_percent": 80,
-				"strategy":                "summarize_to_checkpoint",
-			},
-			"audit": map[string]interface{}{
-				"log_dir":                 ".agents/traces/",
-				"log_all_tool_calls":      true,
-				"log_all_file_operations": false,
-			},
-			"meta_pipeline": map[string]interface{}{
-				"max_depth":        2,
-				"max_total_steps":  20,
-				"max_total_tokens": 500000,
-				"timeout_minutes":  60,
-			},
-		},
-	}
-
-	if project != nil {
-		manifest["project"] = project
-	}
-
-	// Always include base quality context in ontology
-	manifest["ontology"] = map[string]interface{}{
-		"contexts": []map[string]interface{}{
-			{
-				"name":        "quality",
-				"description": "Validation and quality gates — first-pass failure is expected, rework is the norm",
-				"invariants": []string{
-					"First-pass success is the exception, not the rule — validation exists to catch and correct",
-					"Every pipeline output must pass through a validation gate before being considered done",
-					"Rework after review is not a failure — it is the expected path to quality",
-					"Contract validation, PR review, and test suites are gates, not formalities",
-				},
-			},
-		},
-	}
-
-	return manifest
-}
-
-func createExamplePersonas(personas map[string]string) error {
-	for filename, content := range personas {
-		path := filepath.Join(".agents", "personas", filename)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-			absPath, _ := filepath.Abs(path)
-			return fmt.Errorf("failed to write %s: %w", absPath, err)
-		}
-	}
-
-	return nil
-}
-
-func createExamplePipelines(pipelines map[string]string) error {
-	for filename, content := range pipelines {
-		path := filepath.Join(".agents", "pipelines", filename)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-			absPath, _ := filepath.Abs(path)
-			return fmt.Errorf("failed to write %s: %w", absPath, err)
-		}
-	}
-
-	return nil
-}
-
-func createExampleContracts(contracts map[string]string) error {
-	for filename, content := range contracts {
-		path := filepath.Join(".agents", "contracts", filename)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-			absPath, _ := filepath.Abs(path)
-			return fmt.Errorf("failed to write %s: %w", absPath, err)
-		}
-	}
-
-	return nil
-}
-
-func createExamplePrompts(prompts map[string]string) error {
-	for relPath, content := range prompts {
-		path := filepath.Join(".agents", "prompts", relPath)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			return fmt.Errorf("failed to create directory for %s: %w", path, err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-			absPath, _ := filepath.Abs(path)
-			return fmt.Errorf("failed to write %s: %w", absPath, err)
-		}
-	}
-
-	return nil
-}
-
-func createProjectInstructionFiles() error {
-	files := map[string]string{
-		"AGENTS.md": "See CLAUDE.md for project guidelines.",
-		"CLAUDE.md": "See AGENTS.md for project guidelines.",
-		"GEMINI.md": "See AGENTS.md for project guidelines.",
-		"CODEX.md":  "See AGENTS.md for project guidelines.",
-	}
-	for filename, content := range files {
-		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
-				return fmt.Errorf("failed to write %s: %w", filename, err)
-			}
-		}
-	}
-	return nil
-}
-
-// isInitInteractive returns true when stdin is a TTY and interactive prompts are possible.
-func isInitInteractive() bool {
-	if v := os.Getenv("WAVE_FORCE_TTY"); v != "" {
-		return v == "1" || v == "true"
-	}
-	return term.IsTerminal(int(os.Stdin.Fd()))
-}
-
-// ensureGitRepo checks if the current directory is inside a git repository and
-// initializes one if not. Uses git rev-parse to correctly detect parent repos.
-func ensureGitRepo(w io.Writer) error {
-	check := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	check.Stdout = io.Discard
-	check.Stderr = io.Discard
-	if check.Run() == nil {
-		return nil // already inside a git repo
-	}
-
-	fmt.Fprintf(w, "  Initializing git repository...\n")
-	cmd := exec.Command("git", "init")
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to initialize git repository: %w", err)
-	}
-	return nil
-}
-
-// createInitialCommit creates an initial commit with wave files if no commits
-// exist yet. This ensures worktree operations have at least one commit to work with.
-func createInitialCommit(w io.Writer, outputPath string) error {
-	// Check if any commits exist
-	check := exec.Command("git", "rev-parse", "HEAD")
-	check.Stdout = io.Discard
-	check.Stderr = io.Discard
-	if check.Run() == nil {
-		return nil // commits already exist
-	}
-
-	fmt.Fprintf(w, "  Creating initial commit...\n")
-
-	// Ensure git user is configured (may not exist in fresh repos / CI).
-	for _, kv := range [][2]string{
-		{"user.name", "wave"},
-		{"user.email", "wave@localhost"},
-	} {
-		check := exec.Command("git", "config", kv[0])
-		check.Stdout = io.Discard
-		check.Stderr = io.Discard
-		if check.Run() != nil {
-			cfg := exec.Command("git", "config", kv[0], kv[1])
-			cfg.Stdout = io.Discard
-			cfg.Stderr = io.Discard
-			_ = cfg.Run()
-		}
-	}
-
-	// Stage wave files specifically (not git add -A)
-	add := exec.Command("git", "add", outputPath, ".agents/")
-	add.Stdout = io.Discard
-	add.Stderr = io.Discard
-	if err := add.Run(); err != nil {
-		return fmt.Errorf("failed to stage wave files: %w", err)
-	}
-
-	// Explicitly disable commit signing for this invocation. If the user's
-	// global gpg config is broken (keyboxd issues) or misses a secret key,
-	// signing would fail and block cold-start onboarding. The initial
-	// Wave-managed commit should always land.
-	commit := exec.Command("git", "-c", "commit.gpgsign=false", "commit", "-m", "chore: initialize wave project")
-	commit.Stdout = io.Discard
-	commit.Stderr = io.Discard
-	if err := commit.Run(); err != nil {
-		return fmt.Errorf("failed to create initial commit: %w", err)
-	}
-	return nil
-}
-
-// flavourToProjectMap converts a FlavourInfo into the map[string]interface{}
-// format expected by createDefaultManifest.
-func flavourToProjectMap(fi *onboarding.FlavourInfo) map[string]interface{} {
-	if fi == nil {
-		return nil
-	}
-	m := map[string]interface{}{}
-	if fi.Flavour != "" {
-		m["flavour"] = fi.Flavour
-	}
-	if fi.Language != "" {
-		m["language"] = fi.Language
-	}
-	if fi.TestCommand != "" {
-		m["test_command"] = fi.TestCommand
-	}
-	if fi.LintCommand != "" {
-		m["lint_command"] = fi.LintCommand
-	}
-	if fi.BuildCommand != "" {
-		m["build_command"] = fi.BuildCommand
-	}
-	if fi.FormatCommand != "" {
-		m["format_command"] = fi.FormatCommand
-	}
-	if fi.SourceGlob != "" {
-		m["source_glob"] = fi.SourceGlob
-	}
-	if fi.Skill != "" {
-		m["skill"] = fi.Skill
-	}
-	return m
-}
-
-// knownForgePrefixes lists the prefixes used by forge-specific personas.
-var knownForgePrefixes = []string{"github-", "gitlab-", "bitbucket-", "gitea-"}
-
-// forgeTypeToPrefix maps forge types to their persona naming convention prefix.
-var forgeTypeToPrefix = map[forge.ForgeType]string{
-	forge.ForgeGitHub:    "github",
-	forge.ForgeGitLab:    "gitlab",
-	forge.ForgeBitbucket: "bitbucket",
-	forge.ForgeGitea:     "gitea",
-	forge.ForgeCodeberg:  "gitea", // Codeberg is Forgejo — shares Gitea personas
-}
-
-// filterPersonasByForge filters persona configs to only include personas
-// matching the detected forge type. Personas without a forge prefix are always included.
-func filterPersonasByForge(configs map[string]manifest.Persona, ft forge.ForgeType) map[string]manifest.Persona {
-	if ft == forge.ForgeUnknown {
-		return configs // no filtering when forge is unknown
-	}
-
-	prefix, ok := forgeTypeToPrefix[ft]
-	if !ok {
-		return configs
-	}
-
-	result := make(map[string]manifest.Persona)
-	for name, cfg := range configs {
-		hasKnownPrefix := false
-		for _, fp := range knownForgePrefixes {
-			if strings.HasPrefix(name, fp) {
-				hasKnownPrefix = true
-				break
-			}
-		}
-		// Include personas that match the forge prefix or have no forge prefix
-		if strings.HasPrefix(name, prefix+"-") || !hasKnownPrefix {
-			result[name] = cfg
-		}
-	}
-	return result
-}
-
-// suggestFirstRun prints a suggestion for what to run after init.
-func suggestFirstRun(w io.Writer, flavour *onboarding.FlavourInfo) {
-	if flavour == nil || flavour.SourceGlob == "" {
-		fmt.Fprintf(w, "  Suggestion: Run 'wave run ops-bootstrap' to scaffold your project\n")
-		return
-	}
-
-	// Flavour was detected so source files exist — suggest analysis over scaffolding.
-	fmt.Fprintf(w, "  Suggestion: Run 'wave run audit-architecture' to analyze your codebase\n")
-}
-
-// runWizardInit runs the interactive onboarding wizard for first-time setup.
 func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
-	// Cold-start: ensure git repo exists
-	if err := ensureGitRepo(cmd.ErrOrStderr()); err != nil {
+	if err := onboarding.EnsureGitRepo(cmd.ErrOrStderr()); err != nil {
 		return err
 	}
 
-	// Print Wave logo
 	fmt.Fprintln(cmd.OutOrStdout(), tui.WaveLogo())
 
-	// Check if wave.yaml already exists
 	var existing *manifest.Manifest
 	if data, err := os.ReadFile(opts.OutputPath); err == nil {
 		var m manifest.Manifest
@@ -1390,7 +244,6 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 		}
 	}
 
-	// If file exists and not forcing, prompt for confirmation
 	if existing != nil && !opts.Force {
 		confirmed, err := confirmOverwrite(cmd, opts.OutputPath)
 		if err != nil {
@@ -1401,40 +254,16 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 		}
 	}
 
-	// Create .wave directory structure
-	waveDirs := []string{
-		".agents/personas",
-		".agents/pipelines",
-		".agents/contracts",
-		".agents/prompts",
-		".agents/traces",
-		".agents/workspaces",
-		".claude/commands",
-	}
-	for _, dir := range waveDirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			absDir, _ := filepath.Abs(dir)
-			return fmt.Errorf("failed to create directory %s: %w", absDir, err)
-		}
-	}
-
-	// Copy default assets before running wizard (so pipeline selection can discover them)
-	assets, err := getFilteredAssets(cmd, opts)
+	assets, err := onboarding.PrepareWizard(onboarding.WizardOpts{
+		Adapter:    opts.Adapter,
+		Workspace:  opts.Workspace,
+		OutputPath: opts.OutputPath,
+		All:        opts.All,
+		Existing:   existing,
+		Stderr:     cmd.ErrOrStderr(),
+	})
 	if err != nil {
 		return err
-	}
-
-	if err := createExamplePersonas(assets.personas); err != nil {
-		return fmt.Errorf("failed to create example personas: %w", err)
-	}
-	if err := createExamplePipelines(assets.pipelines); err != nil {
-		return fmt.Errorf("failed to create example pipelines: %w", err)
-	}
-	if err := createExampleContracts(assets.contracts); err != nil {
-		return fmt.Errorf("failed to create example contracts: %w", err)
-	}
-	if err := createExamplePrompts(assets.prompts); err != nil {
-		return fmt.Errorf("failed to create example prompts: %w", err)
 	}
 
 	cfg := onboarding.WizardConfig{
@@ -1446,7 +275,7 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 		Adapter:        opts.Adapter,
 		Workspace:      opts.Workspace,
 		OutputPath:     opts.OutputPath,
-		PersonaConfigs: assets.personaConfigs,
+		PersonaConfigs: assets.PersonaConfigs,
 	}
 
 	result, err := onboarding.RunWizard(cfg)
@@ -1454,15 +283,13 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 		return fmt.Errorf("onboarding wizard failed: %w", err)
 	}
 
-	// Remove deselected pipelines
 	if len(result.Pipelines) > 0 {
-		if err := removeDeselectedPipelines(".agents/pipelines", result.Pipelines); err != nil {
+		if err := onboarding.RemoveDeselectedPipelines(".agents/pipelines", result.Pipelines); err != nil {
 			return fmt.Errorf("failed to remove deselected pipelines: %w", err)
 		}
 	}
 
-	// Cold-start: create initial commit if no commits exist
-	if err := createInitialCommit(cmd.ErrOrStderr(), opts.OutputPath); err != nil {
+	if err := onboarding.CreateInitialCommit(cmd.ErrOrStderr(), opts.OutputPath); err != nil {
 		return err
 	}
 
@@ -1470,9 +297,7 @@ func runWizardInit(cmd *cobra.Command, opts InitOptions) error {
 	return nil
 }
 
-// runReconfigure re-runs the wizard with existing values as defaults.
 func runReconfigure(cmd *cobra.Command, opts InitOptions) error {
-	// Read existing manifest
 	data, err := os.ReadFile(opts.OutputPath)
 	if err != nil {
 		return fmt.Errorf("cannot reconfigure: %s not found\nRun 'wave init' first", opts.OutputPath)
@@ -1483,15 +308,12 @@ func runReconfigure(cmd *cobra.Command, opts InitOptions) error {
 		return fmt.Errorf("failed to parse existing manifest: %w", err)
 	}
 
-	// Clear onboarding state so the wizard runs fresh
 	_ = onboarding.ClearOnboarding(".agents")
 
-	interactive := !opts.Yes && isInitInteractive()
+	interactive := !opts.Yes && onboarding.IsInteractive()
 
-	// Print Wave logo
 	fmt.Fprintln(cmd.OutOrStdout(), tui.WaveLogo())
 
-	// Extract persona configs from existing manifest for buildManifest
 	personaConfigs := make(map[string]manifest.Persona)
 	for name, p := range existing.Personas {
 		personaConfigs[name] = p
@@ -1513,9 +335,8 @@ func runReconfigure(cmd *cobra.Command, opts InitOptions) error {
 	if err != nil {
 		return fmt.Errorf("reconfiguration failed: %w", err)
 	}
-	// Remove deselected pipelines
 	if len(result.Pipelines) > 0 {
-		if err := removeDeselectedPipelines(".agents/pipelines", result.Pipelines); err != nil {
+		if err := onboarding.RemoveDeselectedPipelines(".agents/pipelines", result.Pipelines); err != nil {
 			return fmt.Errorf("failed to remove deselected pipelines: %w", err)
 		}
 	}
@@ -1524,52 +345,20 @@ func runReconfigure(cmd *cobra.Command, opts InitOptions) error {
 	return nil
 }
 
-// removeDeselectedPipelines deletes pipeline YAML files that are not in the selected list.
-func removeDeselectedPipelines(pipelinesDir string, selected []string) error { //nolint:unparam // error return kept for future use
-	keep := make(map[string]bool)
-	for _, name := range selected {
-		keep[name] = true
-	}
-	entries, err := os.ReadDir(pipelinesDir)
-	if err != nil {
-		return nil // no dir = nothing to remove
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := strings.TrimSuffix(e.Name(), ".yaml")
-		if name == e.Name() {
-			continue // not a .yaml file
-		}
-		if !keep[name] {
-			_ = os.Remove(filepath.Join(pipelinesDir, e.Name()))
-		}
-	}
-	return nil
+// --- Output formatting wrappers (delegate to internal/onboarding) ---
+
+func printInitSuccess(cmd *cobra.Command, outputPath string, assets *onboarding.AssetSet) {
+	onboarding.PrintInitSuccess(cmd.OutOrStdout(), outputPath, assets)
 }
 
-// printWizardSuccess shows a success message after wizard completion.
+func printMergeSuccess(cmd *cobra.Command, outputPath string) {
+	onboarding.PrintMergeSuccess(cmd.OutOrStdout(), outputPath)
+}
+
 func printWizardSuccess(cmd *cobra.Command, outputPath string, result *onboarding.WizardResult) {
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Onboarding complete!\n")
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Configuration:\n")
-	fmt.Fprintf(out, "    %-20s %s\n", "Manifest:", outputPath)
-	fmt.Fprintf(out, "    %-20s %s\n", "Adapter:", result.Adapter)
-	if result.Model != "" {
-		fmt.Fprintf(out, "    %-20s %s\n", "Model:", result.Model)
-	}
-	if result.Language != "" {
-		fmt.Fprintf(out, "    %-20s %s\n", "Language:", result.Language)
-	}
-	if len(result.Pipelines) > 0 {
-		fmt.Fprintf(out, "    %-20s %d selected\n", "Pipelines:", len(result.Pipelines))
-	}
-	fmt.Fprintf(out, "\n")
-	fmt.Fprintf(out, "  Next steps:\n")
-	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
-	fmt.Fprintf(out, "    2. Run 'wave run' to select and execute a pipeline\n")
-	fmt.Fprintf(out, "\n")
+	onboarding.PrintWizardSuccess(cmd.OutOrStdout(), outputPath, result)
+}
+
+func suggestFirstRun(w io.Writer, flavour *onboarding.FlavourInfo) {
+	onboarding.SuggestFirstRun(w, flavour)
 }

--- a/cmd/wave/commands/init_test.go
+++ b/cmd/wave/commands/init_test.go
@@ -1149,7 +1149,7 @@ func TestDetectProject(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
 			}
 
-			result := flavourToProjectMap(onboarding.DetectFlavour(dir))
+			result := onboarding.FlavourToProjectMap(onboarding.DetectFlavour(dir))
 
 			if tc.wantNil {
 				assert.Nil(t, result, "expected nil for unknown project")
@@ -1313,15 +1313,15 @@ func TestInitPersonaManifestMatchesConfig(t *testing.T) {
 func TestComputeChangeSummary(t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func(t *testing.T, assets *initAssets)
-		wantNewCount  int  // expected minimum count of FileStatusNew entries (-1 means all)
-		wantUpToDate  int  // expected minimum count of FileStatusUpToDate entries (-1 means all)
-		wantPreserved int  // expected minimum count of FileStatusPreserved entries
+		setup         func(t *testing.T, assets *onboarding.AssetSet)
+		wantNewCount  int  // expected minimum count of onboarding.FileStatusNew entries (-1 means all)
+		wantUpToDate  int  // expected minimum count of onboarding.FileStatusUpToDate entries (-1 means all)
+		wantPreserved int  // expected minimum count of onboarding.FileStatusPreserved entries
 		checkUpToDate bool // if true, assert summary.AlreadyUpToDate is true
 	}{
 		{
 			name: "all files new (fresh project)",
-			setup: func(t *testing.T, assets *initAssets) {
+			setup: func(t *testing.T, assets *onboarding.AssetSet) {
 				t.Helper()
 				// Only create wave.yaml — no .agents/ directory at all.
 				require.NoError(t, os.WriteFile("wave.yaml", []byte("apiVersion: v1\nkind: WaveManifest\n"), 0644))
@@ -1330,7 +1330,7 @@ func TestComputeChangeSummary(t *testing.T) {
 		},
 		{
 			name: "all files up-to-date",
-			setup: func(t *testing.T, assets *initAssets) {
+			setup: func(t *testing.T, assets *onboarding.AssetSet) {
 				t.Helper()
 				// Run a full init so every default file is on disk with default content
 				_, _, err := executeInitCmd()
@@ -1341,7 +1341,7 @@ func TestComputeChangeSummary(t *testing.T) {
 		},
 		{
 			name: "mixed states",
-			setup: func(t *testing.T, assets *initAssets) {
+			setup: func(t *testing.T, assets *onboarding.AssetSet) {
 				t.Helper()
 				// Run a full init first
 				_, _, err := executeInitCmd()
@@ -1353,7 +1353,7 @@ func TestComputeChangeSummary(t *testing.T) {
 					0644,
 				))
 				// Remove one pipeline to make it "new" on next check
-				for name := range assets.pipelines {
+				for name := range assets.Pipelines {
 					os.Remove(filepath.Join(".agents", "pipelines", name))
 					break // only remove one
 				}
@@ -1363,7 +1363,7 @@ func TestComputeChangeSummary(t *testing.T) {
 		},
 		{
 			name: "empty persona file treated as preserved",
-			setup: func(t *testing.T, assets *initAssets) {
+			setup: func(t *testing.T, assets *onboarding.AssetSet) {
 				t.Helper()
 				// Run a full init first
 				_, _, err := executeInitCmd()
@@ -1386,7 +1386,7 @@ func TestComputeChangeSummary(t *testing.T) {
 			defer env.cleanup()
 
 			cmd := NewInitCmd()
-			assets, err := getFilteredAssets(cmd, InitOptions{})
+			assets, err := onboarding.LoadAssets(cmd.ErrOrStderr(), onboarding.AssetOptions{})
 			require.NoError(t, err)
 
 			tc.setup(t, assets)
@@ -1400,8 +1400,8 @@ func TestComputeChangeSummary(t *testing.T) {
 				existingManifest = map[string]interface{}{}
 			}
 
-			defaultManifest := createDefaultManifest("claude", ".agents/workspaces", nil, assets.personaConfigs)
-			summary := computeChangeSummary(assets, existingManifest, defaultManifest)
+			defaultManifest := onboarding.BuildDefaultManifest("claude", ".agents/workspaces", nil, assets.PersonaConfigs)
+			summary := onboarding.ComputeChangeSummary(assets, existingManifest, defaultManifest)
 
 			require.NotNil(t, summary)
 			require.NotEmpty(t, summary.Files, "summary should contain file entries")
@@ -1410,11 +1410,11 @@ func TestComputeChangeSummary(t *testing.T) {
 			var newCount, upToDateCount, preservedCount int
 			for _, f := range summary.Files {
 				switch f.Status {
-				case FileStatusNew:
+				case onboarding.FileStatusNew:
 					newCount++
-				case FileStatusUpToDate:
+				case onboarding.FileStatusUpToDate:
 					upToDateCount++
-				case FileStatusPreserved:
+				case onboarding.FileStatusPreserved:
 					preservedCount++
 				}
 			}
@@ -1536,7 +1536,7 @@ func TestComputeManifestDiff(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			merged, changes := computeManifestDiff(tc.defaults, tc.existing)
+			merged, changes := onboarding.ComputeManifestDiff(tc.defaults, tc.existing)
 
 			require.NotNil(t, merged)
 
@@ -1545,9 +1545,9 @@ func TestComputeManifestDiff(t *testing.T) {
 			preservedKeys := make(map[string]bool)
 			for _, c := range changes {
 				switch c.Action {
-				case ManifestActionAdded:
+				case onboarding.ManifestActionAdded:
 					addedKeys[c.KeyPath] = true
-				case ManifestActionPreserved:
+				case onboarding.ManifestActionPreserved:
 					preservedKeys[c.KeyPath] = true
 				}
 			}
@@ -1608,10 +1608,10 @@ func TestInitMergeUpgradeLifecycle(t *testing.T) {
 
 	// Step 3b: Delete one pipeline to create a "new" entry for merge
 	cmd0 := NewInitCmd()
-	assets, err := getFilteredAssets(cmd0, InitOptions{})
+	assets, err := onboarding.LoadAssets(cmd0.ErrOrStderr(), onboarding.AssetOptions{})
 	require.NoError(t, err)
 	var removedPipeline string
-	for name := range assets.pipelines {
+	for name := range assets.Pipelines {
 		removed := filepath.Join(".agents", "pipelines", name)
 		os.Remove(removed)
 		removedPipeline = name
@@ -1900,9 +1900,9 @@ func TestInitMergeEdgeCases(t *testing.T) {
 
 		// Remove a pipeline to ensure there's a "new" entry
 		cmd0 := NewInitCmd()
-		assets, err := getFilteredAssets(cmd0, InitOptions{})
+		assets, err := onboarding.LoadAssets(cmd0.ErrOrStderr(), onboarding.AssetOptions{})
 		require.NoError(t, err)
-		for name := range assets.pipelines {
+		for name := range assets.Pipelines {
 			os.Remove(filepath.Join(".agents", "pipelines", name))
 			break // only remove one
 		}
@@ -1955,7 +1955,7 @@ steps:
 		"unrelated":         {Adapter: "claude"},
 	}
 
-	_, _, personaConfigs := filterTransitiveDeps(cmd, pipelines, nil, nil, allPersonaConfigs)
+	_, _, personaConfigs := onboarding.FilterTransitiveDeps(cmd.ErrOrStderr(), pipelines, nil, nil, allPersonaConfigs)
 
 	// All 4 forge variants should be included
 	assert.Contains(t, personaConfigs, "github-analyst", "github variant should be included")
@@ -2011,7 +2011,7 @@ func TestMergeTypedManifestsPreservesCustomPersonas(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	// Custom persona preserved
 	customAgent, hasCustom := result.Personas["custom-agent"]
@@ -2056,7 +2056,7 @@ func TestMergeTypedManifestsPreservesAdapters(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	// Custom adapter preserved
 	_, hasCustom := result.Adapters["custom-llm"]
@@ -2095,7 +2095,7 @@ func TestMergeTypedManifestsPreservesOntology(t *testing.T) {
 		// No ontology in generated
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	// Ontology preserved entirely from existing
 	require.NotNil(t, result.Ontology, "ontology should be preserved")
@@ -2128,7 +2128,7 @@ func TestMergeTypedManifestsUpdatesInfrastructure(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	// Infrastructure updated from generated
 	assert.Equal(t, "v1", result.APIVersion, "apiVersion should be updated from generated")
@@ -2159,7 +2159,7 @@ func TestMergeTypedManifestsPreservesMetadata(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	assert.Equal(t, "my-project", result.Metadata.Name, "name should be preserved from existing")
 	assert.Equal(t, "My custom description", result.Metadata.Description, "description should be preserved")
@@ -2194,7 +2194,7 @@ func TestMergeTypedManifestsEmptyExisting(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	// When existing is empty, generated values are used
 	assert.Equal(t, "wave-project", result.Metadata.Name, "generated name used when existing is empty")
@@ -2226,7 +2226,7 @@ func TestMergeTypedManifestsPreservesProject(t *testing.T) {
 		},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	require.NotNil(t, result.Project)
 	assert.Equal(t, "go", result.Project.Language)
@@ -2249,7 +2249,7 @@ func TestMergeTypedManifestsMergesSkills(t *testing.T) {
 		Skills:     []string{"skill-b", "skill-c"},
 	}
 
-	result := mergeTypedManifests(existing, generated)
+	result := onboarding.MergeTypedManifests(existing, generated)
 
 	assert.Len(t, result.Skills, 3, "skills should be merged and deduplicated")
 	assert.Contains(t, result.Skills, "skill-a")

--- a/internal/onboarding/diff.go
+++ b/internal/onboarding/diff.go
@@ -1,0 +1,285 @@
+package onboarding
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileStatus represents the status of a file in the merge change summary.
+type FileStatus string
+
+const (
+	FileStatusNew       FileStatus = "new"        // File does not exist, will be created
+	FileStatusPreserved FileStatus = "preserved"  // File exists, differs from default
+	FileStatusUpToDate  FileStatus = "up_to_date" // File exists, matches default byte-for-byte
+)
+
+// FileChangeEntry represents a single file's status in the change summary.
+type FileChangeEntry struct {
+	RelPath  string
+	Category string
+	Status   FileStatus
+}
+
+// ManifestAction represents the type of change to a manifest key.
+type ManifestAction string
+
+const (
+	ManifestActionAdded     ManifestAction = "added"
+	ManifestActionPreserved ManifestAction = "preserved"
+)
+
+// ManifestChangeEntry represents a change to a manifest key.
+type ManifestChangeEntry struct {
+	KeyPath string
+	Action  ManifestAction
+}
+
+// ChangeSummary holds the complete pre-mutation change report.
+type ChangeSummary struct {
+	Files           []FileChangeEntry
+	ManifestChanges []ManifestChangeEntry
+	MergedManifest  map[string]interface{}
+	Assets          *AssetSet
+	AlreadyUpToDate bool
+}
+
+// ComputeChangeSummary builds a pre-mutation change report by comparing on-disk
+// files with embedded defaults and computing the manifest diff.
+func ComputeChangeSummary(assets *AssetSet, existingManifest, defaultManifest map[string]interface{}) *ChangeSummary {
+	var files []FileChangeEntry
+
+	classifyFile := func(path, category, defaultContent string) FileChangeEntry {
+		entry := FileChangeEntry{
+			RelPath:  path,
+			Category: category,
+		}
+		existing, err := os.ReadFile(path)
+		switch {
+		case err != nil:
+			entry.Status = FileStatusNew
+		case bytes.Equal(existing, []byte(defaultContent)):
+			entry.Status = FileStatusUpToDate
+		default:
+			entry.Status = FileStatusPreserved
+		}
+		return entry
+	}
+
+	for filename, content := range assets.Personas {
+		path := filepath.Join(".agents", "personas", filename)
+		files = append(files, classifyFile(path, "persona", content))
+	}
+	for filename, content := range assets.Pipelines {
+		path := filepath.Join(".agents", "pipelines", filename)
+		files = append(files, classifyFile(path, "pipeline", content))
+	}
+	for filename, content := range assets.Contracts {
+		path := filepath.Join(".agents", "contracts", filename)
+		files = append(files, classifyFile(path, "contract", content))
+	}
+	for relPath, content := range assets.Prompts {
+		path := filepath.Join(".agents", "prompts", relPath)
+		files = append(files, classifyFile(path, "prompt", content))
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].RelPath < files[j].RelPath
+	})
+
+	merged, manifestChanges := ComputeManifestDiff(defaultManifest, existingManifest)
+
+	alreadyUpToDate := true
+	for _, f := range files {
+		if f.Status == FileStatusNew {
+			alreadyUpToDate = false
+			break
+		}
+	}
+	if alreadyUpToDate {
+		for _, mc := range manifestChanges {
+			if mc.Action == ManifestActionAdded {
+				alreadyUpToDate = false
+				break
+			}
+		}
+	}
+
+	return &ChangeSummary{
+		Files:           files,
+		ManifestChanges: manifestChanges,
+		MergedManifest:  merged,
+		Assets:          assets,
+		AlreadyUpToDate: alreadyUpToDate,
+	}
+}
+
+// ComputeManifestDiff performs the manifest merge and tracks what changed.
+func ComputeManifestDiff(defaults, existing map[string]interface{}) (map[string]interface{}, []ManifestChangeEntry) {
+	merged := MergeManifests(defaults, existing)
+	var changes []ManifestChangeEntry
+	collectManifestDiff("", defaults, existing, &changes)
+
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].KeyPath < changes[j].KeyPath
+	})
+	return merged, changes
+}
+
+func collectManifestDiff(prefix string, defaults, existing map[string]interface{}, entries *[]ManifestChangeEntry) {
+	for key, defaultVal := range defaults {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+
+		existingVal, exists := existing[key]
+		if !exists {
+			*entries = append(*entries, ManifestChangeEntry{
+				KeyPath: path,
+				Action:  ManifestActionAdded,
+			})
+			continue
+		}
+
+		defaultMap, defaultIsMap := defaultVal.(map[string]interface{})
+		existingMap, existingIsMap := existingVal.(map[string]interface{})
+
+		if defaultIsMap && existingIsMap {
+			collectManifestDiff(path, defaultMap, existingMap, entries)
+		} else if fmt.Sprintf("%v", defaultVal) != fmt.Sprintf("%v", existingVal) {
+			*entries = append(*entries, ManifestChangeEntry{
+				KeyPath: path,
+				Action:  ManifestActionPreserved,
+			})
+		}
+	}
+
+	for key := range existing {
+		if _, inDefaults := defaults[key]; !inDefaults {
+			path := key
+			if prefix != "" {
+				path = prefix + "." + key
+			}
+			*entries = append(*entries, ManifestChangeEntry{
+				KeyPath: path,
+				Action:  ManifestActionPreserved,
+			})
+		}
+	}
+}
+
+// DisplayChangeSummary renders the ChangeSummary as a categorized table to the
+// given writer (typically stderr).
+func DisplayChangeSummary(w io.Writer, summary *ChangeSummary) {
+	fmt.Fprintf(w, "\n  Change Summary:\n\n")
+
+	categories := []struct {
+		name  string
+		label string
+	}{
+		{"persona", "Personas"},
+		{"pipeline", "Pipelines"},
+		{"contract", "Contracts"},
+		{"prompt", "Prompts"},
+	}
+
+	for _, cat := range categories {
+		var catFiles []FileChangeEntry
+		for _, f := range summary.Files {
+			if f.Category == cat.name {
+				catFiles = append(catFiles, f)
+			}
+		}
+		if len(catFiles) == 0 {
+			continue
+		}
+
+		fmt.Fprintf(w, "  %s:\n", cat.label)
+		for _, f := range catFiles {
+			var status string
+			switch f.Status {
+			case FileStatusNew:
+				status = "+ new"
+			case FileStatusPreserved:
+				status = "~ preserved"
+			case FileStatusUpToDate:
+				status = "= up to date"
+			}
+			fmt.Fprintf(w, "    %-14s %s\n", status, f.RelPath)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	if len(summary.ManifestChanges) > 0 {
+		fmt.Fprintf(w, "  Manifest (wave.yaml):\n")
+		for _, mc := range summary.ManifestChanges {
+			var action string
+			switch mc.Action {
+			case ManifestActionAdded:
+				action = "+ added"
+			case ManifestActionPreserved:
+				action = "~ preserved"
+			}
+			fmt.Fprintf(w, "    %-14s %s\n", action, mc.KeyPath)
+		}
+		fmt.Fprintf(w, "\n")
+	}
+}
+
+// ApplyChanges writes only "new" files from the ChangeSummary and writes the
+// merged manifest. Files with status "preserved" or "up_to_date" are not touched.
+func ApplyChanges(summary *ChangeSummary, outputPath string) error {
+	if err := EnsureWaveDirs(DefaultWaveDirs); err != nil {
+		return err
+	}
+
+	for _, f := range summary.Files {
+		if f.Status != FileStatusNew {
+			continue
+		}
+
+		var content string
+		switch f.Category {
+		case "persona":
+			content = summary.Assets.Personas[filepath.Base(f.RelPath)]
+		case "pipeline":
+			content = summary.Assets.Pipelines[filepath.Base(f.RelPath)]
+		case "contract":
+			content = summary.Assets.Contracts[filepath.Base(f.RelPath)]
+		case "prompt":
+			promptPrefix := filepath.Join(".agents", "prompts") + string(filepath.Separator)
+			relPath := strings.TrimPrefix(f.RelPath, promptPrefix)
+			content = summary.Assets.Prompts[relPath]
+		}
+
+		if err := os.MkdirAll(filepath.Dir(f.RelPath), 0755); err != nil {
+			absPath, _ := filepath.Abs(f.RelPath)
+			return fmt.Errorf("failed to create directory for %s: %w", absPath, err)
+		}
+
+		if err := os.WriteFile(f.RelPath, []byte(content), 0644); err != nil {
+			absPath, _ := filepath.Abs(f.RelPath)
+			return fmt.Errorf("failed to write %s: %w", absPath, err)
+		}
+	}
+
+	mergedData, err := yaml.Marshal(summary.MergedManifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal merged manifest: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, mergedData, 0644); err != nil {
+		absPath, _ := filepath.Abs(outputPath)
+		return fmt.Errorf("failed to write manifest to %s: %w", absPath, err)
+	}
+
+	return nil
+}

--- a/internal/onboarding/flow.go
+++ b/internal/onboarding/flow.go
@@ -1,0 +1,138 @@
+package onboarding
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/recinq/wave/internal/forge"
+	"github.com/recinq/wave/internal/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// GreenfieldOpts captures the inputs needed for cold-start scaffolding.
+type GreenfieldOpts struct {
+	Adapter    string
+	Workspace  string
+	OutputPath string
+	All        bool
+	Stderr     io.Writer
+}
+
+// Greenfield runs the cold-start init flow: ensures the .agents directory tree
+// exists, detects the project flavour and forge, builds and writes wave.yaml,
+// copies embedded persona/pipeline/contract/prompt assets, seeds project
+// instruction files, and creates an initial git commit if needed.
+//
+// Returns the loaded asset set (so callers can render a success banner) and
+// the detected flavour info (for first-run suggestions).
+func Greenfield(o GreenfieldOpts) (*AssetSet, *FlavourInfo, error) {
+	if err := EnsureWaveDirs(DefaultWaveDirs); err != nil {
+		return nil, nil, err
+	}
+
+	cwd, _ := os.Getwd()
+	flavour := DetectFlavour(cwd)
+	project := FlavourToProjectMap(flavour)
+
+	assets, err := LoadAssets(o.Stderr, AssetOptions{All: o.All})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	forgeInfo, _ := forge.DetectFromGitRemotes()
+	assets.PersonaConfigs = FilterPersonasByForge(assets.PersonaConfigs, forgeInfo.Type)
+
+	meta := ExtractProjectMetadata(cwd)
+
+	manifestMap := BuildDefaultManifest(o.Adapter, o.Workspace, project, assets.PersonaConfigs)
+	if metaMap, ok := manifestMap["metadata"].(map[string]interface{}); ok {
+		if meta.Name != "" {
+			metaMap["name"] = meta.Name
+		}
+		if meta.Description != "" {
+			metaMap["description"] = meta.Description
+		}
+	}
+
+	manifestData, err := yaml.Marshal(manifestMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	outputDir := filepath.Dir(o.OutputPath)
+	if outputDir != "." && outputDir != "" {
+		absOutputDir, _ := filepath.Abs(outputDir)
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return nil, nil, fmt.Errorf("failed to create output directory %s: %w", absOutputDir, err)
+		}
+	}
+
+	absOutputPath, _ := filepath.Abs(o.OutputPath)
+	if err := os.WriteFile(o.OutputPath, manifestData, 0644); err != nil {
+		return nil, nil, fmt.Errorf("failed to write manifest to %s: %w", absOutputPath, err)
+	}
+
+	if err := CreateExamplePersonas(assets.Personas); err != nil {
+		return nil, nil, fmt.Errorf("failed to create example personas in .agents/personas/: %w", err)
+	}
+	if err := CreateExamplePipelines(assets.Pipelines); err != nil {
+		return nil, nil, fmt.Errorf("failed to create example pipelines in .agents/pipelines/: %w", err)
+	}
+	if err := CreateExampleContracts(assets.Contracts); err != nil {
+		return nil, nil, fmt.Errorf("failed to create example contracts in .agents/contracts/: %w", err)
+	}
+	if err := CreateExamplePrompts(assets.Prompts); err != nil {
+		return nil, nil, fmt.Errorf("failed to create example prompts in .agents/prompts/: %w", err)
+	}
+	if err := CreateProjectInstructionFiles(); err != nil {
+		return nil, nil, fmt.Errorf("failed to create project instruction files: %w", err)
+	}
+
+	if err := CreateInitialCommit(o.Stderr, o.OutputPath); err != nil {
+		return nil, nil, err
+	}
+
+	return assets, flavour, nil
+}
+
+// WizardOpts captures the inputs needed for the interactive wizard flow.
+type WizardOpts struct {
+	Adapter    string
+	Workspace  string
+	OutputPath string
+	All        bool
+	// Existing manifest (read by caller after confirming overwrite). May be nil.
+	Existing *manifest.Manifest
+	Stderr   io.Writer
+}
+
+// PrepareWizard ensures the .agents + .claude/commands directory tree exists,
+// loads filtered assets, and seeds them on disk so the wizard's pipeline
+// picker can discover them. Returns the loaded asset set.
+func PrepareWizard(o WizardOpts) (*AssetSet, error) {
+	if err := EnsureWaveDirs(WizardWaveDirs); err != nil {
+		return nil, err
+	}
+
+	assets, err := LoadAssets(o.Stderr, AssetOptions{All: o.All})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := CreateExamplePersonas(assets.Personas); err != nil {
+		return nil, fmt.Errorf("failed to create example personas: %w", err)
+	}
+	if err := CreateExamplePipelines(assets.Pipelines); err != nil {
+		return nil, fmt.Errorf("failed to create example pipelines: %w", err)
+	}
+	if err := CreateExampleContracts(assets.Contracts); err != nil {
+		return nil, fmt.Errorf("failed to create example contracts: %w", err)
+	}
+	if err := CreateExamplePrompts(assets.Prompts); err != nil {
+		return nil, fmt.Errorf("failed to create example prompts: %w", err)
+	}
+
+	return assets, nil
+}

--- a/internal/onboarding/manifest_build.go
+++ b/internal/onboarding/manifest_build.go
@@ -1,0 +1,510 @@
+package onboarding
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/recinq/wave/internal/defaults"
+	"github.com/recinq/wave/internal/forge"
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipeline"
+	"gopkg.in/yaml.v3"
+)
+
+// AssetSet holds the resolved asset maps for init/merge operations.
+type AssetSet struct {
+	Personas       map[string]string
+	PersonaConfigs map[string]manifest.Persona
+	Pipelines      map[string]string
+	Contracts      map[string]string
+	Prompts        map[string]string
+}
+
+// AssetOptions selects which embedded defaults to load.
+type AssetOptions struct {
+	// All disables the release-only filter when true.
+	All bool
+}
+
+// SystemPersonas are always included in the manifest regardless of pipeline
+// references. They are used by relay compaction, meta-pipelines, and adhoc ops.
+var SystemPersonas = map[string]bool{
+	"summarizer":  true,
+	"navigator":   true,
+	"philosopher": true,
+}
+
+// KnownForgePrefixes lists the prefixes used by forge-specific personas.
+var KnownForgePrefixes = []string{"github-", "gitlab-", "bitbucket-", "gitea-"}
+
+// ForgeTypeToPrefix maps forge types to their persona naming convention prefix.
+var ForgeTypeToPrefix = map[forge.ForgeType]string{
+	forge.ForgeGitHub:    "github",
+	forge.ForgeGitLab:    "gitlab",
+	forge.ForgeBitbucket: "bitbucket",
+	forge.ForgeGitea:     "gitea",
+	forge.ForgeCodeberg:  "gitea", // Codeberg is Forgejo — shares Gitea personas
+}
+
+// LoadAssets returns the asset maps for init, applying release filtering unless
+// opts.All is true. Warnings (unparseable pipelines, missing release pipelines,
+// dangling contract refs) are written to warnW.
+func LoadAssets(warnW io.Writer, opts AssetOptions) (*AssetSet, error) {
+	personas, err := defaults.GetPersonas()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default personas: %w", err)
+	}
+
+	allPersonaConfigs, err := defaults.GetPersonaConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get persona configs: %w", err)
+	}
+
+	if opts.All {
+		pipelines, err := defaults.GetPipelines()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default pipelines: %w", err)
+		}
+		contracts, err := defaults.GetContracts()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default contracts: %w", err)
+		}
+		prompts, err := defaults.GetPrompts()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default prompts: %w", err)
+		}
+		return &AssetSet{
+			Personas:       personas,
+			PersonaConfigs: allPersonaConfigs,
+			Pipelines:      pipelines,
+			Contracts:      contracts,
+			Prompts:        prompts,
+		}, nil
+	}
+
+	pipelines, err := defaults.GetReleasePipelines()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get release pipelines: %w", err)
+	}
+
+	if len(pipelines) == 0 && warnW != nil {
+		fmt.Fprintf(warnW, "warning: no pipelines are marked with release: true\n")
+	}
+
+	allContracts, err := defaults.GetContracts()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default contracts: %w", err)
+	}
+	allPrompts, err := defaults.GetPrompts()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default prompts: %w", err)
+	}
+
+	contracts, prompts, personaConfigs := FilterTransitiveDeps(warnW, pipelines, allContracts, allPrompts, allPersonaConfigs)
+
+	return &AssetSet{
+		Personas:       personas,
+		PersonaConfigs: personaConfigs,
+		Pipelines:      pipelines,
+		Contracts:      contracts,
+		Prompts:        prompts,
+	}, nil
+}
+
+// FilterTransitiveDeps filters contracts, prompts, and persona configs to only
+// those referenced by the given pipeline set. System personas are always included.
+func FilterTransitiveDeps(warnW io.Writer, pipelines, allContracts, allPrompts map[string]string, allPersonaConfigs map[string]manifest.Persona) (contracts, prompts map[string]string, personaConfigs map[string]manifest.Persona) {
+	contractRefs := make(map[string]bool)
+	promptRefs := make(map[string]bool)
+	personaRefs := make(map[string]bool)
+
+	for name, content := range pipelines {
+		var p pipeline.Pipeline
+		if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+			if warnW != nil {
+				fmt.Fprintf(warnW, "warning: failed to parse pipeline %s for dependency resolution: %v\n", name, err)
+			}
+			continue
+		}
+
+		for _, step := range p.Steps {
+			if step.Persona != "" {
+				personaRefs[step.Persona] = true
+			}
+			if step.Handover.Compaction.Persona != "" {
+				personaRefs[step.Handover.Compaction.Persona] = true
+			}
+			if sp := step.Handover.Contract.SchemaPath; sp != "" {
+				normalized := strings.TrimPrefix(sp, ".agents/contracts/")
+				contractRefs[normalized] = true
+			}
+			if sp := step.Exec.SourcePath; sp != "" {
+				if strings.HasPrefix(sp, ".agents/prompts/") {
+					normalized := strings.TrimPrefix(sp, ".agents/prompts/")
+					promptRefs[normalized] = true
+				}
+			}
+		}
+	}
+
+	for name := range SystemPersonas {
+		personaRefs[name] = true
+	}
+
+	// Expand forge-templated persona refs into all 4 forge variants so they
+	// survive filtering. FilterPersonasByForge trims to the detected forge later.
+	expandedRefs := make(map[string]bool)
+	for ref := range personaRefs {
+		if strings.Contains(ref, "{{ forge.type }}") || strings.Contains(ref, "{{forge.type}}") {
+			for _, forgeType := range []string{"github", "gitlab", "gitea", "bitbucket"} {
+				expanded := strings.ReplaceAll(ref, "{{ forge.type }}", forgeType)
+				expanded = strings.ReplaceAll(expanded, "{{forge.type}}", forgeType)
+				expandedRefs[expanded] = true
+			}
+		} else {
+			expandedRefs[ref] = true
+		}
+	}
+	personaRefs = expandedRefs
+
+	personaConfigs = make(map[string]manifest.Persona)
+	for name, cfg := range allPersonaConfigs {
+		if personaRefs[name] {
+			personaConfigs[name] = cfg
+		}
+	}
+
+	contracts = make(map[string]string)
+	for key, content := range allContracts {
+		if contractRefs[key] {
+			contracts[key] = content
+		}
+	}
+
+	for ref := range contractRefs {
+		if _, ok := allContracts[ref]; !ok && warnW != nil {
+			fmt.Fprintf(warnW, "warning: pipeline references contract %s which is not in embedded defaults\n", ref)
+		}
+	}
+
+	prompts = make(map[string]string)
+	for key, content := range allPrompts {
+		if promptRefs[key] {
+			prompts[key] = content
+		}
+	}
+
+	return contracts, prompts, personaConfigs
+}
+
+// FilterPersonasByForge filters persona configs to only include personas
+// matching the detected forge type. Personas without a known forge prefix are
+// always included.
+func FilterPersonasByForge(configs map[string]manifest.Persona, ft forge.ForgeType) map[string]manifest.Persona {
+	if ft == forge.ForgeUnknown {
+		return configs
+	}
+
+	prefix, ok := ForgeTypeToPrefix[ft]
+	if !ok {
+		return configs
+	}
+
+	result := make(map[string]manifest.Persona)
+	for name, cfg := range configs {
+		hasKnownPrefix := false
+		for _, fp := range KnownForgePrefixes {
+			if strings.HasPrefix(name, fp) {
+				hasKnownPrefix = true
+				break
+			}
+		}
+		if strings.HasPrefix(name, prefix+"-") || !hasKnownPrefix {
+			result[name] = cfg
+		}
+	}
+	return result
+}
+
+// FlavourToProjectMap converts a FlavourInfo into the map[string]interface{}
+// shape expected by BuildDefaultManifest.
+func FlavourToProjectMap(fi *FlavourInfo) map[string]interface{} {
+	if fi == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if fi.Flavour != "" {
+		m["flavour"] = fi.Flavour
+	}
+	if fi.Language != "" {
+		m["language"] = fi.Language
+	}
+	if fi.TestCommand != "" {
+		m["test_command"] = fi.TestCommand
+	}
+	if fi.LintCommand != "" {
+		m["lint_command"] = fi.LintCommand
+	}
+	if fi.BuildCommand != "" {
+		m["build_command"] = fi.BuildCommand
+	}
+	if fi.FormatCommand != "" {
+		m["format_command"] = fi.FormatCommand
+	}
+	if fi.SourceGlob != "" {
+		m["source_glob"] = fi.SourceGlob
+	}
+	if fi.Skill != "" {
+		m["skill"] = fi.Skill
+	}
+	return m
+}
+
+// BuildPersonaManifest constructs the personas section of the manifest from
+// embedded persona configs.
+func BuildPersonaManifest(configs map[string]manifest.Persona, adapter string) map[string]interface{} {
+	result := make(map[string]interface{})
+	for name, cfg := range configs {
+		entry := map[string]interface{}{
+			"adapter":            adapter,
+			"description":        cfg.Description,
+			"system_prompt_file": fmt.Sprintf(".agents/personas/%s.md", name),
+			"temperature":        cfg.Temperature,
+			"permissions": map[string]interface{}{
+				"allowed_tools": cfg.Permissions.AllowedTools,
+				"deny":          cfg.Permissions.Deny,
+			},
+		}
+		if cfg.Model != "" {
+			entry["model"] = cfg.Model
+		}
+		result[name] = entry
+	}
+	return result
+}
+
+// BuildDefaultManifest returns a fresh wave.yaml manifest as a generic map,
+// suitable for marshalling. The project map (typically derived from FlavourInfo)
+// is attached only when non-nil.
+func BuildDefaultManifest(adapter, workspace string, project map[string]interface{}, personaConfigs map[string]manifest.Persona) map[string]interface{} {
+	adapterProjectFiles := map[string][]string{
+		"claude":   {"AGENTS.md"},
+		"opencode": {"AGENTS.md"},
+		"gemini":   {"AGENTS.md"},
+		"codex":    {"AGENTS.md"},
+	}
+
+	adapterDefaults := map[string]string{
+		"claude":   "sonnet",
+		"opencode": "zai-coding-plan/glm-5-turbo",
+		"gemini":   "gemini-2.5-flash-lite",
+		"codex":    "o3",
+	}
+
+	adapters := map[string]interface{}{}
+	for name, projectFiles := range adapterProjectFiles {
+		entry := map[string]interface{}{
+			"binary":        name,
+			"default_model": adapterDefaults[name],
+			"mode":          "headless",
+			"output_format": "json",
+			"project_files": projectFiles,
+			"default_permissions": map[string]interface{}{
+				"allowed_tools": []string{"Read", "Write", "Edit", "Bash"},
+				"deny":          []string{},
+			},
+		}
+		adapters[name] = entry
+	}
+
+	m := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "WaveManifest",
+		"metadata": map[string]interface{}{
+			"name":        "wave-project",
+			"description": "A Wave multi-agent project",
+		},
+		"adapters": adapters,
+		"personas": BuildPersonaManifest(personaConfigs, adapter),
+		"runtime": map[string]interface{}{
+			"workspace_root":          workspace,
+			"max_concurrent_workers":  5,
+			"default_timeout_minutes": 30,
+			"relay": map[string]interface{}{
+				"token_threshold_percent": 80,
+				"strategy":                "summarize_to_checkpoint",
+			},
+			"audit": map[string]interface{}{
+				"log_dir":                 ".agents/traces/",
+				"log_all_tool_calls":      true,
+				"log_all_file_operations": false,
+			},
+			"meta_pipeline": map[string]interface{}{
+				"max_depth":        2,
+				"max_total_steps":  20,
+				"max_total_tokens": 500000,
+				"timeout_minutes":  60,
+			},
+		},
+	}
+
+	if project != nil {
+		m["project"] = project
+	}
+
+	m["ontology"] = map[string]interface{}{
+		"contexts": []map[string]interface{}{
+			{
+				"name":        "quality",
+				"description": "Validation and quality gates — first-pass failure is expected, rework is the norm",
+				"invariants": []string{
+					"First-pass success is the exception, not the rule — validation exists to catch and correct",
+					"Every pipeline output must pass through a validation gate before being considered done",
+					"Rework after review is not a failure — it is the expected path to quality",
+					"Contract validation, PR review, and test suites are gates, not formalities",
+				},
+			},
+		},
+	}
+
+	return m
+}
+
+// MergeManifests deep-merges existing into defaults, preserving existing values
+// where keys overlap.
+func MergeManifests(defaults, existing map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for k, v := range defaults {
+		result[k] = v
+	}
+
+	for k, v := range existing {
+		if existingMap, isMap := v.(map[string]interface{}); isMap {
+			if defaultMap, isDefaultMap := result[k].(map[string]interface{}); isDefaultMap {
+				result[k] = mergeMapsRecursive(defaultMap, existingMap)
+			} else {
+				result[k] = v
+			}
+		} else {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+func mergeMapsRecursive(defaults, existing map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for k, v := range defaults {
+		result[k] = v
+	}
+
+	for k, v := range existing {
+		if existingMap, isMap := v.(map[string]interface{}); isMap {
+			if defaultMap, isDefaultMap := result[k].(map[string]interface{}); isDefaultMap {
+				result[k] = mergeMapsRecursive(defaultMap, existingMap)
+			} else {
+				result[k] = v
+			}
+		} else {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+// MergeTypedManifests merges a generated manifest into an existing one,
+// preserving custom settings from the existing manifest while updating
+// infrastructure defaults from the generated manifest.
+//
+// Preservation rules:
+//   - Custom personas (not in generated) are preserved
+//   - Custom adapter configurations are preserved
+//   - Ontology section is preserved entirely from existing
+//   - Metadata.Name is preserved if already set
+//   - Metadata.Description is preserved if already set
+//   - apiVersion, kind, and runtime settings are updated from generated
+func MergeTypedManifests(existing, generated *manifest.Manifest) *manifest.Manifest {
+	result := &manifest.Manifest{}
+
+	result.APIVersion = generated.APIVersion
+	result.Kind = generated.Kind
+
+	result.Metadata = generated.Metadata
+	if existing.Metadata.Name != "" {
+		result.Metadata.Name = existing.Metadata.Name
+	}
+	if existing.Metadata.Description != "" {
+		result.Metadata.Description = existing.Metadata.Description
+	}
+	if existing.Metadata.Repo != "" {
+		result.Metadata.Repo = existing.Metadata.Repo
+	}
+	if existing.Metadata.Forge != "" {
+		result.Metadata.Forge = existing.Metadata.Forge
+	}
+
+	result.Adapters = make(map[string]manifest.Adapter)
+	for name, adapter := range generated.Adapters {
+		result.Adapters[name] = adapter
+	}
+	for name, adapter := range existing.Adapters {
+		result.Adapters[name] = adapter
+	}
+
+	result.Personas = make(map[string]manifest.Persona)
+	for name, persona := range generated.Personas {
+		result.Personas[name] = persona
+	}
+	for name, persona := range existing.Personas {
+		result.Personas[name] = persona
+	}
+
+	if existing.Ontology != nil {
+		result.Ontology = existing.Ontology
+	} else {
+		result.Ontology = generated.Ontology
+	}
+
+	if existing.Project != nil {
+		result.Project = existing.Project
+	} else {
+		result.Project = generated.Project
+	}
+
+	result.Runtime = generated.Runtime
+
+	if existing.Server != nil {
+		result.Server = existing.Server
+	} else {
+		result.Server = generated.Server
+	}
+
+	skillSet := make(map[string]bool)
+	for _, s := range generated.Skills {
+		skillSet[s] = true
+	}
+	for _, s := range existing.Skills {
+		skillSet[s] = true
+	}
+	if len(skillSet) > 0 {
+		result.Skills = make([]string, 0, len(skillSet))
+		for s := range skillSet {
+			result.Skills = append(result.Skills, s)
+		}
+		sort.Strings(result.Skills)
+	}
+
+	if len(existing.Hooks) > 0 {
+		result.Hooks = existing.Hooks
+	} else {
+		result.Hooks = generated.Hooks
+	}
+
+	return result
+}

--- a/internal/onboarding/output.go
+++ b/internal/onboarding/output.go
@@ -1,0 +1,98 @@
+package onboarding
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// PrintInitSuccess writes the cold-start success banner for `wave init`.
+func PrintInitSuccess(out io.Writer, outputPath string, assets *AssetSet) {
+	pipelineNames := make([]string, 0, len(assets.Pipelines))
+	for name := range assets.Pipelines {
+		pipelineNames = append(pipelineNames, strings.TrimSuffix(name, ".yaml"))
+	}
+	sort.Strings(pipelineNames)
+
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  ╦ ╦╔═╗╦  ╦╔═╗\n")
+	fmt.Fprintf(out, "  ║║║╠═╣╚╗╔╝║╣ \n")
+	fmt.Fprintf(out, "  ╚╩╝╩ ╩ ╚╝ ╚═╝\n")
+	fmt.Fprintf(out, "  Multi-Agent Pipeline Orchestrator\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Project initialized successfully!\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Created:\n")
+	fmt.Fprintf(out, "    %-24s Main manifest\n", outputPath)
+	fmt.Fprintf(out, "    .agents/personas/          %d persona archetypes\n", len(assets.Personas))
+	fmt.Fprintf(out, "    .agents/pipelines/         %d pipelines\n", len(assets.Pipelines))
+	fmt.Fprintf(out, "    .agents/contracts/         %d JSON schema validators\n", len(assets.Contracts))
+	fmt.Fprintf(out, "    .agents/prompts/           %d prompt templates\n", len(assets.Prompts))
+	fmt.Fprintf(out, "    .agents/workspaces/        Ephemeral workspace root\n")
+	fmt.Fprintf(out, "    .agents/traces/            Audit log directory\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Pipelines: %s\n", strings.Join(pipelineNames, ", "))
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Next steps:\n")
+	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
+	fmt.Fprintf(out, "    2. Run 'wave run ops-hello-world \"test\"' to verify setup\n")
+	fmt.Fprintf(out, "    3. Run 'wave run plan-task \"your feature\"' to plan a task\n")
+	fmt.Fprintf(out, "\n")
+}
+
+// PrintMergeSuccess writes the success banner for `wave init --merge`.
+func PrintMergeSuccess(out io.Writer, outputPath string) {
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  ╦ ╦╔═╗╦  ╦╔═╗\n")
+	fmt.Fprintf(out, "  ║║║╠═╣╚╗╔╝║╣ \n")
+	fmt.Fprintf(out, "  ╚╩╝╩ ╩ ╚╝ ╚═╝\n")
+	fmt.Fprintf(out, "  Multi-Agent Pipeline Orchestrator\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Configuration merged successfully!\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Updated:\n")
+	fmt.Fprintf(out, "    %s       Preserved your settings\n", outputPath)
+	fmt.Fprintf(out, "    Added missing default adapters and personas\n")
+	fmt.Fprintf(out, "    Created missing .agents/ directories and files\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Next steps:\n")
+	fmt.Fprintf(out, "    1. Run 'wave migrate up' to apply pending migrations\n")
+	fmt.Fprintf(out, "    2. Run 'wave validate' to check configuration\n")
+	fmt.Fprintf(out, "\n")
+}
+
+// PrintWizardSuccess writes the success banner after the interactive wizard.
+func PrintWizardSuccess(out io.Writer, outputPath string, result *WizardResult) {
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Onboarding complete!\n")
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Configuration:\n")
+	fmt.Fprintf(out, "    %-20s %s\n", "Manifest:", outputPath)
+	fmt.Fprintf(out, "    %-20s %s\n", "Adapter:", result.Adapter)
+	if result.Model != "" {
+		fmt.Fprintf(out, "    %-20s %s\n", "Model:", result.Model)
+	}
+	if result.Language != "" {
+		fmt.Fprintf(out, "    %-20s %s\n", "Language:", result.Language)
+	}
+	if len(result.Pipelines) > 0 {
+		fmt.Fprintf(out, "    %-20s %d selected\n", "Pipelines:", len(result.Pipelines))
+	}
+	fmt.Fprintf(out, "\n")
+	fmt.Fprintf(out, "  Next steps:\n")
+	fmt.Fprintf(out, "    1. Run 'wave validate' to check configuration\n")
+	fmt.Fprintf(out, "    2. Run 'wave run' to select and execute a pipeline\n")
+	fmt.Fprintf(out, "\n")
+}
+
+// SuggestFirstRun prints a suggestion for what to run after init based on the
+// detected flavour.
+func SuggestFirstRun(w io.Writer, flavour *FlavourInfo) {
+	if flavour == nil || flavour.SourceGlob == "" {
+		fmt.Fprintf(w, "  Suggestion: Run 'wave run ops-bootstrap' to scaffold your project\n")
+		return
+	}
+
+	fmt.Fprintf(w, "  Suggestion: Run 'wave run audit-architecture' to analyze your codebase\n")
+}

--- a/internal/onboarding/scaffold.go
+++ b/internal/onboarding/scaffold.go
@@ -164,7 +164,7 @@ func CreateProjectInstructionFiles() error {
 
 // RemoveDeselectedPipelines deletes pipeline YAML files in pipelinesDir whose
 // stem (filename without .yaml extension) is not in the selected list.
-func RemoveDeselectedPipelines(pipelinesDir string, selected []string) error { //nolint:unparam // error return kept for future use
+func RemoveDeselectedPipelines(pipelinesDir string, selected []string) error {
 	keep := make(map[string]bool)
 	for _, name := range selected {
 		keep[name] = true

--- a/internal/onboarding/scaffold.go
+++ b/internal/onboarding/scaffold.go
@@ -1,0 +1,189 @@
+package onboarding
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// DefaultWaveDirs lists the directory tree that init/merge always ensures exists.
+var DefaultWaveDirs = []string{
+	".agents/personas",
+	".agents/pipelines",
+	".agents/contracts",
+	".agents/prompts",
+	".agents/traces",
+	".agents/workspaces",
+}
+
+// WizardWaveDirs extends DefaultWaveDirs with the .claude/commands dir used by the
+// interactive wizard for slash-command scaffolding.
+var WizardWaveDirs = append(append([]string{}, DefaultWaveDirs...), ".claude/commands")
+
+// EnsureWaveDirs creates the standard .agents directory tree.
+func EnsureWaveDirs(dirs []string) error {
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			absDir, _ := filepath.Abs(dir)
+			return fmt.Errorf("failed to create directory %s: %w", absDir, err)
+		}
+	}
+	return nil
+}
+
+// IsInteractive reports whether stdin is a TTY (or WAVE_FORCE_TTY is truthy).
+func IsInteractive() bool {
+	if v := os.Getenv("WAVE_FORCE_TTY"); v != "" {
+		return v == "1" || v == "true"
+	}
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// EnsureGitRepo checks if the current directory is inside a git repository and
+// initializes one if not. Uses git rev-parse to correctly detect parent repos.
+func EnsureGitRepo(w io.Writer) error {
+	check := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	check.Stdout = io.Discard
+	check.Stderr = io.Discard
+	if check.Run() == nil {
+		return nil // already inside a git repo
+	}
+
+	fmt.Fprintf(w, "  Initializing git repository...\n")
+	cmd := exec.Command("git", "init")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to initialize git repository: %w", err)
+	}
+	return nil
+}
+
+// CreateInitialCommit creates an initial commit with wave files if no commits
+// exist yet. This ensures worktree operations have at least one commit to work with.
+func CreateInitialCommit(w io.Writer, outputPath string) error {
+	check := exec.Command("git", "rev-parse", "HEAD")
+	check.Stdout = io.Discard
+	check.Stderr = io.Discard
+	if check.Run() == nil {
+		return nil // commits already exist
+	}
+
+	fmt.Fprintf(w, "  Creating initial commit...\n")
+
+	for _, kv := range [][2]string{
+		{"user.name", "wave"},
+		{"user.email", "wave@localhost"},
+	} {
+		check := exec.Command("git", "config", kv[0])
+		check.Stdout = io.Discard
+		check.Stderr = io.Discard
+		if check.Run() != nil {
+			cfg := exec.Command("git", "config", kv[0], kv[1])
+			cfg.Stdout = io.Discard
+			cfg.Stderr = io.Discard
+			_ = cfg.Run()
+		}
+	}
+
+	add := exec.Command("git", "add", outputPath, ".agents/")
+	add.Stdout = io.Discard
+	add.Stderr = io.Discard
+	if err := add.Run(); err != nil {
+		return fmt.Errorf("failed to stage wave files: %w", err)
+	}
+
+	commit := exec.Command("git", "-c", "commit.gpgsign=false", "commit", "-m", "chore: initialize wave project")
+	commit.Stdout = io.Discard
+	commit.Stderr = io.Discard
+	if err := commit.Run(); err != nil {
+		return fmt.Errorf("failed to create initial commit: %w", err)
+	}
+	return nil
+}
+
+// WriteAssetMap writes each (filename, content) pair under baseDir, creating
+// parent directories as needed (used for prompts which may include subdirs).
+func WriteAssetMap(baseDir string, assets map[string]string) error {
+	for relPath, content := range assets {
+		path := filepath.Join(baseDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			absPath, _ := filepath.Abs(path)
+			return fmt.Errorf("failed to write %s: %w", absPath, err)
+		}
+	}
+	return nil
+}
+
+// CreateExamplePersonas writes embedded persona prompts under .agents/personas/.
+func CreateExamplePersonas(personas map[string]string) error {
+	return WriteAssetMap(filepath.Join(".agents", "personas"), personas)
+}
+
+// CreateExamplePipelines writes embedded pipeline YAML under .agents/pipelines/.
+func CreateExamplePipelines(pipelines map[string]string) error {
+	return WriteAssetMap(filepath.Join(".agents", "pipelines"), pipelines)
+}
+
+// CreateExampleContracts writes embedded JSON-schema contracts under .agents/contracts/.
+func CreateExampleContracts(contracts map[string]string) error {
+	return WriteAssetMap(filepath.Join(".agents", "contracts"), contracts)
+}
+
+// CreateExamplePrompts writes embedded prompt templates under .agents/prompts/.
+func CreateExamplePrompts(prompts map[string]string) error {
+	return WriteAssetMap(filepath.Join(".agents", "prompts"), prompts)
+}
+
+// CreateProjectInstructionFiles seeds AGENTS.md and the per-adapter alias files
+// at the project root if they don't yet exist.
+func CreateProjectInstructionFiles() error {
+	files := map[string]string{
+		"AGENTS.md": "See CLAUDE.md for project guidelines.",
+		"CLAUDE.md": "See AGENTS.md for project guidelines.",
+		"GEMINI.md": "See AGENTS.md for project guidelines.",
+		"CODEX.md":  "See AGENTS.md for project guidelines.",
+	}
+	for filename, content := range files {
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+				return fmt.Errorf("failed to write %s: %w", filename, err)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveDeselectedPipelines deletes pipeline YAML files in pipelinesDir whose
+// stem (filename without .yaml extension) is not in the selected list.
+func RemoveDeselectedPipelines(pipelinesDir string, selected []string) error { //nolint:unparam // error return kept for future use
+	keep := make(map[string]bool)
+	for _, name := range selected {
+		keep[name] = true
+	}
+	entries, err := os.ReadDir(pipelinesDir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".yaml")
+		if name == e.Name() {
+			continue
+		}
+		if !keep[name] {
+			_ = os.Remove(filepath.Join(pipelinesDir, e.Name()))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- `cmd/wave/commands/init.go` reduced **1575 → 364 LOC** (well under 400 target)
- New code in `internal/onboarding`: 1220 LOC across 5 new files (scaffold, manifest_build, diff, output, flow)
- CLI behaviour, flags, prompts, output schemas all unchanged
- `wave init --help` byte-identical (verified via `diff`)

## Public API added to `internal/onboarding`

**Flow entrypoints:**
- `Greenfield(ctx, GreenfieldOpts) (Result, error)` — cold-start path, no prompts
- `PrepareWizard(ctx, WizardOpts) (...)` — seeded-then-interactive path

**Supporting types and funcs** (organised by concern):
- `AssetSet`, `AssetOptions`, `LoadAssets`, `FilterTransitiveDeps`, `FilterPersonasByForge`
- `BuildPersonaManifest`, `BuildDefaultManifest`, `MergeManifests`, `MergeTypedManifests`
- `ComputeChangeSummary`, `ComputeManifestDiff`, `DisplayChangeSummary`, `ApplyChanges`
- `EnsureWaveDirs`, `IsInteractive`, `EnsureGitRepo`, `CreateInitialCommit`
- `WriteAssetMap`, `CreateExamplePersonas/Pipelines/Contracts/Prompts`
- `CreateProjectInstructionFiles`, `RemoveDeselectedPipelines`
- `PrintInitSuccess`, `PrintMergeSuccess`, `PrintWizardSuccess`, `SuggestFirstRun`

## Organisation choice

A single `Run()` entrypoint wasn't natural — wizard branch needs interactive cobra-stream prompts in cmd; greenfield needs none. Split into two flow helpers + concern-organised supporting files. cmd retains: cobra wiring + flag parsing + three confirmation prompts + four thin print wrappers.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./...` full suite passes (incl. internal/state 498s, internal/pipeline 86s, cmd/wave/commands 175s)
- `diff <(wave init --help@main) <(wave init --help@branch)` empty

## Out of scope (deferred)

- 1502 run.go thin (depends on #1498)
- 1502 compose.go logic relocate
- 1502 analyze.go evaluate

## Test plan

- [ ] CI green
- [ ] `wave init` greenfield works
- [ ] `wave init` interactive wizard works
- [ ] `wave init` merge into existing manifest works

Partial of #1502 (init.go portion). Parent: #1494.