### PR TITLE
refactor(manifest): centralize pipeline-YAML loaders (#1503 partial 8.2)

### DIFF
--- a/internal/defaults/embed.go
+++ b/internal/defaults/embed.go
@@ -231,8 +231,8 @@ func GetReleasePipelines() (map[string]string, error) {
 
 	result := make(map[string]string)
 	for name, content := range all {
-		var header manifest.PipelineHeader
-		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
+		header, err := manifest.LoadPipelineHeader([]byte(content))
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping pipeline %s: failed to unmarshal: %v\n", name, err)
 			continue
 		}

--- a/internal/defaults/embed_test.go
+++ b/internal/defaults/embed_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/skill"
-	"gopkg.in/yaml.v3"
 )
 
 func TestGetReleasePipelines_ReturnsSubset(t *testing.T) {
@@ -62,8 +61,8 @@ func TestGetReleasePipelines_OnlyReleaseTrue(t *testing.T) {
 	}
 
 	for name, content := range release {
-		var header manifest.PipelineHeader
-		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
+		header, err := manifest.LoadPipelineHeader([]byte(content))
+		if err != nil {
 			t.Errorf("failed to unmarshal release pipeline %q: %v", name, err)
 			continue
 		}
@@ -85,8 +84,8 @@ func TestGetReleasePipelines_ExcludesNonRelease(t *testing.T) {
 	}
 
 	for name, content := range all {
-		var header manifest.PipelineHeader
-		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
+		header, err := manifest.LoadPipelineHeader([]byte(content))
+		if err != nil {
 			continue // skip pipelines that fail to unmarshal
 		}
 		if !header.Metadata.Release {
@@ -137,8 +136,8 @@ func TestGetReleasePipelines_DisabledAndReleaseIncluded(t *testing.T) {
 	}
 
 	for name, content := range all {
-		var header manifest.PipelineHeader
-		if err := yaml.Unmarshal([]byte(content), &header); err != nil {
+		header, err := manifest.LoadPipelineHeader([]byte(content))
+		if err != nil {
 			continue
 		}
 		if header.Metadata.Release && header.Metadata.Disabled {

--- a/internal/doctor/checks_config.go
+++ b/internal/doctor/checks_config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipeline"
 )
 
 // checkOntology lives in checks_ontology.go. It is compiled unconditionally
@@ -37,7 +38,7 @@ func checkAdapterRegistry(m *manifest.Manifest) CheckResult {
 }
 
 func checkRetryPolicies(opts *Options) []CheckResult {
-	pipelines := loadAllPipelines(opts.PipelinesDir)
+	pipelines := pipeline.ScanPipelinesDir(opts.PipelinesDir)
 	if len(pipelines) == 0 {
 		return []CheckResult{{
 			Name:     "Retry Policies",

--- a/internal/doctor/scan.go
+++ b/internal/doctor/scan.go
@@ -1,19 +1,16 @@
 package doctor
 
 import (
-	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/recinq/wave/internal/pipeline"
-	"gopkg.in/yaml.v3"
 )
 
 // collectRequiredTools scans all pipeline YAML files and returns a sorted,
 // deduplicated list of required tools.
 func collectRequiredTools(pipelinesDir string) []string {
 	toolSet := make(map[string]bool)
-	for _, pl := range loadAllPipelines(pipelinesDir) {
+	for _, pl := range pipeline.ScanPipelinesDir(pipelinesDir) {
 		if pl.Requires != nil {
 			for _, tool := range pl.Requires.Tools {
 				toolSet[tool] = true
@@ -33,7 +30,7 @@ func collectRequiredTools(pipelinesDir string) []string {
 // skill name → check command.
 func collectRequiredSkills(pipelinesDir string) map[string]string {
 	skills := make(map[string]string)
-	for _, pl := range loadAllPipelines(pipelinesDir) {
+	for _, pl := range pipeline.ScanPipelinesDir(pipelinesDir) {
 		if pl.Requires != nil {
 			for name, cfg := range pl.Requires.Skills {
 				skills[name] = cfg.Check
@@ -41,36 +38,4 @@ func collectRequiredSkills(pipelinesDir string) map[string]string {
 		}
 	}
 	return skills
-}
-
-// loadAllPipelines reads and parses all YAML files in the pipelines directory.
-func loadAllPipelines(pipelinesDir string) []pipeline.Pipeline {
-	if pipelinesDir == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(pipelinesDir)
-	if err != nil {
-		return nil
-	}
-
-	var pipelines []pipeline.Pipeline
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
-		pipelines = append(pipelines, pl)
-	}
-	return pipelines
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -15,7 +15,6 @@ import (
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
-	"gopkg.in/yaml.v3"
 )
 
 // CheckStatus represents the result of a health check.
@@ -276,8 +275,8 @@ func (p *DefaultDataProvider) checkRequiredTools() CheckResult {
 
 	// Collect all required tools across pipelines
 	toolSet := make(map[string]bool)
-	entries, err := os.ReadDir(p.pipelinesDir)
-	if err != nil {
+	pipelines := pipeline.ScanPipelinesDir(p.pipelinesDir)
+	if pipelines == nil {
 		return CheckResult{
 			Name:    "Required Tools",
 			Status:  StatusOK,
@@ -286,22 +285,7 @@ func (p *DefaultDataProvider) checkRequiredTools() CheckResult {
 		}
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
+	for _, pl := range pipelines {
 		if pl.Requires != nil {
 			for _, tool := range pl.Requires.Tools {
 				toolSet[tool] = true
@@ -357,8 +341,8 @@ func (p *DefaultDataProvider) checkRequiredSkills() CheckResult {
 		}
 	}
 
-	entries, err := os.ReadDir(p.pipelinesDir)
-	if err != nil {
+	pipelines := pipeline.ScanPipelinesDir(p.pipelinesDir)
+	if pipelines == nil {
 		return CheckResult{
 			Name:    "Required Skills",
 			Status:  StatusOK,
@@ -373,22 +357,7 @@ func (p *DefaultDataProvider) checkRequiredSkills() CheckResult {
 	}
 	skillMap := make(map[string]skillEntry)
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
+	for _, pl := range pipelines {
 		if pl.Requires != nil {
 			for name, cfg := range pl.Requires.Skills {
 				skillMap[name] = skillEntry{check: cfg.Check}
@@ -481,8 +450,8 @@ func (p *DefaultDataProvider) checkRetryPolicies() CheckResult {
 		}
 	}
 
-	entries, err := os.ReadDir(p.pipelinesDir)
-	if err != nil {
+	pipelines := pipeline.ScanPipelinesDir(p.pipelinesDir)
+	if pipelines == nil {
 		return CheckResult{
 			Name:    "Retry Policies",
 			Status:  StatusOK,
@@ -495,22 +464,7 @@ func (p *DefaultDataProvider) checkRetryPolicies() CheckResult {
 	totalRetrySteps := 0
 	policySteps := 0
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
+	for _, pl := range pipelines {
 		for _, step := range pl.Steps {
 			if step.Retry.MaxAttempts > 1 || step.Retry.Policy != "" {
 				totalRetrySteps++

--- a/internal/listing/pipelines.go
+++ b/internal/listing/pipelines.go
@@ -7,22 +7,11 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/recinq/wave/internal/pipeline"
 )
 
 // DefaultPipelineDir is where Wave stores pipeline YAML files for a project.
 const DefaultPipelineDir = ".agents/pipelines"
-
-// pipelineFileShape mirrors the relevant subset of pipeline YAML for listing.
-type pipelineFileShape struct {
-	Metadata struct {
-		Description string `yaml:"description"`
-	} `yaml:"metadata"`
-	Steps []struct {
-		ID      string `yaml:"id"`
-		Persona string `yaml:"persona"`
-	} `yaml:"steps"`
-}
 
 // ListPipelines reads all pipeline YAML files under DefaultPipelineDir and
 // returns them in alphabetical order. A missing directory yields a nil slice
@@ -49,15 +38,15 @@ func ListPipelines() ([]PipelineInfo, error) {
 		name := strings.TrimSuffix(entry.Name(), ".yaml")
 		pipelinePath := filepath.Join(DefaultPipelineDir, entry.Name())
 
-		data, err := os.ReadFile(pipelinePath)
+		p, err := pipeline.LoadPipelineFileLenient(pipelinePath)
 		if err != nil {
-			pipelines = append(pipelines, PipelineInfo{Name: name, Description: "(error reading)"})
-			continue
-		}
-
-		var p pipelineFileShape
-		if err := yaml.Unmarshal(data, &p); err != nil {
-			pipelines = append(pipelines, PipelineInfo{Name: name, Description: "(error parsing)"})
+			// Distinguish read errors from parse errors to preserve the
+			// original UX (different placeholder text per failure mode).
+			if _, statErr := os.Stat(pipelinePath); statErr != nil {
+				pipelines = append(pipelines, PipelineInfo{Name: name, Description: "(error reading)"})
+			} else {
+				pipelines = append(pipelines, PipelineInfo{Name: name, Description: "(error parsing)"})
+			}
 			continue
 		}
 

--- a/internal/listing/runs.go
+++ b/internal/listing/runs.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
-	"gopkg.in/yaml.v3"
 )
 
 // DefaultStateDBPath is the default Wave state database location.
@@ -169,21 +169,17 @@ func listRunsFromWorkspaces(opts RunsOptions) ([]RunInfo, error) {
 func inferWorkspaceStatus(wsPath string, pipelineName string) (status string, endTime time.Time) {
 	baseName := ExtractPipelineName(pipelineName)
 	pipelinePath := filepath.Join(DefaultPipelineDir, baseName+".yaml")
-	pipelineData, err := os.ReadFile(pipelinePath)
+	p, err := pipeline.LoadPipelineFileLenient(pipelinePath)
 	if err != nil {
-		stepDirs, _ := os.ReadDir(wsPath)
-		if len(stepDirs) == 0 {
-			return "pending", time.Time{}
+		// File missing → fall back to step-dir heuristic; parse failure →
+		// "unknown" with latest mtime, matching the pre-loader behaviour.
+		if _, statErr := os.Stat(pipelinePath); statErr != nil {
+			stepDirs, _ := os.ReadDir(wsPath)
+			if len(stepDirs) == 0 {
+				return "pending", time.Time{}
+			}
+			return "unknown", latestFileTime(wsPath)
 		}
-		return "unknown", latestFileTime(wsPath)
-	}
-
-	var p struct {
-		Steps []struct {
-			ID string `yaml:"id"`
-		} `yaml:"steps"`
-	}
-	if err := yaml.Unmarshal(pipelineData, &p); err != nil {
 		return "unknown", latestFileTime(wsPath)
 	}
 

--- a/internal/manifest/pipeline_loader.go
+++ b/internal/manifest/pipeline_loader.go
@@ -1,0 +1,35 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadPipelineHeader parses the metadata header of a pipeline YAML document
+// from a byte slice. Unknown fields (steps, hooks, requires, ...) are
+// ignored, so the loader is suitable for read-only scanners that only care
+// about pipeline metadata.
+//
+// This is the single canonical entry point for header-only pipeline parsing
+// across the codebase. Adding a new metadata field requires editing
+// PipelineHeader/PipelineMetadata in this package — not a per-call ad-hoc
+// struct in the consumer.
+func LoadPipelineHeader(data []byte) (*PipelineHeader, error) {
+	var header PipelineHeader
+	if err := yaml.Unmarshal(data, &header); err != nil {
+		return nil, fmt.Errorf("parse pipeline header: %w", err)
+	}
+	return &header, nil
+}
+
+// LoadPipelineHeaderFile reads the file at path and parses its metadata
+// header. See LoadPipelineHeader for semantics.
+func LoadPipelineHeaderFile(path string) (*PipelineHeader, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read pipeline file %s: %w", path, err)
+	}
+	return LoadPipelineHeader(data)
+}

--- a/internal/pipeline/scan.go
+++ b/internal/pipeline/scan.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadPipelineLenient parses pipeline YAML bytes into a Pipeline value
+// without running the strict validation passes that YAMLPipelineLoader
+// applies (KnownFields, IO type checks, WLP enforcement, ...).
+//
+// It is the single canonical entry point for read-only scanners across
+// internal/tui, internal/webui, internal/health, and internal/doctor that
+// need to inspect pipeline definitions in bulk and silently skip ones that
+// fail to parse. Strict validation belongs to the executor's load path
+// (YAMLPipelineLoader), not to discovery scans.
+func LoadPipelineLenient(data []byte) (*Pipeline, error) {
+	var p Pipeline
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse pipeline: %w", err)
+	}
+	return &p, nil
+}
+
+// LoadPipelineFileLenient reads path and parses it as pipeline YAML using
+// LoadPipelineLenient.
+func LoadPipelineFileLenient(path string) (*Pipeline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read pipeline file %s: %w", path, err)
+	}
+	return LoadPipelineLenient(data)
+}
+
+// ScanPipelinesDir walks a pipelines directory and returns every YAML file
+// successfully parsed into a Pipeline, in directory-listing order. Files
+// that fail to read or parse are silently skipped — this matches the
+// existing behaviour of every read-only scanner that previously inlined the
+// walk + yaml.Unmarshal boilerplate.
+//
+// An empty dir argument returns (nil, nil); a missing/unreadable directory
+// also returns (nil, nil) so callers do not need to special-case fresh
+// installs.
+func ScanPipelinesDir(dir string) []Pipeline {
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var out []Pipeline
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		p, err := LoadPipelineFileLenient(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		out = append(out, *p)
+	}
+	return out
+}

--- a/internal/tui/contract_provider.go
+++ b/internal/tui/contract_provider.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/internal/pipeline"
-	"gopkg.in/yaml.v3"
 )
 
 // ContractInfo is the TUI data projection for a contract.
@@ -41,33 +40,10 @@ func (p *DefaultContractDataProvider) FetchContracts() ([]ContractInfo, error) {
 		return nil, nil
 	}
 
-	entries, err := os.ReadDir(p.pipelinesDir)
-	if err != nil {
-		return nil, nil
-	}
-
 	// Map by schema path for deduplication; inline contracts use "pipeline:step" key
 	contractMap := make(map[string]*ContractInfo)
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
-
+	for _, pl := range pipeline.ScanPipelinesDir(p.pipelinesDir) {
 		for _, step := range pl.Steps {
 			contract := step.Handover.Contract
 			if contract.Type == "" {

--- a/internal/tui/persona_provider.go
+++ b/internal/tui/persona_provider.go
@@ -1,15 +1,12 @@
 package tui
 
 import (
-	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
-	"gopkg.in/yaml.v3"
 )
 
 // PersonaInfo is the TUI data projection for a persona.
@@ -61,33 +58,13 @@ func (p *DefaultPersonaDataProvider) FetchPersonas() ([]PersonaInfo, error) {
 
 	// Build pipeline usage map by scanning all pipeline YAML files
 	usageMap := make(map[string][]PipelineStepRef)
-	if p.pipelinesDir != "" {
-		entries, err := os.ReadDir(p.pipelinesDir)
-		if err == nil {
-			for _, entry := range entries {
-				if entry.IsDir() {
-					continue
-				}
-				ext := filepath.Ext(entry.Name())
-				if ext != ".yaml" && ext != ".yml" {
-					continue
-				}
-				data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-				if err != nil {
-					continue
-				}
-				var pl pipeline.Pipeline
-				if err := yaml.Unmarshal(data, &pl); err != nil {
-					continue
-				}
-				for _, step := range pl.Steps {
-					if step.Persona != "" {
-						usageMap[step.Persona] = append(usageMap[step.Persona], PipelineStepRef{
-							PipelineName: pl.Metadata.Name,
-							StepID:       step.ID,
-						})
-					}
-				}
+	for _, pl := range pipeline.ScanPipelinesDir(p.pipelinesDir) {
+		for _, step := range pl.Steps {
+			if step.Persona != "" {
+				usageMap[step.Persona] = append(usageMap[step.Persona], PipelineStepRef{
+					PipelineName: pl.Metadata.Name,
+					StepID:       step.ID,
+				})
 			}
 		}
 	}

--- a/internal/tui/pipeline_detail_provider.go
+++ b/internal/tui/pipeline_detail_provider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
-	"gopkg.in/yaml.v3"
 )
 
 // StepSummary is a lightweight projection of a pipeline step for display.
@@ -113,30 +112,16 @@ func NewDefaultDetailDataProvider(store detailStore, pipelinesDir string) *Defau
 // FetchAvailableDetail reads all YAML files from pipelinesDir, finds the pipeline with the
 // given name, and returns a detailed projection of its configuration.
 func (d *DefaultDetailDataProvider) FetchAvailableDetail(name string) (*AvailableDetail, error) {
-	entries, err := os.ReadDir(d.pipelinesDir)
-	if err != nil {
-		return nil, err
+	pipelines := pipeline.ScanPipelinesDir(d.pipelinesDir)
+	if pipelines == nil {
+		// Distinguish "no pipelines dir / unreadable" from "not found"
+		// — preserve the original error semantics by stat'ing the dir.
+		if _, err := os.Stat(d.pipelinesDir); err != nil {
+			return nil, err
+		}
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(d.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-
-		var p pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &p); err != nil {
-			continue
-		}
-
+	for _, p := range pipelines {
 		if p.Metadata.Name != name {
 			continue
 		}

--- a/internal/tui/skill_provider.go
+++ b/internal/tui/skill_provider.go
@@ -1,12 +1,10 @@
 package tui
 
 import (
-	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/recinq/wave/internal/pipeline"
-	"gopkg.in/yaml.v3"
 )
 
 // SkillInfo is the TUI data projection for a skill.
@@ -40,33 +38,10 @@ func (p *DefaultSkillDataProvider) FetchSkills() ([]SkillInfo, error) {
 		return nil, nil
 	}
 
-	entries, err := os.ReadDir(p.pipelinesDir)
-	if err != nil {
-		return nil, nil
-	}
-
 	// Map by skill name for deduplication
 	skillMap := make(map[string]*SkillInfo)
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(p.pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
-
+	for _, pl := range pipeline.ScanPipelinesDir(p.pipelinesDir) {
 		if pl.Requires == nil || len(pl.Requires.Skills) == 0 {
 			continue
 		}

--- a/internal/webui/handlers_skills.go
+++ b/internal/webui/handlers_skills.go
@@ -13,7 +13,6 @@ import (
 	"github.com/recinq/wave/internal/defaults"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/skill"
-	"gopkg.in/yaml.v3"
 )
 
 // SkillTemplateSummary represents a bundled skill template for the web UI.
@@ -169,32 +168,9 @@ func installedSkillSet() map[string]bool {
 // mirroring the TUI's DefaultSkillDataProvider logic.
 func getSkillSummaries() []SkillSummary {
 	pipelinesDir := filepath.Join(".agents", "pipelines")
-	entries, err := os.ReadDir(pipelinesDir)
-	if err != nil {
-		return nil
-	}
-
 	skillMap := make(map[string]*SkillSummary)
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		ext := filepath.Ext(entry.Name())
-		if ext != ".yaml" && ext != ".yml" {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(pipelinesDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-
-		var pl pipeline.Pipeline
-		if err := yaml.Unmarshal(data, &pl); err != nil {
-			continue
-		}
-
+	for _, pl := range pipeline.ScanPipelinesDir(pipelinesDir) {
 		if pl.Requires == nil || len(pl.Requires.Skills) == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary

- New canonical loaders eliminate ad-hoc `yaml.Unmarshal` of pipeline files across tui, webui, defaults, doctor, listing, health
- Net **-100 LOC** (more boilerplate removed than loader code added)
- 9+ ad-hoc unmarshal sites → 3 canonical loaders

## New API

In `internal/manifest`:
- `LoadPipelineHeader(data []byte) (*PipelineHeader, error)`
- `LoadPipelineHeaderFile(path string) (*PipelineHeader, error)`

In `internal/pipeline`:
- `LoadPipelineLenient(data []byte) (*Pipeline, error)`
- `LoadPipelineFileLenient(path string) (*Pipeline, error)`
- `ScanPipelinesDir(dir string) []Pipeline` — silently skips unreadable/unparseable files (mirrors all 9 prior scanner sites)

## Direction verified

```
$ go list -deps github.com/recinq/wave/internal/manifest | grep "internal/pipeline"
(empty)
```

Manifest stays free of pipeline. The header-only consumer (`defaults`) uses `manifest.LoadPipelineHeader`. Full-pipeline consumers funnel through `pipeline.ScanPipelinesDir` (lives in pipeline since it owns the type — single-function consolidation without forcing manifest to depend on pipeline).

## Migration scope

- 9 brief-listed sites + 4 additional discovered during inventory: `internal/listing/{pipelines,runs}.go`, `internal/health/health.go` (3 sites — moved from tui)
- Files updated: `internal/{defaults,doctor,health,listing,tui,webui}` (13 files)

## Grep before/after

```
$ grep -rn "yaml.Unmarshal" internal --include="*.go" | grep -v _test.go | grep -i pipeline
```

- Before: 11 matches (9 ad-hoc + meta.go strict + dag.go strict)
- After: 3 (all canonical loaders themselves)

## Choice (Hybrid C+A)

Most consumers need full `pipeline.Pipeline` (Steps, Requires, Handover, Retry, Input, Metadata) — narrow header in manifest cannot replace them. Moving Pipeline into manifest (option B) rejected for blast radius. Outcome:
- Header-only consumer (`defaults`) → `manifest.LoadPipelineHeader` (option C)
- Full-Pipeline consumers → `pipeline.ScanPipelinesDir` (option A's spirit, in type's home package)

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./...` full suite passes

## Out of scope

- 8.3 HTTP client centralize
- 8.5 formatDuration verify

## Test plan

- [ ] CI green
- [ ] `wave tui` providers render pipelines correctly
- [ ] `wave init` greenfield filters release pipelines correctly
- [ ] `wave list compositions` works

Partial of #1503 (subset 8.2). Parent: #1494.