### PR TITLE
refactor(pipeline): unify step strategy dispatch (#1506 partial)

### DIFF
--- a/internal/pipeline/executor_composition.go
+++ b/internal/pipeline/executor_composition.go
@@ -14,29 +14,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// executeCompositionStep dispatches a composition step (iterate, aggregate,
+// branch, loop, gate, or bare sub-pipeline) to the matching StrategyExecutor.
+// Routing is driven by the strategy registry in strategy.go rather than a
+// chained if-else, so adding a new primitive is a one-file change.
 func (e *DefaultPipelineExecutor) executeCompositionStep(ctx context.Context, execution *PipelineExecution, step *Step) error {
-	// Route gate steps to the gate executor
-	if step.Gate != nil {
-		return e.executeGateInDAG(ctx, execution, step)
+	if strategy := selectCompositionStrategy(e, step); strategy != nil {
+		return strategy.Execute(ctx, execution, step)
 	}
-
-	// Route composition primitives
-	if step.Iterate != nil {
-		return e.executeIterateInDAG(ctx, execution, step)
-	}
-	if step.Aggregate != nil {
-		return e.executeAggregateInDAG(ctx, execution, step)
-	}
-	if step.Branch != nil {
-		return e.executeBranchInDAG(ctx, execution, step)
-	}
-	if step.Loop != nil {
-		return e.executeLoopInDAG(ctx, execution, step)
-	}
-
-	// Fall through: bare sub-pipeline step
-	input := e.resolveSubPipelineInput(execution, step)
-	return e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input, compositionLaunchInfo{kind: "sub_pipeline_child"})
+	return fmt.Errorf("step %q is not a composition step", step.ID)
 }
 
 // resolveSubPipelineInput resolves the input string for a composition step,

--- a/internal/pipeline/executor_steps.go
+++ b/internal/pipeline/executor_steps.go
@@ -363,19 +363,12 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 		_ = e.store.SaveStepState(pipelineID, step.ID, state.StateRunning, "")
 	}
 
-	// Check if this step uses concurrency (before matrix check — mutually exclusive)
-	if step.Concurrency > 1 {
-		return e.executeConcurrentStep(ctx, execution, step)
-	}
-
-	// Check if this step uses a matrix strategy
-	if step.Strategy != nil && step.Strategy.Type == "matrix" {
-		return e.executeMatrixStep(ctx, execution, step)
-	}
-
-	// Composition step: delegate to sub-pipeline execution
-	if step.IsCompositionStep() {
-		return e.executeCompositionStep(ctx, execution, step)
+	// Strategy dispatch: concurrency, matrix, and all composition primitives
+	// route through the StrategyExecutor registry in strategy.go. When the
+	// step is a regular persona / command step the registry returns nil and
+	// we fall through to the standard adapter pipeline.
+	if strategy := selectStrategy(e, step); strategy != nil {
+		return strategy.Execute(ctx, execution, step)
 	}
 
 	// Command step: execute shell script directly (no adapter/persona needed).

--- a/internal/pipeline/strategy.go
+++ b/internal/pipeline/strategy.go
@@ -1,0 +1,177 @@
+package pipeline
+
+import "context"
+
+// StrategyExecutor is the unified interface for step-level fan-out / dispatch
+// strategies. Matrix expansion, iterate / aggregate / branch / loop / gate
+// composition primitives, and bare sub-pipeline launches all implement this
+// interface.
+//
+// A StrategyExecutor takes a step that has already been routed through the
+// scheduler and runs whatever expansion or sub-execution the step's shape
+// requires. Implementations own context propagation to children, worker-pool
+// management (when applicable), and result aggregation back into the parent
+// PipelineExecution.
+//
+// The interface is intentionally narrow. Authoring a new strategy is a single
+// file: implement Execute and add a clause to the registry below.
+type StrategyExecutor interface {
+	Execute(ctx context.Context, execution *PipelineExecution, step *Step) error
+}
+
+// strategyKind classifies a registry entry so callers that have already
+// filtered to composition steps (nested loop sub-steps, the standalone
+// CompositionExecutor) can skip non-composition shapes.
+type strategyKind int
+
+const (
+	// strategyKindStepLevel applies at the executeStep dispatch boundary
+	// only — concurrency and matrix expansion.
+	strategyKindStepLevel strategyKind = iota
+	// strategyKindComposition applies inside executeCompositionStep too —
+	// gate, iterate, aggregate, branch, loop, sub-pipeline.
+	strategyKindComposition
+)
+
+// strategyEntry pairs a match predicate with the strategy that handles it.
+// Order in the registry determines dispatch precedence: the first matching
+// entry wins. This mirrors the original dispatch order in executeStep and
+// executeCompositionStep so behaviour is preserved exactly.
+type strategyEntry struct {
+	kind  strategyKind
+	match func(step *Step) bool
+	build func(e *DefaultPipelineExecutor) StrategyExecutor
+}
+
+// strategyRegistry is the ordered list of step-strategy dispatch rules.
+// Adding a new primitive is one entry here plus a small struct implementing
+// StrategyExecutor.
+var strategyRegistry = []strategyEntry{
+	{
+		kind:  strategyKindStepLevel,
+		match: func(step *Step) bool { return step.Concurrency > 1 },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return concurrencyStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindStepLevel,
+		match: func(step *Step) bool { return step.Strategy != nil && step.Strategy.Type == "matrix" },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return matrixStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.Gate != nil },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return gateStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.Iterate != nil },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return iterateStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.Aggregate != nil },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return aggregateStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.Branch != nil },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return branchStrategy{e: e} },
+	},
+	{
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.Loop != nil },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return loopStrategy{e: e} },
+	},
+	{
+		// Bare sub-pipeline launch must come last among composition shapes
+		// because Iterate / Branch / Loop steps may also set SubPipeline.
+		kind:  strategyKindComposition,
+		match: func(step *Step) bool { return step.SubPipeline != "" },
+		build: func(e *DefaultPipelineExecutor) StrategyExecutor { return subPipelineStrategy{e: e} },
+	},
+}
+
+// selectStrategy returns the StrategyExecutor that should handle the given
+// step, or nil when no strategy applies (the step is a regular persona /
+// command step and should run through the standard adapter pipeline).
+func selectStrategy(e *DefaultPipelineExecutor, step *Step) StrategyExecutor {
+	for _, entry := range strategyRegistry {
+		if entry.match(step) {
+			return entry.build(e)
+		}
+	}
+	return nil
+}
+
+// selectCompositionStrategy returns the StrategyExecutor for a composition
+// step, skipping the step-level entries (concurrency, matrix). Used by
+// callers that have already routed into the composition dispatch boundary
+// (executor_composition.go and the standalone CompositionExecutor).
+func selectCompositionStrategy(e *DefaultPipelineExecutor, step *Step) StrategyExecutor {
+	for _, entry := range strategyRegistry {
+		if entry.kind != strategyKindComposition {
+			continue
+		}
+		if entry.match(step) {
+			return entry.build(e)
+		}
+	}
+	return nil
+}
+
+// concurrencyStrategy dispatches to executeConcurrentStep.
+type concurrencyStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s concurrencyStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeConcurrentStep(ctx, execution, step)
+}
+
+// matrixStrategy dispatches to executeMatrixStep.
+type matrixStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s matrixStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeMatrixStep(ctx, execution, step)
+}
+
+// iterateStrategy dispatches to executeIterateInDAG.
+type iterateStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s iterateStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeIterateInDAG(ctx, execution, step)
+}
+
+// aggregateStrategy dispatches to executeAggregateInDAG.
+type aggregateStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s aggregateStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeAggregateInDAG(ctx, execution, step)
+}
+
+// branchStrategy dispatches to executeBranchInDAG.
+type branchStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s branchStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeBranchInDAG(ctx, execution, step)
+}
+
+// loopStrategy dispatches to executeLoopInDAG.
+type loopStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s loopStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeLoopInDAG(ctx, execution, step)
+}
+
+// gateStrategy dispatches to executeGateInDAG.
+type gateStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s gateStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	return s.e.executeGateInDAG(ctx, execution, step)
+}
+
+// subPipelineStrategy launches a bare sub-pipeline step.
+type subPipelineStrategy struct{ e *DefaultPipelineExecutor }
+
+func (s subPipelineStrategy) Execute(ctx context.Context, execution *PipelineExecution, step *Step) error {
+	input := s.e.resolveSubPipelineInput(execution, step)
+	return s.e.runNamedSubPipeline(ctx, execution, step, step.SubPipeline, input, compositionLaunchInfo{kind: "sub_pipeline_child"})
+}


### PR DESCRIPTION
## Summary

- New `internal/pipeline/strategy.go` (177 LOC) declares `StrategyExecutor` interface + ordered dispatch registry
- Matrix + composition primitives (gate/iterate/aggregate/branch/loop/sub-pipeline) unified through `selectStrategy` / `selectCompositionStrategy`
- Dispatch surface reduced; implementation logic preserved
- Meta excluded — different signature (free-form task + manifest), forcing into the interface would require either `interface{}` plan/result or two parallel interfaces. Shipped 2-of-3 per failure-mode guidance.

## Interface

```go
type StrategyExecutor interface {
    Execute(ctx context.Context, execution *PipelineExecution, step *Step) error
}
```

## File deltas

| File | Δ |
|---|---|
| `strategy.go` (new) | +177 |
| `executor_composition.go` | -14 |
| `executor_steps.go` | -8 |

Net **+155 LOC** (registry + interface boilerplate); routing centralized vs scattered chain-of-if-else.

## Dispatch points replaced

- `executor_steps.go::executeStep` — concurrency / matrix / composition chain → `selectStrategy(e, step)`
- `executor_composition.go::executeCompositionStep` — gate / iterate / aggregate / branch / loop / sub-pipeline chain → `selectCompositionStrategy(e, step)`

## ChildRunner note

Existing `runNamedSubPipeline` (executor_composition.go) already serves this role for iterate/branch/loop/sub-pipeline. Matrix uses its own `NewChildExecutor()` path because workers run in isolated workspaces with different lifecycle semantics (mounts, item indexing). Extracting a forced-shared helper would over-abstract; left as-is.

## Validation

- `go build ./...` + `go vet ./...` clean
- `go test -race ./internal/pipeline/...` PASS (47s)
- All composition primitive tests pass: matrix expansion, sub-pipeline, iterate, branch, loop, aggregate, gate
- `go test -race ./...` PASS except for `TestStallWatchdog_WriteProgressPreventsCancel` flaky timing test (unrelated)

## Out of scope (deferred follow-up)

- Meta strategy unification — needs interface widening or parallel interface
- ChildRunner extract — current shape works; force-share would be premature

## Test plan

- [ ] CI green
- [ ] Matrix expansion still works (`wave run impl-matrix-test` if present)
- [ ] Sub-pipeline composition unchanged

Partial of #1506. Parent: #1494.