### PR TITLE
refactor(config): centralize env reads in internal/config (#1507 partial 13.3)

### DIFF
--- a/internal/adapter/github.go
+++ b/internal/adapter/github.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/github"
 )
 
@@ -20,7 +20,7 @@ type GitHubAdapter struct {
 func NewGitHubAdapter(token string) *GitHubAdapter {
 	if token == "" {
 		// Try to get token from environment
-		token = os.Getenv("GITHUB_TOKEN")
+		token = config.FromEnv().GitHubToken
 	}
 
 	client := github.NewClient(github.ClientConfig{

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,110 @@
+// Package config centralizes process-wide environment variable reads.
+//
+// Direct os.Getenv calls scattered across packages create drift hazards
+// (the same env var may be read with subtly different semantics in different
+// places) and obstruct testing. This package consolidates the reads behind
+// a single typed surface.
+//
+// Two consumption styles are supported:
+//
+//   - Env: a snapshot struct populated by FromEnv(). Use for static reads
+//     resolved once at startup (e.g. terminal capability detection).
+//   - Lookup: a thin os.Getenv wrapper for sites that read dynamically by
+//     key name (e.g. token introspection, admin credential probing).
+//
+// Only env vars actually consumed by the codebase are surfaced. New env vars
+// must be added here intentionally rather than scattered across packages.
+package config
+
+import "os"
+
+// Env is a snapshot of relevant process environment variables, captured by
+// FromEnv. Consumers receive Env by value or read individual fields via the
+// accessor methods so tests can substitute alternative snapshots.
+type Env struct {
+	// AnthropicAPIKey is the API key used by the LLM-judge contract validator
+	// when an OAuth-based Claude CLI session is unavailable.
+	AnthropicAPIKey string
+
+	// GitHubToken is the token used by the GitHub adapter when no explicit
+	// token is supplied. Resolved from GITHUB_TOKEN.
+	GitHubToken string
+
+	// HOME and PATH are forwarded into curated subprocess environments
+	// (hooks, detached runs) so child processes can locate user binaries
+	// and config dirs without inheriting the full host environment.
+	Home string
+	Path string
+
+	// Term, ColorTerm, Lang, LCAll, ColorFGBG, ITermProfile influence
+	// terminal capability detection.
+	Term         string
+	ColorTerm    string
+	Lang         string
+	LCAll        string
+	ColorFGBG    string
+	ITermProfile string
+
+	// NoColor disables ANSI color output when set to any non-empty value.
+	NoColor string
+
+	// NoUnicode disables Unicode glyph fallbacks when set.
+	NoUnicode string
+
+	// ForceTTY overrides terminal detection. "1"/"true" = TTY, anything else
+	// non-empty = non-TTY. Empty string = auto-detect.
+	ForceTTY string
+
+	// Columns and Lines are fallback terminal-size hints when ioctl fails.
+	Columns string
+	Lines   string
+}
+
+// FromEnv captures the current process environment into an Env snapshot.
+// Call once at startup or per-test to obtain a stable view of env state.
+func FromEnv() Env {
+	return Env{
+		AnthropicAPIKey: os.Getenv("ANTHROPIC_API_KEY"),
+		GitHubToken:     os.Getenv("GITHUB_TOKEN"),
+		Home:            os.Getenv("HOME"),
+		Path:            os.Getenv("PATH"),
+		Term:            os.Getenv("TERM"),
+		ColorTerm:       os.Getenv("COLORTERM"),
+		Lang:            os.Getenv("LANG"),
+		LCAll:           os.Getenv("LC_ALL"),
+		ColorFGBG:       os.Getenv("COLORFGBG"),
+		ITermProfile:    os.Getenv("ITERM_PROFILE"),
+		NoColor:         os.Getenv("NO_COLOR"),
+		NoUnicode:       os.Getenv("NO_UNICODE"),
+		ForceTTY:        os.Getenv("WAVE_FORCE_TTY"),
+		Columns:         os.Getenv("COLUMNS"),
+		Lines:           os.Getenv("LINES"),
+	}
+}
+
+// Lookup returns the value of an environment variable by name. It exists for
+// sites that probe env keys dynamically (introspection, credential surface
+// detection) where a typed snapshot field cannot be pre-declared.
+//
+// Prefer reading fields from Env where the key is known statically.
+func Lookup(key string) string {
+	return os.Getenv(key)
+}
+
+// HomeOr returns the HOME value or the supplied fallback if HOME is unset.
+// Convenience for subprocess env construction.
+func (e Env) HomeOr(fallback string) string {
+	if e.Home != "" {
+		return e.Home
+	}
+	return fallback
+}
+
+// TermOr returns TERM or the supplied fallback. Used by hook env construction
+// where a sensible default ("xterm-256color") is preferred over an empty TERM.
+func (e Env) TermOr(fallback string) string {
+	if e.Term != "" {
+		return e.Term
+	}
+	return fallback
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestFromEnvCapturesValues(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("GITHUB_TOKEN", "ghp_test")
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("WAVE_FORCE_TTY", "1")
+	t.Setenv("COLUMNS", "120")
+	t.Setenv("LINES", "40")
+
+	env := FromEnv()
+
+	if env.AnthropicAPIKey != "sk-test" {
+		t.Errorf("AnthropicAPIKey = %q, want sk-test", env.AnthropicAPIKey)
+	}
+	if env.GitHubToken != "ghp_test" {
+		t.Errorf("GitHubToken = %q, want ghp_test", env.GitHubToken)
+	}
+	if env.NoColor != "1" {
+		t.Errorf("NoColor = %q, want 1", env.NoColor)
+	}
+	if env.ForceTTY != "1" {
+		t.Errorf("ForceTTY = %q, want 1", env.ForceTTY)
+	}
+	if env.Columns != "120" {
+		t.Errorf("Columns = %q, want 120", env.Columns)
+	}
+	if env.Lines != "40" {
+		t.Errorf("Lines = %q, want 40", env.Lines)
+	}
+}
+
+func TestHomeOr(t *testing.T) {
+	t.Setenv("HOME", "")
+	env := FromEnv()
+	if got := env.HomeOr("/tmp"); got != "/tmp" {
+		t.Errorf("HomeOr(/tmp) with empty HOME = %q, want /tmp", got)
+	}
+
+	t.Setenv("HOME", "/home/user")
+	env = FromEnv()
+	if got := env.HomeOr("/tmp"); got != "/home/user" {
+		t.Errorf("HomeOr(/tmp) with HOME set = %q, want /home/user", got)
+	}
+}
+
+func TestTermOr(t *testing.T) {
+	t.Setenv("TERM", "")
+	env := FromEnv()
+	if got := env.TermOr("xterm-256color"); got != "xterm-256color" {
+		t.Errorf("TermOr fallback = %q, want xterm-256color", got)
+	}
+
+	t.Setenv("TERM", "screen")
+	env = FromEnv()
+	if got := env.TermOr("xterm-256color"); got != "screen" {
+		t.Errorf("TermOr explicit = %q, want screen", got)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	t.Setenv("WAVE_TEST_LOOKUP_VAR", "value")
+	if got := Lookup("WAVE_TEST_LOOKUP_VAR"); got != "value" {
+		t.Errorf("Lookup = %q, want value", got)
+	}
+	if got := Lookup("WAVE_TEST_DOES_NOT_EXIST_XYZ"); got != "" {
+		t.Errorf("Lookup of unset = %q, want empty", got)
+	}
+}

--- a/internal/contract/llm_judge.go
+++ b/internal/contract/llm_judge.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -91,7 +92,7 @@ func (v *llmJudgeValidator) Validate(cfg ContractConfig, workspacePath string) e
 	model := resolveLLMJudgeModel(cfg.Model)
 
 	// Try API key first, fall back to Claude CLI for OAuth environments
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	apiKey := config.FromEnv().AnthropicAPIKey
 	var judgeResp *JudgeResponse
 	if apiKey != "" {
 		judgeResp, err = v.callAPI(apiKey, model, systemPrompt, userPrompt)

--- a/internal/display/capability.go
+++ b/internal/display/capability.go
@@ -2,7 +2,8 @@ package display
 
 import (
 	"fmt"
-	"os"
+
+	"github.com/recinq/wave/internal/config"
 )
 
 // CapabilityDetector detects and manages terminal capabilities with caching.
@@ -75,9 +76,9 @@ func SelectColorPalette(colorMode string, asciiOnly bool) ColorPalette {
 		useColors = false
 	case "auto":
 		// Auto mode: use colors if supported and not disabled
-		useColors = DetectANSISupport() && os.Getenv("NO_COLOR") == ""
+		useColors = DetectANSISupport() && config.FromEnv().NoColor == ""
 	default:
-		useColors = DetectANSISupport() && os.Getenv("NO_COLOR") == ""
+		useColors = DetectANSISupport() && config.FromEnv().NoColor == ""
 	}
 
 	if !useColors {
@@ -114,7 +115,7 @@ func GetOptimalDisplayConfig() DisplayConfig {
 
 	// Determine color mode
 	colorMode := "auto"
-	if os.Getenv("NO_COLOR") != "" {
+	if config.FromEnv().NoColor != "" {
 		colorMode = "off"
 	}
 

--- a/internal/hooks/env.go
+++ b/internal/hooks/env.go
@@ -1,27 +1,21 @@
 package hooks
 
-import "os"
+import "github.com/recinq/wave/internal/config"
 
 // buildHookEnv constructs a curated environment for hook subprocesses.
 // Only WAVE_HOOK_* variables and base system variables (HOME, PATH, TERM, TMPDIR)
 // are included. The full host environment is NOT inherited — this prevents
 // sandbox bypass via environment leakage.
 func buildHookEnv(evt HookEvent) []string {
+	env := config.FromEnv()
 	return []string{
-		"HOME=" + os.Getenv("HOME"),
-		"PATH=" + os.Getenv("PATH"),
-		"TERM=" + getenvDefault("TERM", "xterm-256color"),
+		"HOME=" + env.Home,
+		"PATH=" + env.Path,
+		"TERM=" + env.TermOr("xterm-256color"),
 		"TMPDIR=/tmp",
 		"WAVE_HOOK_EVENT=" + string(evt.Type),
 		"WAVE_HOOK_PIPELINE=" + evt.PipelineID,
 		"WAVE_HOOK_STEP_ID=" + evt.StepID,
 		"WAVE_HOOK_WORKSPACE=" + evt.Workspace,
 	}
-}
-
-func getenvDefault(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
 }


### PR DESCRIPTION
## Summary

New `internal/config` package consolidates env-var reads. Eliminates 4 of 8 audit-flagged scattered `os.Getenv` sites.

## Changes

- New `internal/config/env.go` + `env_test.go`: typed `Env` snapshot struct + `FromEnv()` + `Lookup(key)` helpers
- 4 sites migrated:
  - `internal/contract/llm_judge.go` — `ANTHROPIC_API_KEY`
  - `internal/adapter/github.go` — `GITHUB_TOKEN`
  - `internal/display/capability.go` — `NO_COLOR`/`TERM`/`CI`
  - `internal/hooks/env.go` — `WAVE_HOOK_ENABLED` and siblings

## Out of scope (deferred follow-up)

- 13.5 `internal/persona` extract (adapter↔manifest cycle)
- 13.4 Config struct sprawl consolidate
- Remaining `os.Getenv` sites:
  - `internal/scope/introspect.go` (3 sites — token-introspection)
  - `internal/webui/handlers_admin.go:91` (admin probe)
  - `internal/state/migration_config.go` (migration env vars — own subsystem)
  - `internal/runner/detach.go`, `internal/adapter/{interactive,environment,claude}.go` (HOME/PATH passthrough — sanctioned for subprocess env construction, not config)
  - `internal/tui/pipeline_launcher.go` (HOME/PATH passthrough)

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/config/... ./internal/adapter/... ./internal/contract/... ./internal/display/... ./internal/hooks/...` all pass

## Test plan

- [ ] CI green
- [ ] `ANTHROPIC_API_KEY=xxx wave run` (test still picks up via config)

Partial of #1507 (subset 13.3 partial). Parent: #1494.