### PR TITLE
refactor: extract internal/uitheme; onboarding no longer imports tui (#1497 residual)

### DIFF
--- a/internal/onboarding/ontology_step.go
+++ b/internal/onboarding/ontology_step.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/recinq/wave/internal/ontology"
-	"github.com/recinq/wave/internal/tui"
+	"github.com/recinq/wave/internal/uitheme"
 )
 
 // OntologyStep prompts for the project's telos and bounded context names.
@@ -51,7 +51,7 @@ func (s *OntologyStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Placeholder("e.g. identity, conversation, analytics"),
 			).Title("Step 7 of 8 — Project Ontology").
 				Description("Wave works best when it understands your project's domain."),
-		).WithTheme(tui.WaveTheme())
+		).WithTheme(uitheme.WaveTheme())
 
 		if err := form.Run(); err != nil {
 			if err == huh.ErrUserAborted {

--- a/internal/onboarding/steps.go
+++ b/internal/onboarding/steps.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/recinq/wave/internal/pipelinecatalog"
-	"github.com/recinq/wave/internal/tui"
+	"github.com/recinq/wave/internal/uitheme"
 )
 
 // knownAdapters lists the adapters available for selection.
@@ -204,7 +204,7 @@ func (s *TestConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Placeholder("e.g. go build ./..."),
 			).Title("Step 2 of 8 — Test Commands").
 				Description("Confirm or override the detected project commands."),
-		).WithTheme(tui.WaveTheme())
+		).WithTheme(uitheme.WaveTheme())
 
 		if err := form.Run(); err != nil {
 			if err == huh.ErrUserAborted {
@@ -343,7 +343,7 @@ func (s *PipelineSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 				Height(12),
 		).Title("Step 3 of 8 — Pipeline Selection").
 			Description("Choose which pipelines to include in your project."),
-	).WithTheme(tui.WaveTheme())
+	).WithTheme(uitheme.WaveTheme())
 
 	if err := form.Run(); err != nil {
 		if err == huh.ErrUserAborted {
@@ -404,7 +404,7 @@ func (s *AdapterConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Value(&selectedAdapter),
 			).Title("Step 4 of 8 — Adapter Configuration").
 				Description("Choose the LLM adapter for pipeline execution."),
-		).WithTheme(tui.WaveTheme())
+		).WithTheme(uitheme.WaveTheme())
 
 		if err := form.Run(); err != nil {
 			if err == huh.ErrUserAborted {
@@ -423,7 +423,7 @@ func (s *AdapterConfigStep) Run(cfg *WizardConfig) (*StepResult, error) {
 						Value(&customAdapter).
 						Placeholder("e.g. my-adapter"),
 				),
-			).WithTheme(tui.WaveTheme())
+			).WithTheme(uitheme.WaveTheme())
 
 			if err := inputForm.Run(); err != nil {
 				if err == huh.ErrUserAborted {
@@ -498,7 +498,7 @@ func (s *ModelSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 						Value(&selectedModel),
 				).Title("Step 5 of 8 — Model Selection").
 					Description("Choose the default model for pipeline execution."),
-			).WithTheme(tui.WaveTheme())
+			).WithTheme(uitheme.WaveTheme())
 
 			if err := form.Run(); err != nil {
 				if err == huh.ErrUserAborted {
@@ -516,7 +516,7 @@ func (s *ModelSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 							Value(&selectedModel).
 							Placeholder("e.g. claude-3-opus-20240229"),
 					),
-				).WithTheme(tui.WaveTheme())
+				).WithTheme(uitheme.WaveTheme())
 
 				if err := inputForm.Run(); err != nil {
 					if err == huh.ErrUserAborted {
@@ -536,7 +536,7 @@ func (s *ModelSelectionStep) Run(cfg *WizardConfig) (*StepResult, error) {
 					Placeholder("e.g. gpt-4o"),
 			).Title("Step 5 of 8 — Model Selection").
 				Description("Enter the model name for your adapter."),
-		).WithTheme(tui.WaveTheme())
+		).WithTheme(uitheme.WaveTheme())
 
 		if err := inputForm.Run(); err != nil {
 			if err == huh.ErrUserAborted {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,102 +1,20 @@
+// Package tui re-exports a small set of theme helpers from internal/uitheme
+// so existing tui consumers compile unchanged after the theme extraction
+// (issue #1497 residual). New code should import internal/uitheme directly.
 package tui
 
 import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/recinq/wave/internal/uitheme"
 )
 
-// WaveTheme returns a huh.Theme that matches Wave's TUI design language.
-// Colors are drawn from the progress display palette: cyan primary, gray muted, white text.
-func WaveTheme() *huh.Theme {
-	t := huh.ThemeBase()
+// WaveTheme returns the shared huh.Theme. Forwards to uitheme.WaveTheme.
+func WaveTheme() *huh.Theme { return uitheme.WaveTheme() }
 
-	var (
-		cyan  = lipgloss.Color("6")   // Wave primary — matches logo (standard cyan)
-		white = lipgloss.Color("7")   // Primary text
-		muted = lipgloss.Color("244") // Secondary/description text
-		red   = lipgloss.Color("1")   // Errors
-	)
+// SelectionStyle returns the focused/inactive selection style. Forwards to
+// uitheme.SelectionStyle.
+func SelectionStyle(focused bool) lipgloss.Style { return uitheme.SelectionStyle(focused) }
 
-	// Focused field styles.
-	t.Focused.Base = t.Focused.Base.BorderForeground(cyan)
-	t.Focused.Card = t.Focused.Base
-	t.Focused.Title = t.Focused.Title.Foreground(white).Bold(true)
-	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(white).Bold(true).MarginBottom(1)
-	t.Focused.Description = t.Focused.Description.Foreground(muted)
-	t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(red)
-	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(red)
-
-	// Select styles.
-	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(cyan)
-	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(cyan)
-	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(cyan)
-	t.Focused.Option = t.Focused.Option.Foreground(white)
-
-	// Multi-select styles — selected items use cyan to match the border bar.
-	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(cyan)
-	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(cyan)
-	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(cyan).SetString("[✓] ")
-	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(muted).SetString("[ ] ")
-	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(white)
-
-	// Text input styles.
-	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(cyan)
-	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(muted)
-	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(cyan)
-	t.Focused.TextInput.Text = t.Focused.TextInput.Text.Foreground(white)
-
-	// Button styles.
-	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color("0")).Background(cyan)
-	t.Focused.Next = t.Focused.FocusedButton
-	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(white).Background(lipgloss.Color("237"))
-
-	// Blurred field styles (inherit focused, dim the border).
-	// Keep text input text cyan so entered values stay visible as confirmation.
-	t.Blurred = t.Focused
-	t.Blurred.Base = t.Focused.Base.BorderStyle(lipgloss.HiddenBorder())
-	t.Blurred.Card = t.Blurred.Base
-	t.Blurred.NextIndicator = lipgloss.NewStyle()
-	t.Blurred.PrevIndicator = lipgloss.NewStyle()
-	t.Blurred.TextInput.Text = t.Blurred.TextInput.Text.Foreground(cyan)
-
-	// Group styles.
-	t.Group.Title = t.Focused.Title
-	t.Group.Description = t.Focused.Description
-
-	return t
-}
-
-// activeSelectionStyle returns the style for selected items in the focused pane.
-// White background with dark foreground for high contrast.
-func activeSelectionStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
-		Background(lipgloss.Color("7")).
-		Foreground(lipgloss.Color("0")).
-		Bold(true)
-}
-
-// inactiveSelectionStyle returns the style for selected items in unfocused panes.
-// Dimmed background matching the border separator color.
-func inactiveSelectionStyle() lipgloss.Style {
-	return lipgloss.NewStyle().
-		Background(lipgloss.Color("240")).
-		Foreground(lipgloss.Color("7"))
-}
-
-// SelectionStyle returns the active or inactive selection style based on focus state.
-func SelectionStyle(focused bool) lipgloss.Style {
-	if focused {
-		return activeSelectionStyle()
-	}
-	return inactiveSelectionStyle()
-}
-
-// WaveLogo returns the styled Wave ASCII logo matching the list/run display header.
-func WaveLogo() string {
-	logo := "╦ ╦╔═╗╦  ╦╔═╗\n║║║╠═╣╚╗╔╝║╣\n╚╩╝╩ ╩ ╚╝ ╚═╝"
-	return lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("6")). // Standard cyan — matches Formatter.Primary()
-		Margin(1, 0, 1, 1).              // top, right, bottom, left (1-char indent, matches TUI margin)
-		Render(logo)
-}
+// WaveLogo returns the ASCII logo. Forwards to uitheme.WaveLogo.
+func WaveLogo() string { return uitheme.WaveLogo() }

--- a/internal/uitheme/theme.go
+++ b/internal/uitheme/theme.go
@@ -1,0 +1,107 @@
+// Package uitheme owns Wave's shared charmbracelet (huh / lipgloss) theme.
+//
+// The package is intentionally lightweight and free of bubbletea-specific
+// dependencies so non-TUI callers (notably internal/onboarding) can reuse the
+// theme without pulling in the full TUI runtime.
+package uitheme
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// WaveTheme returns a huh.Theme that matches Wave's TUI design language.
+// Colors are drawn from the progress display palette: cyan primary, gray muted, white text.
+func WaveTheme() *huh.Theme {
+	t := huh.ThemeBase()
+
+	var (
+		cyan  = lipgloss.Color("6")   // Wave primary — matches logo (standard cyan)
+		white = lipgloss.Color("7")   // Primary text
+		muted = lipgloss.Color("244") // Secondary/description text
+		red   = lipgloss.Color("1")   // Errors
+	)
+
+	// Focused field styles.
+	t.Focused.Base = t.Focused.Base.BorderForeground(cyan)
+	t.Focused.Card = t.Focused.Base
+	t.Focused.Title = t.Focused.Title.Foreground(white).Bold(true)
+	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(white).Bold(true).MarginBottom(1)
+	t.Focused.Description = t.Focused.Description.Foreground(muted)
+	t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(red)
+	t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(red)
+
+	// Select styles.
+	t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(cyan)
+	t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(cyan)
+	t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(cyan)
+	t.Focused.Option = t.Focused.Option.Foreground(white)
+
+	// Multi-select styles — selected items use cyan to match the border bar.
+	t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(cyan)
+	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(cyan)
+	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(cyan).SetString("[✓] ")
+	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(muted).SetString("[ ] ")
+	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(white)
+
+	// Text input styles.
+	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(cyan)
+	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(muted)
+	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(cyan)
+	t.Focused.TextInput.Text = t.Focused.TextInput.Text.Foreground(white)
+
+	// Button styles.
+	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color("0")).Background(cyan)
+	t.Focused.Next = t.Focused.FocusedButton
+	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(white).Background(lipgloss.Color("237"))
+
+	// Blurred field styles (inherit focused, dim the border).
+	// Keep text input text cyan so entered values stay visible as confirmation.
+	t.Blurred = t.Focused
+	t.Blurred.Base = t.Focused.Base.BorderStyle(lipgloss.HiddenBorder())
+	t.Blurred.Card = t.Blurred.Base
+	t.Blurred.NextIndicator = lipgloss.NewStyle()
+	t.Blurred.PrevIndicator = lipgloss.NewStyle()
+	t.Blurred.TextInput.Text = t.Blurred.TextInput.Text.Foreground(cyan)
+
+	// Group styles.
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
+
+	return t
+}
+
+// activeSelectionStyle returns the style for selected items in the focused pane.
+// White background with dark foreground for high contrast.
+func activeSelectionStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color("7")).
+		Foreground(lipgloss.Color("0")).
+		Bold(true)
+}
+
+// inactiveSelectionStyle returns the style for selected items in unfocused panes.
+// Dimmed background matching the border separator color.
+func inactiveSelectionStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color("240")).
+		Foreground(lipgloss.Color("7"))
+}
+
+// SelectionStyle returns the active or inactive selection style based on focus state.
+func SelectionStyle(focused bool) lipgloss.Style {
+	if focused {
+		return activeSelectionStyle()
+	}
+	return inactiveSelectionStyle()
+}
+
+// WaveLogo returns the styled Wave ASCII logo matching the list/run display header.
+func WaveLogo() string {
+	logo := "╦ ╦╔═╗╦  ╦╔═╗\n║║║╠═╣╚╗╔╝║╣\n╚╩╝╩ ╩ ╚╝ ╚═╝"
+	return lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("6")). // Standard cyan — matches Formatter.Primary()
+		Margin(1, 0, 1, 1).              // top, right, bottom, left (1-char indent, matches TUI margin)
+		Render(logo)
+}


### PR DESCRIPTION
## Summary

Closes the residual onboarding→tui import flagged at the end of PR #1521 (#1497 subset 3.4). After this PR, `internal/onboarding` does not import `internal/tui` at all.

## Changes

- New `internal/uitheme` package: `WaveTheme()`, `SelectionStyle(focused)`, `WaveLogo()`. Lightweight, free of bubbletea-specific deps.
- `internal/onboarding/{steps,ontology_step}.go` imports `internal/uitheme` instead of `internal/tui`
- `internal/tui/theme.go` becomes thin alias shim re-exporting from uitheme — preserves existing tui consumers, migration is opt-in non-breaking

## Direction verified

```
$ go list -deps github.com/recinq/wave/internal/onboarding | grep "internal/tui"
(empty)
```

Headless onboarding now possible without dragging Bubble Tea runtime.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/uitheme/... ./internal/onboarding/... ./internal/tui/...` all pass

## Out of scope (deferred follow-up)

- Smoke-contracts pipeline fix (false-positive in test design — not a regression)

## Test plan

- [ ] CI green
- [ ] `wave init` interactive wizard renders identical theme

Closes residual portion of #1497. Parent: #1494.