### PR TITLE
refactor: centralize HTTP client in internal/httpx (#1503 partial 8.3)

### DIFF
--- a/internal/contract/llm_judge.go
+++ b/internal/contract/llm_judge.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/recinq/wave/internal/config"
+	"github.com/recinq/wave/internal/httpx"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -25,9 +26,12 @@ var anthropicAPIURL = "https://api.anthropic.com/v1/messages"
 // judgeHTTPClient is used for all LLM judge API calls instead of
 // http.DefaultClient so that callers sharing the process cannot observe
 // or mutate transport-level settings (timeouts, cookies, redirects).
-var judgeHTTPClient = &http.Client{
-	Timeout: 60 * time.Second,
-}
+// Built on the shared internal/httpx Client for consistent retry and
+// audit policy across Wave's outbound HTTP traffic.
+var judgeHTTPClient = httpx.New(httpx.Config{
+	Timeout:    60 * time.Second,
+	MaxRetries: 2, // Anthropic API can transiently 5xx; retry conservatively.
+})
 
 type llmJudgeValidator struct{}
 
@@ -206,7 +210,7 @@ func (v *llmJudgeValidator) callAPI(apiKey, model, systemPrompt, userPrompt stri
 	req.Header.Set("x-api-key", apiKey)
 	req.Header.Set("anthropic-version", "2023-06-01")
 
-	resp, err := judgeHTTPClient.Do(req)
+	resp, err := judgeHTTPClient.Do(ctx, req)
 	if err != nil {
 		return nil, &ValidationError{
 			ContractType: "llm_judge",

--- a/internal/forge/detect.go
+++ b/internal/forge/detect.go
@@ -1,11 +1,14 @@
 package forge
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/recinq/wave/internal/httpx"
 )
 
 // ForgeType identifies the source code hosting platform.
@@ -302,16 +305,21 @@ func forgeMetadata(ft ForgeType) (cli, prefix, prTerm, prCommand string) {
 }
 
 // probeHTTPClient is the HTTP client used by probeForgeType. Package-level
-// variable so tests can replace it with a client pointing at httptest servers.
-var probeHTTPClient = &http.Client{
-	Timeout: 3 * time.Second,
+// variable so tests can replace it with a client pointing at httptest
+// servers. Single-shot (MaxRetries: 0) — probes are best-effort and a
+// failed probe just means "this isn't that forge", retrying would only
+// slow detection. Self-signed TLS is tolerated because self-hosted Gitea
+// or GitLab instances frequently ship with non-public CAs.
+var probeHTTPClient = httpx.New(httpx.Config{
+	Timeout:    3 * time.Second,
+	MaxRetries: 0,
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-hosted instances often use self-signed certs
 	},
 	CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse // don't follow redirects
 	},
-}
+})
 
 // probeForgeType probes well-known API endpoints on the given host to identify
 // the forge software. Each probe uses a 3s HTTP timeout. Returns the first
@@ -331,7 +339,9 @@ func probeForgeType(host string) ForgeType {
 
 	for _, p := range probes {
 		url := "https://" + host + p.path
-		resp, err := probeHTTPClient.Get(url) //nolint:noctx // fire-and-forget probe; context not needed
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		resp, err := probeHTTPClient.Get(ctx, url)
+		cancel()
 		if err != nil {
 			continue
 		}

--- a/internal/forge/detect_test.go
+++ b/internal/forge/detect_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/httpx"
 )
 
 // disableProbing stubs the tea CLI check and HTTP probe client so tests don't
@@ -17,10 +20,11 @@ func disableProbing(t *testing.T) {
 	origTeaFunc := checkTeaCLIFunc
 
 	// HTTP client that always fails (no server listening on 127.0.0.1:1)
-	probeHTTPClient = &http.Client{
-		Transport: &http.Transport{},
-		Timeout:   1, // 1ns — effectively instant timeout
-	}
+	probeHTTPClient = httpx.New(httpx.Config{
+		Timeout:    1, // 1ns — effectively instant timeout
+		MaxRetries: 0,
+		Transport:  &http.Transport{},
+	})
 	checkTeaCLIFunc = func(string) ForgeType { return ForgeUnknown }
 
 	t.Cleanup(func() {
@@ -607,28 +611,23 @@ func TestProbeForgeType(t *testing.T) {
 			defer srv.Close()
 
 			origClient := probeHTTPClient
-			probeHTTPClient = srv.Client()
 			defer func() { probeHTTPClient = origClient }()
 
 			// Extract host:port from test server URL (strip "http://")
 			host := strings.TrimPrefix(srv.URL, "http://")
 
-			// Override the probe to use http:// instead of https:// for test server.
-			// We achieve this by temporarily wrapping the client transport to
-			// rewrite URLs. Instead, we use a simpler approach: directly test
-			// probeForgeType after monkey-patching the probeHTTPClient to point
-			// at the test server.
-
 			// probeForgeType builds "https://host/path" but our test server is
 			// http. We work around this by intercepting with a custom RoundTripper.
-			probeHTTPClient = &http.Client{
+			probeHTTPClient = httpx.New(httpx.Config{
+				Timeout:    2 * time.Second,
+				MaxRetries: 0,
 				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 					// Rewrite https → http and point at test server
 					req.URL.Scheme = "http"
 					req.URL.Host = host
 					return http.DefaultTransport.RoundTrip(req)
 				}),
-			}
+			})
 
 			got := probeForgeType(host)
 			if got != tt.wantType {
@@ -663,13 +662,15 @@ func TestClassifyHost_UnknownFallsToProbe(t *testing.T) {
 
 	origClient := probeHTTPClient
 	origTeaFunc := checkTeaCLIFunc
-	probeHTTPClient = &http.Client{
+	probeHTTPClient = httpx.New(httpx.Config{
+		Timeout:    2 * time.Second,
+		MaxRetries: 0,
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			req.URL.Scheme = "http"
 			req.URL.Host = host
 			return http.DefaultTransport.RoundTrip(req)
 		}),
-	}
+	})
 	checkTeaCLIFunc = func(string) ForgeType { return ForgeUnknown }
 	defer func() {
 		probeHTTPClient = origClient

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/recinq/wave/internal/httpx"
 	"github.com/recinq/wave/internal/timeouts"
 )
 
@@ -24,7 +25,7 @@ const (
 // Client is a production-ready GitHub API client
 type Client struct {
 	baseURL     string
-	httpClient  *http.Client
+	httpClient  *httpx.Client
 	token       string
 	userAgent   string
 	maxRetries  int
@@ -35,20 +36,24 @@ type Client struct {
 type ClientConfig struct {
 	Token      string
 	BaseURL    string
-	HTTPClient *http.Client
+	HTTPClient *httpx.Client
 	UserAgent  string
 	MaxRetries int
 }
 
-// NewClient creates a new GitHub API client
+// NewClient creates a new GitHub API client. Transport-level requests go
+// through internal/httpx for unified timeout/audit policy. Retry and rate
+// limiting are handled at this layer (see doRequest), so the embedded
+// httpx.Client runs in single-shot mode (MaxRetries: 0).
 func NewClient(config ClientConfig) *Client {
 	if config.BaseURL == "" {
 		config.BaseURL = DefaultAPIURL
 	}
 	if config.HTTPClient == nil {
-		config.HTTPClient = &http.Client{
-			Timeout: timeouts.ForgeAPI,
-		}
+		config.HTTPClient = httpx.New(httpx.Config{
+			Timeout:    timeouts.ForgeAPI,
+			MaxRetries: 0,
+		})
 	}
 	if config.UserAgent == "" {
 		config.UserAgent = DefaultUserAgent
@@ -113,7 +118,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 			req.Header.Set("Content-Type", "application/json")
 		}
 
-		resp, err := c.httpClient.Do(req)
+		resp, err := c.httpClient.Do(ctx, req)
 		if err != nil {
 			lastErr = fmt.Errorf("request failed: %w", err)
 			continue

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -1,0 +1,322 @@
+// Package httpx provides a single, shared HTTP Client wrapper used across
+// Wave for outbound HTTP traffic (forge probes, GitHub API, LLM judge,
+// onboarding probes). Centralizing the client unifies the timeout, retry,
+// and audit policy so transport behaviour is consistent and observable
+// regardless of caller.
+//
+// httpx is intentionally a leaf package: it has no internal Wave imports
+// other than standard library types so it cannot create import cycles. All
+// callers consume *httpx.Client; the underlying *http.Client is never
+// constructed directly by feature packages.
+//
+// The shared Client supports retries with exponential backoff for transient
+// failures (network errors and 5xx responses). Set MaxRetries to 0 to opt
+// out of retries entirely (used by fast-fail probes). A pluggable
+// AuditEmitter hook receives one Event per request attempt for observability
+// and credential-scrubbed logging.
+package httpx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Defaults reflect sane values picked for general API traffic. Individual
+// callers override via Config.
+const (
+	DefaultTimeout       = 30 * time.Second
+	DefaultMaxRetries    = 3
+	DefaultRetryBaseWait = 500 * time.Millisecond
+	DefaultRetryMaxWait  = 30 * time.Second
+)
+
+// Event describes a single HTTP request attempt. AuditEmitter hooks receive
+// one Event per attempt (so a request that retries twice produces three
+// events, one per attempt). Err is non-nil for network-level failures;
+// StatusCode is zero in that case. URL has any query string preserved but
+// callers should scrub credentials before logging.
+type Event struct {
+	URL        string
+	Method     string
+	StatusCode int
+	Attempt    int
+	Duration   time.Duration
+	Err        error
+}
+
+// Config configures a Client. Zero values fall back to package defaults.
+type Config struct {
+	// Timeout is the per-request timeout applied via http.Client.Timeout.
+	// It bounds the total time including connection + body read.
+	Timeout time.Duration
+
+	// MaxRetries is the maximum number of additional attempts after the
+	// initial request. Zero disables retries entirely (single-shot mode).
+	// Negative values are clamped to zero.
+	MaxRetries int
+
+	// RetryBaseWait is the starting backoff delay between retry attempts.
+	// Backoff doubles each attempt, capped at RetryMaxWait.
+	RetryBaseWait time.Duration
+
+	// RetryMaxWait caps the backoff delay between retries.
+	RetryMaxWait time.Duration
+
+	// Transport overrides the underlying RoundTripper. When nil, the
+	// standard http.DefaultTransport is used. Callers with special TLS
+	// requirements (e.g. self-hosted forge probes) supply a custom
+	// transport here.
+	Transport http.RoundTripper
+
+	// CheckRedirect mirrors http.Client.CheckRedirect for callers (e.g.
+	// forge probes) that need to disable redirect-following.
+	CheckRedirect func(req *http.Request, via []*http.Request) error
+
+	// AuditEmitter receives one Event per attempt. Optional; when nil no
+	// audit events are emitted. Implementations must be cheap and
+	// thread-safe.
+	AuditEmitter func(Event)
+}
+
+// Client is the shared HTTP client wrapping *http.Client with retry and
+// audit instrumentation. Exposed methods are concurrency-safe.
+type Client struct {
+	httpClient    *http.Client
+	maxRetries    int
+	retryBaseWait time.Duration
+	retryMaxWait  time.Duration
+	emitAudit     func(Event)
+}
+
+// New constructs a Client with the supplied configuration, applying
+// package defaults for any zero-valued fields.
+func New(cfg Config) *Client {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.MaxRetries < 0 {
+		cfg.MaxRetries = 0
+	}
+	// Caller may explicitly set MaxRetries = 0 for single-shot probes; only
+	// substitute the default when MaxRetries was left at zero AND the caller
+	// did not explicitly want a single-shot. We distinguish by checking
+	// RetryBaseWait/RetryMaxWait — if those are also zero we apply full
+	// defaults including DefaultMaxRetries. If the caller set retry waits
+	// but left MaxRetries at zero we treat it as single-shot intent.
+	applyRetryDefault := cfg.MaxRetries == 0 && cfg.RetryBaseWait == 0 && cfg.RetryMaxWait == 0
+	if applyRetryDefault {
+		cfg.MaxRetries = DefaultMaxRetries
+	}
+	if cfg.RetryBaseWait <= 0 {
+		cfg.RetryBaseWait = DefaultRetryBaseWait
+	}
+	if cfg.RetryMaxWait <= 0 {
+		cfg.RetryMaxWait = DefaultRetryMaxWait
+	}
+
+	hc := &http.Client{
+		Timeout:       cfg.Timeout,
+		Transport:     cfg.Transport,
+		CheckRedirect: cfg.CheckRedirect,
+	}
+
+	return &Client{
+		httpClient:    hc,
+		maxRetries:    cfg.MaxRetries,
+		retryBaseWait: cfg.RetryBaseWait,
+		retryMaxWait:  cfg.RetryMaxWait,
+		emitAudit:     cfg.AuditEmitter,
+	}
+}
+
+// HTTPClient returns the underlying *http.Client. Provided so callers that
+// must hand a raw *http.Client to a third-party API (or to httptest server
+// helpers) can do so without duplicating transport configuration.
+func (c *Client) HTTPClient() *http.Client {
+	if c == nil {
+		return http.DefaultClient
+	}
+	return c.httpClient
+}
+
+// Do executes the request honouring the supplied context, the client
+// timeout, and the retry policy. The request body must be replayable
+// (bytes.Reader, strings.Reader, or nil) for retries to function; requests
+// with a non-replayable body are sent once regardless of MaxRetries.
+//
+// Successful responses (2xx, 3xx, 4xx) are returned to the caller. 5xx
+// responses are retried up to MaxRetries times with exponential backoff
+// before being returned. Network errors and timeouts are likewise retried.
+//
+// Callers are responsible for closing resp.Body when err is nil.
+func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("httpx: nil request")
+	}
+	// Capture body bytes for replay across retries when possible.
+	bodyBytes, replayable, err := snapshotBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("httpx: snapshot body: %w", err)
+	}
+
+	attempts := c.maxRetries + 1
+	if !replayable && req.Body != nil {
+		// Non-replayable body: fall back to single-shot.
+		attempts = 1
+	}
+
+	var lastResp *http.Response
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			delay := c.backoff(attempt - 1)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		// Re-arm body for replay attempts.
+		if replayable && bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+			}
+		}
+
+		// Honour caller context on every attempt.
+		reqWithCtx := req.WithContext(ctx)
+		start := time.Now()
+		resp, err := c.httpClient.Do(reqWithCtx)
+		dur := time.Since(start)
+
+		c.audit(Event{
+			URL:        reqWithCtx.URL.String(),
+			Method:     reqWithCtx.Method,
+			StatusCode: statusCodeOf(resp),
+			Attempt:    attempt,
+			Duration:   dur,
+			Err:        err,
+		})
+
+		if err != nil {
+			lastErr = err
+			lastResp = nil
+			if !shouldRetryErr(err) || attempt == attempts {
+				return nil, err
+			}
+			continue
+		}
+
+		if resp.StatusCode >= 500 && resp.StatusCode <= 599 && attempt < attempts {
+			// Drain and close so the connection can be reused for retry.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			lastResp = nil
+			lastErr = fmt.Errorf("httpx: server returned %d", resp.StatusCode)
+			continue
+		}
+
+		return resp, nil
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	if lastResp != nil {
+		return lastResp, nil
+	}
+	return nil, errors.New("httpx: request failed with no response")
+}
+
+// Get is a convenience wrapper for GET requests.
+func (c *Client) Get(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(ctx, req)
+}
+
+// Post is a convenience wrapper for POST requests with an explicit
+// Content-Type. Body may be nil.
+func (c *Client) Post(ctx context.Context, url, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return c.Do(ctx, req)
+}
+
+func (c *Client) audit(e Event) {
+	if c == nil || c.emitAudit == nil {
+		return
+	}
+	c.emitAudit(e)
+}
+
+// backoff returns the wait before the (attempt+1)-th retry, doubling each
+// step up to retryMaxWait.
+func (c *Client) backoff(retry int) time.Duration {
+	d := c.retryBaseWait
+	for i := 1; i < retry; i++ {
+		d *= 2
+		if d >= c.retryMaxWait {
+			return c.retryMaxWait
+		}
+	}
+	if d > c.retryMaxWait {
+		return c.retryMaxWait
+	}
+	return d
+}
+
+// snapshotBody reads the request body into memory so it can be replayed
+// across retries. Returns (bytes, replayable, err). For nil bodies returns
+// (nil, true, nil).
+//
+// http.NewRequestWithContext sets GetBody for known seekable readers
+// (bytes.Reader, bytes.Buffer, strings.Reader); we always read into memory
+// here so the retry loop can re-arm req.Body uniformly without depending on
+// transport-level redirect machinery.
+func snapshotBody(req *http.Request) ([]byte, bool, error) {
+	if req.Body == nil {
+		return nil, true, nil
+	}
+	data, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+func statusCodeOf(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
+// shouldRetryErr identifies transient transport errors worth retrying.
+// Conservatively we retry context-independent errors only — context.Canceled
+// and context.DeadlineExceeded short-circuit because the caller has already
+// given up.
+func shouldRetryErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -1,0 +1,342 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewAppliesDefaults(t *testing.T) {
+	c := New(Config{})
+	if c.maxRetries != DefaultMaxRetries {
+		t.Errorf("maxRetries = %d, want %d", c.maxRetries, DefaultMaxRetries)
+	}
+	if c.retryBaseWait != DefaultRetryBaseWait {
+		t.Errorf("retryBaseWait = %v, want %v", c.retryBaseWait, DefaultRetryBaseWait)
+	}
+	if c.retryMaxWait != DefaultRetryMaxWait {
+		t.Errorf("retryMaxWait = %v, want %v", c.retryMaxWait, DefaultRetryMaxWait)
+	}
+	if c.httpClient.Timeout != DefaultTimeout {
+		t.Errorf("Timeout = %v, want %v", c.httpClient.Timeout, DefaultTimeout)
+	}
+}
+
+func TestNewSingleShotPreservedWhenRetryWaitsSet(t *testing.T) {
+	// Caller setting retry waits but leaving MaxRetries=0 expresses
+	// single-shot intent — the default-application heuristic must not
+	// override that.
+	c := New(Config{
+		MaxRetries:    0,
+		RetryBaseWait: 100 * time.Millisecond,
+	})
+	if c.maxRetries != 0 {
+		t.Errorf("maxRetries = %d, want 0 (single-shot)", c.maxRetries)
+	}
+}
+
+func TestGetSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	c := New(Config{Timeout: 2 * time.Second, MaxRetries: 1})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", string(body), "hello")
+	}
+}
+
+func TestRetryOn5xxThenSuccess(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    3,
+		RetryBaseWait: 1 * time.Millisecond,
+		RetryMaxWait:  10 * time.Millisecond,
+	})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Errorf("hits = %d, want 3", got)
+	}
+}
+
+func TestRetriesExhaustedReturns5xx(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    2,
+		RetryBaseWait: 1 * time.Millisecond,
+		RetryMaxWait:  5 * time.Millisecond,
+	})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected resp returned with 5xx, got err: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Errorf("hits = %d, want 3 (1 initial + 2 retries)", got)
+	}
+}
+
+func TestNoRetryOn4xx(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    3,
+		RetryBaseWait: 1 * time.Millisecond,
+	})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("hits = %d, want 1 (no retry on 4xx)", got)
+	}
+}
+
+func TestSingleShotMode(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    0,
+		RetryBaseWait: 1 * time.Millisecond,
+	})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("hits = %d, want 1 (single-shot)", got)
+	}
+}
+
+func TestPostBodyReplayedAcrossRetries(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "payload" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		n := atomic.AddInt32(&hits, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    2,
+		RetryBaseWait: 1 * time.Millisecond,
+	})
+	resp, err := c.Post(context.Background(), srv.URL, "text/plain", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("Post error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestAuditEmitterReceivesEventPerAttempt(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var events []Event
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    3,
+		RetryBaseWait: 1 * time.Millisecond,
+		AuditEmitter: func(e Event) {
+			events = append(events, e)
+		},
+	})
+	resp, err := c.Get(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].Attempt != 1 || events[1].Attempt != 2 {
+		t.Errorf("attempts = %d,%d, want 1,2", events[0].Attempt, events[1].Attempt)
+	}
+	if events[0].StatusCode != http.StatusInternalServerError {
+		t.Errorf("event[0].StatusCode = %d, want 500", events[0].StatusCode)
+	}
+	if events[1].StatusCode != http.StatusOK {
+		t.Errorf("event[1].StatusCode = %d, want 200", events[1].StatusCode)
+	}
+	if events[0].Method != http.MethodGet {
+		t.Errorf("event[0].Method = %q, want GET", events[0].Method)
+	}
+}
+
+func TestContextCancellationStopsRetry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		Timeout:       2 * time.Second,
+		MaxRetries:    5,
+		RetryBaseWait: 50 * time.Millisecond,
+		RetryMaxWait:  100 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Get(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestCustomTransport(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Custom RoundTripper that rewrites every request to the test server.
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	c := New(Config{
+		Timeout:    2 * time.Second,
+		MaxRetries: 0,
+		Transport:  transport,
+	})
+	resp, err := c.Get(context.Background(), "https://example.invalid/")
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestCheckRedirectHonoured(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer final.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, final.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	c := New(Config{
+		Timeout:    2 * time.Second,
+		MaxRetries: 0,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	})
+	resp, err := c.Get(context.Background(), redirector.URL)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302 (redirect not followed)", resp.StatusCode)
+	}
+}
+
+func TestHTTPClientAccessor(t *testing.T) {
+	c := New(Config{Timeout: 5 * time.Second})
+	hc := c.HTTPClient()
+	if hc == nil {
+		t.Fatal("HTTPClient() returned nil")
+	}
+	if hc.Timeout != 5*time.Second {
+		t.Errorf("underlying timeout = %v, want 5s", hc.Timeout)
+	}
+}
+
+// roundTripFunc adapts a function to http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/onboarding/steps.go
+++ b/internal/onboarding/steps.go
@@ -1,15 +1,16 @@
 package onboarding
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"sort"
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/httpx"
 	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/uitheme"
 )
@@ -36,9 +37,12 @@ func probeAdapter(binary string) bool {
 
 // probeOllamaModels queries a running Ollama server for available models.
 func probeOllamaModels() []string {
-	// Try to connect to local Ollama
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get("http://localhost:11434/api/tags")
+	// Single-shot probe — Ollama either responds immediately on localhost
+	// or it isn't running. Retries would only delay startup.
+	client := httpx.New(httpx.Config{Timeout: 2 * time.Second, MaxRetries: 0})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, err := client.Get(ctx, "http://localhost:11434/api/tags")
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

New `internal/httpx` package: shared HTTP `Client` with timeout, retry (exponential backoff with cap), and audit-emitter hooks. Eliminates 7 of 9 `&http.Client{}` constructions across the codebase. 8.5 formatDuration verified — already consolidated by PR #1408.

## Public API

```go
type Config struct {
    Timeout       time.Duration
    MaxRetries    int
    RetryBaseWait time.Duration
    RetryMaxWait  time.Duration
    Transport     http.RoundTripper
    CheckRedirect func(*http.Request, []*http.Request) error
    AuditEmitter  func(Event)
}

type Event struct { URL, Method string; StatusCode, Attempt int; Duration time.Duration; Err error }

func New(cfg Config) *Client
func (c *Client) Do(ctx, *http.Request) (*http.Response, error)
func (c *Client) Get(ctx, url string) (*http.Response, error)
func (c *Client) Post(ctx, url, contentType string, body io.Reader) (*http.Response, error)
func (c *Client) HTTPClient() *http.Client  // escape hatch
```

## Defaults

- 30s timeout, 3 retries, 500ms base / 30s cap exponential backoff
- Single-shot opt-in: `MaxRetries: 0` + non-zero retry-wait fields = explicit single-shot intent

## Per-site policy migrated

| Site | Timeout | Retries | Notes |
|---|---|---|---|
| `contract/llm_judge` | 60s | 2 | Anthropic API transients |
| `forge/detect.probeHTTPClient` | 3s | 0 | Best-effort probe; preserves InsecureSkipVerify + no-redirect |
| `github.Client` | ForgeAPI (15s) | 0 | github layer has its own retry/rate-limit loop |
| `onboarding.probeOllamaModels` | 2s | 0 | Localhost probe |

## 8.5 formatDuration verification

- `tui/pipeline_list.go`: removed by PR #1408
- `webui/embed.go`, `webui/handlers_runs.go`: use `humanize.DurationSeconds`
- `audit/logger.go:144`: keeps private `formatDuration` returning `"%.3fs"` (millisecond precision) — intentional per spec `specs/1163-consolidate-humanizers/spec.md:33`. **No migration needed.**

## Out of scope (deferred follow-up)

- `internal/hooks/{http,webhook_runner}.go` — 2 remaining `&http.Client{}`. Trivial follow-up.

## Validation

- `go build ./...` + `go vet ./...` clean
- `go test -race ./internal/httpx/... ./internal/contract/... ./internal/forge/... ./internal/github/... ./internal/onboarding/...` all pass
- `golangci-lint` 0 issues

## Test plan

- [ ] CI green
- [ ] LLM judge still calls Claude (`wave run` with agent_review contract)
- [ ] Forge detection still works (`wave init`)

Partial of #1503 (subset 8.3 + 8.5 verify). Parent: #1494.