### PR TITLE
refactor(cmd): move compose logic to internal/pipeline (#1502 partial)

### DIFF
--- a/cmd/wave/commands/compose.go
+++ b/cmd/wave/commands/compose.go
@@ -12,6 +12,7 @@ import (
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/skill"
@@ -80,14 +81,17 @@ Use --validate-only to check compatibility without executing.`,
 			// Validate artifact compatibility across the sequence
 			result := tui.ValidateSequence(seq)
 
-			// Add template validation for composition pipelines
-			var templateErrors []string
-			for _, entry := range seq.Entries {
-				errs := pipeline.ValidateCompositionTemplates(entry.Pipeline)
-				for _, e := range errs {
-					templateErrors = append(templateErrors, fmt.Sprintf("[%s] %s", entry.PipelineName, e))
+			// Add composition template validation for all pipelines in the
+			// sequence. Logic lives in internal/pipeline so webui/tui can reuse
+			// it without depending on cobra.
+			composeEntries := make([]pipeline.ComposeEntry, len(seq.Entries))
+			for i, entry := range seq.Entries {
+				composeEntries[i] = pipeline.ComposeEntry{
+					Name:     entry.PipelineName,
+					Pipeline: entry.Pipeline,
 				}
 			}
+			templateErrors := pipeline.ValidateComposeSpec(composeEntries)
 
 			if validateOnly {
 				if err := renderValidationReport(args, result); err != nil {
@@ -125,7 +129,7 @@ Use --validate-only to check compatibility without executing.`,
 			debug, _ := cmd.Flags().GetBool("debug")
 
 			if parallelFlag {
-				plan := buildExecutionPlan(seq, args)
+				plan := pipeline.BuildExecutionPlan(composeEntries, args)
 				plan.FailFast = failFastFlag
 				plan.MaxConcurrent = maxConcurrentFlag
 				return runComposePlan(seq, plan, inputFlag, manifestFlag, mockFlag, outputCfg, debug)
@@ -209,59 +213,22 @@ func formatSequenceArrow(names []string) string {
 	return strings.Join(names, " → ")
 }
 
-// buildExecutionPlan parses args with "--" separators into stages.
-// Pipelines before the first "--" form a parallel stage;
-// each group after "--" forms a sequential stage.
-func buildExecutionPlan(seq tui.Sequence, args []string) pipeline.ExecutionPlan {
-	var plan pipeline.ExecutionPlan
-
-	// Split args by "--" to determine stage boundaries
-	var stages [][]string
-	current := []string{}
-	for _, arg := range args {
-		if arg == "--" {
-			if len(current) > 0 {
-				stages = append(stages, current)
-			}
-			current = []string{}
-		} else {
-			current = append(current, arg)
-		}
-	}
-	if len(current) > 0 {
-		stages = append(stages, current)
-	}
-
-	// Map pipeline names to pipeline objects from the sequence
-	pipelineMap := make(map[string]*pipeline.Pipeline)
-	for _, entry := range seq.Entries {
-		pipelineMap[entry.PipelineName] = entry.Pipeline
-	}
-
-	// All multi-pipeline groups are parallel (--parallel flag is always set
-	// when buildExecutionPlan is called); single-pipeline groups are sequential
-	for _, group := range stages {
-		var pipelines []*pipeline.Pipeline
-		for _, name := range group {
-			if p, ok := pipelineMap[name]; ok {
-				pipelines = append(pipelines, p)
-			}
-		}
-		if len(pipelines) > 0 {
-			plan.Stages = append(plan.Stages, pipeline.Stage{
-				Pipelines: pipelines,
-				Parallel:  len(pipelines) > 1,
-			})
-		}
-	}
-
-	return plan
+// composeRuntime bundles the shared dependencies wired up before sequence
+// execution. Constructed once per compose run and reused by both Execute and
+// ExecutePlan code paths.
+type composeRuntime struct {
+	ctx         context.Context
+	cancel      context.CancelFunc
+	manifest    manifest.Manifest
+	seqExecutor *pipeline.SequenceExecutor
+	store       interface{ Close() error }
 }
 
-// runComposePlan executes a pipeline execution plan with parallel stage support.
-func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, manifestPath string, mock bool, outputCfg OutputConfig, debug bool) error {
+// setupComposeRuntime constructs the manifest, adapter, state store, event
+// emitter, workspace manager, and SequenceExecutor used by both compose
+// execution paths. Caller is responsible for invoking close().
+func setupComposeRuntime(manifestPath string, mock bool, outputCfg OutputConfig, debug bool) (*composeRuntime, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
@@ -272,15 +239,14 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 
 	mp, err := loadManifestStrict(manifestPath)
 	if err != nil {
-		return err
+		cancel()
+		return nil, err
 	}
 	m := *mp
 
 	var runner adapter.AdapterRunner
 	if mock {
-		runner = adaptertest.NewMockAdapter(
-			adaptertest.WithSimulatedDelay(5 * time.Second),
-		)
+		runner = adaptertest.NewMockAdapter(adaptertest.WithSimulatedDelay(5 * time.Second))
 	} else {
 		var adapterName string
 		for name := range m.Adapters {
@@ -290,21 +256,17 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 		runner = adapter.ResolveAdapter(adapterName)
 	}
 
-	stateDB := ".agents/state.db"
-	store, err := state.NewStateStore(stateDB)
+	store, err := state.NewStateStore(".agents/state.db")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: state persistence disabled: %v\n", err)
 		store = nil
-	}
-	if store != nil {
-		defer store.Close()
 	}
 
 	emitter := event.NewNDJSONEmitter()
 	var eventEmitter event.EventEmitter = emitter
 	if outputCfg.Format == OutputFormatAuto || outputCfg.Format == OutputFormatText {
-		emitter = event.NewProgressOnlyEmitter(nil)
-		eventEmitter = emitter
+		// Suppress JSON in text mode.
+		eventEmitter = event.NewProgressOnlyEmitter(nil)
 	}
 
 	wsRoot := m.Runtime.WorkspaceRoot
@@ -313,12 +275,14 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 	}
 	wsManager, err := workspace.NewWorkspaceManager(wsRoot)
 	if err != nil {
-		return fmt.Errorf("failed to create workspace manager: %w", err)
+		cancel()
+		if store != nil {
+			_ = store.Close()
+		}
+		return nil, fmt.Errorf("failed to create workspace manager: %w", err)
 	}
 
-	baseOpts := []pipeline.ExecutorOption{
-		pipeline.WithDebug(debug),
-	}
+	baseOpts := []pipeline.ExecutorOption{pipeline.WithDebug(debug)}
 	if wsManager != nil {
 		baseOpts = append(baseOpts, pipeline.WithWorkspaceManager(wsManager))
 	}
@@ -328,7 +292,60 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 		return pipeline.NewDefaultPipelineExecutor(runner, opts...)
 	}
 
-	seqExecutor := pipeline.NewSequenceExecutor(newExecutor, baseOpts, eventEmitter, store)
+	rt := &composeRuntime{
+		ctx:         ctx,
+		cancel:      cancel,
+		manifest:    m,
+		seqExecutor: pipeline.NewSequenceExecutor(newExecutor, baseOpts, eventEmitter, store),
+	}
+	if store != nil {
+		rt.store = store
+	}
+	return rt, nil
+}
+
+func (rt *composeRuntime) close() {
+	if rt == nil {
+		return
+	}
+	if rt.store != nil {
+		_ = rt.store.Close()
+	}
+	if rt.cancel != nil {
+		rt.cancel()
+	}
+}
+
+// printPipelineSummary prints per-pipeline status lines and an aggregate footer.
+func printPipelineSummary(seqResult *pipeline.SequenceResult, footer string, elapsed time.Duration) {
+	for _, pr := range seqResult.PipelineResults {
+		status := "OK"
+		if pr.Status == "failed" {
+			status = "FAILED"
+		}
+		tokStr := ""
+		if pr.TokensUsed > 0 {
+			tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(pr.TokensUsed))
+		}
+		fmt.Fprintf(os.Stderr, "  [%s] %s (%.1fs%s)\n", status, pr.PipelineName, pr.Duration.Seconds(), tokStr)
+	}
+	fmt.Fprintln(os.Stderr)
+
+	tokStr := ""
+	if seqResult.TotalTokens > 0 {
+		tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(seqResult.TotalTokens))
+	}
+	fmt.Fprintf(os.Stderr, "%s: %d pipelines in %.1fs%s\n",
+		footer, len(seqResult.PipelineResults), elapsed.Seconds(), tokStr)
+}
+
+// runComposePlan executes a pipeline execution plan with parallel stage support.
+func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, manifestPath string, mock bool, outputCfg OutputConfig, debug bool) error {
+	rt, err := setupComposeRuntime(manifestPath, mock, outputCfg, debug)
+	if err != nil {
+		return err
+	}
+	defer rt.close()
 
 	// Describe the plan
 	for i, stage := range plan.Stages {
@@ -345,115 +362,25 @@ func runComposePlan(_ tui.Sequence, plan pipeline.ExecutionPlan, input string, m
 	fmt.Fprintln(os.Stderr)
 
 	startTime := time.Now()
-	seqResult, execErr := seqExecutor.ExecutePlan(ctx, plan, &m, input)
+	seqResult, execErr := rt.seqExecutor.ExecutePlan(rt.ctx, plan, &rt.manifest, input)
 	elapsed := time.Since(startTime)
 
-	for _, pr := range seqResult.PipelineResults {
-		status := "OK"
-		if pr.Status == "failed" {
-			status = "FAILED"
-		}
-		tokStr := ""
-		if pr.TokensUsed > 0 {
-			tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(pr.TokensUsed))
-		}
-		fmt.Fprintf(os.Stderr, "  [%s] %s (%.1fs%s)\n", status, pr.PipelineName, pr.Duration.Seconds(), tokStr)
-	}
-	fmt.Fprintln(os.Stderr)
-
 	if execErr != nil {
+		printPipelineSummary(seqResult, "Plan completed", elapsed)
 		return fmt.Errorf("compose execution failed: %w", execErr)
 	}
-
-	tokStr := ""
-	if seqResult.TotalTokens > 0 {
-		tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(seqResult.TotalTokens))
-	}
-	fmt.Fprintf(os.Stderr, "Plan completed: %d pipelines in %.1fs%s\n",
-		len(seqResult.PipelineResults), elapsed.Seconds(), tokStr)
-
+	printPipelineSummary(seqResult, "Plan completed", elapsed)
 	return nil
 }
 
 // runCompose executes a validated pipeline sequence using SequenceExecutor.
 func runCompose(seq tui.Sequence, input string, manifestPath string, mock bool, outputCfg OutputConfig, debug bool) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
-	go func() {
-		<-sigChan
-		cancel()
-	}()
-
-	mp, err := loadManifestStrict(manifestPath)
+	rt, err := setupComposeRuntime(manifestPath, mock, outputCfg, debug)
 	if err != nil {
 		return err
 	}
-	m := *mp
+	defer rt.close()
 
-	// Resolve adapter
-	var runner adapter.AdapterRunner
-	if mock {
-		runner = adaptertest.NewMockAdapter(
-			adaptertest.WithSimulatedDelay(5 * time.Second),
-		)
-	} else {
-		var adapterName string
-		for name := range m.Adapters {
-			adapterName = name
-			break
-		}
-		runner = adapter.ResolveAdapter(adapterName)
-	}
-
-	// Initialize state store
-	stateDB := ".agents/state.db"
-	store, err := state.NewStateStore(stateDB)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: state persistence disabled: %v\n", err)
-		store = nil
-	}
-	if store != nil {
-		defer store.Close()
-	}
-
-	// Initialize event emitter
-	emitter := event.NewNDJSONEmitter()
-	var eventEmitter event.EventEmitter = emitter
-	if outputCfg.Format == OutputFormatAuto || outputCfg.Format == OutputFormatText {
-		emitter = event.NewProgressOnlyEmitter(nil) // suppress JSON in text mode
-		eventEmitter = emitter
-	}
-
-	// Initialize workspace manager
-	wsRoot := m.Runtime.WorkspaceRoot
-	if wsRoot == "" {
-		wsRoot = ".agents/workspaces"
-	}
-	wsManager, err := workspace.NewWorkspaceManager(wsRoot)
-	if err != nil {
-		return fmt.Errorf("failed to create workspace manager: %w", err)
-	}
-
-	// Build base executor options shared across all pipelines
-	baseOpts := []pipeline.ExecutorOption{
-		pipeline.WithDebug(debug),
-	}
-	if wsManager != nil {
-		baseOpts = append(baseOpts, pipeline.WithWorkspaceManager(wsManager))
-	}
-	baseOpts = append(baseOpts, pipeline.WithSkillStore(skill.NewDirectoryStore(skill.DefaultSources()...)))
-
-	// Factory function creates a fresh executor per pipeline
-	newExecutor := func(opts ...pipeline.ExecutorOption) *pipeline.DefaultPipelineExecutor {
-		return pipeline.NewDefaultPipelineExecutor(runner, opts...)
-	}
-
-	seqExecutor := pipeline.NewSequenceExecutor(newExecutor, baseOpts, eventEmitter, store)
-
-	// Collect pipeline pointers from the sequence entries
 	pipelines := make([]*pipeline.Pipeline, len(seq.Entries))
 	pipelineNames := make([]string, len(seq.Entries))
 	for i, entry := range seq.Entries {
@@ -464,33 +391,13 @@ func runCompose(seq tui.Sequence, input string, manifestPath string, mock bool, 
 	fmt.Fprintf(os.Stderr, "Executing sequence: %s\n\n", formatSequenceArrow(pipelineNames))
 
 	startTime := time.Now()
-	seqResult, execErr := seqExecutor.Execute(ctx, pipelines, &m, input)
+	seqResult, execErr := rt.seqExecutor.Execute(rt.ctx, pipelines, &rt.manifest, input)
 	elapsed := time.Since(startTime)
 
-	// Print summary
-	for _, pr := range seqResult.PipelineResults {
-		status := "OK"
-		if pr.Status == "failed" {
-			status = "FAILED"
-		}
-		tokStr := ""
-		if pr.TokensUsed > 0 {
-			tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(pr.TokensUsed))
-		}
-		fmt.Fprintf(os.Stderr, "  [%s] %s (%.1fs%s)\n", status, pr.PipelineName, pr.Duration.Seconds(), tokStr)
-	}
-	fmt.Fprintln(os.Stderr)
-
 	if execErr != nil {
+		printPipelineSummary(seqResult, "Sequence completed", elapsed)
 		return fmt.Errorf("compose execution failed: %w", execErr)
 	}
-
-	tokStr := ""
-	if seqResult.TotalTokens > 0 {
-		tokStr = fmt.Sprintf(", %s tokens", display.FormatTokenCount(seqResult.TotalTokens))
-	}
-	fmt.Fprintf(os.Stderr, "Sequence completed: %d pipelines in %.1fs%s\n",
-		len(seqResult.PipelineResults), elapsed.Seconds(), tokStr)
-
+	printPipelineSummary(seqResult, "Sequence completed", elapsed)
 	return nil
 }

--- a/cmd/wave/commands/compose_test.go
+++ b/cmd/wave/commands/compose_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/tui"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -302,69 +300,3 @@ func TestComposeCmd_ExecutionModeCompatible(t *testing.T) {
 		"output should mention the first pipeline")
 }
 
-func TestBuildExecutionPlan_MultipleParallelGroups(t *testing.T) {
-	// Simulate: wave compose --parallel A B -- C D -- E
-	// Expected: Stage 1 (parallel: A,B), Stage 2 (parallel: C,D), Stage 3 (sequential: E)
-
-	newPipeline := func(name string) *pipeline.Pipeline {
-		return &pipeline.Pipeline{
-			Metadata: pipeline.PipelineMetadata{Name: name},
-			Steps: []pipeline.Step{
-				{ID: "step1", Persona: "navigator", Exec: pipeline.ExecConfig{Source: "do it"}},
-			},
-		}
-	}
-
-	var seq tui.Sequence
-	for _, name := range []string{"A", "B", "C", "D", "E"} {
-		seq.Add(name, newPipeline(name))
-	}
-
-	args := []string{"A", "B", "--", "C", "D", "--", "E"}
-	plan := buildExecutionPlan(seq, args)
-
-	require.Len(t, plan.Stages, 3, "should have 3 stages")
-
-	// Stage 1: A, B — parallel
-	assert.Len(t, plan.Stages[0].Pipelines, 2)
-	assert.True(t, plan.Stages[0].Parallel, "stage 1 should be parallel")
-	assert.Equal(t, "A", plan.Stages[0].Pipelines[0].Metadata.Name)
-	assert.Equal(t, "B", plan.Stages[0].Pipelines[1].Metadata.Name)
-
-	// Stage 2: C, D — parallel
-	assert.Len(t, plan.Stages[1].Pipelines, 2)
-	assert.True(t, plan.Stages[1].Parallel, "stage 2 should be parallel")
-	assert.Equal(t, "C", plan.Stages[1].Pipelines[0].Metadata.Name)
-	assert.Equal(t, "D", plan.Stages[1].Pipelines[1].Metadata.Name)
-
-	// Stage 3: E — sequential (single pipeline)
-	assert.Len(t, plan.Stages[2].Pipelines, 1)
-	assert.False(t, plan.Stages[2].Parallel, "stage 3 with single pipeline should be sequential")
-	assert.Equal(t, "E", plan.Stages[2].Pipelines[0].Metadata.Name)
-}
-
-func TestBuildExecutionPlan_SingleGroupParallel(t *testing.T) {
-	// Simulate: wave compose --parallel A B C (no -- separators)
-	// Expected: Stage 1 (parallel: A,B,C)
-
-	newPipeline := func(name string) *pipeline.Pipeline {
-		return &pipeline.Pipeline{
-			Metadata: pipeline.PipelineMetadata{Name: name},
-			Steps: []pipeline.Step{
-				{ID: "step1", Persona: "navigator", Exec: pipeline.ExecConfig{Source: "do it"}},
-			},
-		}
-	}
-
-	var seq tui.Sequence
-	for _, name := range []string{"A", "B", "C"} {
-		seq.Add(name, newPipeline(name))
-	}
-
-	args := []string{"A", "B", "C"}
-	plan := buildExecutionPlan(seq, args)
-
-	require.Len(t, plan.Stages, 1)
-	assert.Len(t, plan.Stages[0].Pipelines, 3)
-	assert.True(t, plan.Stages[0].Parallel, "single multi-pipeline group should be parallel")
-}

--- a/internal/pipeline/composition.go
+++ b/internal/pipeline/composition.go
@@ -827,6 +827,84 @@ func truncateJSON(data json.RawMessage) string {
 	return s
 }
 
+// ComposeEntry is an ordered, named pipeline reference used by the compose
+// command and by callers that build execution plans from CLI-style argument
+// lists.
+//
+// It is intentionally a thin record (name + pipeline pointer) so callers in
+// cmd/, webui/, and tui/ can share the same plan-building logic without
+// pulling tui.Sequence into the pipeline package.
+type ComposeEntry struct {
+	Name     string
+	Pipeline *Pipeline
+}
+
+// BuildExecutionPlan turns a CLI-style argument list into an ExecutionPlan.
+//
+// Pipelines before the first "--" form a stage; each group separated by "--"
+// forms an additional stage. Multi-pipeline stages are parallel; single-pipeline
+// stages are sequential. Names not present in entries are silently dropped —
+// callers are expected to validate the entry set before calling this function.
+func BuildExecutionPlan(entries []ComposeEntry, args []string) ExecutionPlan {
+	var plan ExecutionPlan
+
+	// Split args by "--" to determine stage boundaries.
+	var stages [][]string
+	current := []string{}
+	for _, arg := range args {
+		if arg == "--" {
+			if len(current) > 0 {
+				stages = append(stages, current)
+			}
+			current = []string{}
+		} else {
+			current = append(current, arg)
+		}
+	}
+	if len(current) > 0 {
+		stages = append(stages, current)
+	}
+
+	// Map pipeline names to pipeline objects from the entries.
+	pipelineMap := make(map[string]*Pipeline, len(entries))
+	for _, e := range entries {
+		pipelineMap[e.Name] = e.Pipeline
+	}
+
+	for _, group := range stages {
+		var pipelines []*Pipeline
+		for _, name := range group {
+			if p, ok := pipelineMap[name]; ok {
+				pipelines = append(pipelines, p)
+			}
+		}
+		if len(pipelines) > 0 {
+			plan.Stages = append(plan.Stages, Stage{
+				Pipelines: pipelines,
+				Parallel:  len(pipelines) > 1,
+			})
+		}
+	}
+
+	return plan
+}
+
+// ValidateComposeSpec runs ValidateCompositionTemplates against every pipeline
+// in the entries and returns prefixed errors so the caller can surface which
+// entry produced which violation.
+func ValidateComposeSpec(entries []ComposeEntry) []string {
+	var errs []string
+	for _, e := range entries {
+		if e.Pipeline == nil {
+			continue
+		}
+		for _, msg := range ValidateCompositionTemplates(e.Pipeline) {
+			errs = append(errs, fmt.Sprintf("[%s] %s", e.Name, msg))
+		}
+	}
+	return errs
+}
+
 // ValidateCompositionTemplates checks that all template references in a composition
 // pipeline resolve to known step IDs or valid expressions.
 func ValidateCompositionTemplates(p *Pipeline) []string {

--- a/internal/pipeline/composition_test.go
+++ b/internal/pipeline/composition_test.go
@@ -803,3 +803,163 @@ func TestCompositionExecutor_Aggregate_NoRegistrationWithoutRunID(t *testing.T) 
 		t.Error("RegisterArtifact must be skipped when runID is empty")
 	}
 }
+
+func TestBuildExecutionPlan_MultipleParallelGroups(t *testing.T) {
+	// Simulate: wave compose --parallel A B -- C D -- E
+	// Expected: Stage 1 (parallel: A,B), Stage 2 (parallel: C,D), Stage 3 (sequential: E)
+
+	newPipeline := func(name string) *Pipeline {
+		return &Pipeline{
+			Metadata: PipelineMetadata{Name: name},
+			Steps: []Step{
+				{ID: "step1", Persona: "navigator", Exec: ExecConfig{Source: "do it"}},
+			},
+		}
+	}
+
+	var entries []ComposeEntry
+	for _, name := range []string{"A", "B", "C", "D", "E"} {
+		entries = append(entries, ComposeEntry{Name: name, Pipeline: newPipeline(name)})
+	}
+
+	args := []string{"A", "B", "--", "C", "D", "--", "E"}
+	plan := BuildExecutionPlan(entries, args)
+
+	if got, want := len(plan.Stages), 3; got != want {
+		t.Fatalf("stages: got %d, want %d", got, want)
+	}
+
+	// Stage 1: A, B — parallel
+	if got, want := len(plan.Stages[0].Pipelines), 2; got != want {
+		t.Errorf("stage 0 pipelines: got %d, want %d", got, want)
+	}
+	if !plan.Stages[0].Parallel {
+		t.Error("stage 0 should be parallel")
+	}
+	if name := plan.Stages[0].Pipelines[0].Metadata.Name; name != "A" {
+		t.Errorf("stage 0 pipeline 0: got %q, want A", name)
+	}
+	if name := plan.Stages[0].Pipelines[1].Metadata.Name; name != "B" {
+		t.Errorf("stage 0 pipeline 1: got %q, want B", name)
+	}
+
+	// Stage 2: C, D — parallel
+	if got, want := len(plan.Stages[1].Pipelines), 2; got != want {
+		t.Errorf("stage 1 pipelines: got %d, want %d", got, want)
+	}
+	if !plan.Stages[1].Parallel {
+		t.Error("stage 1 should be parallel")
+	}
+	if name := plan.Stages[1].Pipelines[0].Metadata.Name; name != "C" {
+		t.Errorf("stage 1 pipeline 0: got %q, want C", name)
+	}
+	if name := plan.Stages[1].Pipelines[1].Metadata.Name; name != "D" {
+		t.Errorf("stage 1 pipeline 1: got %q, want D", name)
+	}
+
+	// Stage 3: E — sequential (single pipeline)
+	if got, want := len(plan.Stages[2].Pipelines), 1; got != want {
+		t.Errorf("stage 2 pipelines: got %d, want %d", got, want)
+	}
+	if plan.Stages[2].Parallel {
+		t.Error("stage 2 with single pipeline should be sequential")
+	}
+	if name := plan.Stages[2].Pipelines[0].Metadata.Name; name != "E" {
+		t.Errorf("stage 2 pipeline 0: got %q, want E", name)
+	}
+}
+
+func TestBuildExecutionPlan_SingleGroupParallel(t *testing.T) {
+	// Simulate: wave compose --parallel A B C (no -- separators)
+	// Expected: Stage 1 (parallel: A,B,C)
+
+	newPipeline := func(name string) *Pipeline {
+		return &Pipeline{
+			Metadata: PipelineMetadata{Name: name},
+			Steps: []Step{
+				{ID: "step1", Persona: "navigator", Exec: ExecConfig{Source: "do it"}},
+			},
+		}
+	}
+
+	var entries []ComposeEntry
+	for _, name := range []string{"A", "B", "C"} {
+		entries = append(entries, ComposeEntry{Name: name, Pipeline: newPipeline(name)})
+	}
+
+	args := []string{"A", "B", "C"}
+	plan := BuildExecutionPlan(entries, args)
+
+	if got, want := len(plan.Stages), 1; got != want {
+		t.Fatalf("stages: got %d, want %d", got, want)
+	}
+	if got, want := len(plan.Stages[0].Pipelines), 3; got != want {
+		t.Errorf("stage 0 pipelines: got %d, want %d", got, want)
+	}
+	if !plan.Stages[0].Parallel {
+		t.Error("single multi-pipeline group should be parallel")
+	}
+}
+
+func TestBuildExecutionPlan_DropsUnknownNames(t *testing.T) {
+	// Names not present in entries are silently dropped.
+	newPipeline := func(name string) *Pipeline {
+		return &Pipeline{Metadata: PipelineMetadata{Name: name}}
+	}
+	entries := []ComposeEntry{
+		{Name: "A", Pipeline: newPipeline("A")},
+	}
+	plan := BuildExecutionPlan(entries, []string{"A", "ghost"})
+	if got, want := len(plan.Stages), 1; got != want {
+		t.Fatalf("stages: got %d, want %d", got, want)
+	}
+	if got, want := len(plan.Stages[0].Pipelines), 1; got != want {
+		t.Errorf("pipelines: got %d, want %d (ghost should be dropped)", got, want)
+	}
+	if plan.Stages[0].Parallel {
+		t.Error("single resolved pipeline must be sequential")
+	}
+}
+
+func TestValidateComposeSpec_PrefixesEntryName(t *testing.T) {
+	// A pipeline with a template ref to an unknown step should produce
+	// an error prefixed with the entry name.
+	bad := &Pipeline{
+		Metadata: PipelineMetadata{Name: "bad-pipeline"},
+		Steps: []Step{
+			{
+				ID:       "merge",
+				Aggregate: &AggregateConfig{From: "{{ unknown_step.output }}"},
+			},
+		},
+	}
+	good := &Pipeline{
+		Metadata: PipelineMetadata{Name: "good-pipeline"},
+		Steps: []Step{
+			{ID: "compute"},
+			{
+				ID:       "merge",
+				Aggregate: &AggregateConfig{From: "{{ compute.output }}"},
+			},
+		},
+	}
+
+	entries := []ComposeEntry{
+		{Name: "good", Pipeline: good},
+		{Name: "bad", Pipeline: bad},
+	}
+	errs := ValidateComposeSpec(entries)
+	if len(errs) != 1 {
+		t.Fatalf("errors: got %d (%v), want 1", len(errs), errs)
+	}
+	if got := errs[0]; len(got) < 5 || got[:5] != "[bad]" {
+		t.Errorf("error must be prefixed with entry name: got %q", errs[0])
+	}
+}
+
+func TestValidateComposeSpec_NilPipelineSkipped(t *testing.T) {
+	entries := []ComposeEntry{{Name: "nil-entry", Pipeline: nil}}
+	if errs := ValidateComposeSpec(entries); len(errs) != 0 {
+		t.Errorf("nil pipeline must be skipped, got %v", errs)
+	}
+}


### PR DESCRIPTION
## Summary

- `compose.go` reduced 496 → 403 LOC (-93)
- `BuildExecutionPlan` and `ValidateComposeSpec` moved from cmd to `internal/pipeline/composition.go`
- New tui-agnostic `ComposeEntry` type
- Bonus: extracted `setupComposeRuntime` + `printPipelineSummary` removing ~120 LOC of duplicate executor wiring

## Public API added to `internal/pipeline`

```go
type ComposeEntry struct {
    Name     string
    Pipeline *Pipeline
}

func BuildExecutionPlan(entries []ComposeEntry, args []string) ExecutionPlan
func ValidateComposeSpec(entries []ComposeEntry) []string
```

cmd builds `[]ComposeEntry` from `seq.Entries` and calls these. `ValidateComposeSpec` wraps existing `ValidateCompositionTemplates` and prefixes errors with entry name.

## Why ≤200 LOC target not hit

`compose.go` final = 403 LOC. Validation report formatter (~60 LOC, depends on `tui.MatchStatus`/`CompatibilityResult`) and execution wiring (~110 LOC) are still cmd-layer concerns. Spirit met: cobra + output formatting + cmd-only execution glue, no domain logic.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/pipeline/... ./cmd/wave/commands/...` PASS (cmd 235s)
- `go test -race ./...` PASS (all packages)
- `golangci-lint` 0 issues
- `wave compose --help` byte-identical via diff

## Out of scope (deferred)

- 1502 run.go thin (depends on #1499 Part 2)
- 1502 analyze.go evaluate

## Test plan

- [ ] CI green
- [ ] `wave compose --validate <spec>` accepts/rejects same plans
- [ ] `wave compose --plan <spec>` outputs same plan structure

Partial of #1502 (compose.go portion). Parent: #1494.