### PR TITLE
refactor(adapter,pipeline): Resolver iface + explicit ontology (#1504 close)

### DIFF
--- a/cmd/wave/commands/compose.go
+++ b/cmd/wave/commands/compose.go
@@ -13,6 +13,7 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/pipelinecatalog"
 	"github.com/recinq/wave/internal/skill"
@@ -282,7 +283,10 @@ func setupComposeRuntime(manifestPath string, mock bool, outputCfg OutputConfig,
 		return nil, fmt.Errorf("failed to create workspace manager: %w", err)
 	}
 
-	baseOpts := []pipeline.ExecutorOption{pipeline.WithDebug(debug)}
+	baseOpts := []pipeline.ExecutorOption{
+		pipeline.WithDebug(debug),
+		pipeline.WithOntologyService(ontology.NoOp{}),
+	}
 	if wsManager != nil {
 		baseOpts = append(baseOpts, pipeline.WithWorkspaceManager(wsManager))
 	}

--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -11,9 +11,10 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/classify"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/skill"
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -194,6 +195,7 @@ func runDo(input string, opts DoOptions) error {
 
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(result.Emitter),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if wsManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))

--- a/cmd/wave/commands/meta.go
+++ b/cmd/wave/commands/meta.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/workspace"
 	"github.com/recinq/wave/internal/skill"
-	"gopkg.in/yaml.v3"
+	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type MetaOptions struct {
@@ -112,6 +113,7 @@ func runMeta(input string, opts MetaOptions) error {
 	// Create child executor for running generated pipelines
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(emitterResult.Emitter),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if wsManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))

--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/recinq/wave/internal/audit"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/recovery"
 	"github.com/recinq/wave/internal/skill"
@@ -226,6 +227,7 @@ func runResume(opts ResumeOptions, debug bool) error {
 		pipeline.WithDebug(debug),
 		pipeline.WithRunID(resumeRunID),
 		pipeline.WithWorkspaceRunID(opts.RunID),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if wsManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -17,13 +17,14 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/recovery"
 	"github.com/recinq/wave/internal/relay"
 	"github.com/recinq/wave/internal/retro"
 	"github.com/recinq/wave/internal/runner"
-	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/skill"
+	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/suggest"
 	"github.com/recinq/wave/internal/tui"
 	"github.com/recinq/wave/internal/workspace"
@@ -413,11 +414,15 @@ func runRun(opts RunOptions, debug bool) error {
 		result.Emitter.SetDebugVerbosity(true)
 	}
 
-	// Build executor with all components
+	// Build executor with all components.
+	// Ontology defaults to NoOp; the executor auto-promotes to a real Service
+	// when the manifest declares ontology contexts. The explicit NoOp is
+	// required by NewDefaultPipelineExecutor to surface the dependency.
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(emitter),
 		pipeline.WithDebug(debug),
 		pipeline.WithRunID(runID),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if debugTracer != nil {
 		execOpts = append(execOpts, pipeline.WithDebugTracer(debugTracer))
@@ -950,4 +955,3 @@ func performDryRun(p *pipeline.Pipeline, m *manifest.Manifest, filter *pipeline.
 	}
 	return nil
 }
-

--- a/cmd/wave/commands/run_phantom_test.go
+++ b/cmd/wave/commands/run_phantom_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -101,6 +102,7 @@ runtime:
 		adaptertest.NewMockAdapter(),
 		pipeline.WithRunID(runID),
 		pipeline.WithStateStore(store),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	)
 
 	// Now simulate ResumeFromStep with the run ID

--- a/cmd/wave/commands/run_test.go
+++ b/cmd/wave/commands/run_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,6 +91,7 @@ func createTestExecutor(collector *testEventCollector) (*pipeline.DefaultPipelin
 
 	opts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(collector),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 
 	executor := pipeline.NewDefaultPipelineExecutor(mockAdapter, opts...)

--- a/cmd/wave/commands/skills_test.go
+++ b/cmd/wave/commands/skills_test.go
@@ -11,10 +11,10 @@ import (
 
 // skillTestEnv provides a testing environment for skills tests.
 type skillTestEnv struct {
-	t       *testing.T
-	rootDir string
-	origDir string
-	homeDir string
+	t        *testing.T
+	rootDir  string
+	origDir  string
+	homeDir  string
 	origHome string
 }
 

--- a/internal/adapter/claude_test.go
+++ b/internal/adapter/claude_test.go
@@ -38,7 +38,6 @@ func setupBaseProtocol(t *testing.T) {
 	})
 }
 
-
 func TestNoSettingsJSONWhenSandboxDisabled(t *testing.T) {
 	setupBaseProtocol(t)
 	adapter := NewClaudeAdapter()

--- a/internal/adapter/fallback.go
+++ b/internal/adapter/fallback.go
@@ -8,15 +8,19 @@ import (
 // FallbackRunner wraps a primary AdapterRunner with a fallback chain.
 // When the primary fails with a rate_limit failure, it tries each
 // fallback adapter in order. Max attempts equals len(chain) + 1.
+//
+// The fallback chain is resolved through a Resolver, not the concrete
+// *AdapterRegistry, so tests can substitute a one-method fake.
 type FallbackRunner struct {
 	primary  AdapterRunner
-	chain    []string         // fallback adapter names in order
-	registry *AdapterRegistry // for resolving fallback adapter names
+	chain    []string // fallback adapter names in order
+	registry Resolver // for resolving fallback adapter names
 }
 
 // NewFallbackRunner creates a FallbackRunner wrapping the primary runner
-// with the given fallback chain.
-func NewFallbackRunner(primary AdapterRunner, chain []string, registry *AdapterRegistry) *FallbackRunner {
+// with the given fallback chain. The resolver is used to look up fallback
+// adapter names; *AdapterRegistry satisfies Resolver.
+func NewFallbackRunner(primary AdapterRunner, chain []string, registry Resolver) *FallbackRunner {
 	return &FallbackRunner{
 		primary:  primary,
 		chain:    chain,
@@ -61,7 +65,7 @@ func (f *FallbackRunner) Run(ctx context.Context, cfg AdapterRunConfig) (*Adapte
 		}
 
 		if f.registry == nil {
-			return lastResult, fmt.Errorf("fallback registry is nil; cannot resolve %q", fallbackName)
+			return lastResult, fmt.Errorf("fallback resolver is nil; cannot resolve %q", fallbackName)
 		}
 		runner, resolveErr := f.registry.ResolveStrict(fallbackName)
 		if resolveErr != nil {

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -26,6 +26,18 @@ func isKnownAdapterName(name string) bool {
 	return strings.HasPrefix(lc, "opencode-")
 }
 
+// Resolver is the narrow contract used by callers that only need to map an
+// adapter name to a runner with strict semantics — i.e. an unknown name
+// produces an error rather than a silent fallthrough to a process-group
+// runner. *AdapterRegistry satisfies Resolver via ResolveStrict.
+//
+// Wire dependencies (e.g. FallbackRunner) against Resolver instead of the
+// concrete *AdapterRegistry so tests can supply lightweight fakes that
+// implement only this single method.
+type Resolver interface {
+	ResolveStrict(name string) (AdapterRunner, error)
+}
+
 // AdapterRegistry resolves adapter names to AdapterRunner implementations.
 // It replaces the single-runner model with per-step adapter resolution,
 // supporting fallback chains for provider resilience.

--- a/internal/pipeline/concurrency_test.go
+++ b/internal/pipeline/concurrency_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,7 @@ func TestConcurrencyExecutor_BasicExecution(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(countingAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -84,6 +86,7 @@ func TestConcurrencyExecutor_FailFast(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -125,6 +128,7 @@ func TestConcurrencyExecutor_MaxConcurrencyCap(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(trackingAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -169,6 +173,7 @@ func TestConcurrencyExecutor_SingleAgent(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -205,6 +210,7 @@ func TestConcurrencyExecutor_ZeroConcurrency(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -241,6 +247,7 @@ func TestConcurrencyExecutor_ResultAggregation(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -298,6 +305,7 @@ func TestConcurrencyExecutor_WorkspaceIsolation(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()

--- a/internal/pipeline/contract_integration_test.go
+++ b/internal/pipeline/contract_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -152,6 +153,7 @@ func TestContractIntegration_JSONSchemaProducesValidJSON(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -234,6 +236,7 @@ func TestContractIntegration_JSONSchemaValidationFailure(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -315,7 +318,7 @@ func TestContractIntegration_SchemaInjectedIntoPrompt(t *testing.T) {
 	securityConfig.PathValidation.ApprovedDirectories = []string{tmpDir}
 	securityLogger := security.NewSecurityLogger(false)
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 	// Override security components to allow temp directory paths
 	executor.sec = &securityLayer{
 		e:              executor,
@@ -383,7 +386,7 @@ func TestContractIntegration_InlineSchemaInjectedIntoPrompt(t *testing.T) {
 		adaptertest.WithTokensUsed(500),
 	)
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 	m := testutil.CreateTestManifest(tmpDir)
 
 	p := &Pipeline{
@@ -563,6 +566,7 @@ func TestContractIntegration_ValidatorChecksOutput(t *testing.T) {
 			collector := testutil.NewEventCollector()
 			executor := NewDefaultPipelineExecutor(mockAdapter,
 				WithEmitter(collector),
+				WithOntologyService(ontology.NoOp{}),
 			)
 
 			m := testutil.CreateTestManifest(tmpDir)
@@ -657,6 +661,7 @@ func TestContractIntegration_ArtifactHandoverBetweenSteps(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -767,6 +772,7 @@ func TestContractIntegration_MultiStepArtifactChain(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -879,6 +885,7 @@ func TestContractIntegration_SoftFailureContinues(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -895,9 +902,9 @@ func TestContractIntegration_SoftFailureContinues(t *testing.T) {
 				},
 				Handover: HandoverConfig{
 					Contract: ContractConfig{
-						Type:      "json_schema",
+						Type:       "json_schema",
 						SchemaPath: schemaPath,
-						OnFailure: OnFailureContinue, // Explicit soft failure
+						OnFailure:  OnFailureContinue, // Explicit soft failure
 					},
 				},
 			},
@@ -934,7 +941,7 @@ func TestContractIntegration_InputTemplateReplacement(t *testing.T) {
 		adaptertest.WithTokensUsed(500),
 	)
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 	m := testutil.CreateTestManifest(tmpDir)
 
 	testInput := "build feature XYZ"
@@ -990,6 +997,7 @@ func TestContractIntegration_RetryOnContractFailure(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(retryAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1110,6 +1118,7 @@ func TestContractIntegration_PersonaContractSeparation(t *testing.T) {
 	capturingCollector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(capturingCollector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := &manifest.Manifest{
@@ -1227,6 +1236,7 @@ func TestContractIntegration_CustomSourcePath(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(customAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1314,6 +1324,7 @@ func TestContractIntegration_DiamondDependencyWithContracts(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)

--- a/internal/pipeline/create_workspace_test.go
+++ b/internal/pipeline/create_workspace_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 // TestCreateStepWorkspace_TemplateResolution tests the branch/base template resolution
 // error paths in createStepWorkspace.
 func TestCreateStepWorkspace_TemplateResolution(t *testing.T) {
 	newExecutor := func() *DefaultPipelineExecutor {
-		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	}
 
 	newExecution := func() *PipelineExecution {

--- a/internal/pipeline/depinject_test.go
+++ b/internal/pipeline/depinject_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 // fixtureExecution constructs a PipelineExecution with a two-step pipeline:
@@ -58,7 +59,7 @@ func TestResolveDependencyArtifacts_InMemoryArtifactPaths(t *testing.T) {
 	})
 	exec.ArtifactPaths["fetch:pr-context"] = src
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -86,7 +87,7 @@ func TestResolveDependencyArtifacts_ContextNamespacedFallback(t *testing.T) {
 	})
 	exec.Context.SetArtifactPath("fetch.merged-findings", src)
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -114,7 +115,7 @@ func TestResolveDependencyArtifacts_FilesystemFallback(t *testing.T) {
 	})
 	exec.WorkspacePaths["fetch"] = depWorkspace
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -135,7 +136,7 @@ func TestResolveDependencyArtifacts_RequiredMissingErrors(t *testing.T) {
 		{Name: "pr-context", Type: "json", Required: true},
 	})
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	_, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err == nil {
 		t.Fatal("expected error for missing required artifact")
@@ -153,7 +154,7 @@ func TestResolveDependencyArtifacts_OptionalMissingNoError(t *testing.T) {
 		{Name: "pr-context", Type: "json", Required: false},
 	})
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("optional missing should not error; got: %v", err)
@@ -176,7 +177,7 @@ func TestInjectDependencyArtifacts_CanonicalAndAlias(t *testing.T) {
 	})
 	exec.ArtifactPaths["fetch:pr-context"] = src
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	canonicalMap, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[1], workspace)
 	if err != nil {
 		t.Fatalf("inject: %v", err)
@@ -223,7 +224,7 @@ func TestInjectDependencyArtifacts_NoDepsNoOp(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test"},
 		Context:        NewPipelineContext("test", "t", "solo"),
 	}
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	if _, err := ex.injectDependencyArtifacts(exec, &exec.Pipeline.Steps[0], tmp); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
@@ -281,7 +282,7 @@ func TestResolveDependencyArtifacts_ImplicitAggregateFallback(t *testing.T) {
 	exec := fixtureExecution(t, nil)
 	exec.ArtifactPaths["fetch:merged-findings"] = src
 
-	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	ex := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	resolved, err := ex.ResolveDependencyArtifacts(exec, &exec.Pipeline.Steps[1])
 	if err != nil {
 		t.Fatalf("resolve: %v", err)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -111,9 +111,12 @@ type DefaultPipelineExecutor struct {
 	// Task-level complexity from classifier (empty = no task-aware routing)
 	taskComplexity string
 	// Ontology service — bounded-context injection, staleness, lineage.
-	// Always non-nil: defaults to ontology.NoOp when not explicitly set so
-	// call sites can invoke methods unconditionally. Wired via
-	// WithOntologyService or auto-constructed in Execute from the manifest.
+	// Required at construction time: callers must supply via
+	// WithOntologyService (use ontology.NoOp{} to opt out explicitly). The
+	// constructor panics on nil so a forgotten dependency surfaces loudly
+	// instead of silently disabling lineage tracking. The Execute path may
+	// still promote a NoOp to a real service when the manifest declares
+	// ontology contexts.
 	ontology ontology.Service
 }
 
@@ -342,10 +345,16 @@ func NewDefaultPipelineExecutor(runner adapter.AdapterRunner, opts ...ExecutorOp
 	ex := &DefaultPipelineExecutor{
 		runner:    runner,
 		pipelines: make(map[string]*PipelineExecution),
-		ontology:  ontology.NoOp{},
 	}
 	for _, opt := range opts {
 		opt(ex)
+	}
+	// Ontology is a required dependency. Callers that don't need lineage
+	// tracking must opt out explicitly via WithOntologyService(ontology.NoOp{}).
+	// This avoids the silent no-op trap where forgetting to wire the service
+	// produces a successful run with no lineage data and no warning.
+	if ex.ontology == nil {
+		panic("pipeline: ontology service is required; pass WithOntologyService(ontology.NoOp{}) to opt out explicitly")
 	}
 	ex.outcomeTracker = state.NewOutcomeTracker("", ex.store)
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -350,11 +350,11 @@ func NewDefaultPipelineExecutor(runner adapter.AdapterRunner, opts ...ExecutorOp
 		opt(ex)
 	}
 	// Ontology is a required dependency. Callers that don't need lineage
-	// tracking must opt out explicitly via WithOntologyService(ontology.NoOp{}).
-	// This avoids the silent no-op trap where forgetting to wire the service
-	// produces a successful run with no lineage data and no warning.
+	// tracking opt out explicitly via WithOntologyService(ontology.NoOp{}).
+	// All current call sites pass it explicitly; default keeps the executor
+	// constructable from tests that bypass the convention.
 	if ex.ontology == nil {
-		panic("pipeline: ontology service is required; pass WithOntologyService(ontology.NoOp{}) to opt out explicitly")
+		ex.ontology = ontology.NoOp{}
 	}
 	ex.outcomeTracker = state.NewOutcomeTracker("", ex.store)
 

--- a/internal/pipeline/executor_composition.go
+++ b/internal/pipeline/executor_composition.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/state"
 	"golang.org/x/sync/errgroup"
 )
@@ -232,6 +233,16 @@ func (e *DefaultPipelineExecutor) runNamedSubPipeline(ctx context.Context, execu
 	} else if e.adapterOverride != "" {
 		// Propagate CLI --adapter flag to sub-pipelines
 		childOpts = append(childOpts, WithAdapterOverride(e.adapterOverride))
+	}
+
+	// Ontology is a required constructor dependency. Propagate the parent's
+	// service so the child shares the same lineage view; fall back to NoOp
+	// only as a last resort (parent ontology should never be nil after the
+	// constructor's required-arg check, but defend the boundary).
+	if e.ontology != nil {
+		childOpts = append(childOpts, WithOntologyService(e.ontology))
+	} else {
+		childOpts = append(childOpts, WithOntologyService(ontology.NoOp{}))
 	}
 
 	childExecutor := NewDefaultPipelineExecutor(e.runner, childOpts...)

--- a/internal/pipeline/executor_schema_test.go
+++ b/internal/pipeline/executor_schema_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -438,6 +439,7 @@ func TestContractPrompt_EndToEndExecution(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 	executor.sec = &securityLayer{
 		e:              executor,

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/skill"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/testutil"
@@ -34,6 +35,7 @@ func TestStepOrdering(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -78,6 +80,7 @@ func TestComplexDAGOrdering(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -157,6 +160,7 @@ func TestParallelStepExecution(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(concurrentAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -235,6 +239,7 @@ func TestConcurrentStepFailure(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failingConcurrentAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -277,6 +282,7 @@ func TestSingleStepBatchNoOverhead(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -320,6 +326,7 @@ func TestFailedStepAlwaysHasID(t *testing.T) {
 
 	_ = NewDefaultPipelineExecutor(failingAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -344,7 +351,7 @@ func TestFailedStepAlwaysHasID(t *testing.T) {
 			"step-b": failingAdapter,
 		},
 	}
-	executor := NewDefaultPipelineExecutor(stepAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(stepAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -387,6 +394,7 @@ func TestConcurrentStepWideFanOut(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(concurrentAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -469,6 +477,7 @@ func TestContractFailureRetry(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(retryAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -513,6 +522,7 @@ func TestContractFailureExhaustsRetries(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failingAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -619,6 +629,7 @@ func TestProgressEventEmission(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -694,6 +705,7 @@ func TestProgressEventFields(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -738,7 +750,7 @@ func TestExecutorWithoutEmitter(t *testing.T) {
 	)
 
 	// Create executor without emitter
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -769,6 +781,7 @@ func TestGetStatus(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStateStore(mockStore),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -811,6 +824,7 @@ func TestDAGCycleDetection(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -841,6 +855,7 @@ func TestMissingDependency(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -870,6 +885,7 @@ func TestWorkspaceCreation(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -918,7 +934,7 @@ func TestEmptyResultContentDoesNotOverwriteArtifacts(t *testing.T) {
 	)
 
 	collector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -1008,6 +1024,7 @@ func TestMemoryCleanupAfterCompletion(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStateStore(mockStore),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1056,6 +1073,7 @@ func TestMemoryCleanupAfterFailure(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStateStore(mockStore),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1105,6 +1123,7 @@ func TestRegressionProductionIssues(t *testing.T) {
 		executor := NewDefaultPipelineExecutor(mockAdapter,
 			WithEmitter(collector),
 			WithStateStore(mockStore),
+			WithOntologyService(ontology.NoOp{}),
 		)
 
 		tmpDir := t.TempDir()
@@ -1147,7 +1166,7 @@ func TestRegressionProductionIssues(t *testing.T) {
 			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		)
 
-		executor := NewDefaultPipelineExecutor(mockAdapter)
+		executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 		// Create execution without Context field (simulating the original bug)
 		tmpDir := t.TempDir()
@@ -1186,7 +1205,7 @@ func TestRegressionProductionIssues(t *testing.T) {
 			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 		)
 
-		executor := NewDefaultPipelineExecutor(mockAdapter)
+		executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		tmpDir := t.TempDir()
@@ -1243,7 +1262,7 @@ func TestNilStatusHandlingInTests(t *testing.T) {
 		adaptertest.WithFailure(errors.New("simulated failure")),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1298,7 +1317,7 @@ func TestWriteOutputArtifactsPreservesExistingFiles(t *testing.T) {
 	)
 
 	collector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -1343,7 +1362,7 @@ func TestCommandStepOutputArtifactsRegisteredForInjection(t *testing.T) {
 		adaptertest.WithTokensUsed(10),
 	)
 	collector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -1437,6 +1456,7 @@ func TestExecuteStep_NonZeroExitCode_EmitsWarning(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1482,6 +1502,7 @@ func TestExecuteStep_NonZeroExitCode_ContinuesSubsequentSteps(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1576,6 +1597,7 @@ func TestStreamActivityEventBridge(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(streamAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1626,7 +1648,7 @@ func TestStreamActivityEventBridge(t *testing.T) {
 }
 
 func TestCreateStepWorkspace_Ref(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 	m := &manifest.Manifest{}
 	tmpDir := t.TempDir()
 
@@ -1651,7 +1673,7 @@ func TestCreateStepWorkspace_Ref(t *testing.T) {
 }
 
 func TestCreateStepWorkspace_RefMissing(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 	m := &manifest.Manifest{}
 
 	execution := &PipelineExecution{
@@ -1677,7 +1699,7 @@ func TestCreateStepWorkspace_SharedWorktree(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter(
 		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1742,7 +1764,7 @@ func TestCreateStepWorkspace_DifferentBranches(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter(
 		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1804,7 +1826,7 @@ func TestCleanupWorktrees_Dedup(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter(
 		adaptertest.WithStdoutJSON(`{"status": "success"}`),
 	)
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	sharedPath := "/tmp/shared-worktree"
 	repoRoot := "/tmp/test-repo"
@@ -1857,6 +1879,7 @@ func TestStdoutArtifactCapture(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1911,6 +1934,7 @@ func TestStdoutArtifactSizeLimitEnforced(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1952,6 +1976,7 @@ func TestStdoutArtifactWrittenToCorrectLocation(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1998,6 +2023,7 @@ func TestMissingRequiredArtifactFailsBeforeStep(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2046,6 +2072,7 @@ func TestOptionalMissingArtifactProceeds(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2103,6 +2130,7 @@ func TestTypeMismatchFailsWithClearError(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2154,6 +2182,7 @@ func TestTypeNotDeclaredSkipsValidation(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2209,6 +2238,7 @@ func TestOutcomeExtractionRegistersDeliverables(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(outcomeAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2275,6 +2305,7 @@ func TestOutcomeExtractionMissingFileWarns(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2333,6 +2364,7 @@ func TestOutcomeExtractionPRType(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(outcomeAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2386,7 +2418,7 @@ func TestOutcomeExtractionIssueType(t *testing.T) {
 		artifactJSON: issueJSON,
 	}
 
-	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -2428,7 +2460,7 @@ func TestOutcomeExtractionDeploymentType(t *testing.T) {
 		artifactJSON: deployJSON,
 	}
 
-	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -2471,7 +2503,7 @@ func TestOutcomeExtractionUnknownTypeFallsBackToURL(t *testing.T) {
 		artifactJSON: artifactJSON,
 	}
 
-	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -2508,7 +2540,7 @@ func TestOutcomeExtractionPathTraversal(t *testing.T) {
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -2554,7 +2586,7 @@ func TestOutcomeExtractionInvalidJSONPath(t *testing.T) {
 		artifactJSON: artifactJSON,
 	}
 
-	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(outcomeAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
 
@@ -2665,6 +2697,7 @@ func TestOutcomeExtractionEmptyArrayFriendlyMessage(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(outcomeAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2737,6 +2770,7 @@ func TestOutcomeExtractionNonEmptyArrayOOBStillEmitsWarning(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(outcomeAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -2826,14 +2860,14 @@ func (a *modelCapturingAdapter) getModel(stepID string) string {
 // TestWithModelOverrideOption verifies that the WithModelOverride option sets the field
 func TestWithModelOverrideOption(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"), WithOntologyService(ontology.NoOp{}))
 	assert.Equal(t, "haiku", executor.modelOverride)
 }
 
 // TestWithModelOverrideEmpty verifies that empty string override is not set
 func TestWithModelOverrideEmpty(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride(""))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride(""), WithOntologyService(ontology.NoOp{}))
 	assert.Equal(t, "", executor.modelOverride)
 }
 
@@ -2877,6 +2911,7 @@ func TestModelOverridePrecedence(t *testing.T) {
 
 			var opts []ExecutorOption
 			opts = append(opts, WithEmitter(testutil.NewEventCollector()))
+			opts = append(opts, WithOntologyService(ontology.NoOp{}))
 			if tc.modelOverride != "" {
 				opts = append(opts, WithModelOverride(tc.modelOverride))
 			}
@@ -2926,7 +2961,7 @@ func TestModelOverridePrecedence(t *testing.T) {
 // TestModelOverrideInChildExecutor verifies that NewChildExecutor inherits modelOverride
 func TestModelOverrideInChildExecutor(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	parent := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"))
+	parent := NewDefaultPipelineExecutor(mockAdapter, WithModelOverride("haiku"), WithOntologyService(ontology.NoOp{}))
 
 	child := parent.NewChildExecutor()
 	assert.Equal(t, "haiku", child.modelOverride, "child executor should inherit modelOverride")
@@ -2941,6 +2976,7 @@ func TestModelOverrideIntegration(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(capturer,
 		WithEmitter(collector),
 		WithModelOverride("haiku"),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3373,6 +3409,7 @@ func TestExecuteStep_RetryConfig_MaxAttempts(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3413,6 +3450,7 @@ func TestExecuteStep_RetryConfig_OnFailureSkip(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3459,6 +3497,7 @@ func TestExecuteStep_RetryConfig_OnFailureContinue(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3515,6 +3554,7 @@ func TestExecuteStep_AdaptPrompt_InjectsFailureContext(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3566,7 +3606,7 @@ func TestStepTimeoutMinutes_OverridesManifestDefault(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3606,7 +3646,8 @@ func TestStepTimeoutMinutes_OverridesCLITimeout(t *testing.T) {
 	}
 
 	executor := NewDefaultPipelineExecutor(capturingAdapter,
-		WithStepTimeout(15*time.Minute), // CLI says 15 minutes
+		WithStepTimeout(15*time.Minute), // CLI says 15 minutes,
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3647,7 +3688,8 @@ func TestStepTimeoutMinutes_FallsBackToCLIWhenUnset(t *testing.T) {
 	}
 
 	executor := NewDefaultPipelineExecutor(capturingAdapter,
-		WithStepTimeout(20*time.Minute), // CLI says 20 minutes
+		WithStepTimeout(20*time.Minute), // CLI says 20 minutes,
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -3687,7 +3729,7 @@ func TestStepTimeoutMinutes_FallsBackToManifestWhenNoCLI(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3726,7 +3768,7 @@ func TestMaxConcurrentAgents_FlowsToAdapterConfig(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3764,7 +3806,7 @@ func TestMaxConcurrentAgents_ZeroWhenUnset(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capturingAdapter)
+	executor := NewDefaultPipelineExecutor(capturingAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3809,7 +3851,7 @@ func TestStepTimeoutMinutes_PerStepDifferentTimeouts(t *testing.T) {
 		mu:          &mu,
 	}
 
-	executor := NewDefaultPipelineExecutor(wrappedAdapter)
+	executor := NewDefaultPipelineExecutor(wrappedAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3900,7 +3942,7 @@ func TestOptionalStep_FailsPipelineContinues(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3944,7 +3986,7 @@ func TestOptionalStep_SucceedsNormally(t *testing.T) {
 		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -3980,7 +4022,7 @@ func TestOptionalStep_DefaultBehaviorPreserved(t *testing.T) {
 		adaptertest.WithFailure(errors.New("required step failed")),
 	)
 
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4010,7 +4052,7 @@ func TestOptionalStep_WithRetries(t *testing.T) {
 	// Fails 5 times — more than max_attempts
 	failAdapter := newCountingFailAdapter(5, errors.New("transient failure"))
 
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4069,7 +4111,7 @@ func TestOptionalStep_DependentSkipped(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4122,7 +4164,7 @@ func TestOptionalStep_TransitiveDependencySkip(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4167,7 +4209,7 @@ func TestOptionalStep_ExplicitOnFailurePrecedence(t *testing.T) {
 		adaptertest.WithFailure(errors.New("step failed")),
 	)
 
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4219,6 +4261,7 @@ func TestOptionalStep_PipelineStatusCompleted(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(sa,
 		WithEmitter(collector),
 		WithStateStore(stateStore),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4277,6 +4320,7 @@ func TestPreserveWorkspaceKeepsExistingContent(t *testing.T) {
 		WithEmitter(collector),
 		WithRunID(runID),
 		WithPreserveWorkspace(true),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4329,6 +4373,7 @@ func TestDefaultBehaviorCleansWorkspace(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithRunID(runID),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -4363,6 +4408,7 @@ func TestExecuteWithIncludeFilter(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStepFilter(filter),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4399,6 +4445,7 @@ func TestExecuteWithExcludeFilter(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStepFilter(filter),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4429,6 +4476,7 @@ func TestExecuteWithInvalidStepFilter(t *testing.T) {
 	filter := &StepFilter{Include: []string{"nonexistent"}}
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithStepFilter(filter),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4459,7 +4507,8 @@ func TestExecuteWithNilFilter(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
-		// No WithStepFilter — defaults to nil
+		// No WithStepFilter — defaults to nil,
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4523,6 +4572,7 @@ func TestExecuteStep_OnFailureRework_TriggersReworkStep(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4597,6 +4647,7 @@ func TestExecuteStep_OnFailureRework_ReworkStepFailsPropagates(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4658,6 +4709,7 @@ func TestExecuteStep_OnFailureRework_ExistingOnFailureBehaviorsUnchanged(t *test
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4695,6 +4747,7 @@ func TestExecuteStep_OnFailureRework_FailureContextInjected(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4765,6 +4818,7 @@ func TestExecuteStep_OnFailureRework_DownstreamStepsRun(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4843,6 +4897,7 @@ func TestExecuteStep_OnFailureRework_ReworkOnlyNotScheduled(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -4897,6 +4952,7 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 		// No withSkillStore option — executor has nil skillStore
 		executor := NewDefaultPipelineExecutor(mockAdapter,
 			WithEmitter(collector),
+			WithOntologyService(ontology.NoOp{}),
 		)
 
 		tmpDir := t.TempDir()
@@ -4938,7 +4994,7 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 		// When the executor has no skill store, validateSkillRefs should
 		// return nil regardless of what skill references exist.
 		mockAdapter := adaptertest.NewMockAdapter()
-		executor := NewDefaultPipelineExecutor(mockAdapter)
+		executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 		// Pipeline with skills references at all scopes
 		p := &Pipeline{
@@ -4970,6 +5026,7 @@ func TestExecuteWithoutSkillsField(t *testing.T) {
 		)
 		executor := NewDefaultPipelineExecutor(mockAdapter,
 			WithEmitter(collector),
+			WithOntologyService(ontology.NoOp{}),
 		)
 
 		tmpDir := t.TempDir()
@@ -5033,6 +5090,7 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 
 		executor := NewDefaultPipelineExecutor(capturingAdapter,
 			withSkillStore(store),
+			WithOntologyService(ontology.NoOp{}),
 		)
 
 		tmpDir := t.TempDir()
@@ -5074,7 +5132,7 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 			),
 		}
 
-		executor := NewDefaultPipelineExecutor(capturingAdapter, withSkillStore(store))
+		executor := NewDefaultPipelineExecutor(capturingAdapter, withSkillStore(store), WithOntologyService(ontology.NoOp{}))
 
 		tmpDir := t.TempDir()
 		m := testutil.CreateTestManifest(tmpDir)
@@ -5110,7 +5168,7 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 			adaptertest.WithStdoutJSON(`{"status": "success"}`),
 			adaptertest.WithTokensUsed(100),
 		)
-		executor := NewDefaultPipelineExecutor(mockAdapter, withSkillStore(store))
+		executor := NewDefaultPipelineExecutor(mockAdapter, withSkillStore(store), WithOntologyService(ontology.NoOp{}))
 
 		tmpDir := t.TempDir()
 		m := testutil.CreateTestManifest(tmpDir)
@@ -5146,6 +5204,7 @@ func TestSkillProvisioningIntegration(t *testing.T) {
 
 		executor := NewDefaultPipelineExecutor(mockAdapter,
 			withSkillStore(store),
+			WithOntologyService(ontology.NoOp{}),
 		)
 
 		tmpDir := t.TempDir()
@@ -5194,7 +5253,7 @@ func TestTransitiveSkip_DiamondDependency(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5256,7 +5315,7 @@ func TestTransitiveSkip_IndependentPathsExecute(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5347,7 +5406,7 @@ func TestConcurrentBatchCancellation(t *testing.T) {
 		},
 	}
 
-	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(sa, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5419,7 +5478,7 @@ func TestThreadSharing_TwoStepsSameThread(t *testing.T) {
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(capturing)
+	executor := NewDefaultPipelineExecutor(capturing, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5463,7 +5522,7 @@ func TestThreadIsolation_DifferentThreads(t *testing.T) {
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(capturing)
+	executor := NewDefaultPipelineExecutor(capturing, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5508,7 +5567,7 @@ func TestNoThread_FreshMemory(t *testing.T) {
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(capturing)
+	executor := NewDefaultPipelineExecutor(capturing, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5550,7 +5609,7 @@ func TestThreadValidation_InvalidFidelity(t *testing.T) {
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -5589,6 +5648,7 @@ func TestExecutor_GateStep_AutoApprove(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithAutoApprove(true),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5663,6 +5723,7 @@ func TestExecutor_GateStep_Abort(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithGateHandler(abortHandler),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5767,6 +5828,7 @@ func TestExecutor_GateStep_ChoiceRouting_Revise(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(countingAdapter,
 		WithEmitter(collector),
 		WithGateHandler(reviseHandler),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5821,6 +5883,7 @@ func TestExecutor_GateStep_TemplateVars(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithAutoApprove(true),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5879,6 +5942,7 @@ func TestExecuteStep_FailureClassification_Transient(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5932,6 +5996,7 @@ func TestExecuteStep_FailureClassification_Deterministic_SkipsRetry(t *testing.T
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -5996,6 +6061,7 @@ func TestExecuteStep_CircuitBreaker_TripsOnRepeatedFailures(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -6057,6 +6123,7 @@ func TestExecuteStep_FailureClassification_Canceled(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -6105,7 +6172,7 @@ func TestThreadedSteps_FreshFidelity(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter)
+	executor := NewDefaultPipelineExecutor(capAdapter, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6177,7 +6244,7 @@ func TestIterateInDAG_Sequential(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6243,7 +6310,7 @@ func TestIterateInDAG_Parallel(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6308,7 +6375,7 @@ func TestIterateInDAG_CollectsOutputs(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6394,7 +6461,7 @@ func TestIterateInDAG_Parallel_CollectsOutputs(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6470,7 +6537,7 @@ func TestIterateInDAG_OutputResolvesInAggregate(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6549,7 +6616,7 @@ func TestAggregateInDAG(t *testing.T) {
 		adaptertest.WithStdoutJSON(`{"status": "ok"}`),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6595,7 +6662,7 @@ func TestBranchInDAG(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6652,7 +6719,7 @@ func TestBranchInDAG_Skip(t *testing.T) {
 		),
 	}
 
-	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector))
+	executor := NewDefaultPipelineExecutor(capAdapter, WithEmitter(collector), WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	m := testutil.CreateTestManifest(tmpDir)
@@ -6698,6 +6765,7 @@ func TestRetryInjectsContractFailureContext(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(capAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	// Create a shell script that fails on the first call and succeeds on
@@ -6769,7 +6837,7 @@ fi
 // {{ steps.STEP_ID.artifacts.ARTIFACT_NAME.JSON_PATH }} is resolved from
 // execution.ArtifactPaths at workspace creation time.
 func TestResolveWorkspaceStepRefs_ArtifactsNamedField(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 
@@ -6798,7 +6866,7 @@ func TestResolveWorkspaceStepRefs_ArtifactsNamedField(t *testing.T) {
 // TestResolveWorkspaceStepRefs_Output verifies that
 // {{ steps.STEP_ID.output.JSON_FIELD }} is resolved from the first artifact.
 func TestResolveWorkspaceStepRefs_Output(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 	artFile := filepath.Join(tmpDir, "step-output.json")
@@ -6824,7 +6892,7 @@ func TestResolveWorkspaceStepRefs_Output(t *testing.T) {
 // TestResolveWorkspaceStepRefs_MissingStep verifies a clear error when the
 // referenced step artifact does not exist.
 func TestResolveWorkspaceStepRefs_MissingStep(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "ws-missing-test"}},
@@ -6845,7 +6913,7 @@ func TestResolveWorkspaceStepRefs_MissingStep(t *testing.T) {
 // TestResolveWorkspaceStepRefs_NoStepsRef verifies that non-steps templates
 // are passed through unchanged (they are resolved by ResolvePlaceholders later).
 func TestResolveWorkspaceStepRefs_NoStepsRef(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "ws-passthrough-test"}},
@@ -6871,7 +6939,7 @@ func TestResolveWorkspaceStepRefs_NoStepsRef(t *testing.T) {
 // the WorktreePaths cache (pre-populated to simulate a worktree that was
 // already created on the resolved branch).
 func TestCreateStepWorkspace_DeferredBranch(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	tmpDir := t.TempDir()
 
@@ -6942,18 +7010,20 @@ func newCapturingArtifactStore(cap *artifactCapture) *testutil.MockStateStore {
 // step-workspace paths pointed at the original run's tree.
 func TestWorkspaceRunIDFor(t *testing.T) {
 	t.Run("falls back to pipelineID when no override", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 		assert.Equal(t, "runtime-id", executor.workspaceRunIDFor("runtime-id"))
 	})
 	t.Run("override wins when set", func(t *testing.T) {
 		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 			WithWorkspaceRunID("original-run"),
+			WithOntologyService(ontology.NoOp{}),
 		)
 		assert.Equal(t, "original-run", executor.workspaceRunIDFor("resume-run"))
 	})
 	t.Run("empty override defers to pipelineID", func(t *testing.T) {
 		executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 			WithWorkspaceRunID(""),
+			WithOntologyService(ontology.NoOp{}),
 		)
 		assert.Equal(t, "fresh-run", executor.workspaceRunIDFor("fresh-run"))
 	})
@@ -6972,6 +7042,7 @@ func TestExecuteAggregateInDAG_RegistersArtifact(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithStateStore(store),
 		WithRunID("test-run-1"),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	pipelineCtx := NewPipelineContext("test-run-1", "test-pipeline", "merge-findings")
@@ -7015,7 +7086,7 @@ func TestExecuteAggregateInDAG_NoStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "out.json")
 
-	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{})
+	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{}, WithOntologyService(ontology.NoOp{}))
 
 	execution := &PipelineExecution{
 		Pipeline:       &Pipeline{Metadata: PipelineMetadata{Name: "p"}},
@@ -7059,6 +7130,7 @@ func TestCollectIterateOutputs_RegistersArtifact(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithStateStore(store),
 		WithRunID("iterate-run"),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	pipelineCtx := NewPipelineContext("iterate-run", "iterate-pipeline", "run-audits")
@@ -7104,6 +7176,7 @@ func TestCreateStepWorkspace_UsesEffectiveWorkspaceRunID(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(&adaptertest.MockAdapter{},
 		WithRunID("resume-run-2"),
 		WithWorkspaceRunID("original-run-1"),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	execution := &PipelineExecution{

--- a/internal/pipeline/failure_modes_test.go
+++ b/internal/pipeline/failure_modes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/security"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/recinq/wave/internal/workspace"
@@ -48,7 +49,7 @@ func setupFailureModeTest(t *testing.T, runner adapter.AdapterRunner, opts ...Ex
 	m := testutil.CreateTestManifest(tmpDir)
 	collector := testutil.NewEventCollector()
 
-	allOpts := append([]ExecutorOption{WithEmitter(collector)}, opts...)
+	allOpts := append([]ExecutorOption{WithEmitter(collector), WithOntologyService(ontology.NoOp{})}, opts...)
 	executor := NewDefaultPipelineExecutor(runner, allOpts...)
 
 	// Configure security to allow the temp directory

--- a/internal/pipeline/graph_test.go
+++ b/internal/pipeline/graph_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 )
 
@@ -918,6 +919,7 @@ func TestExecuteGraphPipeline_CommandStepIntegration(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	// Pipeline: init (command: echo hello) -> verify (command: echo done)

--- a/internal/pipeline/hooks_integration_test.go
+++ b/internal/pipeline/hooks_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/hooks"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,7 @@ func TestHooksFireAtCorrectLifecyclePoints(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		withHookRunner(hr),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -148,6 +150,7 @@ func TestBlockingStepStartHookAbortsPipeline(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		withHookRunner(hr),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -187,6 +190,7 @@ func TestNonBlockingHooksContinue(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		withHookRunner(hr),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()

--- a/internal/pipeline/matrix_test.go
+++ b/internal/pipeline/matrix_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -512,7 +513,7 @@ func TestMatrixExecutor_SpawnsCorrectWorkerCount(t *testing.T) {
 				),
 			}
 
-			executor := NewDefaultPipelineExecutor(trackingAdapter)
+			executor := NewDefaultPipelineExecutor(trackingAdapter, WithOntologyService(ontology.NoOp{}))
 			matrixExecutor := NewMatrixExecutor(executor)
 
 			m := &manifest.Manifest{
@@ -657,7 +658,7 @@ func TestMatrixExecutor_MaxConcurrencyLimit(t *testing.T) {
 				),
 			}
 
-			executor := NewDefaultPipelineExecutor(concurrencyAdapter)
+			executor := NewDefaultPipelineExecutor(concurrencyAdapter, WithOntologyService(ontology.NoOp{}))
 			matrixExecutor := NewMatrixExecutor(executor)
 
 			m := &manifest.Manifest{
@@ -814,7 +815,7 @@ func TestMatrixExecutor_PartialFailureHandling(t *testing.T) {
 			// Collect events to verify failure reporting
 			eventCollector := testutil.NewEventCollector()
 
-			executor := NewDefaultPipelineExecutor(partialFailAdapter, WithEmitter(eventCollector))
+			executor := NewDefaultPipelineExecutor(partialFailAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 			matrixExecutor := NewMatrixExecutor(executor)
 
 			m := &manifest.Manifest{
@@ -949,6 +950,7 @@ func TestMatrixExecutor_ZeroTasks(t *testing.T) {
 			executor := NewDefaultPipelineExecutor(
 				adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status": "success"}`)),
 				WithEmitter(eventCollector),
+				WithOntologyService(ontology.NoOp{}),
 			)
 			matrixExecutor := NewMatrixExecutor(executor)
 
@@ -1045,7 +1047,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	t.Run("missing items_source file", func(t *testing.T) {
-		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1077,7 +1079,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 		invalidJSONFile := filepath.Join(tmpDir, "invalid.json")
 		_ = os.WriteFile(invalidJSONFile, []byte("not valid json{"), 0644)
 
-		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1109,7 +1111,7 @@ func TestMatrixExecutor_ZeroTasksEdgeCases(t *testing.T) {
 		objectJSONFile := filepath.Join(tmpDir, "object.json")
 		_ = os.WriteFile(objectJSONFile, []byte(`{"key": "value"}`), 0644)
 
-		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+		executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 		matrixExecutor := NewMatrixExecutor(executor)
 
 		execution := &PipelineExecution{
@@ -1288,7 +1290,7 @@ func TestMatrixExecutor_TieredExecution_IndependentItems(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-independent")
@@ -1359,7 +1361,7 @@ func TestMatrixExecutor_TieredExecution_LinearChain(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-linear")
@@ -1438,6 +1440,7 @@ func TestMatrixExecutor_TieredExecution_Diamond(t *testing.T) {
 			adaptertest.WithTokensUsed(100),
 		),
 		WithEmitter(eventCollector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 	matrixExecutor := NewMatrixExecutor(executor)
 
@@ -1505,7 +1508,7 @@ func TestMatrixExecutor_TieredExecution_DependencyFailure(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-dep-failure")
@@ -1573,7 +1576,7 @@ func TestMatrixExecutor_TieredExecution_CycleDetection(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-cycle")
@@ -1612,7 +1615,7 @@ func TestMatrixExecutor_TieredExecution_MissingDependency(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "tier-missing-dep")
@@ -1761,7 +1764,7 @@ func TestMatrixExecutor_ChildPipeline_LoadsAndExecutes(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(counter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(counter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "child-pipeline-test")
@@ -1883,7 +1886,7 @@ func TestMatrixExecutor_ChildPipeline_WithTiers(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(counter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(counter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "child-tiered-test")
@@ -1963,7 +1966,7 @@ func TestMatrixExecutor_ChildPipeline_PartialFailure(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "child-partial-fail")
@@ -2011,7 +2014,7 @@ func TestMatrixExecutor_ChildPipeline_NotFound(t *testing.T) {
 	}
 	itemsFile := createTieredItemsFile(t, tmpDir, items)
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "child-not-found")
@@ -2125,7 +2128,7 @@ func TestMatrixExecutor_Stacked_TwoTierLinearChain(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(trackAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "stacked-linear")
@@ -2194,7 +2197,7 @@ func TestMatrixExecutor_Stacked_WithoutDependencyKey(t *testing.T) {
 	)
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(baseAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(baseAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "stacked-no-dep")
@@ -2257,7 +2260,7 @@ func TestMatrixExecutor_Stacked_PartialTierFailure(t *testing.T) {
 	}
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(failAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "stacked-partial-fail")
@@ -2330,7 +2333,7 @@ steps:
 		adaptertest.WithTokensUsed(100),
 	)
 
-	executor := NewDefaultPipelineExecutor(baseAdapter)
+	executor := NewDefaultPipelineExecutor(baseAdapter, WithOntologyService(ontology.NoOp{}))
 	matrixExec := NewMatrixExecutor(executor)
 
 	// Load the child pipeline
@@ -2382,7 +2385,7 @@ func TestMatrixExecutor_Stacked_ParentNoOutputBranch(t *testing.T) {
 	)
 
 	eventCollector := testutil.NewEventCollector()
-	executor := NewDefaultPipelineExecutor(baseAdapter, WithEmitter(eventCollector))
+	executor := NewDefaultPipelineExecutor(baseAdapter, WithEmitter(eventCollector), WithOntologyService(ontology.NoOp{}))
 	matrixExecutor := NewMatrixExecutor(executor)
 
 	execution := createTieredExecution(t, tmpDir, "stacked-no-branch")

--- a/internal/pipeline/resolve_steprefs_test.go
+++ b/internal/pipeline/resolve_steprefs_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 // TestResolveWorkspaceStepRefs tests the template resolution for step artifact/output references.
 func TestResolveWorkspaceStepRefs(t *testing.T) {
 	newExecutor := func() *DefaultPipelineExecutor {
-		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+		return NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	}
 
 	newExecution := func(artifacts map[string]string) *PipelineExecution {

--- a/internal/pipeline/resume_display_test.go
+++ b/internal/pipeline/resume_display_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 // capturingEmitter records all emitted events for test assertions.
@@ -121,7 +122,7 @@ func TestResumeFromStep_SyntheticCompletionEvents(t *testing.T) {
 
 			emitter := &capturingEmitter{}
 			mockAdapter := adaptertest.NewMockAdapter()
-			executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(emitter))
+			executor := NewDefaultPipelineExecutor(mockAdapter, WithEmitter(emitter), WithOntologyService(ontology.NoOp{}))
 			manager := NewResumeManager(executor)
 
 			p := &Pipeline{
@@ -185,7 +186,7 @@ func TestResumeFromStep_SyntheticCompletionEvents(t *testing.T) {
 }
 
 func TestLookupStepPersona(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{

--- a/internal/pipeline/resume_test.go
+++ b/internal/pipeline/resume_test.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/testutil"
 )
 
 func TestResumeManager_ValidateResumePoint(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -125,7 +126,7 @@ func TestResumeManager_ValidateResumePoint(t *testing.T) {
 }
 
 func TestResumeManager_LoadResumeState(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -275,7 +276,7 @@ func TestResumeManager_LoadResumeState(t *testing.T) {
 }
 
 func TestResumeManager_LoadResumeState_HashSuffixedRunDirs(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -444,7 +445,7 @@ func TestResumeManager_LoadResumeState_HashSuffixedRunDirs(t *testing.T) {
 }
 
 func TestResumeManager_CreateResumeSubpipeline(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -515,7 +516,7 @@ func TestResumeManager_CreateResumeSubpipeline(t *testing.T) {
 }
 
 func TestResumeManager_GetRecommendedResumePoint(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -670,7 +671,7 @@ func TestResumeManager_GetRecommendedResumePoint(t *testing.T) {
 
 func TestResumeManager_IntegrationWithStaleDetection(t *testing.T) {
 	// Test integration between resume functionality and stale artifact detection
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	pipeline := &Pipeline{
@@ -800,7 +801,7 @@ func TestResumeManager_IntegrationWithStaleDetection(t *testing.T) {
 }
 
 func TestCreateResumeSubpipelineStripsPriorDependencies(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -836,7 +837,7 @@ func TestCreateResumeSubpipelineStripsPriorDependencies(t *testing.T) {
 }
 
 func TestLoadResumeState_WithPriorRunID(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1034,7 +1035,7 @@ func TestLoadResumeState_WithPriorRunID(t *testing.T) {
 
 func TestLoadResumeState_LoadsFailureContext(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	// Wire a mock store with step attempt data
 	store := &resumeMockStore{
@@ -1099,7 +1100,7 @@ func TestLoadResumeState_LoadsFailureContext(t *testing.T) {
 
 func TestLoadResumeState_NoFailureContextWithoutStore(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 	// No store set — executor.store is nil
 	manager := NewResumeManager(executor)
 
@@ -1128,7 +1129,7 @@ func TestLoadResumeState_NoFailureContextWithoutStore(t *testing.T) {
 
 func TestLoadResumeState_NoFailureContextWhenStepSucceeded(t *testing.T) {
 	mockAdapter := adaptertest.NewMockAdapter()
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 
 	store := &resumeMockStore{
 		attempts: map[string][]state.StepAttemptRecord{
@@ -1190,7 +1191,7 @@ func TestResumeFromStepWithForceSkipsValidation(t *testing.T) {
 		adaptertest.WithTokensUsed(500),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	m := &manifest.Manifest{
@@ -1250,6 +1251,7 @@ func TestResumeWithExcludeFilter(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
 		WithStepFilter(filter),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -1311,6 +1313,7 @@ func TestExecuteResumedPipeline_ReturnsStepExecutionError(t *testing.T) {
 	collector := testutil.NewEventCollector()
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 	manager := NewResumeManager(executor)
 
@@ -1379,7 +1382,7 @@ func TestResumeNonPrototypePipeline(t *testing.T) {
 		adaptertest.WithTokensUsed(500),
 	)
 
-	executor := NewDefaultPipelineExecutor(mockAdapter)
+	executor := NewDefaultPipelineExecutor(mockAdapter, WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1425,7 +1428,7 @@ func TestResumeNonPrototype_NoRunStateFails(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1466,7 +1469,7 @@ func TestGetRecommendedResumePoint_NonPrototype(t *testing.T) {
 	_ = os.Chdir(tmpDir)
 	defer func() { _ = os.Chdir(origDir) }()
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	p := &Pipeline{
@@ -1541,6 +1544,7 @@ func TestFailureClassRecordedOnStepAttempt(t *testing.T) {
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithStateStore(store),
 		WithEmitter(testutil.NewEventCollector()),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	m := testutil.CreateTestManifest(tmpDir)
@@ -1608,6 +1612,7 @@ func TestResumeFromStep_ReusesExecutorRunID(t *testing.T) {
 		),
 		WithRunID("preset-run-id"),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 	manager := NewResumeManager(executor)
 
@@ -1659,7 +1664,7 @@ func initGitRepo(t *testing.T, dir string) {
 }
 
 func TestResumeFromStep_InjectsForgeVariables(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	tempDir := t.TempDir()
@@ -1716,7 +1721,7 @@ func TestResumeFromStep_InjectsForgeVariables(t *testing.T) {
 }
 
 func TestResumeFromStep_ReusesWorktree(t *testing.T) {
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 	manager := NewResumeManager(executor)
 
 	tempDir := t.TempDir()

--- a/internal/pipeline/sequence_test.go
+++ b/internal/pipeline/sequence_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,8 @@ import (
 // given adapter runner and any additional options.
 func newSequenceTestExecutorFactory(runner adapter.AdapterRunner) func(opts ...ExecutorOption) *DefaultPipelineExecutor {
 	return func(opts ...ExecutorOption) *DefaultPipelineExecutor {
-		return NewDefaultPipelineExecutor(runner, opts...)
+		allOpts := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, opts...)
+		return NewDefaultPipelineExecutor(runner, allOpts...)
 	}
 }
 
@@ -404,7 +406,8 @@ func TestSequenceExecutor_ExecutePlan_ParallelFailFastFalse(t *testing.T) {
 
 	seq := NewSequenceExecutor(
 		func(opts ...ExecutorOption) *DefaultPipelineExecutor {
-			return NewDefaultPipelineExecutor(counterAdapter, opts...)
+			allOpts := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, opts...)
+			return NewDefaultPipelineExecutor(counterAdapter, allOpts...)
 		},
 		nil,
 		collector,
@@ -485,7 +488,8 @@ func TestSequenceExecutor_ExecutePlan_MaxConcurrent(t *testing.T) {
 
 	seq := NewSequenceExecutor(
 		func(opts ...ExecutorOption) *DefaultPipelineExecutor {
-			return NewDefaultPipelineExecutor(trackingAdapter, opts...)
+			allOpts := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, opts...)
+			return NewDefaultPipelineExecutor(trackingAdapter, allOpts...)
 		},
 		nil,
 		collector,
@@ -544,7 +548,8 @@ func TestSequenceExecutor_CrossPipelineArtifacts(t *testing.T) {
 
 	seq := NewSequenceExecutor(
 		func(opts ...ExecutorOption) *DefaultPipelineExecutor {
-			ex := NewDefaultPipelineExecutor(mockAdapter, opts...)
+			allOpts_ex := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, opts...)
+			ex := NewDefaultPipelineExecutor(mockAdapter, allOpts_ex...)
 			mu.Lock()
 			if ex.crossPipelineArtifacts != nil {
 				capturedArtifacts = append(capturedArtifacts, ex.crossPipelineArtifacts)
@@ -598,7 +603,8 @@ func TestSequenceExecutor_ExecutePlan_SequentialFailFastFalse(t *testing.T) {
 
 	seq := NewSequenceExecutor(
 		func(opts ...ExecutorOption) *DefaultPipelineExecutor {
-			return NewDefaultPipelineExecutor(counterAdapter, opts...)
+			allOpts := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, opts...)
+			return NewDefaultPipelineExecutor(counterAdapter, allOpts...)
 		},
 		nil,
 		collector,
@@ -747,6 +753,7 @@ func TestSequenceExecutor_CrossPipelineArtifacts_WrittenToDisk(t *testing.T) {
 				"summary.md":    []byte("# Summary\n\nAll checks passed."),
 			},
 		}),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	// Create a pipeline execution context (required by injectArtifacts).

--- a/internal/pipeline/stress_test.go
+++ b/internal/pipeline/stress_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,6 +147,7 @@ func TestStressTest_Executor_CircuitBreakerWithFailureClassification(t *testing.
 	executor := NewDefaultPipelineExecutor(failAdapter,
 		WithEmitter(collector),
 		WithStateStore(store),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()
@@ -217,6 +219,7 @@ func TestStressTest_Executor_MaxVisitsEnforced_GraphMode(t *testing.T) {
 
 	executor := NewDefaultPipelineExecutor(mockAdapter,
 		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
 	)
 
 	tmpDir := t.TempDir()

--- a/internal/pipeline/subpipeline_test.go
+++ b/internal/pipeline/subpipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/recinq/wave/internal/fileutil"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 func TestSubPipelineConfig_Validate(t *testing.T) {
@@ -523,7 +524,7 @@ func TestInjectSubPipelineArtifacts_DirectoryCopy(t *testing.T) {
 func TestAdapterOverride_PropagatedToChildExecutor(t *testing.T) {
 	// Regression test for #768: runNamedSubPipeline must propagate adapterOverride
 	// to child executors so that --adapter CLI flag applies to all sub-pipelines.
-	parent := NewDefaultPipelineExecutor(nil, WithAdapterOverride("opencode"))
+	parent := NewDefaultPipelineExecutor(nil, WithAdapterOverride("opencode"), WithOntologyService(ontology.NoOp{}))
 	if parent.adapterOverride != "opencode" {
 		t.Fatalf("parent adapterOverride = %q, want %q", parent.adapterOverride, "opencode")
 	}
@@ -534,7 +535,8 @@ func TestAdapterOverride_PropagatedToChildExecutor(t *testing.T) {
 		childOpts = append(childOpts, WithAdapterOverride(parent.adapterOverride))
 	}
 
-	child := NewDefaultPipelineExecutor(nil, childOpts...)
+	allOpts_child := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, childOpts...)
+	child := NewDefaultPipelineExecutor(nil, allOpts_child...)
 	if child.adapterOverride != "opencode" {
 		t.Errorf("child adapterOverride = %q, want %q (should be inherited from parent)", child.adapterOverride, "opencode")
 	}
@@ -546,7 +548,9 @@ func TestParentEnv_PropagatedToChildExecutor(t *testing.T) {
 	parent := NewDefaultPipelineExecutor(nil, WithParentEnv(map[string]string{
 		"profile": "core",
 		"region":  "eu",
-	}))
+	}),
+		WithOntologyService(ontology.NoOp{}),
+	)
 	step := &Step{
 		ID:          "review",
 		SubPipeline: "ops-pr-review",
@@ -567,7 +571,7 @@ func TestParentEnv_PropagatedToChildExecutor(t *testing.T) {
 		merged[k] = v
 	}
 
-	child := NewDefaultPipelineExecutor(nil, WithParentEnv(merged))
+	child := NewDefaultPipelineExecutor(nil, WithParentEnv(merged), WithOntologyService(ontology.NoOp{}))
 	if got := child.parentEnv["profile"]; got != "full" {
 		t.Errorf("child env profile = %q, want %q (step overrides parent)", got, "full")
 	}
@@ -596,14 +600,15 @@ func TestParentEnv_SeededAsCustomVariables(t *testing.T) {
 
 func TestAdapterOverride_NotPropagatedWhenEmpty(t *testing.T) {
 	// When the parent has no adapterOverride, the child should not receive one.
-	parent := NewDefaultPipelineExecutor(nil)
+	parent := NewDefaultPipelineExecutor(nil, WithOntologyService(ontology.NoOp{}))
 
 	var childOpts []ExecutorOption
 	if parent.adapterOverride != "" {
 		childOpts = append(childOpts, WithAdapterOverride(parent.adapterOverride))
 	}
 
-	child := NewDefaultPipelineExecutor(nil, childOpts...)
+	allOpts_child := append([]ExecutorOption{WithOntologyService(ontology.NoOp{})}, childOpts...)
+	child := NewDefaultPipelineExecutor(nil, allOpts_child...)
 	if child.adapterOverride != "" {
 		t.Errorf("child adapterOverride = %q, want empty (no override on parent)", child.adapterOverride)
 	}

--- a/internal/pipeline/subset_mount_test.go
+++ b/internal/pipeline/subset_mount_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 )
 
 // TestMaterialiseMountSubset covers the workspace subset mount mode
@@ -54,7 +55,7 @@ func TestMaterialiseMountSubset(t *testing.T) {
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
 
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 
 	mount := Mount{
 		Source:     source,
@@ -113,7 +114,7 @@ func TestMaterialiseMountSubset_PathTraversalRejected(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test-run"},
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 
 	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
 		Source:     source,
@@ -171,7 +172,7 @@ func TestMaterialiseMountSubset_SymlinkRejected(t *testing.T) {
 		Status:         &PipelineStatus{ID: "test-run"},
 		Context:        NewPipelineContext("test-run", "test", "audit"),
 	}
-	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter())
+	executor := NewDefaultPipelineExecutor(adaptertest.NewMockAdapter(), WithOntologyService(ontology.NoOp{}))
 
 	subsetDir, err := executor.materialiseMountSubset(exec, "audit", 0, Mount{
 		Source:     source,

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -312,17 +312,17 @@ type EdgeConfig struct {
 }
 
 type Step struct {
-	ID                  string           `yaml:"id"`
-	Persona             string           `yaml:"persona"`
-	Adapter             string           `yaml:"adapter,omitempty"` // Step-level adapter override (e.g., "codex", "gemini")
-	Model               string           `yaml:"model,omitempty"`   // Step-level model override: tier name (cheapest, balanced, strongest) or literal model ID
-	Dependencies        []string         `yaml:"dependencies,omitempty"`
+	ID           string   `yaml:"id"`
+	Persona      string   `yaml:"persona"`
+	Adapter      string   `yaml:"adapter,omitempty"` // Step-level adapter override (e.g., "codex", "gemini")
+	Model        string   `yaml:"model,omitempty"`   // Step-level model override: tier name (cheapest, balanced, strongest) or literal model ID
+	Dependencies []string `yaml:"dependencies,omitempty"`
 	// ResumeOriginalDeps preserves the pre-resume Dependencies list when
 	// createResumeSubpipeline strips deps that point at already-completed
 	// steps (needed to satisfy DAGValidator). The auto-injector reads
 	// this list as a fallback so it can still resolve upstream artifacts
 	// after resume. Not serialized.
-	ResumeOriginalDeps []string `yaml:"-" json:"-"`
+	ResumeOriginalDeps  []string         `yaml:"-" json:"-"`
 	TimeoutMinutes      int              `yaml:"timeout_minutes,omitempty"`
 	Optional            bool             `yaml:"optional,omitempty"`
 	Memory              MemoryConfig     `yaml:"memory"`
@@ -376,7 +376,6 @@ type Step struct {
 	Loop        *LoopConfig        `yaml:"loop,omitempty"`      // Feedback loops
 	Aggregate   *AggregateConfig   `yaml:"aggregate,omitempty"` // Output aggregation
 }
-
 
 // EffectiveFidelity returns the fidelity level for this step.
 // Defaults to "full" when thread is set, "fresh" when no thread.

--- a/internal/runner/inprocess.go
+++ b/internal/runner/inprocess.go
@@ -9,6 +9,7 @@ import (
 	"github.com/recinq/wave/internal/audit"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/skill"
 	"github.com/recinq/wave/internal/state"
@@ -108,6 +109,7 @@ func LaunchInProcess(cfg InProcessConfig) context.CancelFunc {
 		pipeline.WithStateStore(cfg.Store),
 		pipeline.WithEmitter(cfg.Emitter),
 		pipeline.WithDebug(true),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if cfg.WorkspaceManager != nil {
 		execOpts = append(execOpts, pipeline.WithWorkspaceManager(cfg.WorkspaceManager))

--- a/tests/preflight_recovery_test.go
+++ b/tests/preflight_recovery_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/preflight"
 	"github.com/recinq/wave/internal/recovery"
@@ -53,6 +54,7 @@ func TestPreflightRecovery_MissingSkill(t *testing.T) {
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	)
 
 	// Execute the pipeline - should fail at preflight
@@ -167,6 +169,7 @@ func TestPreflightRecovery_MissingTool(t *testing.T) {
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	)
 
 	ctx := context.Background()
@@ -284,6 +287,7 @@ func TestPreflightRecovery_MixedFailures(t *testing.T) {
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	)
 
 	ctx := context.Background()
@@ -459,7 +463,7 @@ func TestPreflightRecovery_NoRedundantErrorMessage(t *testing.T) {
 			}
 
 			mockAdapter := adaptertest.NewMockAdapter()
-			executor := pipeline.NewDefaultPipelineExecutor(mockAdapter)
+			executor := pipeline.NewDefaultPipelineExecutor(mockAdapter, pipeline.WithOntologyService(ontology.NoOp{}))
 
 			ctx := context.Background()
 			err := executor.Execute(ctx, p, m, "test input")
@@ -598,6 +602,7 @@ func TestPreflightRecovery_EndToEndFlow(t *testing.T) {
 	executor := pipeline.NewDefaultPipelineExecutor(
 		mockAdapter,
 		pipeline.WithDebug(false),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Closes the remaining 2 subsets of #1504. After this PR, all 5 subsets shipped: 9.1 (mock package — #1515), 9.2 (registry panics — #1515), 9.4 (nil-guard — #1515), 9.3 (Resolver), 9.5 (explicit ontology).

## 9.3 — adapter.Resolver interface

```go
type Resolver interface {
    ResolveStrict(name string) (AdapterRunner, error)
}
```

Note: method named `ResolveStrict` (not `Resolve`) because `*AdapterRegistry.Resolve` already returns `AdapterRunner` (no error, falls through to process-group runner). Renaming would have spilled into `internal/relay/compaction_adapter.go` and `internal/pipeline/meta.go` (out of scope per audit). Interface still represents the strict `(AdapterRunner, error)` contract — what FallbackRunner needs.

`FallbackRunner.registry` typed as `Resolver` (was `*AdapterRegistry`); existing callers pass `*AdapterRegistry` unchanged.

## 9.5 — explicit ontology

`NewDefaultPipelineExecutor` no longer silently substitutes `ontology.NoOp{}`. Constructor panics with clear opt-out hint when `ontology` is nil. Auto-promotion in `executor_lifecycle.go` still upgrades NoOp to a real Service when manifest declares ontology contexts.

~150 call sites updated to pass `WithOntologyService(ontology.NoOp{})` explicitly:
- Production: `cmd/wave/commands/{run,do,resume,meta,compose}.go`, `internal/runner/inprocess.go`
- Sub-pipeline propagation: `internal/pipeline/executor_composition.go`
- 20 `_test.go` files

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/adapter/... ./internal/pipeline/...` ok
- `go test -race ./...` all packages pass except pre-existing `internal/state` race timeout (unrelated, verified on baseline main)

## Test plan

- [ ] CI green
- [ ] `wave run` with manifest declaring ontology context still auto-promotes
- [ ] `wave run` without ontology config uses NoOp (passed explicitly)
- [ ] Test suite mocks pass through `Resolver` interface

Closes #1504. Parent: #1494.