### PR TITLE
refactor(cmd): split runRun god function into stages (#1499 close)

### DIFF
--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -1,33 +1,18 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/huh"
-	"github.com/recinq/wave/internal/adapter"
-	"github.com/recinq/wave/internal/adapter/adaptertest"
-	"github.com/recinq/wave/internal/audit"
-	"github.com/recinq/wave/internal/continuous"
-	"github.com/recinq/wave/internal/display"
-	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
-	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/recovery"
-	"github.com/recinq/wave/internal/relay"
-	"github.com/recinq/wave/internal/retro"
 	"github.com/recinq/wave/internal/runner"
-	"github.com/recinq/wave/internal/skill"
 	"github.com/recinq/wave/internal/state"
 	"github.com/recinq/wave/internal/suggest"
 	"github.com/recinq/wave/internal/tui"
-	"github.com/recinq/wave/internal/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -210,86 +195,19 @@ Model formats vary by adapter: claude uses "haiku"/"opus", opencode uses
 }
 
 func runRun(opts RunOptions, debug bool) error {
-	// Gate on onboarding completion — skip when --force is set
-	if !opts.Force {
-		if err := checkOnboarding(); err != nil {
-			return NewCLIError(CodeOnboardingRequired,
-				"onboarding not complete",
-				"Run 'wave init' to complete setup before running pipelines")
-		}
+	if err := validateFlags(opts); err != nil {
+		return err
 	}
 
-	// Validate mutual exclusion: --continuous and --from-step cannot be combined
-	if opts.Continuous && opts.FromStep != "" {
-		return NewCLIError(CodeInvalidArgs,
-			"--continuous and --from-step are mutually exclusive",
-			"Use --continuous for batch processing or --from-step for resuming a single run")
-	}
-
-	// Validate --continuous requires --source
-	if opts.Continuous && opts.Source == "" {
-		return NewCLIError(CodeInvalidArgs,
-			"--continuous requires --source",
-			"Specify a source URI, e.g., --source \"github:label=bug\" or --source \"file:queue.txt\"")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := setupSignalHandling()
 	defer cancel()
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
-	go func() {
-		<-sigChan
-		cancel()
-	}()
-
-	mp, err := loadManifestStrict(opts.Manifest)
+	p, m, stepFilter, aborted, err := loadManifestAndPipeline(&opts, &debug)
 	if err != nil {
 		return err
 	}
-	m := *mp
-
-	p, err := pipeline.LoadByName(opts.Pipeline)
-	if err != nil {
-		// Pipeline not found — if interactive, try TUI with partial name as filter
-		if isInteractive() {
-			sel, tuiErr := tui.RunPipelineSelector(pipelinesDir(), opts.Pipeline)
-			if tuiErr != nil {
-				if errors.Is(tuiErr, huh.ErrUserAborted) {
-					return nil
-				}
-				return tuiErr
-			}
-			applySelection(&opts, sel, &debug)
-			p, err = pipeline.LoadByName(opts.Pipeline)
-			if err != nil {
-				return NewCLIError(CodePipelineNotFound,
-					fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
-					"Run 'wave list pipelines' to see available pipelines")
-			}
-		} else {
-			return NewCLIError(CodePipelineNotFound,
-				fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
-				"Run 'wave list pipelines' to see available pipelines")
-		}
-	}
-
-	// Warn on input/pipeline mismatch (non-blocking)
-	if opts.Input != "" {
-		if mismatch := suggest.CheckInputPipelineMismatch(opts.Input, opts.Pipeline); mismatch != nil {
-			fmt.Fprintf(os.Stderr, "  warning: %s\n", mismatch.SuggestedReason)
-		}
-	}
-
-	// Parse and validate step filter flags
-	stepFilter := pipeline.ParseStepFilter(opts.Steps, opts.Exclude)
-	if stepFilter != nil {
-		if err := stepFilter.Validate(p); err != nil {
-			return err
-		}
-		if err := stepFilter.ValidateCombinations(opts.FromStep); err != nil {
-			return err
-		}
+	if aborted {
+		return nil
 	}
 
 	if opts.DryRun {
@@ -308,435 +226,46 @@ func runRun(opts RunOptions, debug bool) error {
 		return runDetached(opts, p, &m)
 	}
 
-	// Resolve adapter — use mock if --mock or if no adapter binary found
-	var runner adapter.AdapterRunner
-	if opts.Mock {
-		runner = adaptertest.NewMockAdapter(
-			adaptertest.WithSimulatedDelay(5 * time.Second),
-		)
-	} else {
-		runner = adapter.ResolveAdapter("claude")
-	}
-
 	// Initialize state store under .agents/ — must happen before run ID generation
 	// so we can use CreateRun() to produce IDs visible to the dashboard.
-	stateDB := ".agents/state.db"
-	store, err := state.NewStateStore(stateDB)
-	if err != nil {
-		// Non-fatal: continue without state persistence
-		fmt.Fprintf(os.Stderr, "warning: state persistence disabled: %v\n", err)
-		store = nil
-	}
+	store := buildStateStore()
 	if store != nil {
 		defer store.Close()
 	}
 
-	// Auto-recover input when resuming without explicit --input
-	if opts.FromStep != "" && opts.Input == "" && store != nil {
-		if opts.RunID != "" {
-			if run, err := store.GetRun(opts.RunID); err == nil && run.Input != "" {
-				opts.Input = run.Input
-				fmt.Fprintf(os.Stderr, "  Resuming with input from run %s: %s\n", opts.RunID, truncateString(opts.Input, 80))
-			}
-		} else {
-			runs, err := store.ListRuns(state.ListRunsOptions{
-				PipelineName: p.Metadata.Name,
-				Limit:        1,
-			})
-			if err == nil && len(runs) > 0 && runs[0].Input != "" {
-				opts.Input = runs[0].Input
-				fmt.Fprintf(os.Stderr, "  Resuming with input from previous run: %s\n", truncateString(opts.Input, 80))
-			}
-		}
-	}
+	autoRecoverResumeInput(&opts, store, p)
 
-	// Generate run ID — use pre-created ID when --run is set (covers both the detach
-	// subprocess path and TUI subprocesses, regardless of whether --from-step is also set),
-	// or prefer CreateRun() so CLI runs appear in the dashboard.
-	// Falls back to GenerateRunID() if the state store is unavailable.
-	runID, resolveIDErr := resolveRunID(opts.RunID, store, p.Metadata.Name, opts.Input)
-	if resolveIDErr != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to create run record: %v\n", resolveIDErr)
-	}
-	if runID == "" {
-		runID = pipeline.GenerateRunID(p.Metadata.Name, m.Runtime.PipelineIDHashLength)
-	}
+	runID := resolveOrGenerateRunID(opts, store, p, &m)
 
-	// Initialize event emitter based on output format
-	result := CreateEmitter(opts.Output, runID, p.Metadata.Name, p.Steps, &m)
-	progressDisplay := result.Progress
-	defer result.Cleanup()
-	// Wrap with DB logging so "wave logs <run-id>" returns full history for CLI runs.
-	var emitter event.EventEmitter = result.Emitter
-	if store != nil {
-		emitter = &event.DBLoggingEmitter{Inner: result.Emitter, Store: store, RunID: runID}
-	}
-
-	// Initialize workspace manager under .agents/workspaces
-	wsRoot := m.Runtime.WorkspaceRoot
-	if wsRoot == "" {
-		wsRoot = ".agents/workspaces"
-	}
-	wsManager, err := workspace.NewWorkspaceManager(wsRoot)
+	res, err := buildExecutor(opts, &m, p, store, stepFilter, runID, debug)
 	if err != nil {
-		return fmt.Errorf("failed to create workspace manager: %w", err)
+		return err
 	}
-
-	// Initialize audit logger under .agents/traces/
-	var logger audit.AuditLogger
-	if m.Runtime.Audit.LogAllToolCalls {
-		traceDir := m.Runtime.Audit.LogDir
-		if traceDir == "" {
-			traceDir = ".agents/traces"
-		}
-		if l, err := audit.NewTraceLoggerWithDir(traceDir); err == nil {
-			logger = l
-			defer l.Close()
-		}
-	}
-
-	// Initialize debug tracer when --debug is set
-	var debugTracer *audit.DebugTracer
-	if debug {
-		traceDir := m.Runtime.Audit.LogDir
-		if traceDir == "" {
-			traceDir = ".agents/traces"
-		}
-		if dt, dtErr := audit.NewDebugTracer(traceDir, runID, audit.WithStderrMirror(true)); dtErr == nil {
-			debugTracer = dt
-			defer dt.Close()
-			fmt.Fprintf(os.Stderr, "  Debug trace: %s\n", dt.TracePath())
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: failed to create debug tracer: %v\n", dtErr)
-		}
-
-		// Enable debug verbosity on the emitter for richer NDJSON output
-		result.Emitter.SetDebugVerbosity(true)
-	}
-
-	// Build executor with all components.
-	// Ontology defaults to NoOp; the executor auto-promotes to a real Service
-	// when the manifest declares ontology contexts. The explicit NoOp is
-	// required by NewDefaultPipelineExecutor to surface the dependency.
-	execOpts := []pipeline.ExecutorOption{
-		pipeline.WithEmitter(emitter),
-		pipeline.WithDebug(debug),
-		pipeline.WithRunID(runID),
-		pipeline.WithOntologyService(ontology.NoOp{}),
-	}
-	if debugTracer != nil {
-		execOpts = append(execOpts, pipeline.WithDebugTracer(debugTracer))
-	}
-	if wsManager != nil {
-		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))
-	}
-	if store != nil {
-		execOpts = append(execOpts, pipeline.WithStateStore(store))
-	}
-	if logger != nil {
-		execOpts = append(execOpts, pipeline.WithAuditLogger(logger))
-	}
-	if opts.Timeout > 0 {
-		execOpts = append(execOpts, pipeline.WithStepTimeout(time.Duration(opts.Timeout)*time.Minute))
-	}
-	if opts.Model != "" {
-		execOpts = append(execOpts, pipeline.WithModelOverride(opts.Model))
-	}
-	if opts.ForceModel {
-		execOpts = append(execOpts, pipeline.WithForceModel(true))
-	}
-	registry := adapter.NewAdapterRegistry(nil)
-	for name, a := range m.Adapters {
-		if a.Binary != "" {
-			registry.SetBinary(name, a.Binary)
-		}
-	}
-	if opts.Mock {
-		// Route every adapter declared in the manifest through the mock runner.
-		// "mock" itself is always registered so pipelines that pin adapter: mock
-		// resolve correctly even when the manifest does not enumerate it.
-		registry.RegisterOverride("mock", runner)
-		for name := range m.Adapters {
-			registry.RegisterOverride(name, runner)
-		}
-	}
-	execOpts = append(execOpts, pipeline.WithRegistry(registry))
-
-	// Wire skill store so declared skills are provisioned into adapter workspaces.
-	// Source ordering (project skills/ wins over installed .agents/skills/) is
-	// owned by the skill package — see skill.DefaultSources.
-	skillStore := skill.NewDirectoryStore(skill.DefaultSources()...)
-	execOpts = append(execOpts, pipeline.WithSkillStore(skillStore))
-	if opts.Adapter != "" {
-		execOpts = append(execOpts, pipeline.WithAdapterOverride(opts.Adapter))
-	}
-	if opts.PreserveWorkspace {
-		execOpts = append(execOpts, pipeline.WithPreserveWorkspace(true))
-	}
-	if stepFilter != nil {
-		execOpts = append(execOpts, pipeline.WithStepFilter(stepFilter))
-	}
-	if opts.AutoApprove {
-		execOpts = append(execOpts, pipeline.WithAutoApprove(true))
-	}
-	if store != nil && !opts.NoRetro {
-		retroGen := retro.NewGenerator(store, runner, ".agents/retros", &m.Runtime.Retros)
-		execOpts = append(execOpts, pipeline.WithRetroGenerator(retroGen))
-	}
-
-	// Wire relay context compaction — prevents long-running steps from exhausting
-	// the Claude context window by summarizing conversation at a token threshold.
-	if m.Runtime.Relay.TokenThresholdPercent > 0 {
-		relayCfg := relay.RelayMonitorConfig{
-			DefaultThreshold:   m.Runtime.Relay.TokenThresholdPercent,
-			MinTokensToCompact: 1000,
-			ContextWindow:      m.Runtime.Relay.ContextWindow,
-			CompactionTimeout:  m.Runtime.Timeouts.GetRelayCompaction(),
-		}
-		compactionAdapter := relay.NewAdapterCompactionRunner(registry, &m)
-		relayMon := relay.NewRelayMonitor(relayCfg, compactionAdapter)
-		execOpts = append(execOpts, pipeline.WithRelayMonitor(relayMon))
-	}
-
-	executor := pipeline.NewDefaultPipelineExecutor(runner, execOpts...)
-
-	// Connect outcome tracker to progress display
-	if btpd, ok := progressDisplay.(*display.BubbleTeaProgressDisplay); ok {
-		btpd.SetOutcomeTracker(executor.GetOutcomeTracker())
-	}
+	defer res.Close()
+	executor := res.executor
+	emitter := res.emitter
+	wsRoot := res.wsRoot
+	runner := res.runner
+	execOpts := res.execOpts
 
 	if opts.Continuous {
-		// Parse source URI
-		srcCfg, err := continuous.ParseSourceURI(opts.Source)
-		if err != nil {
-			return fmt.Errorf("invalid --source: %w", err)
-		}
-		src, err := continuous.NewSourceFromConfig(srcCfg)
-		if err != nil {
-			return fmt.Errorf("failed to create source: %w", err)
-		}
-
-		// Parse delay
-		delay, err := time.ParseDuration(opts.Delay)
-		if err != nil {
-			return fmt.Errorf("invalid --delay %q: %w", opts.Delay, err)
-		}
-
-		contRunner := &continuous.Runner{
-			Source:        src,
-			PipelineName:  p.Metadata.Name,
-			OnFailure:     continuous.ParseFailurePolicy(opts.OnFailure),
-			MaxIterations: opts.MaxIterations,
-			Delay:         delay,
-			Emitter:       emitter,
-			ExecutorFactory: func(input string) continuous.ExecutorFunc {
-				return func(execCtx context.Context, execInput string) (string, error) {
-					// Create a new run ID for each iteration
-					var iterRunID string
-					if store != nil {
-						iterRunID, _ = store.CreateRun(p.Metadata.Name, execInput)
-					}
-					if iterRunID == "" {
-						iterRunID = pipeline.GenerateRunID(p.Metadata.Name, m.Runtime.PipelineIDHashLength)
-					}
-
-					// Create a fresh executor for this iteration
-					iterOpts := make([]pipeline.ExecutorOption, len(execOpts))
-					copy(iterOpts, execOpts)
-					iterOpts = append(iterOpts, pipeline.WithRunID(iterRunID))
-
-					iterExecutor := pipeline.NewDefaultPipelineExecutor(runner, iterOpts...)
-					execErr := iterExecutor.Execute(execCtx, p, &m, execInput)
-
-					// Update run status
-					if store != nil {
-						tokens := iterExecutor.GetTotalTokens()
-						if execErr != nil {
-							if updateErr := store.UpdateRunStatus(iterRunID, "failed", execErr.Error(), tokens); updateErr != nil {
-								fmt.Fprintf(os.Stderr, "warning: failed to update run status: %v\n", updateErr)
-							}
-						} else {
-							if updateErr := store.UpdateRunStatus(iterRunID, "completed", "", tokens); updateErr != nil {
-								fmt.Fprintf(os.Stderr, "warning: failed to update run status: %v\n", updateErr)
-							}
-						}
-					}
-
-					return iterRunID, execErr
-				}
-			},
-		}
-
-		summary, contErr := contRunner.Run(ctx)
-		if contErr != nil {
-			return fmt.Errorf("continuous run failed: %w", contErr)
-		}
-
-		// Print summary
-		if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
-			fmt.Fprintf(os.Stderr, "\n  %s\n", summary.String())
-		}
-
-		// Exit code 1 if any failures
-		if summary.HasFailures() {
-			return fmt.Errorf("continuous run completed with %d failures", summary.Failed)
-		}
-		return nil
+		return runContinuous(ctx, opts, &m, p, store, runner, emitter, execOpts)
 	}
 
 	pipelineStart := time.Now()
-
-	// Transition run from pending → running so dashboards and wave status reflect active execution.
-	if store != nil {
-		_ = store.UpdateRunStatus(runID, "running", "", 0)
-		_ = store.UpdateRunHeartbeat(runID)
-		// Periodic heartbeat: lets the reconciler distinguish a live run from
-		// a parent process that died without updating the DB. Goroutine exits
-		// when heartbeatCancel fires (deferred just below this block).
-		heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
-		defer heartbeatCancel()
-		go state.RunHeartbeatLoop(heartbeatCtx, store, runID)
-	}
-
-	var execErr error
-	if opts.FromStep != "" {
-		// Resume from specific step - uses ResumeWithValidation which handles artifacts.
-		// When --run is specified, pass the run ID so artifact paths resolve from
-		// that specific run's workspace instead of scanning for the most recent match.
-		if opts.RunID != "" {
-			execErr = executor.ResumeWithValidation(ctx, p, &m, opts.Input, opts.FromStep, opts.Force, opts.RunID)
-		} else {
-			execErr = executor.ResumeWithValidation(ctx, p, &m, opts.Input, opts.FromStep, opts.Force)
-		}
-	} else {
-		execErr = executor.Execute(ctx, p, &m, opts.Input)
-	}
-
-	// Update the pipeline_run record so the dashboard reflects final status
-	if store != nil {
-		tokens := executor.GetTotalTokens()
-		switch {
-		case ctx.Err() != nil:
-			_ = store.UpdateRunStatus(runID, "cancelled", "pipeline cancelled", tokens)
-			_ = store.ClearCancellation(runID)
-		case execErr != nil:
-			_ = store.UpdateRunStatus(runID, "failed", execErr.Error(), tokens)
-		default:
-			_ = store.UpdateRunStatus(runID, "completed", "", tokens)
-		}
-	}
+	execErr := runOnce(ctx, executor, opts, &m, p, store, runID)
 
 	if execErr != nil {
-		// Extract step ID from StepExecutionError when available; fall back gracefully
-		// so recovery hints are shown for all failure paths (including resume).
-		var (
-			stepErr *pipeline.StepExecutionError
-			stepID  string
-			cause   = execErr
-		)
-		if errors.As(execErr, &stepErr) {
-			stepID = stepErr.StepID
-			cause = stepErr.Err
-		}
-
-		errClass := recovery.ClassifyError(cause)
-
-		// Extract preflight metadata when the error is a preflight failure
-		var preflightMeta *recovery.PreflightMetadata
-		if errClass == recovery.ClassPreflight {
-			preflightMeta = recovery.ExtractPreflightMetadata(cause)
-		}
-
-		block := recovery.BuildRecoveryBlock(recovery.RecoveryBlockOpts{
-			PipelineName:  p.Metadata.Name,
-			Input:         opts.Input,
-			StepID:        stepID,
-			RunID:         runID,
-			WorkspaceRoot: wsRoot,
-			ErrClass:      errClass,
-			PreflightMeta: preflightMeta,
-		})
-
-		if opts.Output.Format == OutputFormatJSON {
-			// In JSON mode, emit recovery hints as structured data.
-			// The executor already emits a bare "failed" event; this enriched
-			// event carries the hints so consumers only need one event.
-			hints := make([]event.RecoveryHintJSON, len(block.Hints))
-			for i, h := range block.Hints {
-				hints[i] = event.RecoveryHintJSON{
-					Label:   h.Label,
-					Command: h.Command,
-					Type:    string(h.Type),
-				}
-			}
-			emitter.Emit(event.Event{
-				Timestamp:     time.Now(),
-				PipelineID:    runID,
-				StepID:        stepID,
-				State:         "recovery",
-				Message:       execErr.Error(),
-				RecoveryHints: hints,
-			})
-		} else {
-			// In text/auto/quiet modes, append recovery hints after the error
-			// line by embedding them in the returned error message.
-			hintBlock := recovery.FormatRecoveryBlock(block)
-			if hintBlock != "" {
-				return fmt.Errorf("pipeline execution failed: %w\n%s", execErr, hintBlock)
-			}
-		}
-		return fmt.Errorf("pipeline execution failed: %w", execErr)
+		return formatRecoveryError(execErr, opts, p, runID, wsRoot, emitter)
 	}
 
 	elapsed := time.Since(pipelineStart)
 
 	// Stop the TUI before printing post-run output to avoid terminal corruption.
 	// Cleanup is idempotent so the deferred call above becomes a no-op.
-	result.Cleanup()
+	res.Close()
 
-	// Show human summary only in auto/text modes — json and quiet stay clean
-	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
-		totalTokens := executor.GetTotalTokens()
-		if totalTokens > 0 {
-			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs, %s tokens)\n",
-				p.Metadata.Name, elapsed.Seconds(), display.FormatTokenCount(totalTokens))
-		} else {
-			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs)\n",
-				p.Metadata.Name, elapsed.Seconds())
-		}
-		// Build structured outcome summary from outcome tracker
-		tracker := executor.GetOutcomeTracker()
-		outcome := display.BuildOutcome(tracker, p.Metadata.Name, runID, true, elapsed, totalTokens, "", nil)
-		summary := display.RenderOutcomeSummary(outcome, opts.Output.Verbose, display.NewFormatter())
-		if summary != "" {
-			fmt.Fprint(os.Stderr, "\n")
-			lines := strings.Split(summary, "\n")
-			for _, line := range lines {
-				if line != "" {
-					fmt.Fprintf(os.Stderr, "  %s\n", line)
-				} else {
-					fmt.Fprint(os.Stderr, "\n")
-				}
-			}
-			fmt.Fprint(os.Stderr, "\n")
-		}
-	}
-
-	// For JSON output mode, emit structured outcomes in the final completion event
-	if opts.Output.Format == OutputFormatJSON {
-		tracker := executor.GetOutcomeTracker()
-		outcome := display.BuildOutcome(tracker, p.Metadata.Name, runID, true, elapsed, executor.GetTotalTokens(), "", nil)
-		outJSON := outcome.ToOutcomesJSON()
-		emitter.Emit(event.Event{
-			Timestamp:  time.Now(),
-			PipelineID: runID,
-			State:      "completed",
-			DurationMs: elapsed.Milliseconds(),
-			Message:    fmt.Sprintf("Pipeline '%s' completed", p.Metadata.Name),
-			Outcomes:   outJSON,
-		})
-	}
-
+	printSummary(opts, executor, p, runID, elapsed, emitter)
 	return nil
 }
 
@@ -843,115 +372,4 @@ func applySelection(opts *RunOptions, sel *tui.Selection, debug *bool) {
 	}
 }
 
-func performDryRun(p *pipeline.Pipeline, m *manifest.Manifest, filter *pipeline.StepFilter) error {
-	fmt.Fprintf(os.Stderr, "Dry run for pipeline: %s\n", p.Metadata.Name)
-	fmt.Fprintf(os.Stderr, "Description: %s\n", p.Metadata.Description)
-	fmt.Fprintf(os.Stderr, "Steps: %d\n\n", len(p.Steps))
-	fmt.Fprintf(os.Stderr, "Execution plan:\n")
 
-	for i, step := range p.Steps {
-		// Show [SKIP] or [RUN] status when a filter is active
-		status := ""
-		if filter != nil && filter.IsActive() {
-			if filter.ShouldRun(step.ID) {
-				status = " [RUN]"
-			} else {
-				status = " [SKIP]"
-			}
-		}
-		if step.SubPipeline != "" {
-			fmt.Fprintf(os.Stderr, "  %d. %s (pipeline: %s)%s\n", i+1, step.ID, step.SubPipeline, status)
-		} else {
-			fmt.Fprintf(os.Stderr, "  %d. %s (persona: %s)%s\n", i+1, step.ID, step.Persona, status)
-		}
-
-		if len(step.Dependencies) > 0 {
-			fmt.Fprintf(os.Stderr, "     Dependencies: %v\n", step.Dependencies)
-		}
-
-		persona := m.GetPersona(step.Persona)
-		if persona != nil {
-			fmt.Fprintf(os.Stderr, "     Adapter: %s  Temp: %.1f\n", persona.Adapter, persona.Temperature)
-			fmt.Fprintf(os.Stderr, "     System prompt: %s\n", persona.SystemPromptFile)
-			if len(persona.Permissions.AllowedTools) > 0 {
-				fmt.Fprintf(os.Stderr, "     Allowed tools: %v\n", persona.Permissions.AllowedTools)
-			}
-			if len(persona.Permissions.Deny) > 0 {
-				fmt.Fprintf(os.Stderr, "     Denied tools: %v\n", persona.Permissions.Deny)
-			}
-		}
-
-		if len(step.Workspace.Mount) > 0 {
-			for _, mount := range step.Workspace.Mount {
-				fmt.Fprintf(os.Stderr, "     Mount: %s → %s (%s)\n", mount.Source, mount.Target, mount.Mode)
-			}
-		}
-
-		fmt.Fprintf(os.Stderr, "     Workspace: .agents/workspaces/%s/%s/\n", p.Metadata.Name, step.ID)
-
-		if step.Memory.Strategy != "" {
-			fmt.Fprintf(os.Stderr, "     Memory: %s\n", step.Memory.Strategy)
-		}
-
-		if len(step.Memory.InjectArtifacts) > 0 {
-			for _, art := range step.Memory.InjectArtifacts {
-				fmt.Fprintf(os.Stderr, "     Inject: %s:%s as %s\n", art.Step, art.Artifact, art.As)
-			}
-		}
-
-		if len(step.OutputArtifacts) > 0 {
-			for _, art := range step.OutputArtifacts {
-				fmt.Fprintf(os.Stderr, "     Output: %s → %s (%s)\n", art.Name, art.Path, art.Type)
-			}
-		}
-
-		if step.Handover.Contract.Type != "" {
-			fmt.Fprintf(os.Stderr, "     Contract: %s", step.Handover.Contract.Type)
-			if step.Handover.Contract.OnFailure != "" {
-				fmt.Fprintf(os.Stderr, " (on_failure: %s, max_retries: %d)", step.Handover.Contract.OnFailure, step.Handover.Contract.MaxRetries)
-			}
-			fmt.Fprintln(os.Stderr)
-		}
-
-		fmt.Fprintln(os.Stderr)
-	}
-
-	// Show artifact warnings when a filter is active
-	if filter != nil && filter.IsActive() {
-		skippedSteps := make(map[string]bool)
-		for _, step := range p.Steps {
-			if !filter.ShouldRun(step.ID) {
-				skippedSteps[step.ID] = true
-			}
-		}
-		var warnings []string
-		for _, step := range p.Steps {
-			if !filter.ShouldRun(step.ID) {
-				continue
-			}
-			for _, dep := range step.Dependencies {
-				if skippedSteps[dep] {
-					warnings = append(warnings, fmt.Sprintf("  ⚠ Step %q depends on skipped step %q — ensure prior artifacts exist", step.ID, dep))
-				}
-			}
-		}
-		if len(warnings) > 0 {
-			fmt.Fprintln(os.Stderr, "Artifact warnings:")
-			for _, w := range warnings {
-				fmt.Fprintln(os.Stderr, w)
-			}
-			fmt.Fprintln(os.Stderr)
-		}
-	}
-
-	// Run composition validation and report findings.
-	validator := pipeline.NewDryRunValidator(pipelinesDir())
-	report := validator.Validate(p, m)
-	fmt.Fprint(os.Stderr, "\n")
-	fmt.Fprint(os.Stderr, report.Format())
-
-	if report.HasErrors() {
-		return fmt.Errorf("dry-run validation found %d error(s) — pipeline is not safe to execute", report.ErrorCount())
-	}
-	return nil
-}

--- a/cmd/wave/commands/run_dryrun.go
+++ b/cmd/wave/commands/run_dryrun.go
@@ -1,0 +1,131 @@
+package commands
+
+// performDryRun renders the execution plan for a pipeline without running
+// any steps. Each step prints its persona/sub-pipeline, dependencies,
+// adapter and tool permissions, mounted directories, memory strategy,
+// inject/output artifacts, and contract policy. When a step filter is
+// active, [RUN]/[SKIP] markers and downstream artifact warnings are shown.
+// Finally, dry-run composition validation is delegated to
+// pipeline.NewDryRunValidator and printed to stderr; an error is returned
+// when the validator reports any errors so the caller can exit non-zero.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipeline"
+)
+
+func performDryRun(p *pipeline.Pipeline, m *manifest.Manifest, filter *pipeline.StepFilter) error {
+	fmt.Fprintf(os.Stderr, "Dry run for pipeline: %s\n", p.Metadata.Name)
+	fmt.Fprintf(os.Stderr, "Description: %s\n", p.Metadata.Description)
+	fmt.Fprintf(os.Stderr, "Steps: %d\n\n", len(p.Steps))
+	fmt.Fprintf(os.Stderr, "Execution plan:\n")
+
+	for i, step := range p.Steps {
+		// Show [SKIP] or [RUN] status when a filter is active
+		status := ""
+		if filter != nil && filter.IsActive() {
+			if filter.ShouldRun(step.ID) {
+				status = " [RUN]"
+			} else {
+				status = " [SKIP]"
+			}
+		}
+		if step.SubPipeline != "" {
+			fmt.Fprintf(os.Stderr, "  %d. %s (pipeline: %s)%s\n", i+1, step.ID, step.SubPipeline, status)
+		} else {
+			fmt.Fprintf(os.Stderr, "  %d. %s (persona: %s)%s\n", i+1, step.ID, step.Persona, status)
+		}
+
+		if len(step.Dependencies) > 0 {
+			fmt.Fprintf(os.Stderr, "     Dependencies: %v\n", step.Dependencies)
+		}
+
+		persona := m.GetPersona(step.Persona)
+		if persona != nil {
+			fmt.Fprintf(os.Stderr, "     Adapter: %s  Temp: %.1f\n", persona.Adapter, persona.Temperature)
+			fmt.Fprintf(os.Stderr, "     System prompt: %s\n", persona.SystemPromptFile)
+			if len(persona.Permissions.AllowedTools) > 0 {
+				fmt.Fprintf(os.Stderr, "     Allowed tools: %v\n", persona.Permissions.AllowedTools)
+			}
+			if len(persona.Permissions.Deny) > 0 {
+				fmt.Fprintf(os.Stderr, "     Denied tools: %v\n", persona.Permissions.Deny)
+			}
+		}
+
+		if len(step.Workspace.Mount) > 0 {
+			for _, mount := range step.Workspace.Mount {
+				fmt.Fprintf(os.Stderr, "     Mount: %s → %s (%s)\n", mount.Source, mount.Target, mount.Mode)
+			}
+		}
+
+		fmt.Fprintf(os.Stderr, "     Workspace: .agents/workspaces/%s/%s/\n", p.Metadata.Name, step.ID)
+
+		if step.Memory.Strategy != "" {
+			fmt.Fprintf(os.Stderr, "     Memory: %s\n", step.Memory.Strategy)
+		}
+
+		if len(step.Memory.InjectArtifacts) > 0 {
+			for _, art := range step.Memory.InjectArtifacts {
+				fmt.Fprintf(os.Stderr, "     Inject: %s:%s as %s\n", art.Step, art.Artifact, art.As)
+			}
+		}
+
+		if len(step.OutputArtifacts) > 0 {
+			for _, art := range step.OutputArtifacts {
+				fmt.Fprintf(os.Stderr, "     Output: %s → %s (%s)\n", art.Name, art.Path, art.Type)
+			}
+		}
+
+		if step.Handover.Contract.Type != "" {
+			fmt.Fprintf(os.Stderr, "     Contract: %s", step.Handover.Contract.Type)
+			if step.Handover.Contract.OnFailure != "" {
+				fmt.Fprintf(os.Stderr, " (on_failure: %s, max_retries: %d)", step.Handover.Contract.OnFailure, step.Handover.Contract.MaxRetries)
+			}
+			fmt.Fprintln(os.Stderr)
+		}
+
+		fmt.Fprintln(os.Stderr)
+	}
+
+	// Show artifact warnings when a filter is active
+	if filter != nil && filter.IsActive() {
+		skippedSteps := make(map[string]bool)
+		for _, step := range p.Steps {
+			if !filter.ShouldRun(step.ID) {
+				skippedSteps[step.ID] = true
+			}
+		}
+		var warnings []string
+		for _, step := range p.Steps {
+			if !filter.ShouldRun(step.ID) {
+				continue
+			}
+			for _, dep := range step.Dependencies {
+				if skippedSteps[dep] {
+					warnings = append(warnings, fmt.Sprintf("  ⚠ Step %q depends on skipped step %q — ensure prior artifacts exist", step.ID, dep))
+				}
+			}
+		}
+		if len(warnings) > 0 {
+			fmt.Fprintln(os.Stderr, "Artifact warnings:")
+			for _, w := range warnings {
+				fmt.Fprintln(os.Stderr, w)
+			}
+			fmt.Fprintln(os.Stderr)
+		}
+	}
+
+	// Run composition validation and report findings.
+	validator := pipeline.NewDryRunValidator(pipelinesDir())
+	report := validator.Validate(p, m)
+	fmt.Fprint(os.Stderr, "\n")
+	fmt.Fprint(os.Stderr, report.Format())
+
+	if report.HasErrors() {
+		return fmt.Errorf("dry-run validation found %d error(s) — pipeline is not safe to execute", report.ErrorCount())
+	}
+	return nil
+}

--- a/cmd/wave/commands/run_stages.go
+++ b/cmd/wave/commands/run_stages.go
@@ -1,0 +1,650 @@
+package commands
+
+// Stage helpers extracted from runRun. Each function corresponds to one
+// phase of pipeline execution (flag validation, signal wiring, manifest +
+// pipeline loading, state-store init, executor build, single-run vs
+// continuous dispatch, recovery formatting, post-run summary). runRun in
+// run.go is now a thin orchestrator that calls these in order; behaviour
+// is unchanged versus the pre-split version.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/adapter"
+	"github.com/recinq/wave/internal/adapter/adaptertest"
+	"github.com/recinq/wave/internal/audit"
+	"github.com/recinq/wave/internal/continuous"
+	"github.com/recinq/wave/internal/display"
+	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/recovery"
+	"github.com/recinq/wave/internal/relay"
+	"github.com/recinq/wave/internal/retro"
+	"github.com/recinq/wave/internal/skill"
+	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/suggest"
+	"github.com/recinq/wave/internal/tui"
+	"github.com/recinq/wave/internal/workspace"
+)
+
+// validateFlags enforces the onboarding gate and CLI-level mutual exclusions
+// that must hold before any I/O happens. Each guard returns a CLIError so the
+// caller surfaces a structured exit code.
+func validateFlags(opts RunOptions) error {
+	// Gate on onboarding completion — skip when --force is set
+	if !opts.Force {
+		if err := checkOnboarding(); err != nil {
+			return NewCLIError(CodeOnboardingRequired,
+				"onboarding not complete",
+				"Run 'wave init' to complete setup before running pipelines")
+		}
+	}
+
+	// Validate mutual exclusion: --continuous and --from-step cannot be combined
+	if opts.Continuous && opts.FromStep != "" {
+		return NewCLIError(CodeInvalidArgs,
+			"--continuous and --from-step are mutually exclusive",
+			"Use --continuous for batch processing or --from-step for resuming a single run")
+	}
+
+	// Validate --continuous requires --source
+	if opts.Continuous && opts.Source == "" {
+		return NewCLIError(CodeInvalidArgs,
+			"--continuous requires --source",
+			"Specify a source URI, e.g., --source \"github:label=bug\" or --source \"file:queue.txt\"")
+	}
+
+	return nil
+}
+
+// setupSignalHandling returns a context that is cancelled when the process
+// receives an interrupt signal. The returned cancel function should be
+// deferred by the caller so the goroutine exits when runRun returns.
+func setupSignalHandling() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		<-sigChan
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// loadManifestAndPipeline loads the manifest, resolves the pipeline (falling
+// back to the interactive selector when the named pipeline is missing in TTY
+// mode), warns on input/pipeline mismatches, and validates step filter flags.
+//
+// Mutates opts (and debug) when the user picks a different pipeline through
+// the TUI, so both are taken by pointer. Returns aborted=true when the user
+// cancelled the selector — the caller should exit cleanly without an error.
+func loadManifestAndPipeline(opts *RunOptions, debug *bool) (*pipeline.Pipeline, manifest.Manifest, *pipeline.StepFilter, bool, error) {
+	mp, err := loadManifestStrict(opts.Manifest)
+	if err != nil {
+		return nil, manifest.Manifest{}, nil, false, err
+	}
+	m := *mp
+
+	p, err := pipeline.LoadByName(opts.Pipeline)
+	if err != nil {
+		// Pipeline not found — if interactive, try TUI with partial name as filter
+		if isInteractive() {
+			sel, tuiErr := tui.RunPipelineSelector(pipelinesDir(), opts.Pipeline)
+			if tuiErr != nil {
+				if errors.Is(tuiErr, huh.ErrUserAborted) {
+					return nil, m, nil, true, nil
+				}
+				return nil, m, nil, false, tuiErr
+			}
+			applySelection(opts, sel, debug)
+			p, err = pipeline.LoadByName(opts.Pipeline)
+			if err != nil {
+				return nil, m, nil, false, NewCLIError(CodePipelineNotFound,
+					fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
+					"Run 'wave list pipelines' to see available pipelines")
+			}
+		} else {
+			return nil, m, nil, false, NewCLIError(CodePipelineNotFound,
+				fmt.Sprintf("pipeline '%s' not found", opts.Pipeline),
+				"Run 'wave list pipelines' to see available pipelines")
+		}
+	}
+
+	// Warn on input/pipeline mismatch (non-blocking)
+	if opts.Input != "" {
+		if mismatch := suggest.CheckInputPipelineMismatch(opts.Input, opts.Pipeline); mismatch != nil {
+			fmt.Fprintf(os.Stderr, "  warning: %s\n", mismatch.SuggestedReason)
+		}
+	}
+
+	// Parse and validate step filter flags
+	stepFilter := pipeline.ParseStepFilter(opts.Steps, opts.Exclude)
+	if stepFilter != nil {
+		if err := stepFilter.Validate(p); err != nil {
+			return nil, m, nil, false, err
+		}
+		if err := stepFilter.ValidateCombinations(opts.FromStep); err != nil {
+			return nil, m, nil, false, err
+		}
+	}
+
+	return p, m, stepFilter, false, nil
+}
+
+// buildStateStore opens the SQLite-backed state store under `.agents/state.db`.
+// State persistence is best-effort: a failure to open the DB downgrades the
+// run to in-memory operation with a warning, returning nil so callers can
+// nil-check without separate error plumbing.
+func buildStateStore() state.StateStore {
+	store, err := state.NewStateStore(".agents/state.db")
+	if err != nil {
+		// Non-fatal: continue without state persistence
+		fmt.Fprintf(os.Stderr, "warning: state persistence disabled: %v\n", err)
+		return nil
+	}
+	return store
+}
+
+// autoRecoverResumeInput rehydrates opts.Input when --from-step is used
+// without an explicit --input by reading from the state store. Resume needs
+// the original input so the executor can replay deterministic prompts; this
+// is best-effort and silently leaves opts.Input empty if no record is found.
+func autoRecoverResumeInput(opts *RunOptions, store state.StateStore, p *pipeline.Pipeline) {
+	if opts.FromStep == "" || opts.Input != "" || store == nil {
+		return
+	}
+	if opts.RunID != "" {
+		if run, err := store.GetRun(opts.RunID); err == nil && run.Input != "" {
+			opts.Input = run.Input
+			fmt.Fprintf(os.Stderr, "  Resuming with input from run %s: %s\n", opts.RunID, truncateString(opts.Input, 80))
+		}
+		return
+	}
+	runs, err := store.ListRuns(state.ListRunsOptions{
+		PipelineName: p.Metadata.Name,
+		Limit:        1,
+	})
+	if err == nil && len(runs) > 0 && runs[0].Input != "" {
+		opts.Input = runs[0].Input
+		fmt.Fprintf(os.Stderr, "  Resuming with input from previous run: %s\n", truncateString(opts.Input, 80))
+	}
+}
+
+// resolveOrGenerateRunID picks the run ID for this execution. When --run is
+// set (detach subprocess or TUI launch) it is reused verbatim; otherwise the
+// state store mints a new ID via CreateRun so the run shows up in the
+// dashboard. Falls back to GenerateRunID when the store is unavailable.
+func resolveOrGenerateRunID(opts RunOptions, store state.StateStore, p *pipeline.Pipeline, m *manifest.Manifest) string {
+	runID, resolveIDErr := resolveRunID(opts.RunID, store, p.Metadata.Name, opts.Input)
+	if resolveIDErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create run record: %v\n", resolveIDErr)
+	}
+	if runID == "" {
+		runID = pipeline.GenerateRunID(p.Metadata.Name, m.Runtime.PipelineIDHashLength)
+	}
+	return runID
+}
+
+// runResources bundles every component the runRun execution path needs after
+// the executor is wired (executor, emitter, adapter runner, workspace root,
+// raw execOpts so continuous mode can clone them per iteration). Close runs
+// the cleanups for emitter, audit logger, and debug tracer in reverse order
+// so the caller can defer a single Close() instead of tracking each.
+type runResources struct {
+	executor    *pipeline.DefaultPipelineExecutor
+	emitter     event.EventEmitter
+	emitterAux  *EmitterResult
+	wsRoot      string
+	runner      adapter.AdapterRunner
+	execOpts    []pipeline.ExecutorOption
+	closeFns    []func()
+	cleanupOnce bool
+}
+
+// Close runs all registered cleanup functions in LIFO order. Safe to call
+// multiple times — the second call is a no-op so post-run logic in runRun
+// can stop the TUI eagerly without breaking the deferred Close.
+func (r *runResources) Close() {
+	if r == nil || r.cleanupOnce {
+		return
+	}
+	r.cleanupOnce = true
+	for i := len(r.closeFns) - 1; i >= 0; i-- {
+		r.closeFns[i]()
+	}
+}
+
+// resolveAdapterRunner picks between the mock adapter and the real claude
+// binary. Kept as a tiny helper so the buildExecutor body stays focused on
+// option assembly rather than adapter selection details.
+func resolveAdapterRunner(mock bool) adapter.AdapterRunner {
+	if mock {
+		return adaptertest.NewMockAdapter(
+			adaptertest.WithSimulatedDelay(5 * time.Second),
+		)
+	}
+	return adapter.ResolveAdapter("claude")
+}
+
+// buildExecutor wires the workspace manager, audit logger, debug tracer,
+// adapter registry, skill store, retro generator, and relay monitor into a
+// fresh DefaultPipelineExecutor. The returned runResources owns every
+// resource that needs cleanup; callers must defer Close().
+//
+// Behaviour mirrors the original inline block exactly — option ordering,
+// nil-checks, and warning text are preserved so this refactor stays a
+// no-op at runtime.
+func buildExecutor(opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, store state.StateStore, stepFilter *pipeline.StepFilter, runID string, debug bool) (*runResources, error) {
+	res := &runResources{}
+
+	res.runner = resolveAdapterRunner(opts.Mock)
+
+	// Initialize event emitter based on output format
+	emitterResult := CreateEmitter(opts.Output, runID, p.Metadata.Name, p.Steps, m)
+	res.emitterAux = &emitterResult
+	res.closeFns = append(res.closeFns, emitterResult.Cleanup)
+
+	// Wrap with DB logging so "wave logs <run-id>" returns full history for CLI runs.
+	var emitter event.EventEmitter = emitterResult.Emitter
+	if store != nil {
+		emitter = &event.DBLoggingEmitter{Inner: emitterResult.Emitter, Store: store, RunID: runID}
+	}
+	res.emitter = emitter
+
+	// Initialize workspace manager under .agents/workspaces
+	wsRoot := m.Runtime.WorkspaceRoot
+	if wsRoot == "" {
+		wsRoot = ".agents/workspaces"
+	}
+	res.wsRoot = wsRoot
+	wsManager, err := workspace.NewWorkspaceManager(wsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create workspace manager: %w", err)
+	}
+
+	// Initialize audit logger under .agents/traces/
+	var logger audit.AuditLogger
+	if m.Runtime.Audit.LogAllToolCalls {
+		traceDir := m.Runtime.Audit.LogDir
+		if traceDir == "" {
+			traceDir = ".agents/traces"
+		}
+		if l, err := audit.NewTraceLoggerWithDir(traceDir); err == nil {
+			logger = l
+			res.closeFns = append(res.closeFns, func() { _ = l.Close() })
+		}
+	}
+
+	// Initialize debug tracer when --debug is set
+	var debugTracer *audit.DebugTracer
+	if debug {
+		traceDir := m.Runtime.Audit.LogDir
+		if traceDir == "" {
+			traceDir = ".agents/traces"
+		}
+		if dt, dtErr := audit.NewDebugTracer(traceDir, runID, audit.WithStderrMirror(true)); dtErr == nil {
+			debugTracer = dt
+			res.closeFns = append(res.closeFns, func() { _ = dt.Close() })
+			fmt.Fprintf(os.Stderr, "  Debug trace: %s\n", dt.TracePath())
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: failed to create debug tracer: %v\n", dtErr)
+		}
+		// Enable debug verbosity on the emitter for richer NDJSON output
+		emitterResult.Emitter.SetDebugVerbosity(true)
+	}
+
+	execOpts := assembleExecutorOptions(opts, m, p, store, stepFilter, runID, debug, emitter, wsManager, logger, debugTracer, res.runner)
+	res.execOpts = execOpts
+
+	executor := pipeline.NewDefaultPipelineExecutor(res.runner, execOpts...)
+	res.executor = executor
+
+	// Connect outcome tracker to progress display
+	if btpd, ok := emitterResult.Progress.(*display.BubbleTeaProgressDisplay); ok {
+		btpd.SetOutcomeTracker(executor.GetOutcomeTracker())
+	}
+
+	return res, nil
+}
+
+// assembleExecutorOptions builds the ExecutorOption slice from opts and the
+// already-constructed dependencies. Split out from buildExecutor so the
+// option list — the part most likely to grow — has its own focused function
+// without the resource-bookkeeping noise.
+func assembleExecutorOptions(opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, store state.StateStore, stepFilter *pipeline.StepFilter, runID string, debug bool, emitter event.EventEmitter, wsManager workspace.WorkspaceManager, logger audit.AuditLogger, debugTracer *audit.DebugTracer, runner adapter.AdapterRunner) []pipeline.ExecutorOption {
+	execOpts := []pipeline.ExecutorOption{
+		pipeline.WithEmitter(emitter),
+		pipeline.WithDebug(debug),
+		pipeline.WithRunID(runID),
+	}
+	if debugTracer != nil {
+		execOpts = append(execOpts, pipeline.WithDebugTracer(debugTracer))
+	}
+	if wsManager != nil {
+		execOpts = append(execOpts, pipeline.WithWorkspaceManager(wsManager))
+	}
+	if store != nil {
+		execOpts = append(execOpts, pipeline.WithStateStore(store))
+	}
+	if logger != nil {
+		execOpts = append(execOpts, pipeline.WithAuditLogger(logger))
+	}
+	if opts.Timeout > 0 {
+		execOpts = append(execOpts, pipeline.WithStepTimeout(time.Duration(opts.Timeout)*time.Minute))
+	}
+	if opts.Model != "" {
+		execOpts = append(execOpts, pipeline.WithModelOverride(opts.Model))
+	}
+	if opts.ForceModel {
+		execOpts = append(execOpts, pipeline.WithForceModel(true))
+	}
+	registry := adapter.NewAdapterRegistry(nil)
+	for name, a := range m.Adapters {
+		if a.Binary != "" {
+			registry.SetBinary(name, a.Binary)
+		}
+	}
+	if opts.Mock {
+		// Route every adapter declared in the manifest through the mock runner.
+		// "mock" itself is always registered so pipelines that pin adapter: mock
+		// resolve correctly even when the manifest does not enumerate it.
+		registry.RegisterOverride("mock", runner)
+		for name := range m.Adapters {
+			registry.RegisterOverride(name, runner)
+		}
+	}
+	execOpts = append(execOpts, pipeline.WithRegistry(registry))
+
+	// Wire skill store so declared skills are provisioned into adapter workspaces.
+	// Source ordering (project skills/ wins over installed .agents/skills/) is
+	// owned by the skill package — see skill.DefaultSources.
+	skillStore := skill.NewDirectoryStore(skill.DefaultSources()...)
+	execOpts = append(execOpts, pipeline.WithSkillStore(skillStore))
+	if opts.Adapter != "" {
+		execOpts = append(execOpts, pipeline.WithAdapterOverride(opts.Adapter))
+	}
+	if opts.PreserveWorkspace {
+		execOpts = append(execOpts, pipeline.WithPreserveWorkspace(true))
+	}
+	if stepFilter != nil {
+		execOpts = append(execOpts, pipeline.WithStepFilter(stepFilter))
+	}
+	if opts.AutoApprove {
+		execOpts = append(execOpts, pipeline.WithAutoApprove(true))
+	}
+	if store != nil && !opts.NoRetro {
+		retroGen := retro.NewGenerator(store, runner, ".agents/retros", &m.Runtime.Retros)
+		execOpts = append(execOpts, pipeline.WithRetroGenerator(retroGen))
+	}
+
+	// Wire relay context compaction — prevents long-running steps from exhausting
+	// the Claude context window by summarizing conversation at a token threshold.
+	if m.Runtime.Relay.TokenThresholdPercent > 0 {
+		relayCfg := relay.RelayMonitorConfig{
+			DefaultThreshold:   m.Runtime.Relay.TokenThresholdPercent,
+			MinTokensToCompact: 1000,
+			ContextWindow:      m.Runtime.Relay.ContextWindow,
+			CompactionTimeout:  m.Runtime.Timeouts.GetRelayCompaction(),
+		}
+		compactionAdapter := relay.NewAdapterCompactionRunner(registry, m)
+		relayMon := relay.NewRelayMonitor(relayCfg, compactionAdapter)
+		execOpts = append(execOpts, pipeline.WithRelayMonitor(relayMon))
+	}
+
+	return execOpts
+}
+
+// runOnce executes the pipeline a single time. It transitions the run from
+// pending → running, spawns the heartbeat goroutine, dispatches to either
+// Execute or ResumeWithValidation depending on --from-step, and records the
+// terminal status (cancelled/failed/completed) so the dashboard converges
+// even when the caller bails on the returned error.
+func runOnce(ctx context.Context, executor *pipeline.DefaultPipelineExecutor, opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, store state.StateStore, runID string) error {
+	// Transition run from pending → running so dashboards and wave status reflect active execution.
+	if store != nil {
+		_ = store.UpdateRunStatus(runID, "running", "", 0)
+		_ = store.UpdateRunHeartbeat(runID)
+		// Periodic heartbeat: lets the reconciler distinguish a live run from
+		// a parent process that died without updating the DB. Goroutine exits
+		// when heartbeatCancel fires (deferred just below this block).
+		heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+		defer heartbeatCancel()
+		go state.RunHeartbeatLoop(heartbeatCtx, store, runID)
+	}
+
+	var execErr error
+	if opts.FromStep != "" {
+		// Resume from specific step - uses ResumeWithValidation which handles artifacts.
+		// When --run is specified, pass the run ID so artifact paths resolve from
+		// that specific run's workspace instead of scanning for the most recent match.
+		if opts.RunID != "" {
+			execErr = executor.ResumeWithValidation(ctx, p, m, opts.Input, opts.FromStep, opts.Force, opts.RunID)
+		} else {
+			execErr = executor.ResumeWithValidation(ctx, p, m, opts.Input, opts.FromStep, opts.Force)
+		}
+	} else {
+		execErr = executor.Execute(ctx, p, m, opts.Input)
+	}
+
+	// Update the pipeline_run record so the dashboard reflects final status
+	if store != nil {
+		tokens := executor.GetTotalTokens()
+		switch {
+		case ctx.Err() != nil:
+			_ = store.UpdateRunStatus(runID, "cancelled", "pipeline cancelled", tokens)
+			_ = store.ClearCancellation(runID)
+		case execErr != nil:
+			_ = store.UpdateRunStatus(runID, "failed", execErr.Error(), tokens)
+		default:
+			_ = store.UpdateRunStatus(runID, "completed", "", tokens)
+		}
+	}
+
+	return execErr
+}
+
+// runContinuous drives the --continuous batch loop. Each work item from the
+// configured source spawns a fresh executor that clones execOpts and pins a
+// new run ID, so iterations stay independent in the dashboard. Returns
+// non-nil when the loop itself fails or any iteration fails (with a count).
+func runContinuous(ctx context.Context, opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, store state.StateStore, runner adapter.AdapterRunner, emitter event.EventEmitter, execOpts []pipeline.ExecutorOption) error {
+	// Parse source URI
+	srcCfg, err := continuous.ParseSourceURI(opts.Source)
+	if err != nil {
+		return fmt.Errorf("invalid --source: %w", err)
+	}
+	src, err := continuous.NewSourceFromConfig(srcCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create source: %w", err)
+	}
+
+	// Parse delay
+	delay, err := time.ParseDuration(opts.Delay)
+	if err != nil {
+		return fmt.Errorf("invalid --delay %q: %w", opts.Delay, err)
+	}
+
+	contRunner := &continuous.Runner{
+		Source:        src,
+		PipelineName:  p.Metadata.Name,
+		OnFailure:     continuous.ParseFailurePolicy(opts.OnFailure),
+		MaxIterations: opts.MaxIterations,
+		Delay:         delay,
+		Emitter:       emitter,
+		ExecutorFactory: func(input string) continuous.ExecutorFunc {
+			return func(execCtx context.Context, execInput string) (string, error) {
+				// Create a new run ID for each iteration
+				var iterRunID string
+				if store != nil {
+					iterRunID, _ = store.CreateRun(p.Metadata.Name, execInput)
+				}
+				if iterRunID == "" {
+					iterRunID = pipeline.GenerateRunID(p.Metadata.Name, m.Runtime.PipelineIDHashLength)
+				}
+
+				// Create a fresh executor for this iteration
+				iterOpts := make([]pipeline.ExecutorOption, len(execOpts))
+				copy(iterOpts, execOpts)
+				iterOpts = append(iterOpts, pipeline.WithRunID(iterRunID))
+
+				iterExecutor := pipeline.NewDefaultPipelineExecutor(runner, iterOpts...)
+				execErr := iterExecutor.Execute(execCtx, p, m, execInput)
+
+				// Update run status
+				if store != nil {
+					tokens := iterExecutor.GetTotalTokens()
+					if execErr != nil {
+						if updateErr := store.UpdateRunStatus(iterRunID, "failed", execErr.Error(), tokens); updateErr != nil {
+							fmt.Fprintf(os.Stderr, "warning: failed to update run status: %v\n", updateErr)
+						}
+					} else {
+						if updateErr := store.UpdateRunStatus(iterRunID, "completed", "", tokens); updateErr != nil {
+							fmt.Fprintf(os.Stderr, "warning: failed to update run status: %v\n", updateErr)
+						}
+					}
+				}
+
+				return iterRunID, execErr
+			}
+		},
+	}
+
+	summary, contErr := contRunner.Run(ctx)
+	if contErr != nil {
+		return fmt.Errorf("continuous run failed: %w", contErr)
+	}
+
+	// Print summary
+	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
+		fmt.Fprintf(os.Stderr, "\n  %s\n", summary.String())
+	}
+
+	// Exit code 1 if any failures
+	if summary.HasFailures() {
+		return fmt.Errorf("continuous run completed with %d failures", summary.Failed)
+	}
+	return nil
+}
+
+// formatRecoveryError classifies execErr, builds a recovery hint block, and
+// either emits structured hints (JSON mode) or appends them to the wrapped
+// error string (text/auto/quiet mode). Always returns a non-nil error so
+// callers can `return formatRecoveryError(...)` directly.
+func formatRecoveryError(execErr error, opts RunOptions, p *pipeline.Pipeline, runID, wsRoot string, emitter event.EventEmitter) error {
+	// Extract step ID from StepExecutionError when available; fall back gracefully
+	// so recovery hints are shown for all failure paths (including resume).
+	var (
+		stepErr *pipeline.StepExecutionError
+		stepID  string
+		cause   = execErr
+	)
+	if errors.As(execErr, &stepErr) {
+		stepID = stepErr.StepID
+		cause = stepErr.Err
+	}
+
+	errClass := recovery.ClassifyError(cause)
+
+	// Extract preflight metadata when the error is a preflight failure
+	var preflightMeta *recovery.PreflightMetadata
+	if errClass == recovery.ClassPreflight {
+		preflightMeta = recovery.ExtractPreflightMetadata(cause)
+	}
+
+	block := recovery.BuildRecoveryBlock(recovery.RecoveryBlockOpts{
+		PipelineName:  p.Metadata.Name,
+		Input:         opts.Input,
+		StepID:        stepID,
+		RunID:         runID,
+		WorkspaceRoot: wsRoot,
+		ErrClass:      errClass,
+		PreflightMeta: preflightMeta,
+	})
+
+	if opts.Output.Format == OutputFormatJSON {
+		// In JSON mode, emit recovery hints as structured data.
+		// The executor already emits a bare "failed" event; this enriched
+		// event carries the hints so consumers only need one event.
+		hints := make([]event.RecoveryHintJSON, len(block.Hints))
+		for i, h := range block.Hints {
+			hints[i] = event.RecoveryHintJSON{
+				Label:   h.Label,
+				Command: h.Command,
+				Type:    string(h.Type),
+			}
+		}
+		emitter.Emit(event.Event{
+			Timestamp:     time.Now(),
+			PipelineID:    runID,
+			StepID:        stepID,
+			State:         "recovery",
+			Message:       execErr.Error(),
+			RecoveryHints: hints,
+		})
+	} else {
+		// In text/auto/quiet modes, append recovery hints after the error
+		// line by embedding them in the returned error message.
+		hintBlock := recovery.FormatRecoveryBlock(block)
+		if hintBlock != "" {
+			return fmt.Errorf("pipeline execution failed: %w\n%s", execErr, hintBlock)
+		}
+	}
+	return fmt.Errorf("pipeline execution failed: %w", execErr)
+}
+
+// printSummary writes the post-run human or JSON outcome surface. Text/auto
+// modes print the green "completed" banner plus an indented outcome
+// breakdown to stderr; JSON mode emits a final "completed" event with the
+// structured outcomes payload. Quiet mode is intentionally silent.
+func printSummary(opts RunOptions, executor *pipeline.DefaultPipelineExecutor, p *pipeline.Pipeline, runID string, elapsed time.Duration, emitter event.EventEmitter) {
+	// Show human summary only in auto/text modes — json and quiet stay clean
+	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
+		totalTokens := executor.GetTotalTokens()
+		if totalTokens > 0 {
+			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs, %s tokens)\n",
+				p.Metadata.Name, elapsed.Seconds(), display.FormatTokenCount(totalTokens))
+		} else {
+			fmt.Fprintf(os.Stderr, "\n  ✓ Pipeline '%s' completed successfully (%.1fs)\n",
+				p.Metadata.Name, elapsed.Seconds())
+		}
+		// Build structured outcome summary from outcome tracker
+		tracker := executor.GetOutcomeTracker()
+		outcome := display.BuildOutcome(tracker, p.Metadata.Name, runID, true, elapsed, totalTokens, "", nil)
+		summary := display.RenderOutcomeSummary(outcome, opts.Output.Verbose, display.NewFormatter())
+		if summary != "" {
+			fmt.Fprint(os.Stderr, "\n")
+			lines := strings.Split(summary, "\n")
+			for _, line := range lines {
+				if line != "" {
+					fmt.Fprintf(os.Stderr, "  %s\n", line)
+				} else {
+					fmt.Fprint(os.Stderr, "\n")
+				}
+			}
+			fmt.Fprint(os.Stderr, "\n")
+		}
+	}
+
+	// For JSON output mode, emit structured outcomes in the final completion event
+	if opts.Output.Format == OutputFormatJSON {
+		tracker := executor.GetOutcomeTracker()
+		outcome := display.BuildOutcome(tracker, p.Metadata.Name, runID, true, elapsed, executor.GetTotalTokens(), "", nil)
+		outJSON := outcome.ToOutcomesJSON()
+		emitter.Emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: runID,
+			State:      "completed",
+			DurationMs: elapsed.Milliseconds(),
+			Message:    fmt.Sprintf("Pipeline '%s' completed", p.Metadata.Name),
+			Outcomes:   outJSON,
+		})
+	}
+}

--- a/cmd/wave/commands/run_stages.go
+++ b/cmd/wave/commands/run_stages.go
@@ -24,6 +24,7 @@ import (
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/ontology"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/recovery"
 	"github.com/recinq/wave/internal/relay"
@@ -301,7 +302,7 @@ func buildExecutor(opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, 
 		emitterResult.Emitter.SetDebugVerbosity(true)
 	}
 
-	execOpts := assembleExecutorOptions(opts, m, p, store, stepFilter, runID, debug, emitter, wsManager, logger, debugTracer, res.runner)
+	execOpts := assembleExecutorOptions(opts, m, store, stepFilter, runID, debug, emitter, wsManager, logger, debugTracer, res.runner)
 	res.execOpts = execOpts
 
 	executor := pipeline.NewDefaultPipelineExecutor(res.runner, execOpts...)
@@ -319,11 +320,12 @@ func buildExecutor(opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, 
 // already-constructed dependencies. Split out from buildExecutor so the
 // option list — the part most likely to grow — has its own focused function
 // without the resource-bookkeeping noise.
-func assembleExecutorOptions(opts RunOptions, m *manifest.Manifest, p *pipeline.Pipeline, store state.StateStore, stepFilter *pipeline.StepFilter, runID string, debug bool, emitter event.EventEmitter, wsManager workspace.WorkspaceManager, logger audit.AuditLogger, debugTracer *audit.DebugTracer, runner adapter.AdapterRunner) []pipeline.ExecutorOption {
+func assembleExecutorOptions(opts RunOptions, m *manifest.Manifest, store state.StateStore, stepFilter *pipeline.StepFilter, runID string, debug bool, emitter event.EventEmitter, wsManager workspace.WorkspaceManager, logger audit.AuditLogger, debugTracer *audit.DebugTracer, runner adapter.AdapterRunner) []pipeline.ExecutorOption {
 	execOpts := []pipeline.ExecutorOption{
 		pipeline.WithEmitter(emitter),
 		pipeline.WithDebug(debug),
 		pipeline.WithRunID(runID),
+		pipeline.WithOntologyService(ontology.NoOp{}),
 	}
 	if debugTracer != nil {
 		execOpts = append(execOpts, pipeline.WithDebugTracer(debugTracer))


### PR DESCRIPTION
## Summary

Closes #1499. After Part 1 (PR #1530) relocated 6 misplaced types, Part 2 splits runRun (~525 LOC) into stages.

## LOC

- `cmd/wave/commands/run.go`: **953 → 375 LOC** (target ≤400 met)
- `cmd/wave/commands/run_stages.go`: 650 LOC (new, stage helpers)
- `cmd/wave/commands/run_dryrun.go`: 131 LOC (new, performDryRun)

**runRun body: 74 LOC** (target ≤80 met)

## Stages extracted

| Stage | LOC |
|-------|-----|
| validateFlags | 26 |
| setupSignalHandling | 10 |
| loadManifestAndPipeline | 52 |
| buildStateStore | 9 |
| autoRecoverResumeInput | 20 |
| resolveOrGenerateRunID | 10 |
| resolveAdapterRunner | 8 |
| buildExecutor | 72 |
| assembleExecutorOptions | 82 |
| runOnce | 43 |
| runContinuous | 78 |
| formatRecoveryError | 61 |
| printSummary | 44 |

Plus `runResources` struct + `Close()` method bundling emitter / audit logger / debug tracer cleanup so runRun can defer a single Close().

## Constraint deviation

Brief said "Touch ONLY run.go + run_test.go" but also "≤400 LOC". Conflict: keeping every helper inline pushes run.go to ~1115. Created two new files (`run_stages.go`, `run_dryrun.go`) mirroring existing `run_helpers.go` pattern. No tests touched; no other CLI files touched.

## Behaviour preservation

- `runResources.Close()` idempotent — runRun calls eagerly before post-run banner (matches original `result.Cleanup()`); deferred call becomes no-op
- `loadManifestAndPipeline` returns `aborted` bool so user-aborted TUI selector still produces clean `return nil`
- All error wrapping, signal-cancel context propagation, store-update sequencing unchanged

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./...` exit 0; full suite green (commands 246s, state 475s)
- Smoke: `wave run ops-hello-world --dry-run` succeeds, prints expected execution plan

## Test plan

- [ ] CI green
- [ ] `wave run impl-bugfix --adapter claude --model cheapest`
- [ ] `wave run --detach`, `wave run --continuous`
- [ ] `wave run --from-step` resume

Closes #1499. Parent: #1494.