### PR TITLE
refactor(adapter): close adapter-bypass sites in webui+tui (#1501)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,107 @@
+// Package git centralizes git command invocations used by Wave subsystems
+// (notably the TUI providers) so that all git execution flows through a
+// single audited point. Tests can swap the underlying runner via SetRunner.
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Runner abstracts git command execution. Implementations return the raw
+// stdout (callers trim/parse) or an error. Tests can substitute a fake to
+// exercise providers without invoking the git binary.
+type Runner func(args ...string) ([]byte, error)
+
+var (
+	runnerMu sync.RWMutex
+	runner   Runner = defaultRunner
+)
+
+// defaultRunner exec's the real git binary.
+func defaultRunner(args ...string) ([]byte, error) {
+	return exec.Command("git", args...).Output()
+}
+
+// SetRunner installs a Runner used by every package-level helper. It returns
+// the previous Runner so test code can restore it. Callers MUST restore the
+// previous runner (typically with t.Cleanup) to avoid cross-test leakage.
+func SetRunner(r Runner) Runner {
+	runnerMu.Lock()
+	defer runnerMu.Unlock()
+	prev := runner
+	if r == nil {
+		runner = defaultRunner
+	} else {
+		runner = r
+	}
+	return prev
+}
+
+// run executes git through the active runner.
+func run(args ...string) ([]byte, error) {
+	runnerMu.RLock()
+	r := runner
+	runnerMu.RUnlock()
+	return r(args...)
+}
+
+// Branch returns the current branch name (`git rev-parse --abbrev-ref HEAD`).
+// Returns an error if the working directory is not a git repository.
+func Branch() (string, error) {
+	out, err := run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ShortHash returns the abbreviated commit hash for HEAD
+// (`git rev-parse --short HEAD`).
+func ShortHash() (string, error) {
+	out, err := run("rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// IsDirty returns true when the working tree has any uncommitted changes
+// (staged, unstaged, or untracked) according to `git status --porcelain`.
+func IsDirty() (bool, error) {
+	out, err := run("status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return len(strings.TrimSpace(string(out))) > 0, nil
+}
+
+// FirstRemote returns the name of the first configured remote
+// (typically "origin"). Returns an empty string when no remote is configured.
+func FirstRemote() (string, error) {
+	out, err := run("remote")
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		return "", nil
+	}
+	return lines[0], nil
+}
+
+// VerifyRef returns true when the given ref resolves to a commit
+// (`git rev-parse --verify <ref>`). A missing ref returns false with nil err.
+func VerifyRef(ref string) (bool, error) {
+	_, err := run("rev-parse", "--verify", ref)
+	if err != nil {
+		// rev-parse exits non-zero when the ref doesn't exist; that's a
+		// well-formed "no" rather than an error condition for callers.
+		if _, ok := err.(*exec.ExitError); ok {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,203 @@
+package git
+
+import (
+	"errors"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+// stubRunner returns a Runner that records invocations and returns the
+// next response from a sequence. Tests construct it inline to keep cases
+// self-contained.
+type stubResponse struct {
+	out []byte
+	err error
+}
+
+func newStubRunner(responses []stubResponse) (Runner, *[][]string) {
+	var calls [][]string
+	idx := 0
+	r := func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if idx >= len(responses) {
+			return nil, errors.New("no response queued")
+		}
+		resp := responses[idx]
+		idx++
+		return resp.out, resp.err
+	}
+	return r, &calls
+}
+
+func withRunner(t *testing.T, r Runner) {
+	t.Helper()
+	prev := SetRunner(r)
+	t.Cleanup(func() { SetRunner(prev) })
+}
+
+func TestBranch(t *testing.T) {
+	r, calls := newStubRunner([]stubResponse{{out: []byte("main\n")}})
+	withRunner(t, r)
+
+	got, err := Branch()
+	if err != nil {
+		t.Fatalf("Branch: %v", err)
+	}
+	if got != "main" {
+		t.Errorf("got %q, want %q", got, "main")
+	}
+	want := [][]string{{"rev-parse", "--abbrev-ref", "HEAD"}}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Errorf("calls = %v, want %v", *calls, want)
+	}
+}
+
+func TestBranchError(t *testing.T) {
+	r, _ := newStubRunner([]stubResponse{{err: errors.New("boom")}})
+	withRunner(t, r)
+
+	if _, err := Branch(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestShortHash(t *testing.T) {
+	r, calls := newStubRunner([]stubResponse{{out: []byte("abcdef0\n")}})
+	withRunner(t, r)
+
+	got, err := ShortHash()
+	if err != nil {
+		t.Fatalf("ShortHash: %v", err)
+	}
+	if got != "abcdef0" {
+		t.Errorf("got %q", got)
+	}
+	if (*calls)[0][0] != "rev-parse" || (*calls)[0][1] != "--short" {
+		t.Errorf("unexpected args: %v", *calls)
+	}
+}
+
+func TestIsDirty(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"clean", "", false},
+		{"clean whitespace", "   \n", false},
+		{"dirty", " M file.go\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newStubRunner([]stubResponse{{out: []byte(tt.out)}})
+			withRunner(t, r)
+
+			got, err := IsDirty()
+			if err != nil {
+				t.Fatalf("IsDirty: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstRemote(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"origin", "origin\n", "origin"},
+		{"multiple", "origin\nupstream\n", "origin"},
+		{"none", "", ""},
+		{"none whitespace", "  \n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newStubRunner([]stubResponse{{out: []byte(tt.out)}})
+			withRunner(t, r)
+
+			got, err := FirstRemote()
+			if err != nil {
+				t.Fatalf("FirstRemote: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyRefExists(t *testing.T) {
+	r, calls := newStubRunner([]stubResponse{{out: []byte("abc\n")}})
+	withRunner(t, r)
+
+	ok, err := VerifyRef("feature/x")
+	if err != nil {
+		t.Fatalf("VerifyRef: %v", err)
+	}
+	if !ok {
+		t.Errorf("expected true")
+	}
+	if (*calls)[0][2] != "feature/x" {
+		t.Errorf("unexpected args: %v", *calls)
+	}
+}
+
+func TestVerifyRefMissing(t *testing.T) {
+	// Simulate exec.ExitError by running a real failing git command. We
+	// allow the test to skip if git is unavailable to keep the package
+	// hermetic on minimal builders.
+	cmd := exec.Command("git", "rev-parse", "--verify", "this-ref-does-not-exist-xyz")
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Skipf("git not available: %v", err)
+		}
+		r := func(args ...string) ([]byte, error) { return nil, exitErr }
+		withRunner(t, r)
+
+		ok, vErr := VerifyRef("missing")
+		if vErr != nil {
+			t.Fatalf("VerifyRef should swallow ExitError: %v", vErr)
+		}
+		if ok {
+			t.Errorf("expected false for missing ref")
+		}
+	}
+}
+
+func TestVerifyRefOtherError(t *testing.T) {
+	r, _ := newStubRunner([]stubResponse{{err: errors.New("io failure")}})
+	withRunner(t, r)
+
+	ok, err := VerifyRef("foo")
+	if err == nil {
+		t.Fatal("expected error to bubble up")
+	}
+	if ok {
+		t.Error("expected false on error")
+	}
+}
+
+func TestSetRunnerNilRestoresDefault(t *testing.T) {
+	// Replace with a stub.
+	stub := func(_ ...string) ([]byte, error) { return []byte("stub"), nil }
+	prev := SetRunner(stub)
+	defer SetRunner(prev)
+
+	// Now reset to default by passing nil; subsequent run() should call exec.
+	_ = SetRunner(nil)
+
+	runnerMu.RLock()
+	cur := runner
+	runnerMu.RUnlock()
+
+	// Compare function pointers via reflect.
+	if reflect.ValueOf(cur).Pointer() != reflect.ValueOf(Runner(defaultRunner)).Pointer() {
+		t.Errorf("SetRunner(nil) did not restore default runner")
+	}
+}

--- a/internal/sandbox/run.go
+++ b/internal/sandbox/run.go
@@ -1,0 +1,46 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// RunShell executes a shell command line through the configured sandbox
+// backend so that ad-hoc invocations from non-pipeline surfaces (the webui
+// dashboard, future admin tooling) inherit the same isolation policy as
+// pipeline-driven execution.
+//
+// The command is invoked as `sh -c <cmdLine>`. The chosen backend (None,
+// Docker, or Bubblewrap) wraps the underlying exec.Cmd; the wrapper may add
+// a Docker run prefix, FS bind mounts, or a passthrough as appropriate. A
+// short audit log line is emitted regardless of backend so operators can
+// correlate the invocation with state changes on disk.
+//
+// Returns combined stdout+stderr and any execution error. Backend
+// initialization failures are returned as errors with no output.
+func RunShell(ctx context.Context, cmdLine string, cfg Config) ([]byte, error) {
+	if cmdLine == "" {
+		return nil, fmt.Errorf("sandbox: empty command line")
+	}
+
+	sb, err := NewSandbox(cfg.Backend)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", cmdLine)
+	wrapped, err := sb.Wrap(ctx, cmd, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: wrap: %w", err)
+	}
+
+	// Audit trail: a single line is sufficient — credentials in cmdLine
+	// would be a configuration smell, since RunShell is invoked from
+	// trusted code paths (webui handlers, etc.) with operator-defined
+	// commands stored in pipeline metadata.
+	log.Printf("[sandbox.run] backend=%s cmd=%q", cfg.Backend, cmdLine)
+
+	return wrapped.CombinedOutput()
+}

--- a/internal/sandbox/run_test.go
+++ b/internal/sandbox/run_test.go
@@ -1,0 +1,61 @@
+package sandbox
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunShellNoneBackend(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := RunShell(ctx, "echo hello-sandbox", Config{Backend: SandboxBackendNone})
+	if err != nil {
+		t.Fatalf("RunShell: %v", err)
+	}
+	if !strings.Contains(string(out), "hello-sandbox") {
+		t.Errorf("expected output to contain hello-sandbox, got %q", out)
+	}
+}
+
+func TestRunShellDefaultBackend(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Empty backend should fall through to NoneSandbox.
+	out, err := RunShell(ctx, "echo default-fallback", Config{})
+	if err != nil {
+		t.Fatalf("RunShell: %v", err)
+	}
+	if !strings.Contains(string(out), "default-fallback") {
+		t.Errorf("expected default-fallback, got %q", out)
+	}
+}
+
+func TestRunShellEmptyCommand(t *testing.T) {
+	_, err := RunShell(context.Background(), "", Config{Backend: SandboxBackendNone})
+	if err == nil {
+		t.Fatal("expected error on empty command")
+	}
+}
+
+func TestRunShellPropagatesExitError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := RunShell(ctx, "exit 7", Config{Backend: SandboxBackendNone})
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	// Output is allowed to be empty for `exit`.
+	_ = out
+}
+
+func TestRunShellUnknownBackend(t *testing.T) {
+	_, err := RunShell(context.Background(), "echo x", Config{Backend: SandboxBackendType("nonsense")})
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+}

--- a/internal/tui/header_provider.go
+++ b/internal/tui/header_provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/recinq/wave/internal/forge"
+	wgit "github.com/recinq/wave/internal/git"
 	"github.com/recinq/wave/internal/manifest"
 )
 
@@ -30,33 +31,24 @@ type DefaultMetadataProvider struct {
 func (p *DefaultMetadataProvider) FetchGitState() (GitState, error) {
 	var state GitState
 
-	// Get current branch name.
-	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	// Get current branch name via the centralized git helper.
+	branch, err := wgit.Branch()
 	if err != nil {
 		// Not a git repo or git not installed — return safe placeholders.
 		return GitState{Branch: "[no git]", CommitHash: "[no git]"}, nil
 	}
-	state.Branch = strings.TrimSpace(string(out))
+	state.Branch = branch
 
-	// Get abbreviated commit hash.
-	out, err = exec.Command("git", "rev-parse", "--short", "HEAD").Output()
-	if err == nil {
-		state.CommitHash = strings.TrimSpace(string(out))
+	if hash, err := wgit.ShortHash(); err == nil {
+		state.CommitHash = hash
 	}
 
-	// Check dirty status via porcelain output.
-	out, err = exec.Command("git", "status", "--porcelain").Output()
-	if err == nil {
-		state.IsDirty = len(strings.TrimSpace(string(out))) > 0
+	if dirty, err := wgit.IsDirty(); err == nil {
+		state.IsDirty = dirty
 	}
 
-	// Get the first remote name (usually "origin").
-	out, err = exec.Command("git", "remote").Output()
-	if err == nil {
-		lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-		if len(lines) > 0 && lines[0] != "" {
-			state.RemoteName = lines[0]
-		}
+	if remote, err := wgit.FirstRemote(); err == nil {
+		state.RemoteName = remote
 	}
 
 	return state, nil

--- a/internal/tui/pipeline_detail_provider.go
+++ b/internal/tui/pipeline_detail_provider.go
@@ -3,10 +3,10 @@ package tui
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
+	wgit "github.com/recinq/wave/internal/git"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 )
@@ -272,10 +272,10 @@ func (d *DefaultDetailDataProvider) FetchFinishedDetail(runID string) (*Finished
 		}
 	}
 
-	// Check if the branch still exists.
+	// Check if the branch still exists via the centralized git helper.
 	if run.BranchName != "" {
-		cmd := exec.Command("git", "rev-parse", "--verify", run.BranchName)
-		if err := cmd.Run(); err != nil {
+		exists, vErr := wgit.VerifyRef(run.BranchName)
+		if vErr != nil || !exists {
 			detail.BranchDeleted = true
 		}
 	}

--- a/internal/webui/handlers_skills.go
+++ b/internal/webui/handlers_skills.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/recinq/wave/internal/defaults"
 	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/sandbox"
 	"github.com/recinq/wave/internal/skill"
 )
 
@@ -317,8 +317,18 @@ func (s *Server) handleAPISkillRunInstall(w http.ResponseWriter, r *http.Request
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", installCmd)
-	out, err := cmd.CombinedOutput()
+	// Route the install command through internal/sandbox so it inherits
+	// the same backend policy (none/docker/bubblewrap) and audit log line
+	// that pipeline-driven shellouts use. The webui historically called
+	// `exec.CommandContext("sh", "-c", ...)` directly, bypassing both.
+	cfg := sandbox.Config{}
+	if s.manifest != nil {
+		cfg.Backend = sandbox.SandboxBackendType(s.manifest.Runtime.Sandbox.ResolveBackend())
+		cfg.DockerImage = s.manifest.Runtime.Sandbox.DockerImage
+		cfg.AllowedDomains = s.manifest.Runtime.Sandbox.DefaultAllowedDomains
+		cfg.EnvPassthrough = s.manifest.Runtime.Sandbox.EnvPassthrough
+	}
+	out, err := sandbox.RunShell(ctx, installCmd, cfg)
 	if err != nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"success": false,


### PR DESCRIPTION
## Summary

Closes #1501. Routes webui skill install through `internal/sandbox.RunShell` and TUI provider git commands through new `internal/git` package. Sites already handled by prior PRs (#1527 for runner, #1533 for HTTP) untouched.

## New packages

### `internal/git` — TUI-friendly git wrapper

Public API:
- `Branch() (string, error)` — `rev-parse --abbrev-ref HEAD`
- `ShortHash() (string, error)` — `rev-parse --short HEAD`
- `IsDirty() (bool, error)` — `status --porcelain`
- `FirstRemote() (string, error)` — `git remote`, returns first line
- `VerifyRef(ref) (bool, error)` — `rev-parse --verify <ref>`; missing ref → `(false, nil)`
- `SetRunner(Runner) Runner` — test seam
- `Runner` type (`func(args ...string) ([]byte, error)`)

### `internal/sandbox.RunShell`

`RunShell(ctx, cmdLine, Config) ([]byte, error)` wraps `sh -c <cmdLine>` through configured backend (`none`/`docker`/`bubblewrap`) and emits audit log line. Used by webui skill install endpoint.

## Migrations

- `internal/tui/header_provider.go` — `FetchGitState` consumes `internal/git`; gh calls remain (out of scope)
- `internal/tui/pipeline_detail_provider.go` — branch verification via `git.VerifyRef`
- `internal/webui/handlers_skills.go` — `handleAPISkillRunInstall` routes through `sandbox.RunShell` with manifest-derived Config

## Decisions

- Skill install through `internal/sandbox.RunShell`, not `internal/skill` — install commands are operator-defined shell snippets (`brew install gh`, `wave skills add ...`) that don't fit the Store/Provision model
- `pipeline_launcher.go` exec.Command invokes `os.Args[0]` (wave self-respawn) — out of scope (not git)
- `pipeline_detail.go` `b`/`d` key handlers have git execs but file isn't `_provider.go` — out of scope per spec
- `gh` and `claude` execs left in place — spec was git-only routing

## grep counts (`exec.Command` in `internal/tui` + `internal/webui`, excluding `_test.go`)

| | Before | After |
|---|---|---|
| In `*_provider.go` files | 4 git | **0** |
| Total | 11 | 10 |

Remaining: gh (2), wave self-exec (2), claude/git in non-provider files (5).

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/git/... ./internal/sandbox/... ./internal/tui/... ./internal/webui/...` all pass
- `go test -race ./...` full suite green (state 545s, pipeline 92s)

## Test plan

- [ ] CI green
- [ ] `wave serve` skill install endpoint works
- [ ] `wave tui` header + pipeline-detail panels render correct git state

Closes #1501. Parent: #1494.