### PR TITLE
refactor: extract internal/persona; resolve adapter<->manifest cycle (#1507.13.5)

### DIFF
--- a/cmd/wave/commands/agent.go
+++ b/cmd/wave/commands/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/manifest"
+	"github.com/recinq/wave/internal/persona"
 	"github.com/spf13/cobra"
 )
 
@@ -252,8 +253,8 @@ func loadManifestForAgent(manifestPath string) (*manifest.Manifest, error) {
 // compilePersonaToAgentMd resolves a persona by name and compiles it to agent
 // markdown. It reads the base protocol and persona system prompt from disk.
 func compilePersonaToAgentMd(name string, m *manifest.Manifest) (string, error) {
-	persona := m.GetPersona(name)
-	if persona == nil {
+	p := m.GetPersona(name)
+	if p == nil {
 		return "", NewCLIError(CodeInvalidArgs,
 			fmt.Sprintf("persona %q not found in manifest", name),
 			"Run 'wave agent list' to see available personas")
@@ -268,8 +269,8 @@ func compilePersonaToAgentMd(name string, m *manifest.Manifest) (string, error) 
 
 	// Load persona system prompt
 	var systemPrompt string
-	if persona.SystemPromptFile != "" {
-		promptPath := persona.GetSystemPromptPath(".")
+	if p.SystemPromptFile != "" {
+		promptPath := p.GetSystemPromptPath(".")
 		data, err := os.ReadFile(promptPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to read system prompt for persona %q from %s: %w", name, promptPath, err)
@@ -285,12 +286,12 @@ func compilePersonaToAgentMd(name string, m *manifest.Manifest) (string, error) 
 		}
 	}
 
-	// Map manifest.Persona to adapter.PersonaSpec to avoid import cycles in the
-	// adapter package (adapter must not import manifest).
-	spec := adapter.PersonaSpec{
-		Model:        persona.Model,
-		AllowedTools: persona.Permissions.AllowedTools,
-		DenyTools:    persona.Permissions.Deny,
+	// Map manifest.Persona to the neutral persona.Persona used by the agent
+	// compiler (internal/persona breaks the would-be adapter↔manifest cycle).
+	spec := persona.Persona{
+		Model:        p.Model,
+		AllowedTools: p.Permissions.AllowedTools,
+		DenyTools:    p.Permissions.Deny,
 	}
 
 	agentMd := adapter.PersonaToAgentMarkdown(

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/recinq/wave/internal/persona"
 	"github.com/recinq/wave/internal/timeouts"
 )
 
@@ -290,7 +291,7 @@ func (a *ClaudeAdapter) prepareWorkspace(workspacePath string, cfg AdapterRunCon
 	restrictions := buildRestrictionSection(cfg)
 
 	// Compile persona into a self-contained agent .md file with YAML frontmatter.
-	spec := PersonaSpec{
+	spec := persona.Persona{
 		Model:        cfg.Model,
 		AllowedTools: cfg.AllowedTools,
 		DenyTools:    cfg.DenyTools,
@@ -857,27 +858,14 @@ func buildRestrictionSection(cfg AdapterRunConfig) string {
 	return b.String()
 }
 
-// PersonaSpec holds the subset of persona configuration needed by the agent
-// compiler. It is intentionally decoupled from manifest.Persona to avoid an
-// import cycle (adapter → manifest → adapter).
+// PersonaSpec is a backward-compatible alias for persona.Persona.
 //
-// Callers that hold a manifest.Persona should map it with PersonaSpecFromManifest
-// (defined in the commands package where the manifest import is already present)
-// or build the struct directly.
-type PersonaSpec struct {
-	// Model is the Claude model identifier (e.g. "claude-opus-4") or tier alias
-	// (cheapest, balanced, strongest, resolved before this point by the executor).
-	// Leave empty to omit the frontmatter field and inherit the CLI default.
-	Model string
+// The agent compiler input type lives in internal/persona so it can be shared
+// by both internal/adapter and internal/manifest without forming an import
+// cycle. New code should reference persona.Persona directly.
+type PersonaSpec = persona.Persona
 
-	// AllowedTools is the list of tool names the agent may use.
-	AllowedTools []string
-
-	// DenyTools is the list of tool patterns the agent must not use.
-	DenyTools []string
-}
-
-// PersonaToAgentMarkdown compiles a PersonaSpec into a Claude Code agent .md
+// PersonaToAgentMarkdown compiles a persona.Persona into a Claude Code agent .md
 // file with YAML frontmatter. The generated file can be passed directly to
 // `claude --agent <path>` to run the persona in agent mode.
 //
@@ -890,30 +878,30 @@ type PersonaSpec struct {
 //  3. systemPrompt — the persona's role/responsibilities/constraints text
 //  4. contractSection — the auto-generated contract compliance section
 //  5. restrictions — the denied/allowed tools and network domain section
-func PersonaToAgentMarkdown(persona PersonaSpec, baseProtocol, ontologySection, systemPrompt, contractSection, restrictions string) string {
+func PersonaToAgentMarkdown(p persona.Persona, baseProtocol, ontologySection, systemPrompt, contractSection, restrictions string) string {
 	var b strings.Builder
 
 	// --- YAML frontmatter ---
 	b.WriteString("---\n")
 
-	if persona.Model != "" {
+	if p.Model != "" {
 		b.WriteString("model: ")
-		b.WriteString(persona.Model)
+		b.WriteString(p.Model)
 		b.WriteString("\n")
 	}
 
-	if len(persona.AllowedTools) > 0 {
+	if len(p.AllowedTools) > 0 {
 		b.WriteString("tools:\n")
-		for _, tool := range persona.AllowedTools {
+		for _, tool := range p.AllowedTools {
 			b.WriteString("  - ")
 			b.WriteString(tool)
 			b.WriteString("\n")
 		}
 	}
 
-	if len(persona.DenyTools) > 0 {
+	if len(p.DenyTools) > 0 {
 		b.WriteString("disallowedTools:\n")
-		for _, tool := range persona.DenyTools {
+		for _, tool := range p.DenyTools {
 			b.WriteString("  - ")
 			b.WriteString(tool)
 			b.WriteString("\n")

--- a/internal/persona/persona.go
+++ b/internal/persona/persona.go
@@ -1,0 +1,27 @@
+// Package persona defines the neutral persona type used by the agent compiler.
+//
+// It exists in its own package so that both internal/manifest (which loads
+// persona definitions from wave.yaml) and internal/adapter (which compiles a
+// persona into an agent .md file) can reference a shared type without forming
+// an import cycle. Prior to this package, internal/adapter defined a private
+// PersonaSpec mirror of the manifest persona to dodge the cycle.
+package persona
+
+// Persona holds the subset of persona configuration needed by the agent
+// compiler. It is intentionally narrower than manifest.Persona: only the
+// fields written into the generated agent .md frontmatter are present.
+//
+// Callers that hold a manifest.Persona should construct this struct from
+// the fields they need (Model, Permissions.AllowedTools, Permissions.Deny).
+type Persona struct {
+	// Model is the Claude model identifier (e.g. "claude-opus-4") or tier alias
+	// (cheapest, balanced, strongest, resolved before this point by the executor).
+	// Leave empty to omit the frontmatter field and inherit the CLI default.
+	Model string
+
+	// AllowedTools is the list of tool names the agent may use.
+	AllowedTools []string
+
+	// DenyTools is the list of tool patterns the agent must not use.
+	DenyTools []string
+}

--- a/internal/persona/persona_test.go
+++ b/internal/persona/persona_test.go
@@ -1,0 +1,38 @@
+package persona
+
+import "testing"
+
+// TestPersonaZeroValue ensures the zero value carries empty fields as expected.
+func TestPersonaZeroValue(t *testing.T) {
+	var p Persona
+	if p.Model != "" {
+		t.Errorf("zero Model = %q, want empty", p.Model)
+	}
+	if len(p.AllowedTools) != 0 {
+		t.Errorf("zero AllowedTools len = %d, want 0", len(p.AllowedTools))
+	}
+	if len(p.DenyTools) != 0 {
+		t.Errorf("zero DenyTools len = %d, want 0", len(p.DenyTools))
+	}
+}
+
+// TestPersonaFieldRoundtrip pins the field shape consumed by the agent
+// compiler. Adding fields here is fine; renaming or removing them is a
+// behavioural change that callers in internal/adapter and cmd/wave/commands
+// depend on.
+func TestPersonaFieldRoundtrip(t *testing.T) {
+	p := Persona{
+		Model:        "claude-opus-4",
+		AllowedTools: []string{"Read", "Glob"},
+		DenyTools:    []string{"Bash(rm*)"},
+	}
+	if p.Model != "claude-opus-4" {
+		t.Errorf("Model = %q", p.Model)
+	}
+	if len(p.AllowedTools) != 2 || p.AllowedTools[0] != "Read" {
+		t.Errorf("AllowedTools = %v", p.AllowedTools)
+	}
+	if len(p.DenyTools) != 1 || p.DenyTools[0] != "Bash(rm*)" {
+		t.Errorf("DenyTools = %v", p.DenyTools)
+	}
+}


### PR DESCRIPTION
## Summary

New `internal/persona` package owns the agent-compiler input type that `adapter.PersonaSpec` previously mirrored. `adapter` no longer imports `manifest`. Backward compat preserved via type alias.

## Public API

```go
package persona

type Persona struct {
    Model        string
    AllowedTools []string
    DenyTools    []string
}
```

## Audit obstacle (surfaced)

Audit described `adapter.PersonaSpec` as a "mirror of `manifest.Persona`" but inspection showed it's actually a **3-field subset** of the 9-field `manifest.Persona` (which carries `SystemPromptFile`, `Temperature`, `Permissions`, `Hooks`, `Sandbox`, `Skills`, `TokenScopes`, etc.).

Decision: did NOT alias `manifest.Persona = persona.Persona` — shapes don't match. Did NOT touch `internal/manifest/`. Instead moved the agent-compiler input type (what the avoid-cycle comment actually referenced) to the neutral package. Future unification of the full manifest persona type would drag `Permissions`, `HookConfig`, `PersonaSandbox` types — separate refactor.

## Backward compat

`adapter.PersonaSpec` kept as `type PersonaSpec = persona.Persona`. All 14 existing `PersonaSpec{...}` call sites in `claude_test.go` and `agent_test.go` compile unchanged.

## Direction verified

```
$ go list -deps github.com/recinq/wave/internal/adapter | grep manifest
(empty)
```

Adapter does NOT import manifest. Cycle workaround is now real and unnecessary. Manifest does not import adapter either.

## Drive-by fixes

- `cmd/wave/commands/agent.go` had local `persona` variable shadowing the package import; renamed to `p`
- `PersonaToAgentMarkdown` parameter renamed from `persona` to `p`

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./internal/persona/... ./internal/manifest/... ./internal/adapter/...` all pass
- `go test -race ./...` 52 packages OK, 0 failures

## LOC delta

+91 / -37 across 4 files

## Test plan

- [ ] CI green
- [ ] `wave run` agent compilation unchanged

Partial of #1507 (subset 13.5). Parent: #1494.