### PR TITLE
refactor(webui): split Server struct into composed sub-structs (#1498 D)

### DIFF
--- a/internal/webui/auth.go
+++ b/internal/webui/auth.go
@@ -8,7 +8,7 @@ import (
 
 // requiresAuth returns true if the server binding requires authentication.
 func (s *Server) requiresAuth() bool {
-	return s.bind != "127.0.0.1" && s.bind != "localhost" && s.bind != ""
+	return s.transport.bind != "127.0.0.1" && s.transport.bind != "localhost" && s.transport.bind != ""
 }
 
 // GenerateToken generates a random 32-byte hex token.

--- a/internal/webui/auth_test.go
+++ b/internal/webui/auth_test.go
@@ -53,7 +53,7 @@ func TestGenerateToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_ValidToken(t *testing.T) {
-	s := &Server{token: "test-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "test-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -69,7 +69,7 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_InvalidToken(t *testing.T) {
-	s := &Server{token: "test-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "test-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -85,7 +85,7 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_NoToken(t *testing.T) {
-	s := &Server{token: "test-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "test-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -100,7 +100,7 @@ func TestAuthMiddleware_NoToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_QueryToken(t *testing.T) {
-	s := &Server{token: "test-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "test-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -115,7 +115,7 @@ func TestAuthMiddleware_QueryToken(t *testing.T) {
 }
 
 func TestAuthMiddleware_StaticBypass(t *testing.T) {
-	s := &Server{token: "test-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "test-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -134,7 +134,7 @@ func TestApplyMiddleware_NonLocalhostEnforcesAuth(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	s := &Server{token: "secret-token", bind: "0.0.0.0"}
+	s := &Server{auth: serverAuth{token: "secret-token"}, transport: serverTransport{bind: "0.0.0.0"}}
 	handler := s.applyMiddleware(inner)
 
 	// Request without token should be rejected
@@ -162,7 +162,7 @@ func TestApplyMiddleware_LocalhostSkipsAuth(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	s := &Server{token: "secret-token", bind: "127.0.0.1"}
+	s := &Server{auth: serverAuth{token: "secret-token"}, transport: serverTransport{bind: "127.0.0.1"}}
 	handler := s.applyMiddleware(inner)
 
 	// Request without token should succeed on localhost
@@ -187,7 +187,7 @@ func TestRequiresAuth(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		s := &Server{bind: tt.bind}
+		s := &Server{transport: serverTransport{bind: tt.bind}}
 		if got := s.requiresAuth(); got != tt.expected {
 			t.Errorf("requiresAuth() for bind %q = %v, want %v", tt.bind, got, tt.expected)
 		}

--- a/internal/webui/handlers_admin.go
+++ b/internal/webui/handlers_admin.go
@@ -19,7 +19,7 @@ func (s *Server) handleAdminPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/admin.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/admin.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -37,11 +37,11 @@ type adminConfigResponse struct {
 
 // handleAPIAdminConfig handles GET /api/admin/config.
 func (s *Server) handleAPIAdminConfig(w http.ResponseWriter, _ *http.Request) {
-	addr := fmt.Sprintf("%s:%d", s.bind, s.port)
+	addr := fmt.Sprintf("%s:%d", s.transport.bind, s.transport.port)
 
 	maxConcurrency := 5
-	if s.scheduler != nil {
-		maxConcurrency = s.scheduler.MaxConcurrency()
+	if s.runtime.scheduler != nil {
+		maxConcurrency = s.runtime.scheduler.MaxConcurrency()
 	}
 
 	binaries := map[string]string{}
@@ -54,8 +54,8 @@ func (s *Server) handleAPIAdminConfig(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	wsRoot := ".agents/workspaces"
-	if s.manifest != nil && s.manifest.Runtime.WorkspaceRoot != "" {
-		wsRoot = s.manifest.Runtime.WorkspaceRoot
+	if s.runtime.manifest != nil && s.runtime.manifest.Runtime.WorkspaceRoot != "" {
+		wsRoot = s.runtime.manifest.Runtime.WorkspaceRoot
 	}
 
 	resp := adminConfigResponse{
@@ -63,7 +63,7 @@ func (s *Server) handleAPIAdminConfig(w http.ResponseWriter, _ *http.Request) {
 		MaxConcurrency:  maxConcurrency,
 		AdapterBinaries: binaries,
 		WorkspaceRoot:   wsRoot,
-		AuthMode:        string(s.authMode),
+		AuthMode:        string(s.auth.authMode),
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -104,7 +104,7 @@ type emergencyStopResponse struct {
 
 // handleAPIEmergencyStop handles POST /api/admin/emergency-stop.
 func (s *Server) handleAPIEmergencyStop(w http.ResponseWriter, _ *http.Request) {
-	runs, err := s.store.GetRunningRuns()
+	runs, err := s.runtime.store.GetRunningRuns()
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to get running runs: "+err.Error())
 		return
@@ -114,12 +114,12 @@ func (s *Server) handleAPIEmergencyStop(w http.ResponseWriter, _ *http.Request) 
 	for _, run := range runs {
 		// Cancel the goroutine context if active
 		s.mu.Lock()
-		if cancelFn, ok := s.activeRuns[run.RunID]; ok {
+		if cancelFn, ok := s.realtime.activeRuns[run.RunID]; ok {
 			cancelFn()
 		}
 		s.mu.Unlock()
 
-		if err := s.rwStore.RequestCancellation(run.RunID, true); err != nil {
+		if err := s.runtime.rwStore.RequestCancellation(run.RunID, true); err != nil {
 			continue // best-effort: skip runs that fail to cancel
 		}
 		cancelledIDs = append(cancelledIDs, run.RunID)
@@ -150,7 +150,7 @@ func (s *Server) handleDisablePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	s.disabledPipelines[name] = true
+	s.realtime.disabledPipelines[name] = true
 	s.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, pipelineToggleResponse{Name: name, Disabled: true})
@@ -165,7 +165,7 @@ func (s *Server) handleEnablePipeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	delete(s.disabledPipelines, name)
+	delete(s.realtime.disabledPipelines, name)
 	s.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, pipelineToggleResponse{Name: name, Disabled: false})
@@ -175,7 +175,7 @@ func (s *Server) handleEnablePipeline(w http.ResponseWriter, r *http.Request) {
 func (s *Server) isPipelineDisabled(name string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.disabledPipelines[name]
+	return s.realtime.disabledPipelines[name]
 }
 
 // --- Audit Log ---
@@ -222,7 +222,7 @@ func (s *Server) handleAPIAdminAudit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	events, err := s.store.GetAuditEvents(auditEventStates, limit, offset)
+	events, err := s.runtime.store.GetAuditEvents(auditEventStates, limit, offset)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to query audit events: "+err.Error())
 		return
@@ -252,8 +252,8 @@ func (s *Server) handleAPIAdminAudit(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getDisabledPipelineSet() map[string]bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	cp := make(map[string]bool, len(s.disabledPipelines))
-	for k, v := range s.disabledPipelines {
+	cp := make(map[string]bool, len(s.realtime.disabledPipelines))
+	for k, v := range s.realtime.disabledPipelines {
 		cp[k] = v
 	}
 	return cp

--- a/internal/webui/handlers_admin_test.go
+++ b/internal/webui/handlers_admin_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHandleAPIAdminConfig(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.scheduler = NewScheduler(3)
+	srv.runtime.scheduler = NewScheduler(3)
 
 	req := httptest.NewRequest("GET", "/api/admin/config", nil)
 	rec := httptest.NewRecorder()
@@ -52,7 +52,7 @@ func TestHandleAPIAdminConfig(t *testing.T) {
 
 func TestHandleAPIAdminConfig_NilScheduler(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.scheduler = nil
+	srv.runtime.scheduler = nil
 
 	req := httptest.NewRequest("GET", "/api/admin/config", nil)
 	rec := httptest.NewRecorder()
@@ -168,7 +168,7 @@ func TestHandleAPIEmergencyStop_WithRunning(t *testing.T) {
 func TestHandleAdminPage(t *testing.T) {
 	srv, _ := testServer(t)
 	// Add admin template stub
-	srv.templates["templates/admin.html"] = testAdminTemplate(t)
+	srv.assets.templates["templates/admin.html"] = testAdminTemplate(t)
 
 	req := httptest.NewRequest("GET", "/admin", nil)
 	rec := httptest.NewRecorder()

--- a/internal/webui/handlers_analytics.go
+++ b/internal/webui/handlers_analytics.go
@@ -79,7 +79,7 @@ func (s *Server) handleAnalyticsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/analytics.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/analytics.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		log.Printf("[webui] template error rendering analytics page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
@@ -100,7 +100,7 @@ func (s *Server) buildTokenAnalytics() TokenAnalytics {
 	var analytics TokenAnalytics
 
 	// Fetch recent runs (up to 200 for aggregation)
-	runs, err := s.store.ListRuns(state.ListRunsOptions{Limit: 200})
+	runs, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 200})
 	if err != nil {
 		log.Printf("[webui] analytics: failed to list runs: %v", err)
 		return analytics
@@ -164,7 +164,7 @@ func (s *Server) buildTokenAnalytics() TokenAnalytics {
 	}
 
 	// Per-persona breakdown from performance metrics
-	metrics, err := s.store.GetRecentPerformanceHistory(state.PerformanceQueryOptions{
+	metrics, err := s.runtime.store.GetRecentPerformanceHistory(state.PerformanceQueryOptions{
 		Limit: 1000,
 	})
 	if err != nil {

--- a/internal/webui/handlers_artifacts.go
+++ b/internal/webui/handlers_artifacts.go
@@ -23,7 +23,7 @@ func (s *Server) handleArtifact(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find the artifact in the database
-	artifacts, err := s.store.GetArtifacts(runID, stepID)
+	artifacts, err := s.runtime.store.GetArtifacts(runID, stepID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to get artifacts")
 		return

--- a/internal/webui/handlers_attention.go
+++ b/internal/webui/handlers_attention.go
@@ -10,7 +10,7 @@ import (
 // handleAttentionSSE handles GET /api/attention/events — a global SSE stream
 // that broadcasts attention summary changes across all active runs.
 func (s *Server) handleAttentionSSE(w http.ResponseWriter, r *http.Request) {
-	if s.attention == nil {
+	if s.realtime.attention == nil {
 		http.Error(w, "attention broker not initialized", http.StatusServiceUnavailable)
 		return
 	}
@@ -30,13 +30,13 @@ func (s *Server) handleAttentionSSE(w http.ResponseWriter, r *http.Request) {
 	flusher.Flush()
 
 	// Send current state immediately.
-	summary := s.attention.Summary()
+	summary := s.realtime.attention.Summary()
 	data, _ := json.Marshal(summary)
 	fmt.Fprintf(w, "event: attention\ndata: %s\n\n", data)
 	flusher.Flush()
 
-	ch := s.attention.Subscribe()
-	defer s.attention.Unsubscribe(ch)
+	ch := s.realtime.attention.Subscribe()
+	defer s.realtime.attention.Unsubscribe(ch)
 
 	keepalive := time.NewTicker(15 * time.Second)
 	defer keepalive.Stop()
@@ -62,14 +62,14 @@ func (s *Server) handleAttentionSSE(w http.ResponseWriter, r *http.Request) {
 
 // handleAttentionSummary handles GET /api/attention — returns current attention summary as JSON.
 func (s *Server) handleAttentionSummary(w http.ResponseWriter, r *http.Request) {
-	if s.attention == nil {
+	if s.realtime.attention == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"worst_state":"autonomous","total_runs":0}`)
 		return
 	}
 
-	summary := s.attention.Summary()
+	summary := s.realtime.attention.Summary()
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(summary); err != nil {
 		http.Error(w, "failed to encode attention summary", http.StatusInternalServerError)

--- a/internal/webui/handlers_cache.go
+++ b/internal/webui/handlers_cache.go
@@ -7,7 +7,7 @@ import (
 
 // handleAPICacheRefresh handles POST /api/cache/refresh — clears all cached API responses.
 func (s *Server) handleAPICacheRefresh(w http.ResponseWriter, r *http.Request) {
-	s.cache.Clear()
+	s.assets.cache.Clear()
 	log.Printf("[webui] cache cleared via API request")
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "message": "cache cleared"})
 }

--- a/internal/webui/handlers_compare.go
+++ b/internal/webui/handlers_compare.go
@@ -68,7 +68,7 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	leftRun, err := s.store.GetRun(leftID)
+	leftRun, err := s.runtime.store.GetRun(leftID)
 	if err != nil {
 		s.renderComparePage(w, comparePageData{
 			ActivePage:   "runs",
@@ -79,7 +79,7 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rightRun, err := s.store.GetRun(rightID)
+	rightRun, err := s.runtime.store.GetRun(rightID)
 	if err != nil {
 		s.renderComparePage(w, comparePageData{
 			ActivePage:   "runs",
@@ -136,7 +136,7 @@ func (s *Server) handleComparePage(w http.ResponseWriter, r *http.Request) {
 // renderComparePage renders the compare template with the given data.
 func (s *Server) renderComparePage(w http.ResponseWriter, data comparePageData) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	tmpl := s.templates["templates/compare.html"]
+	tmpl := s.assets.templates["templates/compare.html"]
 	if tmpl == nil {
 		http.Error(w, "compare template not found", http.StatusInternalServerError)
 		return
@@ -149,7 +149,7 @@ func (s *Server) renderComparePage(w http.ResponseWriter, data comparePageData) 
 
 // listRecentRuns fetches recent runs for the compare selector.
 func (s *Server) listRecentRuns() []RunSummary {
-	runs, err := s.store.ListRuns(state.ListRunsOptions{Limit: 50})
+	runs, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 50})
 	if err != nil {
 		log.Printf("[webui] compare: failed to list recent runs: %v", err)
 		return nil
@@ -171,13 +171,13 @@ func (s *Server) handleAPICompare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	leftRun, err := s.store.GetRun(leftID)
+	leftRun, err := s.runtime.store.GetRun(leftID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "left run not found")
 		return
 	}
 
-	rightRun, err := s.store.GetRun(rightID)
+	rightRun, err := s.runtime.store.GetRun(rightID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "right run not found")
 		return
@@ -406,7 +406,7 @@ func runDuration(r *state.RunRecord) time.Duration {
 
 // listSamePipelineRuns fetches recent runs of the same pipeline, excluding the two being compared.
 func (s *Server) listSamePipelineRuns(pipelineName, excludeLeft, excludeRight string) []RunSummary {
-	runs, err := s.store.ListRuns(state.ListRunsOptions{
+	runs, err := s.runtime.store.ListRuns(state.ListRunsOptions{
 		PipelineName: pipelineName,
 		Limit:        50,
 	})

--- a/internal/webui/handlers_compose.go
+++ b/internal/webui/handlers_compose.go
@@ -15,8 +15,8 @@ func (s *Server) handleComposePage(w http.ResponseWriter, r *http.Request) {
 	pipelines := getCompositionPipelines()
 
 	// Enrich with run counts
-	if s.store != nil {
-		allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 10000})
+	if s.runtime.store != nil {
+		allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 10000})
 		if err == nil {
 			counts := make(map[string]int)
 			for _, run := range allRuns {
@@ -37,7 +37,7 @@ func (s *Server) handleComposePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/compose.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/compose.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_contracts.go
+++ b/internal/webui/handlers_contracts.go
@@ -88,7 +88,7 @@ func (s *Server) handleContractsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/contracts.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/contracts.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -224,7 +224,7 @@ func (s *Server) handleContractDetailPage(w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/contract_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/contract_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -45,7 +45,7 @@ func (s *Server) handleStartPipeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runID, err := s.rwStore.CreateRun(name, req.Input)
+	runID, err := s.runtime.rwStore.CreateRun(name, req.Input)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create run: "+err.Error())
 		return
@@ -80,7 +80,7 @@ func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&req) // best-effort; defaults are fine
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -92,12 +92,12 @@ func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	if cancelFn, ok := s.activeRuns[runID]; ok {
+	if cancelFn, ok := s.realtime.activeRuns[runID]; ok {
 		cancelFn()
 	}
 	s.mu.Unlock()
 
-	if err := s.rwStore.RequestCancellation(runID, req.Force); err != nil {
+	if err := s.runtime.rwStore.RequestCancellation(runID, req.Force); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to request cancellation")
 		return
 	}
@@ -117,7 +117,7 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	originalRun, err := s.store.GetRun(runID)
+	originalRun, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -134,7 +134,7 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newRunID, err := s.rwStore.CreateRun(originalRun.PipelineName, originalRun.Input)
+	newRunID, err := s.runtime.rwStore.CreateRun(originalRun.PipelineName, originalRun.Input)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create retry run")
 		return
@@ -170,7 +170,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	originalRun, err := s.store.GetRun(runID)
+	originalRun, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -199,7 +199,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newRunID, err := s.rwStore.CreateRun(originalRun.PipelineName, originalRun.Input)
+	newRunID, err := s.runtime.rwStore.CreateRun(originalRun.PipelineName, originalRun.Input)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create resume run")
 		return
@@ -245,7 +245,7 @@ func (s *Server) handleSubmitRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runID, err := s.rwStore.CreateRun(req.Pipeline, req.Input)
+	runID, err := s.runtime.rwStore.CreateRun(req.Pipeline, req.Input)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create run: "+err.Error())
 		return
@@ -275,12 +275,12 @@ func (s *Server) handleRunLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.store.GetRun(runID); err != nil {
+	if _, err := s.runtime.store.GetRun(runID); err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
 	}
 
-	events, err := s.store.GetEvents(runID, state.EventQueryOptions{})
+	events, err := s.runtime.store.GetEvents(runID, state.EventQueryOptions{})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to get events")
 		return
@@ -336,18 +336,18 @@ func (s *Server) handleGateApprove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.gateRegistry == nil {
+	if s.realtime.gateRegistry == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "gate registry not initialized")
 		return
 	}
 
-	gate := s.gateRegistry.GetPending(runID)
+	gate := s.realtime.gateRegistry.GetPending(runID)
 	if gate == nil {
 		writeJSONError(w, http.StatusNotFound, "no pending gate for this run")
 		return
 	}
 
-	pendingStepID := s.gateRegistry.GetPendingStepID(runID)
+	pendingStepID := s.realtime.gateRegistry.GetPendingStepID(runID)
 	if pendingStepID != "" && pendingStepID != stepID {
 		writeJSONError(w, http.StatusConflict,
 			fmt.Sprintf("step mismatch: pending gate is for step %q, not %q", pendingStepID, stepID))
@@ -367,7 +367,7 @@ func (s *Server) handleGateApprove(w http.ResponseWriter, r *http.Request) {
 		Target: choice.Target,
 	}
 
-	if err := s.gateRegistry.Resolve(runID, decision); err != nil {
+	if err := s.realtime.gateRegistry.Resolve(runID, decision); err != nil {
 		writeJSONError(w, http.StatusConflict, err.Error())
 		return
 	}

--- a/internal/webui/handlers_diff.go
+++ b/internal/webui/handlers_diff.go
@@ -14,7 +14,7 @@ func (s *Server) handleAPIDiffSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -30,7 +30,7 @@ func (s *Server) handleAPIDiffSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	baseBranch, err := resolveBaseBranch(r.Context(), s.repoDir)
+	baseBranch, err := resolveBaseBranch(r.Context(), s.runtime.repoDir)
 	if err != nil {
 		writeJSON(w, http.StatusOK, &DiffSummary{
 			Available: false,
@@ -40,7 +40,7 @@ func (s *Server) handleAPIDiffSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	summary := computeDiffSummary(r.Context(), s.repoDir, baseBranch, run.BranchName)
+	summary := computeDiffSummary(r.Context(), s.runtime.repoDir, baseBranch, run.BranchName)
 	writeJSON(w, http.StatusOK, summary)
 }
 
@@ -65,7 +65,7 @@ func (s *Server) handleAPIDiffFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -76,13 +76,13 @@ func (s *Server) handleAPIDiffFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	baseBranch, err := resolveBaseBranch(r.Context(), s.repoDir)
+	baseBranch, err := resolveBaseBranch(r.Context(), s.runtime.repoDir)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	fileDiff, err := computeFileDiff(r.Context(), s.repoDir, baseBranch, run.BranchName, cleanPath)
+	fileDiff, err := computeFileDiff(r.Context(), s.runtime.repoDir, baseBranch, run.BranchName, cleanPath)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/webui/handlers_events.go
+++ b/internal/webui/handlers_events.go
@@ -21,7 +21,7 @@ func (s *Server) handleAPIStepEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify run exists
-	_, err := s.store.GetRun(runID)
+	_, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -47,7 +47,7 @@ func (s *Server) handleAPIStepEvents(w http.ResponseWriter, r *http.Request) {
 		Limit:  limit + 1, // fetch one extra to determine hasMore
 	}
 
-	events, err := s.store.GetEvents(runID, opts)
+	events, err := s.runtime.store.GetEvents(runID, opts)
 	if err != nil {
 		log.Printf("[webui] failed to get step events for run %s: %v", runID, err)
 		writeJSONError(w, http.StatusInternalServerError, "failed to get events")

--- a/internal/webui/handlers_fork.go
+++ b/internal/webui/handlers_fork.go
@@ -31,7 +31,7 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	originalRun, err := s.store.GetRun(runID)
+	originalRun, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -48,7 +48,7 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fm := pipeline.NewForkManager(s.rwStore)
+	fm := pipeline.NewForkManager(s.runtime.rwStore)
 	allowFailed := originalRun.Status != "completed"
 	newRunID, err := fm.Fork(runID, req.FromStep, p, allowFailed)
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if resumeStep == "" {
-		if err := s.rwStore.UpdateRunStatus(newRunID, "completed", "", 0); err != nil {
+		if err := s.runtime.rwStore.UpdateRunStatus(newRunID, "completed", "", 0); err != nil {
 			log.Printf("Warning: failed to update forked run %s status: %v", newRunID, err)
 		}
 		writeJSON(w, http.StatusCreated, ForkRunResponse{
@@ -112,7 +112,7 @@ func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -153,13 +153,13 @@ func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.rwStore.DeleteCheckpointsAfterStep(runID, rewindIndex); err != nil {
+	if err := s.runtime.rwStore.DeleteCheckpointsAfterStep(runID, rewindIndex); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "rewind failed: "+err.Error())
 		return
 	}
 
 	rewindMsg := "rewound to step: " + req.ToStep
-	if err := s.rwStore.UpdateRunStatus(runID, "failed", rewindMsg, run.TotalTokens); err != nil {
+	if err := s.runtime.rwStore.UpdateRunStatus(runID, "failed", rewindMsg, run.TotalTokens); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to update run status: "+err.Error())
 		return
 	}
@@ -180,12 +180,12 @@ func (s *Server) handleForkPoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.store.GetRun(runID); err != nil {
+	if _, err := s.runtime.store.GetRun(runID); err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
 	}
 
-	fm := pipeline.NewForkManager(s.store)
+	fm := pipeline.NewForkManager(s.runtime.store)
 	points, err := fm.ListForkPoints(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to list fork points: "+err.Error())

--- a/internal/webui/handlers_gate_test.go
+++ b/internal/webui/handlers_gate_test.go
@@ -137,7 +137,7 @@ func TestHandleGateApprove_MissingCSRFHeader(t *testing.T) {
 		Type:    "approval",
 		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
 	}
-	srv.gateRegistry.Register("run-123", "review", gate)
+	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
 	body, _ := json.Marshal(GateApproveRequest{Choice: "a"})
 	req := httptest.NewRequest("POST", "/api/runs/run-123/gates/review/approve", bytes.NewReader(body))
@@ -163,7 +163,7 @@ func TestHandleGateApprove_Success(t *testing.T) {
 			{Key: "r", Label: "Reject", Target: "_fail"},
 		},
 	}
-	ch := srv.gateRegistry.Register("run-123", "review", gate)
+	ch := srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
 	body, _ := json.Marshal(GateApproveRequest{Choice: "a"})
 	req := httptest.NewRequest("POST", "/api/runs/run-123/gates/review/approve", bytes.NewReader(body))
@@ -219,7 +219,7 @@ func TestHandleGateApprove_NotFound(t *testing.T) {
 
 func TestHandleGateApprove_NoGateRegistry(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.gateRegistry = nil // simulate uninitialized registry
+	srv.realtime.gateRegistry = nil // simulate uninitialized registry
 
 	body, _ := json.Marshal(GateApproveRequest{Choice: "a"})
 	req := httptest.NewRequest("POST", "/api/runs/run-123/gates/review/approve", bytes.NewReader(body))
@@ -242,7 +242,7 @@ func TestHandleGateApprove_StepMismatch(t *testing.T) {
 		Type:    "approval",
 		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
 	}
-	srv.gateRegistry.Register("run-123", "review", gate)
+	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
 	body, _ := json.Marshal(GateApproveRequest{Choice: "a"})
 	req := httptest.NewRequest("POST", "/api/runs/run-123/gates/wrong-step/approve", bytes.NewReader(body))
@@ -265,7 +265,7 @@ func TestHandleGateApprove_InvalidChoice(t *testing.T) {
 		Type:    "approval",
 		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
 	}
-	srv.gateRegistry.Register("run-123", "review", gate)
+	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
 	body, _ := json.Marshal(GateApproveRequest{Choice: "z"})
 	req := httptest.NewRequest("POST", "/api/runs/run-123/gates/review/approve", bytes.NewReader(body))

--- a/internal/webui/handlers_health.go
+++ b/internal/webui/handlers_health.go
@@ -19,7 +19,7 @@ func (s *Server) handleHealthPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/health.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/health.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -31,7 +31,7 @@ func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getHealthListData() HealthListResponse {
-	provider := health.NewDefaultDataProvider(s.manifest, s.store, ".agents/pipelines")
+	provider := health.NewDefaultDataProvider(s.runtime.manifest, s.runtime.store, ".agents/pipelines")
 
 	var checks []HealthCheckResult
 	for _, name := range provider.CheckNames() {

--- a/internal/webui/handlers_issues.go
+++ b/internal/webui/handlers_issues.go
@@ -31,7 +31,7 @@ func (s *Server) handleIssuesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/issues.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/issues.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -72,7 +72,7 @@ func (s *Server) handleAPIStartFromIssue(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	runID, err := s.rwStore.CreateRun(req.PipelineName, req.IssueURL)
+	runID, err := s.runtime.rwStore.CreateRun(req.PipelineName, req.IssueURL)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create run: "+err.Error())
 		return
@@ -118,16 +118,16 @@ func (s *Server) handleIssueDetailPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.forgeClient == nil || s.repoSlug == "" {
+	if s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		http.Error(w, "Forge integration not configured", http.StatusServiceUnavailable)
 		return
 	}
 
-	owner, repo := splitRepoSlug(s.repoSlug)
+	owner, repo := splitRepoSlug(s.runtime.repoSlug)
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.ForgeAPI)
 	defer cancel()
 
-	issue, err := s.forgeClient.GetIssue(ctx, owner, repo, number)
+	issue, err := s.runtime.forgeClient.GetIssue(ctx, owner, repo, number)
 	if err != nil {
 		http.Error(w, "issue not found: "+err.Error(), http.StatusNotFound)
 		return
@@ -143,7 +143,7 @@ func (s *Server) handleIssueDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find runs whose input contains this issue URL
-	allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 500})
+	allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 500})
 	if err != nil {
 		allRuns = nil
 	}
@@ -172,7 +172,7 @@ func (s *Server) handleIssueDetailPage(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch last 10 comments
 	var comments []CommentSummary
-	forgeComments, err := s.forgeClient.ListIssueComments(ctx, owner, repo, number, 10)
+	forgeComments, err := s.runtime.forgeClient.ListIssueComments(ctx, owner, repo, number, 10)
 	if err == nil {
 		for _, c := range forgeComments {
 			comments = append(comments, CommentSummary{
@@ -227,7 +227,7 @@ func (s *Server) handleIssueDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/issue_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/issue_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -246,7 +246,7 @@ func parsePageNumber2(s string) int {
 const issuesPerPage = 10
 
 func (s *Server) getIssueListData(stateFilter string, page int) IssueListResponse {
-	if s.forgeClient == nil || s.repoSlug == "" {
+	if s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		return IssueListResponse{
 			Issues:      []IssueSummary{},
 			FilterState: stateFilter,
@@ -255,7 +255,7 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 		}
 	}
 
-	owner, repo := splitRepoSlug(s.repoSlug)
+	owner, repo := splitRepoSlug(s.runtime.repoSlug)
 	if owner == "" {
 		return IssueListResponse{
 			Issues:      []IssueSummary{},
@@ -269,7 +269,7 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 	cacheKey := fmt.Sprintf("issues:list:%s:%d", stateFilter, page)
 	useCache := stateFilter != "running"
 	if useCache {
-		if cached, ok := s.cache.Get(cacheKey); ok {
+		if cached, ok := s.assets.cache.Get(cacheKey); ok {
 			return cached.(IssueListResponse)
 		}
 	}
@@ -277,7 +277,7 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.ForgeAPIList)
 	defer cancel()
 
-	issues, err := s.forgeClient.ListIssues(ctx, owner, repo, forge.ListIssuesOptions{
+	issues, err := s.runtime.forgeClient.ListIssues(ctx, owner, repo, forge.ListIssuesOptions{
 		State:   stateFilter,
 		PerPage: issuesPerPage + 1, // fetch one extra to detect HasMore
 		Page:    page,
@@ -318,8 +318,8 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 	}
 
 	// Enrich with Wave run stats
-	if s.store != nil {
-		allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 10000})
+	if s.runtime.store != nil {
+		allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 10000})
 		if err == nil {
 			enrichSummariesWithRuns(summaries, allRuns, "issue")
 		}
@@ -337,7 +337,7 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 
 	result := IssueListResponse{
 		Issues:      summaries,
-		RepoSlug:    s.repoSlug,
+		RepoSlug:    s.runtime.repoSlug,
 		FilterState: stateFilter,
 		Page:        page,
 		HasMore:     hasMore,
@@ -346,7 +346,7 @@ func (s *Server) getIssueListData(stateFilter string, page int) IssueListRespons
 	}
 
 	if useCache {
-		s.cache.Set(cacheKey, result)
+		s.assets.cache.Set(cacheKey, result)
 	}
 
 	return result

--- a/internal/webui/handlers_issues_test.go
+++ b/internal/webui/handlers_issues_test.go
@@ -210,8 +210,8 @@ func (f *deadlineCapturingForge) ListIssues(ctx context.Context, _, _ string, _ 
 func TestGetIssueListData_UsesForgeAPIListTimeout(t *testing.T) {
 	srv, _ := testServer(t)
 	fc := &deadlineCapturingForge{}
-	srv.forgeClient = fc
-	srv.repoSlug = "owner/repo"
+	srv.runtime.forgeClient = fc
+	srv.runtime.repoSlug = "owner/repo"
 
 	before := time.Now()
 	srv.getIssueListData("open", 1)

--- a/internal/webui/handlers_meta.go
+++ b/internal/webui/handlers_meta.go
@@ -5,8 +5,8 @@ import "net/http"
 // handleAPIAdapters handles GET /api/adapters — returns available adapter names.
 func (s *Server) handleAPIAdapters(w http.ResponseWriter, r *http.Request) {
 	var names []string
-	if s.manifest != nil {
-		for name := range s.manifest.Adapters {
+	if s.runtime.manifest != nil {
+		for name := range s.runtime.manifest.Adapters {
 			names = append(names, name)
 		}
 	}
@@ -29,8 +29,8 @@ func (s *Server) handleAPIModels(w http.ResponseWriter, r *http.Request) {
 	add("cheapest")
 	add("balanced")
 	add("strongest")
-	if s.manifest != nil {
-		for _, a := range s.manifest.Adapters {
+	if s.runtime.manifest != nil {
+		for _, a := range s.runtime.manifest.Adapters {
 			add(a.DefaultModel)
 			for _, m := range a.TierModels {
 				add(m)

--- a/internal/webui/handlers_ontology.go
+++ b/internal/webui/handlers_ontology.go
@@ -58,7 +58,7 @@ func (s *Server) handleOntologyPage(w http.ResponseWriter, r *http.Request) {
 	data := s.buildOntologyData()
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/ontology.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/ontology.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -75,19 +75,19 @@ func (s *Server) buildOntologyData() OntologyPageData {
 		ActivePage: "ontology",
 	}
 
-	if s.manifest == nil || s.manifest.Ontology == nil {
+	if s.runtime.manifest == nil || s.runtime.manifest.Ontology == nil {
 		return data
 	}
 
-	o := s.manifest.Ontology
+	o := s.runtime.manifest.Ontology
 	data.HasOntology = true
 	data.Telos = o.Telos
 	data.Conventions = o.Conventions
 
 	// Fetch lineage stats from state store
 	statsMap := make(map[string]*state.OntologyStats)
-	if s.store != nil {
-		if allStats, err := s.store.GetOntologyStatsAll(); err == nil {
+	if s.runtime.store != nil {
+		if allStats, err := s.runtime.store.GetOntologyStatsAll(); err == nil {
 			for i := range allStats {
 				statsMap[allStats[i].ContextName] = &allStats[i]
 			}

--- a/internal/webui/handlers_ontology_test.go
+++ b/internal/webui/handlers_ontology_test.go
@@ -41,7 +41,7 @@ func TestOntologyPageRendersEmptyHTML(t *testing.T) {
 // telos and context names from the manifest.
 func TestOntologyPageRendersWithData(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Ontology: &manifest.Ontology{
 			Telos: "Build the best orchestrator",
 			Contexts: []manifest.OntologyContext{
@@ -109,7 +109,7 @@ func TestOntologyAPIReturnsEmptyWhenNoOntology(t *testing.T) {
 // data including telos, contexts, and conventions.
 func TestOntologyAPIReturnsFullData(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Ontology: &manifest.Ontology{
 			Telos: "Ship quality software",
 			Contexts: []manifest.OntologyContext{
@@ -163,7 +163,7 @@ func TestOntologyAPIReturnsFullData(t *testing.T) {
 // sorted by name.
 func TestOntologyContextsSortedAlphabetically(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Ontology: &manifest.Ontology{
 			Contexts: []manifest.OntologyContext{
 				{Name: "zebra"},

--- a/internal/webui/handlers_personas.go
+++ b/internal/webui/handlers_personas.go
@@ -26,7 +26,7 @@ func (s *Server) handlePersonasPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/personas.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/personas.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -39,12 +39,12 @@ func (s *Server) handlePersonaDetailPage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if s.manifest == nil || s.manifest.Personas == nil {
+	if s.runtime.manifest == nil || s.runtime.manifest.Personas == nil {
 		http.Error(w, "persona not found", http.StatusNotFound)
 		return
 	}
 
-	p, ok := s.manifest.Personas[name]
+	p, ok := s.runtime.manifest.Personas[name]
 	if !ok {
 		http.Error(w, "persona not found", http.StatusNotFound)
 		return
@@ -52,7 +52,7 @@ func (s *Server) handlePersonaDetailPage(w http.ResponseWriter, r *http.Request)
 
 	var prompt string
 	if p.SystemPromptFile != "" {
-		promptPath := p.GetSystemPromptPath(s.repoDir)
+		promptPath := p.GetSystemPromptPath(s.runtime.repoDir)
 		if data, err := os.ReadFile(promptPath); err == nil {
 			prompt = string(data)
 		}
@@ -103,22 +103,22 @@ func (s *Server) handlePersonaDetailPage(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/persona_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/persona_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
 
 // getPersonaSummaries returns persona summaries from the manifest.
 func (s *Server) getPersonaSummaries() []PersonaSummary {
-	if s.manifest == nil || s.manifest.Personas == nil {
+	if s.runtime.manifest == nil || s.runtime.manifest.Personas == nil {
 		return nil
 	}
 
 	var personas []PersonaSummary
-	for name, p := range s.manifest.Personas {
+	for name, p := range s.runtime.manifest.Personas {
 		var prompt string
 		if p.SystemPromptFile != "" {
-			promptPath := p.GetSystemPromptPath(s.repoDir)
+			promptPath := p.GetSystemPromptPath(s.runtime.repoDir)
 			if data, err := os.ReadFile(promptPath); err == nil {
 				prompt = string(data)
 			}

--- a/internal/webui/handlers_personas_test.go
+++ b/internal/webui/handlers_personas_test.go
@@ -14,7 +14,7 @@ import (
 // HTML successfully when the manifest is nil.
 func TestPersonasPageRendersWithNilManifest(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = nil
+	srv.runtime.manifest = nil
 
 	req := httptest.NewRequest("GET", "/personas", nil)
 	rec := httptest.NewRecorder()
@@ -39,7 +39,7 @@ func TestPersonasPageRendersWithNilManifest(t *testing.T) {
 // persona names from the manifest.
 func TestPersonasPageRendersPersonaNames(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: map[string]manifest.Persona{
 			"navigator": {
 				Adapter:     "claude",
@@ -73,7 +73,7 @@ func TestPersonasPageRendersPersonaNames(t *testing.T) {
 // persona list when the manifest is nil.
 func TestPersonasAPIReturnsEmptyWithNilManifest(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = nil
+	srv.runtime.manifest = nil
 
 	req := httptest.NewRequest("GET", "/api/personas", nil)
 	rec := httptest.NewRecorder()
@@ -97,7 +97,7 @@ func TestPersonasAPIReturnsEmptyWithNilManifest(t *testing.T) {
 // with a nil personas map.
 func TestPersonasAPIHandlesNilPersonasMap(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: nil,
 	}
 
@@ -123,7 +123,7 @@ func TestPersonasAPIHandlesNilPersonasMap(t *testing.T) {
 // with all fields populated.
 func TestPersonasAPIReturnsAllFields(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: map[string]manifest.Persona{
 			"navigator": {
 				Adapter:     "claude",
@@ -192,7 +192,7 @@ func TestPersonasAPIReturnsAllFields(t *testing.T) {
 // by name for consistent display.
 func TestPersonasAPISortsByName(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: map[string]manifest.Persona{
 			"zebra":  {Adapter: "claude"},
 			"alpha":  {Adapter: "claude"},

--- a/internal/webui/handlers_pipelines.go
+++ b/internal/webui/handlers_pipelines.go
@@ -29,8 +29,8 @@ func (s *Server) handlePipelinesPage(w http.ResponseWriter, r *http.Request) {
 	pipelines := s.getPipelineSummaries()
 
 	// Enrich with run counts
-	if s.store != nil {
-		allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 10000})
+	if s.runtime.store != nil {
+		allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 10000})
 		if err == nil {
 			counts := make(map[string]int)
 			for _, run := range allRuns {
@@ -87,7 +87,7 @@ func (s *Server) handlePipelinesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/pipelines.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/pipelines.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -444,8 +444,8 @@ func (s *Server) handlePipelineDetailPage(w http.ResponseWriter, r *http.Request
 	// Fetch recent runs for this pipeline
 	var recentRuns []RunSummary
 	var runCount int
-	if s.store != nil {
-		runs, err := s.store.ListRuns(state.ListRunsOptions{
+	if s.runtime.store != nil {
+		runs, err := s.runtime.store.ListRuns(state.ListRunsOptions{
 			PipelineName: name,
 			Limit:        1000,
 			// Filter out composition children (issue #1450) — sub-pipeline
@@ -484,7 +484,7 @@ func (s *Server) handlePipelineDetailPage(w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/pipeline_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/pipeline_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_prs.go
+++ b/internal/webui/handlers_prs.go
@@ -33,7 +33,7 @@ func (s *Server) handlePRsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/prs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/prs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		log.Printf("[webui] template error rendering prs page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
@@ -56,16 +56,16 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.forgeClient == nil || s.repoSlug == "" {
+	if s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		http.Error(w, "Forge integration not configured", http.StatusServiceUnavailable)
 		return
 	}
 
-	owner, repo := splitRepoSlug(s.repoSlug)
+	owner, repo := splitRepoSlug(s.runtime.repoSlug)
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.ForgeAPI)
 	defer cancel()
 
-	pr, err := s.forgeClient.GetPullRequest(ctx, owner, repo, number)
+	pr, err := s.runtime.forgeClient.GetPullRequest(ctx, owner, repo, number)
 	if err != nil {
 		log.Printf("[webui] failed to fetch PR #%d: %v", number, err)
 		http.Error(w, "PR not found", http.StatusNotFound)
@@ -75,7 +75,7 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 	// Find related runs — match by PR URL or head branch name
 	prURL := pr.HTMLURL
 
-	allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 500})
+	allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 500})
 	if err != nil {
 		allRuns = nil
 	}
@@ -105,7 +105,7 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 	// Fetch status checks for the PR head commit
 	var checks []PRCheck
 	if pr.HeadSHA != "" {
-		forgeChecks, err := s.forgeClient.GetCommitChecks(ctx, owner, repo, pr.HeadSHA)
+		forgeChecks, err := s.runtime.forgeClient.GetCommitChecks(ctx, owner, repo, pr.HeadSHA)
 		if err != nil {
 			log.Printf("[webui] failed to fetch checks for PR #%d (SHA %s): %v", number, pr.HeadSHA, err)
 		} else {
@@ -122,7 +122,7 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch commits for the PR
 	var commits []CommitSummary
-	forgeCommits, err := s.forgeClient.ListPullRequestCommits(ctx, owner, repo, number)
+	forgeCommits, err := s.runtime.forgeClient.ListPullRequestCommits(ctx, owner, repo, number)
 	if err != nil {
 		log.Printf("[webui] failed to fetch commits for PR #%d: %v", number, err)
 	} else {
@@ -149,7 +149,7 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch last 10 comments
 	var comments []CommentSummary
-	forgeComments, err := s.forgeClient.ListIssueComments(ctx, owner, repo, number, 10)
+	forgeComments, err := s.runtime.forgeClient.ListIssueComments(ctx, owner, repo, number, 10)
 	if err != nil {
 		log.Printf("[webui] failed to fetch comments for PR #%d: %v", number, err)
 	} else {
@@ -216,7 +216,7 @@ func (s *Server) handlePRDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/pr_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/pr_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		log.Printf("[webui] template error rendering PR detail page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
@@ -298,7 +298,7 @@ func aggregateCheckStatus(checks []*forge.CheckRun) string {
 }
 
 func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
-	if s.forgeClient == nil || s.repoSlug == "" {
+	if s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		return PRListResponse{
 			PullRequests: []PRSummary{},
 			FilterState:  stateFilter,
@@ -307,7 +307,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 		}
 	}
 
-	owner, repo := splitRepoSlug(s.repoSlug)
+	owner, repo := splitRepoSlug(s.runtime.repoSlug)
 	if owner == "" {
 		return PRListResponse{
 			PullRequests: []PRSummary{},
@@ -321,7 +321,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	cacheKey := fmt.Sprintf("prs:list:%s:%d", stateFilter, page)
 	useCache := stateFilter != "running"
 	if useCache {
-		if cached, ok := s.cache.Get(cacheKey); ok {
+		if cached, ok := s.assets.cache.Get(cacheKey); ok {
 			return cached.(PRListResponse)
 		}
 	}
@@ -329,7 +329,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.ForgeAPI)
 	defer cancel()
 
-	prs, err := s.forgeClient.ListPullRequests(ctx, owner, repo, forge.ListPullRequestsOptions{
+	prs, err := s.runtime.forgeClient.ListPullRequests(ctx, owner, repo, forge.ListPullRequestsOptions{
 		State:   stateFilter,
 		PerPage: prsPerPage + 1, // fetch one extra to detect HasMore
 		Page:    page,
@@ -349,7 +349,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 		prs = prs[:prsPerPage]
 	}
 
-	checkStatuses := enrichPRStats(ctx, s.forgeClient, owner, repo, prs)
+	checkStatuses := enrichPRStats(ctx, s.runtime.forgeClient, owner, repo, prs)
 
 	var summaries []PRSummary
 	for _, pr := range prs {
@@ -378,10 +378,10 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	}
 
 	// Enrich with Wave run stats
-	if s.store != nil {
-		allRuns, err := s.store.ListRuns(state.ListRunsOptions{Limit: 10000})
+	if s.runtime.store != nil {
+		allRuns, err := s.runtime.store.ListRuns(state.ListRunsOptions{Limit: 10000})
 		if err == nil {
-			enrichPRSummariesWithRuns(summaries, allRuns, s.store)
+			enrichPRSummariesWithRuns(summaries, allRuns, s.runtime.store)
 		}
 	}
 
@@ -396,7 +396,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 
 	result := PRListResponse{
 		PullRequests: summaries,
-		RepoSlug:     s.repoSlug,
+		RepoSlug:     s.runtime.repoSlug,
 		FilterState:  stateFilter,
 		Page:         page,
 		HasMore:      hasMore,
@@ -405,7 +405,7 @@ func (s *Server) getPRListData(stateFilter string, page int) PRListResponse {
 	}
 
 	if useCache {
-		s.cache.Set(cacheKey, result)
+		s.assets.cache.Set(cacheKey, result)
 	}
 
 	return result
@@ -433,7 +433,7 @@ func (s *Server) handlePRReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.forgeClient == nil || s.repoSlug == "" {
+	if s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		writeJSONError(w, http.StatusServiceUnavailable, "forge integration not configured")
 		return
 	}
@@ -461,11 +461,11 @@ func (s *Server) handlePRReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	owner, repo := splitRepoSlug(s.repoSlug)
+	owner, repo := splitRepoSlug(s.runtime.repoSlug)
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.ForgeAPI)
 	defer cancel()
 
-	if err := s.forgeClient.CreatePullRequestReview(ctx, owner, repo, number, req.Event, req.Body); err != nil {
+	if err := s.runtime.forgeClient.CreatePullRequestReview(ctx, owner, repo, number, req.Event, req.Body); err != nil {
 		log.Printf("[webui] failed to submit review for PR #%d: %v", number, err)
 		writeJSONError(w, http.StatusBadGateway, "failed to submit review: "+err.Error())
 		return
@@ -502,7 +502,7 @@ func (s *Server) handleAPIStartFromPR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runID, err := s.rwStore.CreateRun(req.PipelineName, req.PRURL)
+	runID, err := s.runtime.rwStore.CreateRun(req.PipelineName, req.PRURL)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to create run: "+err.Error())
 		return

--- a/internal/webui/handlers_prs_test.go
+++ b/internal/webui/handlers_prs_test.go
@@ -184,7 +184,7 @@ func TestHandlePRsPage_StateParam(t *testing.T) {
 func TestHandleAPIPRs_EmptyRepoSlug(t *testing.T) {
 	srv, _ := testServer(t)
 	// Set a non-nil GitHub client but empty repo slug
-	srv.repoSlug = ""
+	srv.runtime.repoSlug = ""
 
 	req := httptest.NewRequest("GET", "/api/prs", nil)
 	rec := httptest.NewRecorder()
@@ -271,8 +271,8 @@ func TestRunToSummary_LongInputTruncated(t *testing.T) {
 
 func TestGetPRListData_EnrichedStats(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.repoSlug = "owner/repo"
-	srv.forgeClient = &mockForgeClient{
+	srv.runtime.repoSlug = "owner/repo"
+	srv.runtime.forgeClient = &mockForgeClient{
 		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
 			return []*forge.PullRequest{
 				{Number: 1, Title: "PR 1", State: "open", Author: "alice", CreatedAt: time.Now()},
@@ -312,8 +312,8 @@ func TestGetPRListData_EnrichedStats(t *testing.T) {
 
 func TestGetPRListData_PartialEnrichmentFailure(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.repoSlug = "owner/repo"
-	srv.forgeClient = &mockForgeClient{
+	srv.runtime.repoSlug = "owner/repo"
+	srv.runtime.forgeClient = &mockForgeClient{
 		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
 			return []*forge.PullRequest{
 				{Number: 1, Title: "Good PR", State: "open", Author: "alice", CreatedAt: time.Now()},
@@ -349,8 +349,8 @@ func TestGetPRListData_PartialEnrichmentFailure(t *testing.T) {
 
 func TestGetPRListData_Labels(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.repoSlug = "owner/repo"
-	srv.forgeClient = &mockForgeClient{
+	srv.runtime.repoSlug = "owner/repo"
+	srv.runtime.forgeClient = &mockForgeClient{
 		listPRs: func(_ context.Context, _, _ string, _ forge.ListPullRequestsOptions) ([]*forge.PullRequest, error) {
 			return []*forge.PullRequest{
 				{

--- a/internal/webui/handlers_retro_page.go
+++ b/internal/webui/handlers_retro_page.go
@@ -15,7 +15,7 @@ import (
 // handleRetrosPage handles GET /retros - serves the HTML retrospective trends page.
 func (s *Server) handleRetrosPage(w http.ResponseWriter, r *http.Request) {
 	// Fetch recent retrospectives (last 20 for chart, up to 50 for list)
-	records, err := s.store.ListRetrospectives(state.ListRetrosOptions{
+	records, err := s.runtime.store.ListRetrospectives(state.ListRetrosOptions{
 		Limit: 50,
 	})
 	if err != nil {
@@ -23,7 +23,7 @@ func (s *Server) handleRetrosPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	storage := retro.NewStorage(".agents/retros", s.store)
+	storage := retro.NewStorage(".agents/retros", s.runtime.store)
 
 	// Build smoothness trend entries (last 20, reversed to chronological order for chart)
 	chartLimit := 20
@@ -162,7 +162,7 @@ func (s *Server) handleRetrosPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/retros.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/retros.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		log.Printf("[webui] template error rendering retros page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}

--- a/internal/webui/handlers_retros.go
+++ b/internal/webui/handlers_retros.go
@@ -33,7 +33,7 @@ func (s *Server) handleAPIRetros(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	records, err := s.store.ListRetrospectives(state.ListRetrosOptions{
+	records, err := s.runtime.store.ListRetrospectives(state.ListRetrosOptions{
 		PipelineName: pipeline,
 		SinceUnix:    sinceUnix,
 		Limit:        limit,
@@ -54,7 +54,7 @@ func (s *Server) handleAPIRetroDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	storage := retro.NewStorage(".agents/retros", s.store)
+	storage := retro.NewStorage(".agents/retros", s.runtime.store)
 	retro, err := storage.Load(id)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})

--- a/internal/webui/handlers_run_detail.go
+++ b/internal/webui/handlers_run_detail.go
@@ -18,7 +18,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		http.Error(w, "run not found", http.StatusNotFound)
 		return
@@ -33,7 +33,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 		stepDetailMap[sd.StepID] = sd
 	}
 
-	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
+	events, err := s.runtime.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
 	if err != nil {
 		log.Printf("[webui] failed to get events for run %s: %v", runID, err)
 	}
@@ -87,7 +87,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 
 	// Collect child runs for sub-pipeline steps
 	childRuns := make(map[string][]RunSummary)
-	if children, err := s.store.GetChildRuns(runID); err == nil {
+	if children, err := s.runtime.store.GetChildRuns(runID); err == nil {
 		for _, cr := range children {
 			summary := runToSummary(cr)
 			childRuns[cr.ParentStepID] = append(childRuns[cr.ParentStepID], summary)
@@ -172,7 +172,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/run_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/run_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -205,10 +205,10 @@ func buildOutputCard(stepDetails []StepDetail) (summary string, artifacts []Arti
 // linked URL. Returns empty values when no URL is set, the forge client is
 // unavailable, or the URL doesn't match a recognized PR/issue path.
 func (s *Server) enrichLinkedURL(r *http.Request, linkedURL string) (title, state, author, kind string, number int) {
-	if linkedURL == "" || s.forgeClient == nil || s.repoSlug == "" {
+	if linkedURL == "" || s.runtime.forgeClient == nil || s.runtime.repoSlug == "" {
 		return
 	}
-	parts := strings.Split(s.repoSlug, "/")
+	parts := strings.Split(s.runtime.repoSlug, "/")
 	if len(parts) != 2 {
 		return
 	}
@@ -227,7 +227,7 @@ func (s *Server) enrichLinkedURL(r *http.Request, linkedURL string) (title, stat
 		switch p {
 		case "pull", "merge_requests":
 			kind = "pr"
-			if pr, err := s.forgeClient.GetPullRequest(ctx, owner, repo, num); err == nil {
+			if pr, err := s.runtime.forgeClient.GetPullRequest(ctx, owner, repo, num); err == nil {
 				title = pr.Title
 				state = pr.State
 				if pr.Merged {
@@ -237,7 +237,7 @@ func (s *Server) enrichLinkedURL(r *http.Request, linkedURL string) (title, stat
 			}
 		case "issues":
 			kind = "issue"
-			if iss, err := s.forgeClient.GetIssue(ctx, owner, repo, num); err == nil {
+			if iss, err := s.runtime.forgeClient.GetIssue(ctx, owner, repo, num); err == nil {
 				title = iss.Title
 				state = iss.State
 				author = iss.Author
@@ -259,8 +259,8 @@ func (s *Server) buildTemplateVars(input string) map[string]string {
 	templateVars["forge.type"] = string(forgeInfo.Type)
 	templateVars["forge.pr_term"] = forgeInfo.PRTerm
 	templateVars["forge.pr_command"] = forgeInfo.PRCommand
-	if s.manifest != nil && s.manifest.Project != nil {
-		for k, v := range s.manifest.Project.ProjectVars() {
+	if s.runtime.manifest != nil && s.runtime.manifest.Project != nil {
+		for k, v := range s.runtime.manifest.Project.ProjectVars() {
 			templateVars["project."+k] = v
 		}
 	}
@@ -271,14 +271,14 @@ func (s *Server) buildTemplateVars(input string) map[string]string {
 // (timeout, stall timeout) for the run-detail page.
 func (s *Server) buildRunConfigItems() []struct{ Label, Value, Tooltip string } {
 	var items []struct{ Label, Value, Tooltip string }
-	if s.manifest == nil {
+	if s.runtime.manifest == nil {
 		return items
 	}
-	if timeout := s.manifest.Runtime.GetDefaultTimeout(); timeout > 0 {
+	if timeout := s.runtime.manifest.Runtime.GetDefaultTimeout(); timeout > 0 {
 		items = append(items, struct{ Label, Value, Tooltip string }{"Timeout", timeout.String(), "Maximum duration per step before it is cancelled"})
 	}
-	if s.manifest.Runtime.StallTimeout != "" {
-		items = append(items, struct{ Label, Value, Tooltip string }{"Stall timeout", s.manifest.Runtime.StallTimeout, "Step is cancelled if no tool activity for this duration"})
+	if s.runtime.manifest.Runtime.StallTimeout != "" {
+		items = append(items, struct{ Label, Value, Tooltip string }{"Stall timeout", s.runtime.manifest.Runtime.StallTimeout, "Step is cancelled if no tool activity for this duration"})
 	}
 	return items
 }

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -39,7 +39,7 @@ func (s *Server) handleAPIRuns(w http.ResponseWriter, r *http.Request) {
 		opts.BeforeRunID = cursor.RunID
 	}
 
-	runs, err := s.store.ListRuns(opts)
+	runs, err := s.runtime.store.ListRuns(opts)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to list runs")
 		return
@@ -80,12 +80,12 @@ func (s *Server) handleAPIRunChildren(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.store.GetRun(runID); err != nil {
+	if _, err := s.runtime.store.GetRun(runID); err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
 	}
 
-	children, err := s.store.GetChildRuns(runID)
+	children, err := s.runtime.store.GetChildRuns(runID)
 	if err != nil {
 		log.Printf("[webui] failed to get children for run %s: %v", runID, err)
 		writeJSONError(w, http.StatusInternalServerError, "failed to query children")
@@ -96,7 +96,7 @@ func (s *Server) handleAPIRunChildren(w http.ResponseWriter, r *http.Request) {
 		summaries[i] = runToSummary(c)
 	}
 
-	subtreeTokens, err := s.store.GetSubtreeTokens(runID)
+	subtreeTokens, err := s.runtime.store.GetSubtreeTokens(runID)
 	if err != nil {
 		log.Printf("[webui] failed to compute subtree tokens for run %s: %v", runID, err)
 		// Soft-fail: still return children, just without the rollup.
@@ -122,7 +122,7 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.GetRun(runID)
+	run, err := s.runtime.store.GetRun(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "run not found")
 		return
@@ -132,7 +132,7 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 	stepDetails := s.buildStepDetails(runID, run.PipelineName, run.Status)
 
 	// Get events
-	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
+	events, err := s.runtime.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
 	if err != nil {
 		log.Printf("[webui] failed to get events for run %s: %v", runID, err)
 	}
@@ -142,14 +142,14 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get all artifacts
-	allArts, err := s.store.GetArtifacts(runID, "")
+	allArts, err := s.runtime.store.GetArtifacts(runID, "")
 	if err != nil {
 		log.Printf("[webui] failed to get artifacts for run %s: %v", runID, err)
 	}
 	artSummaries := deduplicateArtifacts(allArts)
 
 	runSummary := runToSummary(*run)
-	if subtree, err := s.store.GetSubtreeTokens(runID); err == nil {
+	if subtree, err := s.runtime.store.GetSubtreeTokens(runID); err == nil {
 		runSummary.SubtreeTokens = subtree
 	}
 
@@ -192,7 +192,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		opts.BeforeRunID = cursor.RunID
 	}
 
-	runs, err := s.store.ListRuns(opts)
+	runs, err := s.runtime.store.ListRuns(opts)
 	if err != nil {
 		http.Error(w, "failed to list runs", http.StatusInternalServerError)
 		return
@@ -258,7 +258,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/runs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/runs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -267,7 +267,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 // of the runs page, then nests their child runs (running plus already-finished
 // children of running parents) underneath each parent.
 func (s *Server) collectRunningRuns(pipelineFilter string) []RunSummary {
-	runningRecs, err := s.store.ListRuns(state.ListRunsOptions{
+	runningRecs, err := s.runtime.store.ListRuns(state.ListRunsOptions{
 		Status:       "running",
 		PipelineName: pipelineFilter,
 		Limit:        0,
@@ -287,9 +287,9 @@ func (s *Server) collectRunningRuns(pipelineFilter string) []RunSummary {
 		runningRuns = append(runningRuns, runToSummary(rec))
 	}
 	// Also fetch completed/failed children of running parents from the full run list
-	if s.store != nil {
+	if s.runtime.store != nil {
 		for i := range runningRuns {
-			if children, err := s.store.GetChildRuns(runningRuns[i].RunID); err == nil {
+			if children, err := s.runtime.store.GetChildRuns(runningRuns[i].RunID); err == nil {
 				for _, ch := range children {
 					found := false
 					for _, existing := range childMap[runningRuns[i].RunID] {

--- a/internal/webui/handlers_runs_export.go
+++ b/internal/webui/handlers_runs_export.go
@@ -27,7 +27,7 @@ func (s *Server) handleExportRuns(w http.ResponseWriter, r *http.Request) {
 		Limit:        10000, // reasonable upper bound for export
 	}
 
-	runs, err := s.store.ListRuns(opts)
+	runs, err := s.runtime.store.ListRuns(opts)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to list runs")
 		return

--- a/internal/webui/handlers_runs_projection.go
+++ b/internal/webui/handlers_runs_projection.go
@@ -46,7 +46,7 @@ func (s *Server) enrichRunSummaries(summaries []RunSummary, runs []state.RunReco
 		}
 
 		// Count completed steps from event_log
-		events, err := s.store.GetEvents(runs[i].RunID, state.EventQueryOptions{Limit: 5000})
+		events, err := s.runtime.store.GetEvents(runs[i].RunID, state.EventQueryOptions{Limit: 5000})
 		if err != nil {
 			continue
 		}
@@ -149,7 +149,7 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 	}
 
 	// Get all events for this run
-	events, err := s.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
+	events, err := s.runtime.store.GetEvents(runID, state.EventQueryOptions{Limit: 5000})
 	if err != nil {
 		log.Printf("[webui] buildStepDetails: failed to get events for run %s: %v", runID, err)
 	}
@@ -394,15 +394,15 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 			}
 
 			// Populate failure class from step attempts
-			if sd.State == "failed" && s.store != nil {
-				if attempts, err := s.store.GetStepAttempts(runID, step.ID); err == nil && len(attempts) > 0 {
+			if sd.State == "failed" && s.runtime.store != nil {
+				if attempts, err := s.runtime.store.GetStepAttempts(runID, step.ID); err == nil && len(attempts) > 0 {
 					sd.FailureClass = attempts[len(attempts)-1].FailureClass
 				}
 			}
 
 			// Populate visit count for graph loop steps
-			if step.MaxVisits > 0 && s.store != nil {
-				if vc, err := s.store.GetStepVisitCount(runID, step.ID); err == nil {
+			if step.MaxVisits > 0 && s.runtime.store != nil {
+				if vc, err := s.runtime.store.GetStepVisitCount(runID, step.ID); err == nil {
 					sd.VisitCount = vc
 				}
 			}
@@ -410,7 +410,7 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 
 		// Look up failure class from step attempts for failed steps
 		if sd.State == "failed" {
-			attempts, attErr := s.store.GetStepAttempts(runID, step.ID)
+			attempts, attErr := s.runtime.store.GetStepAttempts(runID, step.ID)
 			if attErr != nil {
 				log.Printf("[webui] failed to get step attempts for run %s step %s: %v", runID, step.ID, attErr)
 			}
@@ -422,7 +422,7 @@ func (s *Server) buildStepDetails(runID, pipelineName string, runStatus ...strin
 			}
 		}
 
-		arts, artErr := s.store.GetArtifacts(runID, step.ID)
+		arts, artErr := s.runtime.store.GetArtifacts(runID, step.ID)
 		if artErr != nil {
 			log.Printf("[webui] failed to get artifacts for run %s step %s: %v", runID, step.ID, artErr)
 		}

--- a/internal/webui/handlers_skills.go
+++ b/internal/webui/handlers_skills.go
@@ -40,7 +40,7 @@ func (s *Server) handleSkillsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/skills.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/skills.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -322,11 +322,11 @@ func (s *Server) handleAPISkillRunInstall(w http.ResponseWriter, r *http.Request
 	// that pipeline-driven shellouts use. The webui historically called
 	// `exec.CommandContext("sh", "-c", ...)` directly, bypassing both.
 	cfg := sandbox.Config{}
-	if s.manifest != nil {
-		cfg.Backend = sandbox.SandboxBackendType(s.manifest.Runtime.Sandbox.ResolveBackend())
-		cfg.DockerImage = s.manifest.Runtime.Sandbox.DockerImage
-		cfg.AllowedDomains = s.manifest.Runtime.Sandbox.DefaultAllowedDomains
-		cfg.EnvPassthrough = s.manifest.Runtime.Sandbox.EnvPassthrough
+	if s.runtime.manifest != nil {
+		cfg.Backend = sandbox.SandboxBackendType(s.runtime.manifest.Runtime.Sandbox.ResolveBackend())
+		cfg.DockerImage = s.runtime.manifest.Runtime.Sandbox.DockerImage
+		cfg.AllowedDomains = s.runtime.manifest.Runtime.Sandbox.DefaultAllowedDomains
+		cfg.EnvPassthrough = s.runtime.manifest.Runtime.Sandbox.EnvPassthrough
 	}
 	out, err := sandbox.RunShell(ctx, installCmd, cfg)
 	if err != nil {
@@ -399,7 +399,7 @@ func (s *Server) handleSkillDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/skill_detail.html"].ExecuteTemplate(w, "templates/layout.html", detail); err != nil {
+	if err := s.assets.templates["templates/skill_detail.html"].ExecuteTemplate(w, "templates/layout.html", detail); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_sse.go
+++ b/internal/webui/handlers_sse.go
@@ -45,7 +45,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Backfill missed events from DB on reconnection
 	if lastEventID > 0 {
-		events, err := s.store.GetEvents(runID, state.EventQueryOptions{
+		events, err := s.runtime.store.GetEvents(runID, state.EventQueryOptions{
 			AfterID: lastEventID,
 		})
 		if err == nil {
@@ -58,8 +58,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Subscribe to live events
-	ch := s.broker.Subscribe()
-	defer s.broker.Unsubscribe(ch)
+	ch := s.realtime.broker.Subscribe()
+	defer s.realtime.broker.Unsubscribe(ch)
 
 	// Keepalive ticker prevents idle connection timeouts.
 	// SSE comments (lines starting with ':') are ignored by EventSource

--- a/internal/webui/handlers_sse_test.go
+++ b/internal/webui/handlers_sse_test.go
@@ -72,8 +72,8 @@ func TestMatchesRunID_SubstringNotPipelineID(t *testing.T) {
 // response headers: Content-Type, Cache-Control, and Connection.
 func TestHandleSSE_Headers(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-001/events", nil)
 	req.SetPathValue("id", "run-001")
@@ -126,8 +126,8 @@ func TestHandleSSE_MissingRunID(t *testing.T) {
 // when the client disconnects via context cancellation and does not block.
 func TestHandleSSE_ClientDisconnect(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-disconnect/events", nil)
 	req.SetPathValue("id", "run-disconnect")
@@ -165,8 +165,8 @@ func TestHandleSSE_ClientDisconnect(t *testing.T) {
 // an error. The handler should simply skip the backfill.
 func TestHandleSSE_InvalidLastEventID(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-invalid-id/events", nil)
 	req.SetPathValue("id", "run-invalid-id")
@@ -201,8 +201,8 @@ func TestHandleSSE_InvalidLastEventID(t *testing.T) {
 // receives the retry directive but no backfill events.
 func TestHandleSSE_NonExistentRunID(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/nonexistent-run-xyz/events", nil)
 	req.SetPathValue("id", "nonexistent-run-xyz")
@@ -239,13 +239,13 @@ func TestHandleSSE_NonExistentRunID(t *testing.T) {
 // does not leak.
 func TestHandleSSE_BrokerCleanupAfterDisconnect(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	// Record initial subscriber count.
-	srv.broker.mu.RLock()
-	initialCount := len(srv.broker.clients)
-	srv.broker.mu.RUnlock()
+	srv.realtime.broker.mu.RLock()
+	initialCount := len(srv.realtime.broker.clients)
+	srv.realtime.broker.mu.RUnlock()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-cleanup/events", nil)
 	req.SetPathValue("id", "run-cleanup")
@@ -265,9 +265,9 @@ func TestHandleSSE_BrokerCleanupAfterDisconnect(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify the subscriber was added.
-	srv.broker.mu.RLock()
-	duringCount := len(srv.broker.clients)
-	srv.broker.mu.RUnlock()
+	srv.realtime.broker.mu.RLock()
+	duringCount := len(srv.realtime.broker.clients)
+	srv.realtime.broker.mu.RUnlock()
 	if duringCount != initialCount+1 {
 		t.Errorf("expected %d subscribers during connection, got %d", initialCount+1, duringCount)
 	}
@@ -280,9 +280,9 @@ func TestHandleSSE_BrokerCleanupAfterDisconnect(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify the subscriber was removed.
-	srv.broker.mu.RLock()
-	afterCount := len(srv.broker.clients)
-	srv.broker.mu.RUnlock()
+	srv.realtime.broker.mu.RLock()
+	afterCount := len(srv.realtime.broker.clients)
+	srv.realtime.broker.mu.RUnlock()
 	if afterCount != initialCount {
 		t.Errorf("expected %d subscribers after disconnect (cleanup), got %d", initialCount, afterCount)
 	}
@@ -293,8 +293,8 @@ func TestHandleSSE_BrokerCleanupAfterDisconnect(t *testing.T) {
 // but the value is not > 0, no backfill should occur.
 func TestHandleSSE_NegativeLastEventID(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-neg-id/events", nil)
 	req.SetPathValue("id", "run-neg-id")
@@ -328,8 +328,8 @@ func TestHandleSSE_NegativeLastEventID(t *testing.T) {
 // (as opposed to absent) is treated the same as no header.
 func TestHandleSSE_EmptyLastEventID(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-empty-id/events", nil)
 	req.SetPathValue("id", "run-empty-id")
@@ -359,8 +359,8 @@ func TestHandleSSE_EmptyLastEventID(t *testing.T) {
 // overflows int64 is handled gracefully (ParseInt fails, so no backfill).
 func TestHandleSSE_OverflowLastEventID(t *testing.T) {
 	srv, _ := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	req := httptest.NewRequest("GET", "/api/runs/run-overflow/events", nil)
 	req.SetPathValue("id", "run-overflow")

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -126,17 +126,27 @@ func testServer(t *testing.T) (*Server, state.StateStore) {
 	tmpl := testTemplates(t)
 
 	srv := &Server{
-		store:             roStore,
-		rwStore:           rwStore,
-		templates:         tmpl,
-		broker:            NewSSEBroker(),
-		bind:              "127.0.0.1",
-		port:              0,
-		activeRuns:        make(map[string]context.CancelFunc),
-		disabledPipelines: make(map[string]bool),
-		gateRegistry:      NewGateRegistry(),
-		csrfToken:         "test-csrf-token",
-		features:          NewFeatureRegistry(),
+		transport: serverTransport{
+			bind: "127.0.0.1",
+			port: 0,
+		},
+		auth: serverAuth{
+			csrfToken: "test-csrf-token",
+		},
+		runtime: serverRuntime{
+			store:   roStore,
+			rwStore: rwStore,
+		},
+		realtime: serverRealtime{
+			broker:            NewSSEBroker(),
+			gateRegistry:      NewGateRegistry(),
+			activeRuns:        make(map[string]context.CancelFunc),
+			disabledPipelines: make(map[string]bool),
+		},
+		assets: serverAssets{
+			templates: tmpl,
+			features:  NewFeatureRegistry(),
+		},
 	}
 
 	t.Cleanup(func() {
@@ -238,7 +248,7 @@ func TestHandleAPIRuns_Pagination(t *testing.T) {
 	// Verify all rows are visible through the read-only store before testing
 	// pagination. SQLite WAL mode can have brief visibility delays between
 	// separate connections.
-	runs, err := srv.store.ListRuns(state.ListRunsOptions{Limit: 50})
+	runs, err := srv.runtime.store.ListRuns(state.ListRunsOptions{Limit: 50})
 	if err != nil {
 		t.Fatalf("failed to verify test data: %v", err)
 	}
@@ -651,8 +661,8 @@ func (f *flusherRecorder) Flush() {}
 
 func TestHandleSSE_BackfillOnReconnect(t *testing.T) {
 	srv, rwStore := testServer(t)
-	go srv.broker.Start()
-	defer srv.broker.Stop()
+	go srv.realtime.broker.Start()
+	defer srv.realtime.broker.Stop()
 
 	runID, _ := rwStore.CreateRun("test-pipeline", "input")
 	if err := rwStore.UpdateRunStatus(runID, "running", "step1", 0); err != nil {
@@ -668,7 +678,7 @@ func TestHandleSSE_BackfillOnReconnect(t *testing.T) {
 	}
 
 	// Get the events to find their IDs
-	events, err := srv.store.GetEvents(runID, state.EventQueryOptions{})
+	events, err := srv.runtime.store.GetEvents(runID, state.EventQueryOptions{})
 	if err != nil {
 		t.Fatalf("failed to get events: %v", err)
 	}
@@ -1503,7 +1513,7 @@ steps:
 
 func TestHandlePersonasPage_NilManifest(t *testing.T) {
 	srv, _ := testServer(t)
-	// srv.manifest is nil by default from testServer
+	// srv.runtime.manifest is nil by default from testServer
 
 	req := httptest.NewRequest("GET", "/personas", nil)
 	rec := httptest.NewRecorder()
@@ -1521,7 +1531,7 @@ func TestHandlePersonasPage_NilManifest(t *testing.T) {
 func TestHandlePersonasPage_WithManifest(t *testing.T) {
 	srv, _ := testServer(t)
 
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: map[string]manifest.Persona{
 			"navigator": {
 				Description: "Guides the process",
@@ -1630,7 +1640,7 @@ steps:
 func TestHandleAPIPersonas_WithManifest(t *testing.T) {
 	srv, _ := testServer(t)
 
-	srv.manifest = &manifest.Manifest{
+	srv.runtime.manifest = &manifest.Manifest{
 		Personas: map[string]manifest.Persona{
 			"reviewer": {
 				Description: "Reviews code",
@@ -1840,9 +1850,13 @@ func TestHandleRunLogs_NotFound(t *testing.T) {
 func TestAuthMiddleware_JWTMode(t *testing.T) {
 	secret := "test-jwt-secret-key"
 	srv := &Server{
-		authMode:  AuthModeJWT,
-		jwtSecret: secret,
-		bind:      "0.0.0.0",
+		auth: serverAuth{
+			authMode:  AuthModeJWT,
+			jwtSecret: secret,
+		},
+		transport: serverTransport{
+			bind: "0.0.0.0",
+		},
 	}
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1893,8 +1907,12 @@ func TestAuthMiddleware_JWTMode(t *testing.T) {
 
 func TestAuthMiddleware_NoneMode(t *testing.T) {
 	srv := &Server{
-		authMode: AuthModeNone,
-		bind:     "0.0.0.0",
+		auth: serverAuth{
+			authMode: AuthModeNone,
+		},
+		transport: serverTransport{
+			bind: "0.0.0.0",
+		},
 	}
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/handlers_webhooks.go
+++ b/internal/webui/handlers_webhooks.go
@@ -51,7 +51,7 @@ func isPublicURL(rawURL string) bool {
 // --- Page Handler ---
 
 func (s *Server) handleWebhooksPage(w http.ResponseWriter, r *http.Request) {
-	webhooks, _ := s.store.ListWebhooks()
+	webhooks, _ := s.runtime.store.ListWebhooks()
 
 	data := struct {
 		ActivePage string
@@ -62,7 +62,7 @@ func (s *Server) handleWebhooksPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/webhooks.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/webhooks.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -75,13 +75,13 @@ func (s *Server) handleWebhookDetailPage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	webhook, err := s.store.GetWebhook(id)
+	webhook, err := s.runtime.store.GetWebhook(id)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("webhook not found: %s", err), http.StatusNotFound)
 		return
 	}
 
-	deliveries, _ := s.store.GetWebhookDeliveries(id, 50)
+	deliveries, _ := s.runtime.store.GetWebhookDeliveries(id, 50)
 
 	data := struct {
 		ActivePage string
@@ -94,7 +94,7 @@ func (s *Server) handleWebhookDetailPage(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.templates["templates/webhook_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/webhook_detail.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -102,7 +102,7 @@ func (s *Server) handleWebhookDetailPage(w http.ResponseWriter, r *http.Request)
 // --- API Endpoints ---
 
 func (s *Server) handleAPIWebhooks(w http.ResponseWriter, r *http.Request) {
-	webhooks, err := s.store.ListWebhooks()
+	webhooks, err := s.runtime.store.ListWebhooks()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to list webhooks: %s", err), http.StatusInternalServerError)
 		return
@@ -152,7 +152,7 @@ func (s *Server) handleAPICreateWebhook(w http.ResponseWriter, r *http.Request) 
 		UpdatedAt: time.Now(),
 	}
 
-	id, err := s.rwStore.CreateWebhook(webhook)
+	id, err := s.runtime.rwStore.CreateWebhook(webhook)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to create webhook: %s", err), http.StatusInternalServerError)
 		return
@@ -172,13 +172,13 @@ func (s *Server) handleAPIWebhookDetail(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	webhook, err := s.store.GetWebhook(id)
+	webhook, err := s.runtime.store.GetWebhook(id)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("webhook not found: %s", err), http.StatusNotFound)
 		return
 	}
 
-	deliveries, _ := s.store.GetWebhookDeliveries(id, 20)
+	deliveries, _ := s.runtime.store.GetWebhookDeliveries(id, 20)
 
 	resp := struct {
 		*state.Webhook
@@ -200,7 +200,7 @@ func (s *Server) handleAPIUpdateWebhook(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	existing, err := s.store.GetWebhook(id)
+	existing, err := s.runtime.store.GetWebhook(id)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("webhook not found: %s", err), http.StatusNotFound)
 		return
@@ -243,7 +243,7 @@ func (s *Server) handleAPIUpdateWebhook(w http.ResponseWriter, r *http.Request) 
 	}
 	existing.UpdatedAt = time.Now()
 
-	if err := s.rwStore.UpdateWebhook(existing); err != nil {
+	if err := s.runtime.rwStore.UpdateWebhook(existing); err != nil {
 		http.Error(w, fmt.Sprintf("failed to update webhook: %s", err), http.StatusInternalServerError)
 		return
 	}
@@ -260,7 +260,7 @@ func (s *Server) handleAPIDeleteWebhook(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := s.rwStore.DeleteWebhook(id); err != nil {
+	if err := s.runtime.rwStore.DeleteWebhook(id); err != nil {
 		http.Error(w, fmt.Sprintf("failed to delete webhook: %s", err), http.StatusInternalServerError)
 		return
 	}
@@ -276,7 +276,7 @@ func (s *Server) handleAPITestWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	webhook, err := s.store.GetWebhook(id)
+	webhook, err := s.runtime.store.GetWebhook(id)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("webhook not found: %s", err), http.StatusNotFound)
 		return

--- a/internal/webui/middleware.go
+++ b/internal/webui/middleware.go
@@ -10,16 +10,16 @@ import (
 // applyMiddleware wraps the given handler with server middleware.
 func (s *Server) applyMiddleware(handler http.Handler) http.Handler {
 	h := handler
-	if s.csrfToken != "" {
+	if s.auth.csrfToken != "" {
 		h = s.csrfMiddleware(h)
 	}
 	h = securityHeaders(h)
 	h = s.loggingMiddleware(h)
 
 	// Apply auth middleware based on resolved auth mode
-	switch s.authMode {
+	switch s.auth.authMode {
 	case AuthModeBearer:
-		if s.token != "" && s.requiresAuth() {
+		if s.auth.token != "" && s.requiresAuth() {
 			h = s.bearerAuthMiddleware(h)
 		}
 	case AuthModeJWT:
@@ -30,7 +30,7 @@ func (s *Server) applyMiddleware(handler http.Handler) http.Handler {
 		// No auth
 	default:
 		// Backward compatibility: use bearer auth if token is set
-		if s.token != "" && s.requiresAuth() {
+		if s.auth.token != "" && s.requiresAuth() {
 			h = s.bearerAuthMiddleware(h)
 		}
 	}
@@ -55,13 +55,13 @@ func (s *Server) bearerAuthMiddleware(next http.Handler) http.Handler {
 
 		// Check Authorization header
 		auth := r.Header.Get("Authorization")
-		if auth == "Bearer "+s.token {
+		if auth == "Bearer "+s.auth.token {
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		// Check query parameter as fallback (for SSE and browser access)
-		if r.URL.Query().Get("token") == s.token {
+		if r.URL.Query().Get("token") == s.auth.token {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -92,7 +92,7 @@ func (s *Server) jwtAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		tokenStr := strings.TrimPrefix(auth, "Bearer ")
-		if _, err := ValidateJWT(tokenStr, s.jwtSecret); err != nil {
+		if _, err := ValidateJWT(tokenStr, s.auth.jwtSecret); err != nil {
 			http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
 			return
 		}
@@ -108,7 +108,7 @@ func (s *Server) csrfMiddleware(next http.Handler) http.Handler {
 		switch r.Method {
 		case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
 			token := r.Header.Get("X-CSRF-Token")
-			if token == "" || token != s.csrfToken {
+			if token == "" || token != s.auth.csrfToken {
 				http.Error(w, "Forbidden: invalid CSRF token", http.StatusForbidden)
 				return
 			}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -91,7 +91,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/admin/audit", s.handleAPIAdminAudit)
 
 	// Optional feature routes (analytics, webhooks, etc.)
-	for _, fn := range s.features.routeFns {
+	for _, fn := range s.assets.features.routeFns {
 		fn(s, mux)
 	}
 
@@ -102,7 +102,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 // handleNotFound renders the 404 page for unmatched routes.
 func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
-	tmpl := s.templates["templates/notfound.html"]
+	tmpl := s.assets.templates["templates/notfound.html"]
 	if tmpl != nil {
 		_ = tmpl.ExecuteTemplate(w, "templates/layout.html", nil)
 	}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -36,35 +36,65 @@ const (
 	AuthModeMTLS   AuthMode = "mtls"
 )
 
-// Server is the HTTP server for the Wave dashboard.
-type Server struct {
-	httpServer        *http.Server
-	store             state.StateStore
-	rwStore           state.StateStore // read-write store for execution control
-	manifest          *manifest.Manifest
-	templates         map[string]*template.Template
+// serverTransport groups HTTP-only fields: the underlying server and its
+// bind address.
+type serverTransport struct {
+	httpServer *http.Server
+	bind       string
+	port       int
+}
+
+// serverAuth groups credentials and TLS material used to authenticate and
+// secure incoming requests.
+type serverAuth struct {
+	token     string
+	authMode  AuthMode
+	jwtSecret string
+	tlsCert   string
+	tlsKey    string
+	tlsCA     string
+	csrfToken string
+}
+
+// serverRuntime groups the long-lived runtime collaborators: state stores,
+// manifest, workspace manager, forge client, and pipeline scheduler.
+type serverRuntime struct {
+	store       state.StateStore
+	rwStore     state.StateStore // read-write store for execution control
+	manifest    *manifest.Manifest
+	wsManager   workspace.WorkspaceManager
+	forgeClient forge.Client
+	repoSlug    string // "owner/repo"
+	repoDir     string // git repository root directory
+	scheduler   *Scheduler
+}
+
+// serverRealtime groups the realtime/eventing collaborators: SSE broker,
+// gate registry, attention broker, and the live run/pipeline tracking maps.
+type serverRealtime struct {
 	broker            *SSEBroker
-	wsManager         workspace.WorkspaceManager
-	forgeClient       forge.Client
-	repoSlug          string // "owner/repo"
-	repoDir           string // git repository root directory
-	bind              string
-	port              int
-	token             string
-	authMode          AuthMode
-	jwtSecret         string
-	scheduler         *Scheduler
 	gateRegistry      *GateRegistry
+	attention         *attention.Broker
 	activeRuns        map[string]context.CancelFunc // runID -> cancel
 	disabledPipelines map[string]bool               // pipeline name -> disabled
-	mu                sync.Mutex
-	tlsCert           string
-	tlsKey            string
-	tlsCA             string
-	csrfToken         string
-	cache             *apiCache
-	attention         *attention.Broker
-	features          *FeatureRegistry
+}
+
+// serverAssets groups templates, the in-memory API cache, and the feature
+// registry — the read-mostly assets used to render responses.
+type serverAssets struct {
+	templates map[string]*template.Template
+	cache     *apiCache
+	features  *FeatureRegistry
+}
+
+// Server is the HTTP server for the Wave dashboard.
+type Server struct {
+	transport serverTransport
+	auth      serverAuth
+	runtime   serverRuntime
+	realtime  serverRealtime
+	assets    serverAssets
+	mu        sync.Mutex
 }
 
 // ServerConfig holds configuration for the dashboard server.
@@ -184,42 +214,52 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 
 	s := &Server{
-		store:             roStore,
-		rwStore:           rwStore,
-		manifest:          cfg.Manifest,
-		templates:         tmpl,
-		broker:            NewSSEBroker(),
-		wsManager:         wsManager,
-		forgeClient:       forgeClient,
-		repoSlug:          repoSlug,
-		repoDir:           repoDir,
-		bind:              cfg.Bind,
-		port:              cfg.Port,
-		token:             cfg.Token,
-		authMode:          authMode,
-		jwtSecret:         cfg.JWTSecret,
-		scheduler:         NewScheduler(cfg.MaxConcurrent),
-		gateRegistry:      NewGateRegistry(),
-		activeRuns:        make(map[string]context.CancelFunc),
-		disabledPipelines: make(map[string]bool),
-		tlsCert:           cfg.TLSCert,
-		tlsKey:            cfg.TLSKey,
-		tlsCA:             cfg.TLSCA,
-		csrfToken:         csrfToken,
-		cache:             newAPICache(5 * time.Minute),
-		attention:         attention.NewBroker(),
-		features:          features,
+		transport: serverTransport{
+			bind: cfg.Bind,
+			port: cfg.Port,
+		},
+		auth: serverAuth{
+			token:     cfg.Token,
+			authMode:  authMode,
+			jwtSecret: cfg.JWTSecret,
+			tlsCert:   cfg.TLSCert,
+			tlsKey:    cfg.TLSKey,
+			tlsCA:     cfg.TLSCA,
+			csrfToken: csrfToken,
+		},
+		runtime: serverRuntime{
+			store:       roStore,
+			rwStore:     rwStore,
+			manifest:    cfg.Manifest,
+			wsManager:   wsManager,
+			forgeClient: forgeClient,
+			repoSlug:    repoSlug,
+			repoDir:     repoDir,
+			scheduler:   NewScheduler(cfg.MaxConcurrent),
+		},
+		realtime: serverRealtime{
+			broker:            NewSSEBroker(),
+			gateRegistry:      NewGateRegistry(),
+			attention:         attention.NewBroker(),
+			activeRuns:        make(map[string]context.CancelFunc),
+			disabledPipelines: make(map[string]bool),
+		},
+		assets: serverAssets{
+			templates: tmpl,
+			cache:     newAPICache(5 * time.Minute),
+			features:  features,
+		},
 	}
 
 	// Wire attention broker into the SSE broker so pipeline events
 	// are automatically forwarded to the attention classifier.
-	s.broker.attentionSink = s.attention
+	s.realtime.broker.attentionSink = s.realtime.attention
 
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
 
 	addr := fmt.Sprintf("%s:%d", cfg.Bind, cfg.Port)
-	s.httpServer = &http.Server{
+	s.transport.httpServer = &http.Server{
 		Addr:         addr,
 		Handler:      s.applyMiddleware(mux),
 		ReadTimeout:  15 * time.Second,
@@ -255,7 +295,7 @@ func (s *Server) reconcileZombiesLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			if reclaimed := state.ReconcileZombies(s.rwStore, 0); reclaimed > 0 {
+			if reclaimed := state.ReconcileZombies(s.runtime.rwStore, 0); reclaimed > 0 {
 				log.Printf("[webui] reconciled %d zombie run(s)", reclaimed)
 			}
 		case <-ctx.Done():
@@ -265,12 +305,12 @@ func (s *Server) reconcileZombiesLoop(ctx context.Context) {
 }
 
 func (s *Server) syncAttentionFromDB() {
-	if s.attention == nil {
+	if s.realtime.attention == nil {
 		return
 	}
 	// Only track running runs. Completed and failed runs are done —
 	// they don't need live attention, the run detail page shows their status.
-	running, err := s.store.ListRuns(state.ListRunsOptions{Status: "running"})
+	running, err := s.runtime.store.ListRuns(state.ListRunsOptions{Status: "running"})
 	if err != nil {
 		log.Printf("[attention] failed to list running runs: %v", err)
 		return
@@ -281,7 +321,7 @@ func (s *Server) syncAttentionFromDB() {
 
 	for _, r := range running {
 		seen[r.RunID] = true
-		s.attention.UpdateWithName(r.RunID, r.PipelineName, event.Event{
+		s.realtime.attention.UpdateWithName(r.RunID, r.PipelineName, event.Event{
 			PipelineID: r.RunID,
 			State:      "running",
 			StepID:     r.CurrentStep,
@@ -290,10 +330,10 @@ func (s *Server) syncAttentionFromDB() {
 	}
 
 	// Clear completed runs that the attention broker still tracks.
-	summary := s.attention.Summary()
+	summary := s.realtime.attention.Summary()
 	for _, ra := range summary.Runs {
 		if !seen[ra.RunID] {
-			s.attention.Update(event.Event{
+			s.realtime.attention.Update(event.Event{
 				PipelineID: ra.RunID,
 				State:      "completed",
 				Timestamp:  now,
@@ -304,34 +344,34 @@ func (s *Server) syncAttentionFromDB() {
 
 // Start starts the HTTP server and blocks until shutdown.
 func (s *Server) Start() error {
-	go s.broker.Start()
+	go s.realtime.broker.Start()
 	attentionCtx, attentionCancel := context.WithCancel(context.Background())
 	defer attentionCancel()
 	go s.pollAttention(attentionCtx)
 	go s.reconcileZombiesLoop(attentionCtx)
 
-	addr := fmt.Sprintf("%s:%d", s.bind, s.port)
+	addr := fmt.Sprintf("%s:%d", s.transport.bind, s.transport.port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", addr, err)
 	}
 
 	// Configure TLS if enabled
-	if s.tlsCert != "" && s.tlsKey != "" {
+	if s.auth.tlsCert != "" && s.auth.tlsKey != "" {
 		tlsConfig := &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		}
 
 		// Load server certificate
-		cert, err := tls.LoadX509KeyPair(s.tlsCert, s.tlsKey)
+		cert, err := tls.LoadX509KeyPair(s.auth.tlsCert, s.auth.tlsKey)
 		if err != nil {
 			return fmt.Errorf("failed to load TLS certificate: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 
 		// Configure mTLS if auth mode is mtls
-		if s.authMode == AuthModeMTLS && s.tlsCA != "" {
-			caCert, err := os.ReadFile(s.tlsCA)
+		if s.auth.authMode == AuthModeMTLS && s.auth.tlsCA != "" {
+			caCert, err := os.ReadFile(s.auth.tlsCA)
 			if err != nil {
 				return fmt.Errorf("failed to read CA certificate: %w", err)
 			}
@@ -349,16 +389,16 @@ func (s *Server) Start() error {
 		fmt.Fprintf(os.Stderr, "Wave dashboard running at http://%s\n", addr)
 	}
 
-	if s.token != "" && s.bind != "127.0.0.1" && s.bind != "localhost" {
-		fmt.Fprintf(os.Stderr, "Dashboard token: %s\n", s.token)
+	if s.auth.token != "" && s.transport.bind != "127.0.0.1" && s.transport.bind != "localhost" {
+		fmt.Fprintf(os.Stderr, "Dashboard token: %s\n", s.auth.token)
 	}
 
 	// Issue #1467 — reap any "running" rows whose owning process died
 	// without writing the deferred UpdateRunStatus (host sleep, sandbox
 	// cycle, SIGKILL). Heartbeats fire every 30s; treat anything stale
 	// for > 5 minutes as orphaned.
-	if s.store != nil {
-		if reaped, err := s.store.ReapOrphans(5 * time.Minute); err != nil {
+	if s.runtime.store != nil {
+		if reaped, err := s.runtime.store.ReapOrphans(5 * time.Minute); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: orphan reap failed: %v\n", err)
 		} else if reaped > 0 {
 			fmt.Fprintf(os.Stderr, "Reaped %d orphaned run(s) on startup\n", reaped)
@@ -371,7 +411,7 @@ func (s *Server) Start() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.httpServer.Serve(listener)
+		errCh <- s.transport.httpServer.Serve(listener)
 	}()
 
 	select {
@@ -384,7 +424,7 @@ func (s *Server) Start() error {
 
 		// Cancel in-process fallback runs only (detached runs are independent processes)
 		s.mu.Lock()
-		for runID, cancelFn := range s.activeRuns {
+		for runID, cancelFn := range s.realtime.activeRuns {
 			log.Printf("Cancelling in-process run %s", runID)
 			cancelFn()
 		}
@@ -393,26 +433,26 @@ func (s *Server) Start() error {
 		// Drain scheduler queue
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer drainCancel()
-		if err := s.scheduler.Shutdown(drainCtx); err != nil {
+		if err := s.runtime.scheduler.Shutdown(drainCtx); err != nil {
 			log.Printf("Warning: scheduler drain timed out: %v", err)
 		}
 
 		// Shutdown HTTP server
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
+		if err := s.transport.httpServer.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("server shutdown error: %w", err)
 		}
 	}
 
-	s.broker.Stop()
-	s.store.Close()
-	s.rwStore.Close()
+	s.realtime.broker.Stop()
+	s.runtime.store.Close()
+	s.runtime.rwStore.Close()
 
 	return nil
 }
 
 // GetBroker returns the SSE broker for external event integration.
 func (s *Server) GetBroker() *SSEBroker {
-	return s.broker
+	return s.realtime.broker
 }

--- a/internal/webui/server_launcher.go
+++ b/internal/webui/server_launcher.go
@@ -25,7 +25,7 @@ type RunOptions = runner.Options
 func (s *Server) launchPipelineExecution(runID, pipelineName, input string, _ *pipeline.Pipeline, opts RunOptions, fromStep ...string) {
 	// Dry-run: handle in-process (instant, no subprocess needed).
 	if opts.DryRun {
-		if err := s.rwStore.UpdateRunStatus(runID, "completed", "dry run (validation only)", 0); err != nil {
+		if err := s.runtime.rwStore.UpdateRunStatus(runID, "completed", "dry run (validation only)", 0); err != nil {
 			log.Printf("Warning: failed to update run %s status for dry-run: %v", runID, err)
 		}
 		return
@@ -57,12 +57,12 @@ func (s *Server) spawnDetachedRun(runID, pipelineName, input string, opts RunOpt
 	opts.Output.Verbose = true
 
 	cfg := runner.DetachConfig{
-		WorkDir:  s.repoDir,
+		WorkDir:  s.runtime.repoDir,
 		ExtraEnv: []string{"GH_TOKEN", "GITHUB_TOKEN"},
 	}
 	// runner.Detach reuses the pre-created run row when opts.RunID exists
 	// in the store, so no extra coordination is needed.
-	if _, err := runner.Detach(opts, s.rwStore, 0, cfg); err != nil {
+	if _, err := runner.Detach(opts, s.runtime.rwStore, 0, cfg); err != nil {
 		return err
 	}
 	log.Printf("Pipeline %s (%s) launched as detached process", pipelineName, runID)
@@ -79,8 +79,8 @@ func (s *Server) launchInProcess(runID, pipelineName, input string, opts RunOpti
 	}
 
 	emitter := &event.DBLoggingEmitter{
-		Inner: s.broker,
-		Store: s.rwStore,
+		Inner: s.realtime.broker,
+		Store: s.runtime.rwStore,
 		RunID: runID,
 		OnError: func(rid string, err error) {
 			log.Printf("Warning: failed to log event for run %s: %v", rid, err)
@@ -88,33 +88,33 @@ func (s *Server) launchInProcess(runID, pipelineName, input string, opts RunOpti
 	}
 
 	var gateHandler pipeline.GateHandler
-	if s.gateRegistry != nil {
-		gateHandler = NewWebUIGateHandler(runID, s.gateRegistry)
+	if s.realtime.gateRegistry != nil {
+		gateHandler = NewWebUIGateHandler(runID, s.realtime.gateRegistry)
 	}
 
 	cancel := runner.LaunchInProcess(runner.InProcessConfig{
 		RunID:            runID,
 		PipelineName:     pipelineName,
 		Input:            input,
-		Manifest:         s.manifest,
-		Store:            s.rwStore,
+		Manifest:         s.runtime.manifest,
+		Store:            s.runtime.rwStore,
 		Emitter:          emitter,
-		WorkspaceManager: s.wsManager,
+		WorkspaceManager: s.runtime.wsManager,
 		GateHandler:      gateHandler,
 		FromStep:         resolvedFromStep,
 		Options:          opts,
 		OnComplete: func(string, error) {
 			// Invalidate issue/PR caches so fresh data shows after pipeline completion.
-			s.cache.InvalidatePrefix("issues:")
-			s.cache.InvalidatePrefix("prs:")
+			s.assets.cache.InvalidatePrefix("issues:")
+			s.assets.cache.InvalidatePrefix("prs:")
 
 			s.mu.Lock()
-			delete(s.activeRuns, runID)
+			delete(s.realtime.activeRuns, runID)
 			s.mu.Unlock()
 		},
 	})
 
 	s.mu.Lock()
-	s.activeRuns[runID] = cancel
+	s.realtime.activeRuns[runID] = cancel
 	s.mu.Unlock()
 }


### PR DESCRIPTION
## Summary

webui.Server: 27 fields → **6 top-level fields** via 5 composed sub-structs. ≤10 target met. No behaviour change.

## Sub-structs

| Group | Field count | Contents |
|---|---|---|
| `serverTransport` | 3 | `httpServer`, `bind`, `port` |
| `serverAuth` | 7 | `token`, `authMode`, `jwtSecret`, `tlsCert`, `tlsKey`, `tlsCA`, `csrfToken` |
| `serverRuntime` | 8 | `store`, `rwStore`, `manifest`, `wsManager`, `forgeClient`, `repoSlug`, `repoDir`, `scheduler` |
| `serverRealtime` | 5 | `broker`, `gateRegistry`, `attention`, `activeRuns`, `disabledPipelines` |
| `serverAssets` | 3 | `templates`, `cache` (apiCache), `features` |

Top-level `Server`: 6 fields (5 sub-structs + `mu`).

## Naming deviation

Used `assets` instead of suggested `cache` — the field name `*apiCache` is also `cache`, so `s.cache.cache` would shadow. `s.assets.cache` reads cleaner.

## Rewrites

296 `s.X` / `srv.X` → `s.subgroup.X` substitutions across 40 files (handlers, middleware, auth, server_launcher, routes, tests). `NewServer(ServerConfig) (*Server, error)` signature unchanged.

## Validation

- `go build ./...` + `go vet ./...` clean
- `go test -race ./internal/webui/...` ok (60s)
- `go test -race ./...` all packages pass
- `wave serve` boots; `/health`, `/runs`, `/pipelines` all 200

## Out of scope (deferred)

- Sub-task B (drop `internal/pipeline` import) — needs design step (DTO replacements for GateChoice + narrow interface layer)

## Test plan

- [ ] CI green
- [ ] `wave serve` endpoints work identically
- [ ] Auth/TLS/CSRF still functional

Partial of #1498 (sub-task D). Parent: #1494.