### PR TITLE
refactor(state): retire StateStore umbrella; narrow consumer ifaces (#1496 P2)

### DIFF
--- a/cmd/wave/commands/chat.go
+++ b/cmd/wave/commands/chat.go
@@ -270,8 +270,15 @@ func runChat(opts ChatOptions) error {
 	return err
 }
 
+// chatResumeStore is the narrow surface resumeChatSession needs to load,
+// list, and persist chat sessions plus resolve a default run ID.
+type chatResumeStore interface {
+	state.ChatStore
+	ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error)
+}
+
 // resumeChatSession loads a previous session and resumes it.
-func resumeChatSession(store state.StateStore, opts ChatOptions) error {
+func resumeChatSession(store chatResumeStore, opts ChatOptions) error {
 	var session *state.ChatSession
 
 	if opts.Resume == "last" {

--- a/cmd/wave/commands/do.go
+++ b/cmd/wave/commands/do.go
@@ -237,9 +237,15 @@ func runDo(input string, opts DoOptions) error {
 	return nil
 }
 
+// orchestrationRecorder is the narrow surface recordOrchestrationDecision
+// needs: append a single classification → routing record.
+type orchestrationRecorder interface {
+	RecordOrchestrationDecision(record *state.OrchestrationDecision) error
+}
+
 // recordOrchestrationDecision persists the classification → pipeline routing decision
 // so it appears in `wave analyze --decisions`.
-func recordOrchestrationDecision(store state.StateStore, runID, input string, profile classify.TaskProfile, cfg classify.PipelineConfig, outcome string, tokensUsed int, durationMs int64) {
+func recordOrchestrationDecision(store orchestrationRecorder, runID, input string, profile classify.TaskProfile, cfg classify.PipelineConfig, outcome string, tokensUsed int, durationMs int64) {
 	if runID == "" {
 		return
 	}

--- a/cmd/wave/commands/logs.go
+++ b/cmd/wave/commands/logs.go
@@ -14,6 +14,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// logsStore is the narrow persistence surface the logs command needs:
+// event lookup + per-run aggregate stats + run identity helpers. Defined
+// in the consumer package so logs.go binds to ISP-sized methods only.
+type logsStore interface {
+	GetMostRecentRunID() (string, error)
+	RunExists(runID string) (bool, error)
+	GetRunStatus(runID string) (string, error)
+	GetEvents(runID string, opts state.EventQueryOptions) ([]state.LogRecord, error)
+	GetEventAggregateStats(runID string) (*state.EventAggregateStats, error)
+}
+
 // LogsOptions holds options for the logs command.
 type LogsOptions struct {
 	RunID    string // Specific run (from args, default: most recent)
@@ -191,7 +202,7 @@ func recordsToEntries(records []state.LogRecord) []LogsEntry {
 }
 
 // runLogsOnce retrieves and displays logs once.
-func runLogsOnce(store state.StateStore, runID string, opts LogsOptions) error {
+func runLogsOnce(store logsStore, runID string, opts LogsOptions) error {
 	q, err := queryEventOptions(opts)
 	if err != nil {
 		return err
@@ -228,7 +239,7 @@ func runLogsOnce(store state.StateStore, runID string, opts LogsOptions) error {
 }
 
 // runLogsFollow streams logs in real-time.
-func runLogsFollow(store state.StateStore, runID string, opts LogsOptions) error {
+func runLogsFollow(store logsStore, runID string, opts LogsOptions) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -483,7 +494,7 @@ func runLogsTrace(opts LogsOptions) error {
 }
 
 // renderPerformanceSummary displays aggregated performance metrics for a run.
-func renderPerformanceSummary(store state.StateStore, runID string) {
+func renderPerformanceSummary(store logsStore, runID string) {
 	stats, err := store.GetEventAggregateStats(runID)
 	if err != nil || stats == nil || stats.TotalEvents == 0 {
 		return

--- a/cmd/wave/commands/postmortem.go
+++ b/cmd/wave/commands/postmortem.go
@@ -308,8 +308,14 @@ func extractContractErrors(events []state.LogRecord) []string {
 	return out
 }
 
+// artifactReader is the narrow surface collectPostmortemArtifacts needs:
+// look up registered artifacts per step.
+type artifactReader interface {
+	GetArtifacts(runID string, stepID string) ([]state.ArtifactRecord, error)
+}
+
 // collectPostmortemArtifacts gathers artifact names from steps that completed successfully.
-func collectPostmortemArtifacts(store state.StateStore, runID string, stepStates []state.StepStateRecord) []string {
+func collectPostmortemArtifacts(store artifactReader, runID string, stepStates []state.StepStateRecord) []string {
 	var artifacts []string
 	seen := map[string]bool{}
 

--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -354,11 +354,17 @@ func runResume(opts ResumeOptions, debug bool) error {
 	return nil
 }
 
+// failedStepReader is the narrow surface detectFailedStep needs: scan
+// recent events to find the last "failed" entry.
+type failedStepReader interface {
+	GetEvents(runID string, opts state.EventQueryOptions) ([]state.LogRecord, error)
+}
+
 // detectFailedStep inspects the run's event log to find which step failed.
 // It prefers an explicit "failed" event for a step. As a fallback it uses
 // the run's CurrentStep field (the step that was active when the run was
 // recorded as failed).
-func detectFailedStep(store state.StateStore, run *state.RunRecord) (string, error) {
+func detectFailedStep(store failedStepReader, run *state.RunRecord) (string, error) {
 	// Query the event log for a "failed" state entry tied to a specific step.
 	events, err := store.GetEvents(run.RunID, state.EventQueryOptions{
 		Limit: 200,

--- a/cmd/wave/commands/rewind.go
+++ b/cmd/wave/commands/rewind.go
@@ -204,8 +204,14 @@ func findStepsAfter(p *pipeline.Pipeline, afterIndex int) []string {
 	return steps
 }
 
+// rewindStore is the narrow surface executeRewind needs: drop checkpoints
+// after a given step index so wave resume re-runs the tail of the pipeline.
+type rewindStore interface {
+	DeleteCheckpointsAfterStep(runID string, stepIndex int) error
+}
+
 // executeRewind deletes state DB records for steps after the rewind point.
-func executeRewind(store state.StateStore, runID string, rewindIndex int) error {
+func executeRewind(store rewindStore, runID string, rewindIndex int) error {
 	// Delete checkpoints after the rewind point
 	if err := store.DeleteCheckpointsAfterStep(runID, rewindIndex); err != nil {
 		return fmt.Errorf("failed to delete checkpoints: %w", err)

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -314,7 +314,9 @@ func runDetached(opts RunOptions, p *pipeline.Pipeline, m *manifest.Manifest) er
 // called so the run is visible in the dashboard.
 // Returns ("", nil) when neither source yields an ID; the caller should then
 // fall back to GenerateRunID.
-func resolveRunID(runIDOpt string, store state.StateStore, pipelineName, input string) (string, error) {
+func resolveRunID(runIDOpt string, store interface {
+	CreateRun(pipelineName string, input string) (string, error)
+}, pipelineName, input string) (string, error) {
 	if runIDOpt != "" {
 		return runIDOpt, nil
 	}

--- a/cmd/wave/commands/status.go
+++ b/cmd/wave/commands/status.go
@@ -141,8 +141,18 @@ func runRecordToStatusInfo(r *state.RunRecord) StatusRunInfo {
 	return info
 }
 
+// statusStore is the narrow surface the status command needs:
+// per-run lookups and the running/recent run listings used by the
+// table/JSON output paths.
+type statusStore interface {
+	GetRun(runID string) (*state.RunRecord, error)
+	GetRunningRuns() ([]state.RunRecord, error)
+	ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error)
+	UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
+}
+
 // showRunDetails shows detailed status for a specific run.
-func showRunDetails(store state.StateStore, opts StatusOptions) error {
+func showRunDetails(store statusStore, opts StatusOptions) error {
 	record, err := store.GetRun(opts.RunID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -197,7 +207,7 @@ func showRunDetails(store state.StateStore, opts StatusOptions) error {
 }
 
 // showRunningRuns shows currently running pipelines.
-func showRunningRuns(store state.StateStore, opts StatusOptions) error {
+func showRunningRuns(store statusStore, opts StatusOptions) error {
 	records, err := store.GetRunningRuns()
 	if err != nil {
 		return err
@@ -228,7 +238,7 @@ func showRunningRuns(store state.StateStore, opts StatusOptions) error {
 }
 
 // showAllRuns shows recent pipelines.
-func showAllRuns(store state.StateStore, opts StatusOptions, limit int) error {
+func showAllRuns(store statusStore, opts StatusOptions, limit int) error {
 	records, err := store.ListRuns(state.ListRunsOptions{Limit: limit})
 	if err != nil {
 		return err

--- a/internal/pipeline/chatcontext.go
+++ b/internal/pipeline/chatcontext.go
@@ -210,8 +210,14 @@ func buildStepContexts(p *Pipeline, events []state.LogRecord, artifacts []state.
 	return steps
 }
 
+// runLister is the minimal store surface MostRecentCompletedRunID needs:
+// list recent runs to find a default analysis target.
+type runLister interface {
+	ListRuns(opts state.ListRunsOptions) ([]state.RunRecord, error)
+}
+
 // MostRecentCompletedRunID finds the most recent completed run ID from the state store.
-func MostRecentCompletedRunID(store state.RunStore) (string, error) {
+func MostRecentCompletedRunID(store runLister) (string, error) {
 	runs, err := store.ListRuns(state.ListRunsOptions{
 		Limit: 10,
 	})

--- a/internal/runner/detach.go
+++ b/internal/runner/detach.go
@@ -171,9 +171,18 @@ type DetachConfig struct {
 // opts.RunID is non-empty it is reused (the resume-in-place path used by
 // `--from-step`, see issue #1452).
 //
+// detachStore is the narrow run-lifecycle surface Detach needs: pre-create
+// or reuse a run row, mark it running, and stamp the spawned PID.
+type detachStore interface {
+	GetRun(runID string) (*state.RunRecord, error)
+	CreateRunWithLimit(pipelineName string, input string, maxConcurrent int) (string, error)
+	UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
+	UpdateRunPID(runID string, pid int) error
+}
+
 // On success the returned runID is the canonical ID for the spawned run and
 // the subprocess has already been fully released (cmd.Process.Release).
-func Detach(opts Options, store state.StateStore, maxConcurrentWorkers int, cfg DetachConfig) (runID string, err error) {
+func Detach(opts Options, store detachStore, maxConcurrentWorkers int, cfg DetachConfig) (runID string, err error) {
 	if store == nil {
 		return "", fmt.Errorf("Detach: state store is required")
 	}

--- a/internal/state/eventstore.go
+++ b/internal/state/eventstore.go
@@ -8,6 +8,7 @@ type EventStore interface {
 	// Event logging
 	LogEvent(runID string, stepID string, state string, persona string, message string, tokens int, durationMs int64, model string, configuredModel string, adapter string) error
 	GetEvents(runID string, opts EventQueryOptions) ([]LogRecord, error)
+	GetEventAggregateStats(runID string) (*EventAggregateStats, error)
 
 	// Audit log (cross-run event queries)
 	GetAuditEvents(states []string, limit, offset int) ([]LogRecord, error)

--- a/internal/state/reconcile.go
+++ b/internal/state/reconcile.go
@@ -29,8 +29,17 @@ const HeartbeatStaleThreshold = 90 * time.Second
 //  3. Age fallback: legacy runs with no PID and no heartbeat are reaped once
 //     their started_at is older than ageThreshold.
 //
+// ZombieReconciler is the minimal store surface ReconcileZombies needs:
+// list "running" runs and mark stale ones as failed. Defined here so any
+// caller-side narrow interface can pass through without inheriting the
+// full RunStore.
+type ZombieReconciler interface {
+	ListRuns(opts ListRunsOptions) ([]RunRecord, error)
+	UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
+}
+
 // Pass the zero value for ageThreshold to use ZombieAgeThreshold.
-func ReconcileZombies(store StateStore, ageThreshold time.Duration) int {
+func ReconcileZombies(store ZombieReconciler, ageThreshold time.Duration) int {
 	if ageThreshold <= 0 {
 		ageThreshold = ZombieAgeThreshold
 	}

--- a/internal/state/runstore.go
+++ b/internal/state/runstore.go
@@ -36,6 +36,11 @@ type RunStore interface {
 	GetRunningRuns() ([]RunRecord, error)
 	ListRuns(opts ListRunsOptions) ([]RunRecord, error)
 	DeleteRun(runID string) error
+	GetMostRecentRunID() (string, error)
+	RunExists(runID string) (bool, error)
+	GetRunStatus(runID string) (string, error)
+	ListPipelineNamesByStatus(status string) ([]string, error)
+	BackfillRunTokens() (int64, error)
 
 	// Cancellation
 	RequestCancellation(runID string, force bool) error
@@ -72,6 +77,7 @@ type RunStore interface {
 	RecordDecision(record *DecisionRecord) error
 	GetDecisions(runID string) ([]*DecisionRecord, error)
 	GetDecisionsByStep(runID, stepID string) ([]*DecisionRecord, error)
+	GetDecisionsFiltered(runID string, opts DecisionQueryOptions) ([]*DecisionRecord, error)
 
 	// Outcomes
 	RecordOutcome(runID, stepID, outcomeType, label, value, description string, metadata map[string]any) error

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -53,11 +53,15 @@ type StepStateRecord struct {
 	VisitCount    int
 }
 
-// StateStore is the aggregate persistence surface combining every
-// domain-scoped store. New consumers should depend on the smallest narrow
-// interface that satisfies their call sites (RunStore, EventStore,
-// OntologyStore, WebhookStore, ChatStore). The aggregate is retained for
-// constructors and root-level orchestrators that span multiple domains.
+// StateStore is the aggregate persistence surface — the union of every
+// domain-scoped sub-interface (RunStore, EventStore, OntologyStore,
+// WebhookStore, ChatStore) plus Close.
+//
+// DEPRECATED for new code: consumers should depend on the smallest narrow
+// interface that satisfies their call sites. StateStore is retained as the
+// composed type returned by NewStateStore so root-level constructors can
+// dispatch domain handles, and so legacy multi-domain consumers continue to
+// compile until they can be narrowed.
 type StateStore interface {
 	RunStore
 	EventStore
@@ -66,128 +70,6 @@ type StateStore interface {
 	ChatStore
 
 	Close() error
-
-	// Run tracking (ops commands)
-	CreateRun(pipelineName string, input string) (string, error)
-	CreateRunWithLimit(pipelineName string, input string, maxConcurrent int) (string, error)
-	UpdateRunStatus(runID string, status string, currentStep string, tokens int) error
-	UpdateRunBranch(runID string, branch string) error
-	GetRun(runID string) (*RunRecord, error)
-	GetRunningRuns() ([]RunRecord, error)
-	ListRuns(opts ListRunsOptions) ([]RunRecord, error)
-	DeleteRun(runID string) error
-	GetMostRecentRunID() (string, error)
-	RunExists(runID string) (bool, error)
-	GetRunStatus(runID string) (string, error)
-	ListPipelineNamesByStatus(status string) ([]string, error)
-	BackfillRunTokens() (int64, error)
-
-	// Event logging
-	LogEvent(runID string, stepID string, state string, persona string, message string, tokens int, durationMs int64, model string, configuredModel string, adapter string) error
-	GetEvents(runID string, opts EventQueryOptions) ([]LogRecord, error)
-	GetEventAggregateStats(runID string) (*EventAggregateStats, error)
-
-	// Artifact tracking
-	RegisterArtifact(runID string, stepID string, name string, path string, artifactType string, sizeBytes int64) error
-	GetArtifacts(runID string, stepID string) ([]ArtifactRecord, error)
-
-	// Cancellation
-	RequestCancellation(runID string, force bool) error
-	CheckCancellation(runID string) (*CancellationRecord, error)
-	ClearCancellation(runID string) error
-
-	// Performance metrics (spec 018)
-	RecordPerformanceMetric(metric *PerformanceMetricRecord) error
-	GetPerformanceMetrics(runID string, stepID string) ([]PerformanceMetricRecord, error)
-	GetStepPerformanceStats(pipelineName string, stepID string, since time.Time) (*StepPerformanceStats, error)
-	GetRecentPerformanceHistory(opts PerformanceQueryOptions) ([]PerformanceMetricRecord, error)
-	CleanupOldPerformanceMetrics(olderThan time.Duration) (int, error)
-
-	// Progress tracking (spec 018 - Enhanced Progress Visualization)
-	SaveProgressSnapshot(runID string, stepID string, progress int, action string, etaMs int64, validationPhase string, compactionStats string) error
-	GetProgressSnapshots(runID string, stepID string, limit int) ([]ProgressSnapshotRecord, error)
-	UpdateStepProgress(runID string, stepID string, persona string, state string, progress int, action string, message string, etaMs int64, tokens int) error
-	GetStepProgress(stepID string) (*StepProgressRecord, error)
-	GetAllStepProgress(runID string) ([]StepProgressRecord, error)
-	UpdatePipelineProgress(runID string, totalSteps int, completedSteps int, currentStepIndex int, overallProgress int, etaMs int64) error
-	GetPipelineProgress(runID string) (*PipelineProgressRecord, error)
-	SaveArtifactMetadata(artifactID int64, runID string, stepID string, previewText string, mimeType string, encoding string, metadataJSON string) error
-	GetArtifactMetadata(artifactID int64) (*ArtifactMetadataRecord, error)
-
-	// Tags support
-	SetRunTags(runID string, tags []string) error
-	GetRunTags(runID string) ([]string, error)
-	AddRunTag(runID string, tag string) error
-	RemoveRunTag(runID string, tag string) error
-
-	// Process tracking (detached subprocess execution)
-	UpdateRunPID(runID string, pid int) error
-	// Liveness tracking — running processes call this periodically so the
-	// reconciler can flag zombies whose owning process died without
-	// updating the DB.
-	UpdateRunHeartbeat(runID string) error
-	ReapOrphans(staleAfter time.Duration) (int, error)
-
-	// Step attempt tracking (retry/recovery)
-	RecordStepAttempt(record *StepAttemptRecord) error
-	GetStepAttempts(runID string, stepID string) ([]StepAttemptRecord, error)
-
-	// Chat session tracking (bidirectional chat)
-	SaveChatSession(session *ChatSession) error
-	GetChatSession(sessionID string) (*ChatSession, error)
-	ListChatSessions(runID string) ([]ChatSession, error)
-
-	// Ontology usage tracking (decision lineage)
-	RecordOntologyUsage(runID, stepID, contextName string, invariantCount int, status string, contractPassed *bool) error
-	GetOntologyStats(contextName string) (*OntologyStats, error)
-	GetOntologyStatsAll() ([]OntologyStats, error)
-
-	// Checkpoint tracking (fork/rewind)
-	SaveCheckpoint(record *CheckpointRecord) error
-	GetCheckpoint(runID, stepID string) (*CheckpointRecord, error)
-	GetCheckpoints(runID string) ([]CheckpointRecord, error)
-	DeleteCheckpointsAfterStep(runID string, stepIndex int) error
-
-	// Fork lineage
-	CreateRunWithFork(pipelineName, input, forkedFromRunID string) (string, error)
-
-	// Parent-child run linkage
-	SetParentRun(childRunID, parentRunID, stepID string) error
-	SetRunComposition(childRunID, runKind, subPipelineRef, iterateMode string, iterateIndex, iterateTotal *int) error
-	GetChildRuns(parentRunID string) ([]RunRecord, error)
-	GetSubtreeTokens(rootRunID string) (int64, error)
-
-	// Retrospective tracking
-	SaveRetrospective(record *RetrospectiveRecord) error
-	GetRetrospective(runID string) (*RetrospectiveRecord, error)
-	ListRetrospectives(opts ListRetrosOptions) ([]RetrospectiveRecord, error)
-	DeleteRetrospective(runID string) error
-	UpdateRetrospectiveSmoothness(runID string, smoothness string) error
-	UpdateRetrospectiveStatus(runID string, status string) error
-
-	// Decision log (append-only structured decision tracking)
-	RecordDecision(record *DecisionRecord) error
-	GetDecisions(runID string) ([]*DecisionRecord, error)
-	GetDecisionsByStep(runID, stepID string) ([]*DecisionRecord, error)
-	GetDecisionsFiltered(runID string, opts DecisionQueryOptions) ([]*DecisionRecord, error)
-
-	// Audit log (cross-run event queries)
-	GetAuditEvents(states []string, limit, offset int) ([]LogRecord, error)
-
-	// Webhook management
-	CreateWebhook(webhook *Webhook) (int64, error)
-	ListWebhooks() ([]*Webhook, error)
-	GetWebhook(id int64) (*Webhook, error)
-	UpdateWebhook(webhook *Webhook) error
-	DeleteWebhook(id int64) error
-	RecordWebhookDelivery(delivery *WebhookDelivery) error
-	GetWebhookDeliveries(webhookID int64, limit int) ([]*WebhookDelivery, error)
-
-	// Orchestration decision tracking (task classification feedback loop)
-	RecordOrchestrationDecision(record *OrchestrationDecision) error
-	UpdateOrchestrationOutcome(runID string, outcome string, tokensUsed int, durationMs int64) error
-	GetOrchestrationStats(pipelineName string) (*OrchestrationStats, error)
-	ListOrchestrationDecisionSummary(limit int) ([]OrchestrationDecisionSummary, error)
 }
 
 // ListRetrosOptions specifies filters for listing retrospectives.
@@ -197,11 +79,16 @@ type ListRetrosOptions struct {
 	Limit        int
 }
 
+// runningRunsLister is the minimal store surface WaitForConcurrencySlot needs.
+type runningRunsLister interface {
+	GetRunningRuns() ([]RunRecord, error)
+}
+
 // WaitForConcurrencySlot polls GetRunningRuns until fewer than maxWorkers
 // pipelines are running. Returns nil when a slot is available, or ctx.Err()
 // if the context is cancelled. This is the single concurrency gate used by
 // CLI --detach, WebUI, and TUI launch paths.
-func WaitForConcurrencySlot(ctx context.Context, store StateStore, maxWorkers int, onWait func(running, max int)) error {
+func WaitForConcurrencySlot(ctx context.Context, store runningRunsLister, maxWorkers int, onWait func(running, max int)) error {
 	for {
 		running, err := store.GetRunningRuns()
 		if err != nil {


### PR DESCRIPTION
## Summary

Closes #1496. Part 2: StateStore umbrella collapsed from 135 hardcoded method declarations into a **13-line composition** (`StateStore = RunStore + EventStore + OntologyStore + WebhookStore + ChatStore + Close`). 12 consumers narrowed to declare only the methods they use; multi-domain consumers (executor, webui handlers) correctly keep the aggregate.

## Consumers narrowed (12 sites across 11 files)

- `cmd/wave/commands/logs.go` — `logsStore` (3 functions)
- `cmd/wave/commands/status.go` — `statusStore` (3 functions)
- `cmd/wave/commands/chat.go` — `chatResumeStore`
- `cmd/wave/commands/rewind.go` — `rewindStore`
- `cmd/wave/commands/postmortem.go` — `artifactReader`
- `cmd/wave/commands/resume.go` — `failedStepReader`
- `cmd/wave/commands/do.go` — `orchestrationRecorder`
- `cmd/wave/commands/run.go` — anonymous iface for `resolveRunID`
- `internal/runner/detach.go` — `detachStore`
- `internal/pipeline/chatcontext.go` — `runLister` (`MostRecentCompletedRunID`)
- `internal/state/reconcile.go` — `ZombieReconciler`
- `internal/state/store.go` — `runningRunsLister` (`WaitForConcurrencySlot`)

## Sub-interface promotions

Methods that only lived on the umbrella moved to their right sub-interface:
- `RunStore` gained: `GetMostRecentRunID`, `RunExists`, `GetRunStatus`, `ListPipelineNamesByStatus`, `BackfillRunTokens`, `GetDecisionsFiltered`
- `EventStore` gained: `GetEventAggregateStats`

## Consumers that resisted narrowing

Genuinely multi-domain — narrowing would rebuild the umbrella under another name:

- `internal/pipeline/executor.go` — uses RunStore + EventStore + WebhookStore + ChatStore + OntologyStore. Keeps `StateStore` aggregate.
- `internal/pipeline/sequence.go`, `internal/pipeline/executor_observers.go` — funnel into executor
- `internal/runner/inprocess.go` — pipes store through to `pipeline.WithStateStore`
- `internal/webui/server.go` — handler set spans 5+ domains; would need per-handler split (separate ticket)
- `internal/tui/pipeline_messages.go`, `internal/tui/pipeline_provider_test.go` — multi-domain
- `cmd/wave/commands/run_stages.go` — funnels into executor
- Test fakes — embed `state.StateStore` for panic-on-unimplemented patterns; still compile because umbrella = composition

## LOC delta

+115 / -143 (net **-28**) across 14 files. Umbrella shrinking dominates.

## Net effect

The umbrella is no longer a list of 93 hardcoded methods — it is purely composition. Adding a method to a sub-interface automatically flows in. ISP restored where consumers have genuinely narrow needs; multi-domain consumers correctly keep the aggregate.

## Out of scope (deferred follow-up)

- `internal/state/perf` or `internal/metrics` extraction (performance metrics out of persistence layer) — separate ticket; touches `internal/state/metrics.go` (346 LOC)
- webui per-handler narrowing — needs DTO design step

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./...` exit 0; full suite green (`cmd/wave/commands` 282s, `internal/state` 411s, `internal/pipeline` 78s, `internal/webui` 73s)

## Test plan

- [ ] CI green
- [ ] `wave run`, `wave logs`, `wave status`, `wave resume` all unchanged
- [ ] `wave serve` boots, `/runs` works

Closes #1496. Parent: #1494.