### PR TITLE
fix(pipeline): isolate command-step workspaces; auto-inject input artifact paths

### DIFF
--- a/.agents/contracts/contract-check.schema.json
+++ b/.agents/contracts/contract-check.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Contract Check Result",
+  "description": "Outcome of the wave-smoke-contracts validate step. Both data_valid and schema_valid must be true for the smoke test to count as passing.",
+  "type": "object",
+  "required": ["data_valid", "schema_valid", "checked_at"],
+  "additionalProperties": true,
+  "properties": {
+    "data_valid": {
+      "type": "boolean",
+      "const": true,
+      "description": "Test data file existed and parsed as valid JSON."
+    },
+    "schema_valid": {
+      "type": "boolean",
+      "const": true,
+      "description": "Test schema file existed and parsed as valid JSON."
+    },
+    "checked_at": {
+      "type": "string",
+      "description": "Timestamp when the check ran."
+    }
+  }
+}

--- a/.agents/pipelines/wave-smoke-contracts.yaml
+++ b/.agents/pipelines/wave-smoke-contracts.yaml
@@ -28,6 +28,9 @@ steps:
       - name: test-data
         path: .agents/output/test-data.json
         type: json
+      - name: test-schema
+        path: .agents/output/test-schema.json
+        type: json
     handover:
       contract:
         type: non_empty_file
@@ -38,19 +41,28 @@ steps:
     persona: navigator
     model: cheapest
     dependencies: [setup]
+    memory:
+      inject_artifacts:
+        - step: setup
+          artifact: test-data
+          as: test-data
+        - step: setup
+          artifact: test-schema
+          as: test-schema
     exec:
       type: prompt
       source: |
-        Read `.agents/output/test-data.json` and `.agents/output/test-schema.json`.
-        Verify both exist and contain valid JSON. Write confirmation to
-        `.agents/output/contract-check.json`:
-        {"data_valid": true, "schema_valid": true, "checked_at": "<timestamp>"}
+        Read the two injected input artifacts. Each must parse as valid JSON.
+        Set `data_valid` true iff `test-data` parses; set `schema_valid` true
+        iff `test-schema` parses. Set `checked_at` to the current RFC3339 UTC
+        timestamp.
     output_artifacts:
       - name: contract-check
         path: .agents/output/contract-check.json
         type: json
     handover:
       contract:
-        type: non_empty_file
+        type: json_schema
         source: .agents/output/contract-check.json
+        schema_path: .agents/contracts/contract-check.schema.json
         on_failure: fail

--- a/internal/defaults/contracts/contract-check.schema.json
+++ b/internal/defaults/contracts/contract-check.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Contract Check Result",
+  "description": "Outcome of the wave-smoke-contracts validate step. Both data_valid and schema_valid must be true for the smoke test to count as passing.",
+  "type": "object",
+  "required": ["data_valid", "schema_valid", "checked_at"],
+  "additionalProperties": true,
+  "properties": {
+    "data_valid": {
+      "type": "boolean",
+      "const": true,
+      "description": "Test data file existed and parsed as valid JSON."
+    },
+    "schema_valid": {
+      "type": "boolean",
+      "const": true,
+      "description": "Test schema file existed and parsed as valid JSON."
+    },
+    "checked_at": {
+      "type": "string",
+      "description": "Timestamp when the check ran."
+    }
+  }
+}

--- a/internal/pipeline/executor_artifacts.go
+++ b/internal/pipeline/executor_artifacts.go
@@ -190,6 +190,24 @@ func (e *DefaultPipelineExecutor) buildStepPrompt(execution *PipelineExecution, 
 		}
 	}
 
+	// Inject input artifact paths so the persona knows where to read upstream files.
+	// Paths mirror injectArtifacts() destination logic: filepath.Join(workspace, ".agents/artifacts", as|artifact).
+	if len(step.Memory.InjectArtifacts) > 0 {
+		var sb strings.Builder
+		sb.WriteString("\n## Input Artifacts\n\n")
+		sb.WriteString("Upstream artifacts have been placed in your workspace at these paths:\n\n")
+		for _, ref := range step.Memory.InjectArtifacts {
+			name := ref.As
+			if name == "" {
+				name = ref.Artifact
+			}
+			sb.WriteString(fmt.Sprintf("- `.agents/artifacts/%s` (from step `%s`, artifact `%s`)\n", name, ref.Step, ref.Artifact))
+		}
+		sb.WriteString("\nRead these files at the paths shown. They are guaranteed to exist before this step runs.\n\n")
+		sb.WriteString(prompt)
+		prompt = sb.String()
+	}
+
 	// Inject output artifact paths so the persona knows where to write artifacts
 	if len(step.OutputArtifacts) > 0 {
 		var sb strings.Builder

--- a/internal/pipeline/executor_workspace.go
+++ b/internal/pipeline/executor_workspace.go
@@ -256,6 +256,11 @@ func (e *DefaultPipelineExecutor) createStepWorkspace(execution *PipelineExecuti
 	if err := os.MkdirAll(wsPath, 0755); err != nil {
 		return "", err
 	}
+	// Pre-create the .agents/output dir so resolveCommandWorkDir treats this
+	// workspace as real and command steps run with CWD here instead of falling
+	// back to the project root (which would pollute the project tree and break
+	// artifact isolation).
+	_ = os.MkdirAll(filepath.Join(wsPath, ".agents", "output"), 0755)
 	// Anchor Claude Code path resolution (see mount-based workspace above)
 	_ = exec.Command("git", "init", "-q", wsPath).Run()
 	return wsPath, nil


### PR DESCRIPTION
## Summary

Three coordinated fixes for silent workspace-pollution + false-positive smoke contract:

- **`createStepWorkspace` pre-creates `.agents/output/`** so `resolveCommandWorkDir` recognises the workspace as real. Without it, command-step scripts were silently CWD-ing to the project root and polluting the actual repo (`.agents/output/test-data.json` showed up in project tree).
- **`buildStepPrompt` emits a `## Input Artifacts` block** listing each `memory.inject_artifacts` ref with its destination path (`.agents/artifacts/<as|artifact>`). Mirrors existing `## Output Artifacts`. Pipeline authors no longer need to (and must not) hand-write paths into prompts.
- **`wave-smoke-contracts.yaml` rewired**: declared the missing `test-schema` artifact, added `inject_artifacts` on the `validate` step, switched handover contract from `non_empty_file` (which passed any non-empty bytes including error JSON) to `json_schema` referencing a new `contract-check.schema.json` requiring both `data_valid: true` and `schema_valid: true`.

## Why this matters

Before this PR the smoke pipeline reported success even when both upstream files were missing and the navigator wrote `{data_valid: false, schema_valid: false}` — the smoke test was lying about contract validation.

## Test plan

- [x] `go test ./internal/pipeline/...` (affected packages)
- [x] `wave run wave-smoke-contracts --adapter claude --model cheapest` — passes with real 16/81-byte payloads
- [x] Verified workspace isolation: setup/.agents/output/ now contains the script-written files; project root is clean
- [x] Verified strict contract: pipeline correctly fails when either flag is false (regression-tested with intentional path break)