### PR TITLE
fix(pipeline): align ops-issue-quality scan output to .agents/output/ convention

### DIFF
--- a/.agents/pipelines/ops-issue-quality.yaml
+++ b/.agents/pipelines/ops-issue-quality.yaml
@@ -163,7 +163,7 @@ steps:
         includes issues above the threshold in the poor-quality list.
     output_artifacts:
       - name: quality-report
-        path: .agents/artifacts/quality-report.json
+        path: .agents/output/quality-report.json
         type: json
         required: true
     retry:
@@ -172,7 +172,7 @@ steps:
     handover:
       contract:
         type: json_schema
-        source: .agents/artifacts/quality-report.json
+        source: .agents/output/quality-report.json
         schema_path: .agents/contracts/github-issue-analysis.schema.json
         on_failure: warn
 


### PR DESCRIPTION
## Summary

- The `scan` step in `.agents/pipelines/ops-issue-quality.yaml` declared its `quality-report.json` output under `.agents/artifacts/`, which is the framework's INTERNAL injection target (populated by `memory.inject_artifacts`), not where pipelines should write outputs.
- Wave convention is `.agents/output/<name>.<ext>` for declared pipeline output artifacts. Using the wrong path breaks downstream consumers and violates the documented convention.
- Updated both `output_artifacts[0].path` and the matching `handover.contract.source` to `.agents/output/quality-report.json`. The artifact name (`quality-report`) is unchanged, so the `enhance` step's `inject_artifacts` reference (which is name-based, not path-based) continues to resolve correctly.

## Audit context

Prior audit flagged this as a path inconsistency that breaks downstream consumers and violates the `.agents/output/` convention for declared pipeline outputs.

## Note on `enhance` step `{{ input }}`

The audit also flagged the `enhance` step prompt referencing `{{ input }}` without a corresponding `memory.input` block. Verified this is a **false positive**: the pipeline declares a top-level `input:` block (lines 19-25) with `source: cli, type: string`, so `{{ input }}` is auto-resolved by Wave's templating from the pipeline-level input. No fix needed.

The `enhance` step's other output (`enhancement-summary.md`) also lives under `.agents/artifacts/` but was NOT flagged by the audit and is left untouched in this PR to keep scope tight. If the same convention should apply, it can be addressed in a follow-up.

## Test plan

- [x] `go build -o ./wave ./cmd/wave` — clean build
- [x] `./wave list pipelines | grep ops-issue-quality` — pipeline parses and lists with both steps (`scan → enhance`)
- [x] `git diff` — change is minimal (2 lines, both path-only)
- [ ] CI: golangci-lint + go test ./...