### PR TITLE
feat(pipeline): auto-escalate model tier on retry; opt-out via retry.no_escalate

### DIFF
--- a/docs/guide/retry-policies.md
+++ b/docs/guide/retry-policies.md
@@ -31,6 +31,41 @@ steps:
 
 Explicit fields override policy defaults — set `policy` for the base, then override individual fields as needed.
 
+## Model Tier Escalation on Retry
+
+When a step retries, Wave automatically escalates the model one tier stronger
+along the cost ladder `cheapest -> balanced -> strongest`. The first retry
+moves up one tier, the second another, and once `strongest` is reached
+further retries stay there.
+
+```yaml
+steps:
+  - id: implement
+    persona: craftsman
+    model: cheapest          # attempt 1: cheapest -> haiku
+    retry:
+      policy: standard       # attempt 2: balanced -> adapter default
+                             # attempt 3: strongest -> opus
+```
+
+Escalation only applies when the step's effective model is a recognized
+tier name (`cheapest`, `balanced`, `strongest`). Literal model IDs (e.g.
+`claude-opus-4`, `gpt-4o-mini`) are user-pinned overrides and are
+preserved verbatim across retries.
+
+Set `retry.no_escalate: true` to disable escalation and reuse the same
+model across retries:
+
+```yaml
+steps:
+  - id: scan
+    persona: navigator
+    model: cheapest
+    retry:
+      policy: standard
+      no_escalate: true      # keep using cheapest on every retry
+```
+
 ## Failure Classification
 
 The retry system classifies failures into 6 categories:

--- a/docs/reference/pipeline-schema.md
+++ b/docs/reference/pipeline-schema.md
@@ -1357,6 +1357,7 @@ Explicit fields override policy defaults.
 | `adapt_prompt` | no | `false` | Inject prior failure context into retry prompt |
 | `on_failure` | no | `fail` | Action when all attempts are exhausted: `fail`, `skip`, `continue`, `rework` |
 | `rework_step` | conditional | - | Step ID to execute when `on_failure: rework`. Required when `on_failure` is `rework`. |
+| `no_escalate` | no | `false` | Disable automatic model tier escalation on retry. By default each retry resolves one tier stronger (`cheapest` -> `balanced` -> `strongest`); set to `true` to reuse the original tier on every retry. Literal model IDs are never auto-escalated regardless. |
 
 ### On-Failure Actions
 

--- a/internal/pipeline/executor_dispatch.go
+++ b/internal/pipeline/executor_dispatch.go
@@ -281,7 +281,18 @@ func (e *DefaultPipelineExecutor) resolveStepResources(ctx context.Context, exec
 	if adapterDef != nil {
 		adapterTierModels = adapterDef.TierModels
 	}
-	resolvedModel := e.resolveModel(step, persona, &execution.Manifest.Runtime.Routing, resolvedPersona, adapterTierModels)
+	// Determine the current attempt number so resolveModelForAttempt can
+	// escalate the model tier on retries. AttemptContexts[step.ID] is
+	// populated by the retry loop after each failed attempt; absence
+	// means this is the first attempt. Rework targets (FailedStepID set)
+	// are separate steps with their own model — do not escalate them.
+	attempt := 1
+	execution.mu.Lock()
+	if ac := execution.AttemptContexts[step.ID]; ac != nil && ac.Attempt > 0 && ac.FailedStepID == "" {
+		attempt = ac.Attempt
+	}
+	execution.mu.Unlock()
+	resolvedModel := e.resolveModelForAttempt(step, persona, &execution.Manifest.Runtime.Routing, resolvedPersona, adapterTierModels, attempt)
 
 	// When no model was resolved, fall back to adapter's default_model
 	if resolvedModel == "" && adapterDef != nil && adapterDef.DefaultModel != "" {

--- a/internal/pipeline/executor_overrides.go
+++ b/internal/pipeline/executor_overrides.go
@@ -8,12 +8,38 @@ import (
 	"github.com/recinq/wave/internal/state"
 )
 
+// resolveModel is a thin wrapper preserved for test ergonomics; production
+// dispatch goes through resolveModelForAttempt so the retry tier escalation
+// path is exercised. The nolint:unparam directive silences the linter
+// noticing that adapterTierModels is always nil in test callers — the
+// parameter is part of the wider tier-resolution API and must stay.
+//
+//nolint:unparam // test-only helper; production callers use resolveModelForAttempt directly.
 func (e *DefaultPipelineExecutor) resolveModel(step *Step, persona *manifest.Persona, routing *manifest.RoutingConfig, personaName string, adapterTierModels map[string]string) string {
+	return e.resolveModelForAttempt(step, persona, routing, personaName, adapterTierModels, 1)
+}
+
+// resolveModelForAttempt is the retry-aware variant of resolveModel. When
+// attempt > 1 and the step's RetryConfig does not set NoEscalate, any
+// tier-named source (cheapest/balanced/strongest) is escalated by
+// (attempt - 1) tiers along the cost ladder before being resolved to a
+// concrete model. Literal model names (user-pinned exact IDs) are
+// preserved verbatim — the auto-escalation only walks the recognized
+// tier ladder so explicit overrides are never overridden.
+func (e *DefaultPipelineExecutor) resolveModelForAttempt(step *Step, persona *manifest.Persona, routing *manifest.RoutingConfig, personaName string, adapterTierModels map[string]string, attempt int) string {
 	// Force override — bypasses all tier logic
 	if e.forceModel {
 		if e.modelOverride != "" {
 			return e.modelOverride
 		}
+	}
+
+	retries := attempt - 1
+	if retries < 0 {
+		retries = 0
+	}
+	if step != nil && step.Retry.NoEscalate {
+		retries = 0
 	}
 
 	// Determine step-level tier (if any)
@@ -29,33 +55,45 @@ func (e *DefaultPipelineExecutor) resolveModel(step *Step, persona *manifest.Per
 		if overrideRank >= 0 && stepTier != "" {
 			// Both are tiers — use the cheaper one
 			effectiveTier := CheaperTier(e.modelOverride, stepTier)
+			effectiveTier = EscalateTier(effectiveTier, retries)
 			if resolved, isTier := resolveTierModel(effectiveTier, routing, adapterTierModels); isTier {
 				return resolved
 			}
 			return effectiveTier
 		}
-		// CLI is a literal model name — use it directly
+		// CLI is a tier name with no step tier — escalate it on retry
+		if overrideRank >= 0 {
+			tier := EscalateTier(e.modelOverride, retries)
+			if resolved, isTier := resolveTierModel(tier, routing, adapterTierModels); isTier {
+				return resolved
+			}
+			return tier
+		}
+		// CLI is a literal model name — use it directly (no escalation)
 		return e.modelOverride
 	}
 
 	// No CLI override — use step, persona, auto-route
 	if step != nil && step.Model != "" {
-		if resolved, isTier := resolveTierModel(step.Model, routing, adapterTierModels); isTier {
+		tier := EscalateTier(step.Model, retries)
+		if resolved, isTier := resolveTierModel(tier, routing, adapterTierModels); isTier {
 			return resolved
 		}
-		return step.Model
+		return tier
 	}
 	if persona.Model != "" {
-		if resolved, isTier := resolveTierModel(persona.Model, routing, adapterTierModels); isTier {
+		tier := EscalateTier(persona.Model, retries)
+		if resolved, isTier := resolveTierModel(tier, routing, adapterTierModels); isTier {
 			return resolved
 		}
-		return persona.Model
+		return tier
 	}
 	if routing != nil && routing.AutoRoute {
 		tier := ClassifyStepComplexity(step, persona, personaName)
 		if e.taskComplexity != "" {
 			tier = AdjustTierForTaskComplexity(tier, e.taskComplexity)
 		}
+		tier = EscalateTier(tier, retries)
 		if resolved, isTier := resolveTierModel(tier, routing, adapterTierModels); isTier {
 			return resolved
 		}

--- a/internal/pipeline/routing.go
+++ b/internal/pipeline/routing.go
@@ -117,3 +117,34 @@ func CheaperTier(a, b string) string {
 	}
 	return b
 }
+
+// EscalateTier returns the tier raised by `retries` steps along the
+// cost ladder cheapest -> balanced -> strongest. retries is the number
+// of prior failed attempts (0 means first attempt; the original tier is
+// returned unchanged). Once strongest is reached, further retries stay
+// at strongest. If `tier` is not a recognized tier (e.g. a literal model
+// name), it is returned unchanged — user-pinned exact models are not
+// auto-escalated.
+func EscalateTier(tier string, retries int) string {
+	if retries <= 0 {
+		return tier
+	}
+	rank := TierRank(tier)
+	if rank < 0 {
+		return tier
+	}
+	newRank := rank + retries
+	if newRank > TierRank(TierStrongest) {
+		newRank = TierRank(TierStrongest)
+	}
+	switch newRank {
+	case 0:
+		return TierCheapest
+	case 1:
+		return TierBalanced
+	case 2:
+		return TierStrongest
+	default:
+		return tier
+	}
+}

--- a/internal/pipeline/routing_test.go
+++ b/internal/pipeline/routing_test.go
@@ -501,6 +501,181 @@ func TestDefaultComplexityMap(t *testing.T) {
 	assert.Len(t, m, 3)
 }
 
+func TestEscalateTier(t *testing.T) {
+	tests := []struct {
+		name    string
+		tier    string
+		retries int
+		want    string
+	}{
+		{"first attempt no escalation cheapest", TierCheapest, 0, TierCheapest},
+		{"first attempt no escalation balanced", TierBalanced, 0, TierBalanced},
+		{"first attempt no escalation strongest", TierStrongest, 0, TierStrongest},
+		{"one retry cheapest -> balanced", TierCheapest, 1, TierBalanced},
+		{"two retries cheapest -> strongest", TierCheapest, 2, TierStrongest},
+		{"three retries cheapest stays at strongest", TierCheapest, 3, TierStrongest},
+		{"one retry balanced -> strongest", TierBalanced, 1, TierStrongest},
+		{"two retries balanced stays at strongest", TierBalanced, 2, TierStrongest},
+		{"strongest never escalates", TierStrongest, 1, TierStrongest},
+		{"strongest with many retries stays strongest", TierStrongest, 10, TierStrongest},
+		{"literal model name not escalated", "claude-opus-4", 1, "claude-opus-4"},
+		{"literal model name many retries", "gpt-4o-mini", 5, "gpt-4o-mini"},
+		{"empty tier returned unchanged", "", 1, ""},
+		{"negative retries treated as zero", TierCheapest, -1, TierCheapest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EscalateTier(tt.tier, tt.retries)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveModelForAttempt_Escalates(t *testing.T) {
+	routing := &manifest.RoutingConfig{AutoRoute: true}
+
+	tests := []struct {
+		name        string
+		step        *Step
+		persona     *manifest.Persona
+		personaName string
+		attempt     int
+		want        string
+	}{
+		// Step model "cheapest": first attempt -> haiku, retry escalates.
+		{
+			name:        "step cheapest first attempt resolves to haiku",
+			step:        &Step{Model: TierCheapest},
+			persona:     &manifest.Persona{},
+			personaName: "any",
+			attempt:     1,
+			want:        "claude-haiku-4-5",
+		},
+		{
+			name:        "step cheapest retry 1 escalates to balanced (adapter default)",
+			step:        &Step{Model: TierCheapest},
+			persona:     &manifest.Persona{},
+			personaName: "any",
+			attempt:     2,
+			want:        "", // balanced resolves to "" (adapter default)
+		},
+		{
+			name:        "step cheapest retry 2 escalates to strongest",
+			step:        &Step{Model: TierCheapest},
+			persona:     &manifest.Persona{},
+			personaName: "any",
+			attempt:     3,
+			want:        "claude-opus-4",
+		},
+		{
+			name:        "step strongest retry stays strongest",
+			step:        &Step{Model: TierStrongest},
+			persona:     &manifest.Persona{},
+			personaName: "any",
+			attempt:     5,
+			want:        "claude-opus-4",
+		},
+		// Persona-pinned tier escalates the same way as step-pinned.
+		{
+			name:        "persona cheapest retry escalates to strongest",
+			step:        &Step{},
+			persona:     &manifest.Persona{Model: TierCheapest},
+			personaName: "any",
+			attempt:     3,
+			want:        "claude-opus-4",
+		},
+		// Auto-routed tier escalates.
+		{
+			name:        "auto-routed navigator (cheapest) retry escalates to strongest",
+			step:        &Step{},
+			persona:     &manifest.Persona{},
+			personaName: "navigator",
+			attempt:     3,
+			want:        "claude-opus-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &DefaultPipelineExecutor{}
+			got := executor.resolveModelForAttempt(tt.step, tt.persona, routing, tt.personaName, nil, tt.attempt)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveModelForAttempt_NoEscalateOptOut(t *testing.T) {
+	routing := &manifest.RoutingConfig{AutoRoute: true}
+	executor := &DefaultPipelineExecutor{}
+
+	// With NoEscalate=true, retries reuse the same tier.
+	step := &Step{
+		Model: TierCheapest,
+		Retry: RetryConfig{NoEscalate: true},
+	}
+	persona := &manifest.Persona{}
+
+	for _, attempt := range []int{1, 2, 3, 5} {
+		got := executor.resolveModelForAttempt(step, persona, routing, "any", nil, attempt)
+		assert.Equal(t, "claude-haiku-4-5", got, "attempt %d should not escalate when no_escalate=true", attempt)
+	}
+}
+
+func TestResolveModelForAttempt_LiteralModelNotEscalated(t *testing.T) {
+	routing := &manifest.RoutingConfig{AutoRoute: true}
+	executor := &DefaultPipelineExecutor{}
+
+	// Literal (non-tier) model name is preserved across retries.
+	step := &Step{Model: "claude-haiku-4-5"}
+	persona := &manifest.Persona{}
+
+	for _, attempt := range []int{1, 2, 3, 10} {
+		got := executor.resolveModelForAttempt(step, persona, routing, "any", nil, attempt)
+		assert.Equal(t, "claude-haiku-4-5", got, "attempt %d should preserve literal model", attempt)
+	}
+
+	// Same for persona-level literal.
+	step2 := &Step{}
+	persona2 := &manifest.Persona{Model: "gpt-4o-mini"}
+	for _, attempt := range []int{1, 2, 3} {
+		got := executor.resolveModelForAttempt(step2, persona2, routing, "any", nil, attempt)
+		assert.Equal(t, "gpt-4o-mini", got, "attempt %d should preserve persona literal", attempt)
+	}
+}
+
+func TestResolveModelForAttempt_BackwardCompatible(t *testing.T) {
+	// resolveModel (the old API) should behave identically to
+	// resolveModelForAttempt(attempt=1) — i.e. first attempt, no escalation.
+	routing := &manifest.RoutingConfig{AutoRoute: true}
+	executor := &DefaultPipelineExecutor{}
+
+	step := &Step{Model: TierCheapest}
+	persona := &manifest.Persona{}
+
+	got1 := executor.resolveModel(step, persona, routing, "any", nil)
+	got2 := executor.resolveModelForAttempt(step, persona, routing, "any", nil, 1)
+	assert.Equal(t, got1, got2)
+	assert.Equal(t, "claude-haiku-4-5", got1)
+}
+
+func TestResolveModelForAttempt_CLIOverrideTierEscalates(t *testing.T) {
+	routing := &manifest.RoutingConfig{AutoRoute: true}
+	executor := &DefaultPipelineExecutor{modelOverride: TierCheapest}
+
+	step := &Step{}
+	persona := &manifest.Persona{}
+
+	// CLI override "cheapest" escalates on retry.
+	got := executor.resolveModelForAttempt(step, persona, routing, "any", nil, 3)
+	assert.Equal(t, "claude-opus-4", got)
+
+	// CLI override that is a literal model is preserved.
+	executor2 := &DefaultPipelineExecutor{modelOverride: "claude-haiku-4-5"}
+	got2 := executor2.resolveModelForAttempt(step, persona, routing, "any", nil, 3)
+	assert.Equal(t, "claude-haiku-4-5", got2)
+}
+
 func TestAdjustTierForTaskComplexity(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -176,6 +176,12 @@ type RetryConfig struct {
 	AdaptPrompt bool   `yaml:"adapt_prompt,omitempty"` // Deprecated: failure context is now always injected on retry. Kept for YAML compat.
 	OnFailure   string `yaml:"on_failure,omitempty"`   // "fail", "skip", "continue", "rework". Default: "fail"
 	ReworkStep  string `yaml:"rework_step,omitempty"`  // Step ID to execute when on_failure is "rework"
+	// NoEscalate disables automatic model tier escalation on retry. By default
+	// (NoEscalate=false) a retried step resolves one tier stronger than the
+	// original attempt: cheapest -> balanced -> strongest. Literal model
+	// names (e.g. "claude-opus-4") never escalate regardless of this flag —
+	// they are user-pinned overrides and are preserved verbatim.
+	NoEscalate bool `yaml:"no_escalate,omitempty"`
 }
 
 // Validate checks that the RetryConfig is well-formed.


### PR DESCRIPTION
## Summary

When a step is retried (attempt > 1), the executor now auto-escalates the model one tier stronger than the originally configured tier: `cheapest -> balanced -> strongest`. Literal model names are treated as user-pinned overrides and preserved verbatim. Default behaviour is **escalation-on**, since that's the higher-quality recovery posture for transient capability failures.

## Why

Most retry-triggering failures (contract validation, schema mismatch, judge rejection) come from the model being under-powered for the task — not from transient infra flakes. Retrying with the same model burns tokens producing the same wrong answer. Escalating gives the retry a real shot.

## Behaviour

- `model: cheapest` -> first retry uses `balanced`, subsequent retries use `strongest`
- `model: balanced` -> retry uses `strongest`
- `model: strongest` -> retry stays `strongest`
- `model: claude-opus-4-7` (literal) -> retry stays `claude-opus-4-7`
- New per-step opt-out: `retry.no_escalate: true`

## Test plan

- [x] `go test ./internal/pipeline/...` — covers escalate ladder, no-escalate flag, literal-name preservation
- [x] `go vet ./...`
- [ ] Soak: real pipeline retry with cheapest seed observed escalating to balanced (verify in next pipeline run)