### PR TITLE
fix(pipeline): align ops-issue-quality enhance output to .agents/output/ convention

### DIFF
--- a/.agents/pipelines/ops-issue-quality.yaml
+++ b/.agents/pipelines/ops-issue-quality.yaml
@@ -330,7 +330,7 @@ steps:
         quick snapshot of issue health across the repository.
     output_artifacts:
       - name: enhancement-summary
-        path: .agents/artifacts/enhancement-summary.md
+        path: .agents/output/enhancement-summary.md
         type: markdown
         required: true
     retry:
@@ -339,4 +339,4 @@ steps:
     handover:
       contract:
         type: non_empty_file
-        source: .agents/artifacts/enhancement-summary.md
+        source: .agents/output/enhancement-summary.md


### PR DESCRIPTION
## Summary

Follow-up to #1543. Same path-convention bug on the second step of `ops-issue-quality.yaml`. The `enhance` step's `enhancement-summary` output_artifact and its handover contract still pointed at `.agents/artifacts/`, which is the framework-reserved path for *injected* upstream files. Producers must write under `.agents/output/`.

## Test plan

- [x] `./wave list pipelines` parses cleanly
- [x] Path now matches the scan-step fix in #1543