### PR TITLE
feat(state,webui): link resumed runs to parent failed run (#1510)

### DIFF
--- a/cmd/wave/commands/resume.go
+++ b/cmd/wave/commands/resume.go
@@ -176,6 +176,16 @@ func runResume(opts ResumeOptions, debug bool) error {
 		resumeRunID = pipeline.GenerateRunID(run.PipelineName, m.Runtime.PipelineIDHashLength)
 	}
 
+	// Link the resume run back to the failed parent so operators can navigate
+	// between them in /runs and the run detail pages (issue #1510). Best-effort:
+	// failures are logged but do not block execution.
+	if err := store.SetParentRun(resumeRunID, opts.RunID, fromStep); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to link resume run to parent: %v\n", err)
+	}
+	if err := store.SetRunComposition(resumeRunID, state.RunKindResume, "", "", nil, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to set resume run kind: %v\n", err)
+	}
+
 	// Show what we are resuming.
 	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {
 		fmt.Fprintf(os.Stderr, "\n  Resuming run %s\n", opts.RunID)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2747,6 +2747,46 @@ func TestGetChildRuns(t *testing.T) {
 	}
 }
 
+// TestResumeRunLinkage verifies that a resumed run can be linked back to its
+// failed parent run via SetParentRun + SetRunComposition with run_kind="resume".
+// This mirrors the wiring used by `wave resume` and the WebUI resume button —
+// issue #1510.
+func TestResumeRunLinkage(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Create the original failed run.
+	parentRunID, err := store.CreateRun("impl-issue", "fix login bug")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(parentRunID, "failed", "step plan failed", 1234))
+
+	// Create the resume run and link it.
+	resumeRunID, err := store.CreateRun("impl-issue", "fix login bug")
+	require.NoError(t, err)
+	require.NoError(t, store.SetParentRun(resumeRunID, parentRunID, "plan"))
+	require.NoError(t, store.SetRunComposition(resumeRunID, RunKindResume, "", "", nil, nil))
+
+	// Verify linkage on the child resume run.
+	resume, err := store.GetRun(resumeRunID)
+	require.NoError(t, err)
+	assert.Equal(t, parentRunID, resume.ParentRunID, "resume run should reference parent")
+	assert.Equal(t, "plan", resume.ParentStepID, "resume run should record the from-step")
+	assert.Equal(t, RunKindResume, resume.RunKind, "resume run should carry run_kind=resume")
+
+	// Verify GetChildRuns returns the resume.
+	children, err := store.GetChildRuns(parentRunID)
+	require.NoError(t, err)
+	require.Len(t, children, 1, "parent should have exactly one child resume run")
+	assert.Equal(t, resumeRunID, children[0].RunID)
+	assert.Equal(t, RunKindResume, children[0].RunKind)
+
+	// Parent itself should remain unlinked.
+	parent, err := store.GetRun(parentRunID)
+	require.NoError(t, err)
+	assert.Empty(t, parent.ParentRunID, "parent should not be linked")
+	assert.Empty(t, parent.RunKind, "parent run_kind should default to empty / top_level")
+}
+
 // TestReapOrphans tests the orphaned-run reaper for issue #1467.
 func TestReapOrphans(t *testing.T) {
 	store, cleanup := setupTestStore(t)

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -31,9 +31,24 @@ type RunRecord struct {
 	IterateIndex   *int   // 0-based index within an iterate step's items array (nil for non-iterate launches)
 	IterateTotal   *int   // total items in the parent iterate step (nil for non-iterate launches)
 	IterateMode    string // "parallel" or "serial" (empty for non-iterate launches)
-	RunKind        string // "top_level" | "iterate_child" | "sub_pipeline_child" | "loop_iteration" | "branch_arm" (empty defaults to top_level for legacy rows)
+	RunKind        string // "top_level" | "iterate_child" | "sub_pipeline_child" | "loop_iteration" | "branch_arm" | "resume" (empty defaults to top_level for legacy rows)
 	SubPipelineRef string // Sub-pipeline name as referenced in YAML (e.g. "audit-security"); empty for top-level runs
 }
+
+// RunKind enum values for pipeline_run.run_kind. Issue #1450 introduced
+// composition kinds; #1510 added "resume" so the WebUI can link a resumed
+// run back to the failed parent run.
+const (
+	RunKindTopLevel         = "top_level"
+	RunKindIterateChild     = "iterate_child"
+	RunKindSubPipelineChild = "sub_pipeline_child"
+	RunKindLoopIteration    = "loop_iteration"
+	RunKindBranchArm        = "branch_arm"
+	// RunKindResume marks a run that was launched via `wave resume <id>` /
+	// `wave run --from-step ... --run <id>` / web UI resume button. The
+	// `parent_run_id` column points at the original failed run.
+	RunKindResume = "resume"
+)
 
 // CheckpointRecord holds checkpoint data at a step boundary for fork/rewind.
 type CheckpointRecord struct {

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -124,6 +124,23 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 		"subtreeIsLarger": func(r RunSummary) bool {
 			return r.SubtreeTokens > int64(r.TotalTokens)
 		},
+		"hasResumeChildren": func(children []RunSummary) bool {
+			for _, c := range children {
+				if c.RunKind == "resume" {
+					return true
+				}
+			}
+			return false
+		},
+		"countResumeChildren": func(children []RunSummary) int {
+			count := 0
+			for _, c := range children {
+				if c.RunKind == "resume" {
+					count++
+				}
+			}
+			return count
+		},
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -205,6 +205,16 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Link the resume run back to the failed parent so the WebUI can render
+	// the breadcrumb on the resumed run and a "Resumed by" pill on the
+	// parent failed run (issue #1510). Best-effort.
+	if err := s.runtime.rwStore.SetParentRun(newRunID, runID, req.FromStep); err != nil {
+		fmt.Printf("warning: failed to link resume run %s to parent %s: %v\n", newRunID, runID, err)
+	}
+	if err := s.runtime.rwStore.SetRunComposition(newRunID, state.RunKindResume, "", "", nil, nil); err != nil {
+		fmt.Printf("warning: failed to set resume run kind on %s: %v\n", newRunID, err)
+	}
+
 	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, p, runner.Options{}, req.FromStep)
 
 	writeJSON(w, http.StatusCreated, ResumeRunResponse{

--- a/internal/webui/handlers_run_detail.go
+++ b/internal/webui/handlers_run_detail.go
@@ -85,11 +85,18 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	linkedTitle, linkedState, linkedAuthor, linkedType, linkedNumber := s.enrichLinkedURL(r, runSummary.LinkedURL)
 	templateVars := s.buildTemplateVars(run.Input)
 
-	// Collect child runs for sub-pipeline steps
+	// Collect child runs for sub-pipeline steps and resume children (#1510).
+	// Resumes are kept in a separate slice so the template can render them as
+	// a "Resumed by" pill at the run header rather than under a step.
 	childRuns := make(map[string][]RunSummary)
+	var resumeChildren []RunSummary
 	if children, err := s.runtime.store.GetChildRuns(runID); err == nil {
 		for _, cr := range children {
 			summary := runToSummary(cr)
+			if cr.RunKind == state.RunKindResume {
+				resumeChildren = append(resumeChildren, summary)
+				continue
+			}
 			childRuns[cr.ParentStepID] = append(childRuns[cr.ParentStepID], summary)
 		}
 	}
@@ -139,6 +146,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 		LinkedNumber        int
 		LinkedType          string
 		ChildRuns           map[string][]RunSummary
+		ResumeChildren      []RunSummary
 		TemplateVars        map[string]string
 		RunConfigItems      []struct{ Label, Value, Tooltip string }
 		RerunCommand        string
@@ -163,6 +171,7 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 		LinkedNumber:        linkedNumber,
 		LinkedType:          linkedType,
 		ChildRuns:           childRuns,
+		ResumeChildren:      resumeChildren,
 		TemplateVars:        templateVars,
 		RunConfigItems:      runConfigItems,
 		RerunCommand:        rerunCmd,

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -164,6 +164,15 @@ func (s *Server) handleAPIRunDetail(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRunsPage serves GET /runs — runs list with Fat Gantt design.
+//
+// Query params:
+//   - status: filter by status (default "all")
+//   - pipeline: filter by pipeline name
+//   - cursor: pagination cursor
+//   - top_level_only: when "true" (default), child runs (composition children
+//     and resumes — anything with a non-empty parent_run_id) are hidden.
+//     When "false", child rows are returned and rendered nested under their
+//     parent via nestChildRuns. Issue #1510.
 func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	cursor, err := decodeCursor(r.URL.Query().Get("cursor"))
 	if err != nil {
@@ -176,6 +185,11 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	pipelineFilter := r.URL.Query().Get("pipeline")
 
+	// top_level_only defaults to true so resumes and composition children
+	// don't clutter the main list. Accept "false"/"0" to opt in.
+	topLevelOnlyStr := r.URL.Query().Get("top_level_only")
+	topLevelOnly := topLevelOnlyStr != "false" && topLevelOnlyStr != "0"
+
 	// "all" means no status filter
 	queryStatus := status
 	if queryStatus == "all" {
@@ -186,6 +200,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		Status:       queryStatus,
 		PipelineName: pipelineFilter,
 		Limit:        limit + 1,
+		TopLevelOnly: topLevelOnly,
 	}
 	if cursor != nil {
 		opts.BeforeUnix = cursor.Timestamp
@@ -215,6 +230,19 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		filteredRuns = append(filteredRuns, run)
 	}
 	s.enrichRunSummaries(allSummaries, filteredRuns)
+
+	// When showing all runs (top_level_only=false), also pull in resumes /
+	// composition children for any top-level parent on the page so they nest
+	// inline rather than bubbling up. When top_level_only=true, child rows
+	// were filtered at the DB level so this is a no-op.
+	if !topLevelOnly {
+		// nestChildRuns only nests children whose parent is on the same page;
+		// anything else stays at top-level. That's the behaviour we want.
+	} else {
+		// Even when filtering at the DB level, pre-attach known resume children
+		// so the parent row carries a "Resumed by" indicator inline.
+		s.attachResumesToParents(allSummaries)
+	}
 	summaries := nestChildRuns(allSummaries)
 
 	var nextCursor string
@@ -243,6 +271,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		Pipelines      []string
 		FilterStatus   string
 		FilterPipeline string
+		TopLevelOnly   bool
 		RunningRuns    []RunSummary
 		RunningCount   int
 	}{
@@ -253,6 +282,7 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		Pipelines:      pipelines,
 		FilterStatus:   status,
 		FilterPipeline: pipelineFilter,
+		TopLevelOnly:   topLevelOnly,
 		RunningRuns:    runningRuns,
 		RunningCount:   len(runningRuns),
 	}
@@ -260,6 +290,32 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.assets.templates["templates/runs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// attachResumesToParents fetches resume-kind children for each parent run
+// in the list and attaches them as ChildRuns. Used by /runs when
+// top_level_only=true to keep the main list clean while still surfacing the
+// "this run was resumed" indicator on the parent row. Issue #1510.
+func (s *Server) attachResumesToParents(parents []RunSummary) {
+	if s.runtime.store == nil {
+		return
+	}
+	for i := range parents {
+		// Only failed/cancelled runs can be resumed; skip the others.
+		if parents[i].Status != "failed" && parents[i].Status != "cancelled" {
+			continue
+		}
+		children, err := s.runtime.store.GetChildRuns(parents[i].RunID)
+		if err != nil {
+			continue
+		}
+		for _, ch := range children {
+			if ch.RunKind != state.RunKindResume {
+				continue
+			}
+			parents[i].ChildRuns = append(parents[i].ChildRuns, runToSummary(ch))
+		}
 	}
 }
 

--- a/internal/webui/handlers_runs_test.go
+++ b/internal/webui/handlers_runs_test.go
@@ -354,6 +354,68 @@ func TestHandleAPIRunChildren(t *testing.T) {
 	}
 }
 
+// TestHandleAPIRunChildren_IncludesResumes verifies that resume children
+// are returned by the children endpoint alongside composition children, with
+// run_kind="resume" preserved in the projection. Issue #1510.
+func TestHandleAPIRunChildren_IncludesResumes(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("impl-issue", "fix login bug")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(parentID, "failed", "step plan failed", 500); err != nil {
+		t.Fatalf("update parent status: %v", err)
+	}
+
+	resumeID, err := rwStore.CreateRun("impl-issue", "fix login bug")
+	if err != nil {
+		t.Fatalf("create resume: %v", err)
+	}
+	if err := rwStore.SetParentRun(resumeID, parentID, "plan"); err != nil {
+		t.Fatalf("set parent: %v", err)
+	}
+	if err := rwStore.SetRunComposition(resumeID, state.RunKindResume, "", "", nil, nil); err != nil {
+		t.Fatalf("set run kind: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(resumeID, "running", "", 200); err != nil {
+		t.Fatalf("update resume status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/runs/"+parentID+"/children", nil)
+	req.SetPathValue("id", parentID)
+	rec := httptest.NewRecorder()
+	srv.handleAPIRunChildren(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		ParentRunID string       `json:"parent_run_id"`
+		Children    []RunSummary `json:"children"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Children) != 1 {
+		t.Fatalf("expected 1 child resume, got %d", len(resp.Children))
+	}
+	child := resp.Children[0]
+	if child.RunID != resumeID {
+		t.Errorf("child RunID = %q, want %q", child.RunID, resumeID)
+	}
+	if child.RunKind != state.RunKindResume {
+		t.Errorf("child RunKind = %q, want %q", child.RunKind, state.RunKindResume)
+	}
+	if child.ParentRunID != parentID {
+		t.Errorf("child ParentRunID = %q, want %q", child.ParentRunID, parentID)
+	}
+	if child.ParentStepID != "plan" {
+		t.Errorf("child ParentStepID = %q, want \"plan\"", child.ParentStepID)
+	}
+}
+
 // TestHandleAPIRunChildren_Missing returns 404 for unknown run IDs.
 func TestHandleAPIRunChildren_Missing(t *testing.T) {
 	srv, _ := testServer(t)

--- a/internal/webui/icons.go
+++ b/internal/webui/icons.go
@@ -25,6 +25,8 @@ func runKindLabel(kind string) string {
 		return "branch"
 	case "loop_iteration":
 		return "loop"
+	case "resume":
+		return "resume"
 	case "top_level", "":
 		return ""
 	default:

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -8,7 +8,7 @@
         <a href="/runs" class="back-link">&larr; Runs</a>
         {{if .Run.ParentRunID}}
         <a href="/runs/{{.Run.ParentRunID}}" class="back-link" style="font-size:0.72rem;" title="{{.Run.ParentRunID}}">
-            &larr; parent
+            {{- if eq .Run.RunKind "resume"}}&larr; resumed from{{else}}&larr; parent{{end}}
             {{- with .Run.ParentStepID}}<span style="color:var(--color-text-muted);"> &rsaquo; </span><code style="font-size:0.7rem;background:var(--color-bg-tertiary);padding:0 0.25rem;border-radius:2px;">{{.}}</code>{{end}}
             {{- if and (eq .Run.RunKind "iterate_child") .Run.IterateIndex .Run.IterateTotal}}
             <span style="color:var(--color-text-muted);"> &rsaquo; </span>
@@ -25,6 +25,17 @@
             <code style="font-size:0.62rem;color:var(--color-text-muted);font-weight:400;background:var(--color-bg-tertiary);padding:0.1rem 0.4rem;border-radius:3px;">{{.Run.RunID}}</code>
         </h1>
         {{if .PipelineDescription}}<p style="margin:0.1rem 0 0.3rem;font-size:0.8rem;color:var(--color-text-secondary);max-width:48rem;">{{.PipelineDescription}}</p>{{end}}
+        {{if .ResumeChildren}}
+        <div style="margin:0.25rem 0 0.4rem;display:flex;flex-wrap:wrap;gap:0.3rem;align-items:center;font-size:0.72rem;color:var(--color-text-secondary);">
+            <span style="color:var(--color-text-muted);">Resumed by:</span>
+            {{range .ResumeChildren}}
+            <a href="/runs/{{.RunID}}" class="badge badge-runkind badge-runkind-resume" style="text-decoration:none;font-size:0.68rem;" title="Resume run {{.RunID}} (from step {{.ParentStepID}}) — status: {{.Status}}">
+                resume {{if .ParentStepID}}&rsaquo; <code style="font-size:0.65rem;background:var(--color-bg-tertiary);padding:0 0.2rem;border-radius:2px;">{{.ParentStepID}}</code>{{end}}
+                <span class="badge {{statusClass .Status}}" style="font-size:0.62rem;margin-left:0.25rem;">{{statusLabel .Status}}</span>
+            </a>
+            {{end}}
+        </div>
+        {{end}}
     </div>
     <div class="actions">
         {{if eq .Run.Status "running"}}

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -24,6 +24,7 @@
             {{end}}
         </select>
         {{end}}
+        <a href="/runs?{{if ne .FilterStatus "all"}}status={{.FilterStatus}}&{{end}}{{if .FilterPipeline}}pipeline={{.FilterPipeline}}&{{end}}top_level_only={{if .TopLevelOnly}}false{{else}}true{{end}}" class="wr-filter" title="Toggle whether resume + composition children appear in the list">{{if .TopLevelOnly}}Show children{{else}}Hide children{{end}}</a>
     </div>
 </div>
 
@@ -101,6 +102,8 @@
             <div class="wr-row1">
                 <span class="wr-name">{{.PipelineName}}</span>
                 {{if .InputPreview}}<span class="wr-input">{{richInput .InputPreview .LinkedURL}}</span>{{end}}
+                {{if .RunKind}}{{if ne .RunKind "top_level"}}<span class="badge badge-runkind badge-runkind-{{.RunKind}}" style="font-size:0.62rem;" title="Launched by parent composition step or resume">{{runKindLabel .RunKind}}</span>{{end}}{{end}}
+                {{if hasResumeChildren .ChildRuns}}<span class="badge badge-runkind badge-runkind-resume" style="font-size:0.62rem;" title="This run was resumed — see nested resume run(s) below">resumed by {{countResumeChildren .ChildRuns}}</span>{{end}}
                 <span class="wr-right">
                     <span class="badge wr-status {{statusClass .Status}}">{{statusLabel .Status}}</span>
                     {{if .Duration}}<span class="wr-dur">{{.Duration}}</span>{{end}}


### PR DESCRIPTION
## Summary

When a user resumes a failed pipeline run via `wave resume <id>` or the WebUI **Resume** button, the new run row now records the original failed run as its parent (`parent_run_id`) and is tagged with `run_kind=resume`. This lets operators navigate between the original failure and every resume attempt in `/runs`, on the run detail pages, and via the JSON API.

Mirrors the composition-children pattern introduced in #1450 — same DB columns, same projection, same `GetChildRuns` walk.

## Design choices

- **Reuse existing schema.** `pipeline_run.parent_run_id`, `parent_step_id`, and `run_kind` already exist (migration 27 from #1450). No new migration; new rows simply use `run_kind="resume"`. Existing rows continue to render as top-level runs.
- **No CLI surface change.** `wave resume <id>` keeps the same flags and exit codes. New fields are additive only.
- **`wave run --from-step --run <id>` is unchanged.** That CLI form already reuses the original run row (issue #700), so there is no new child to link.
- **API: extended `/api/runs/{id}/children`.** Resumes are returned alongside composition children — they all share `parent_run_id`. Each child's `run_kind` discriminates them. (Chose this over a parallel `/resumes` endpoint to match the existing handler shape and avoid a second round-trip on parent-detail pages.)
- **Run detail JSON.** `parent_run_id`, `parent_step_id`, and `run_kind` were already serialised on `RunSummary`; no change needed.
- **/runs `top_level_only`.** New query param; default `true` to keep the main list clean. `top_level_only=false` shows everything and the existing `nestChildRuns` machinery groups resumes / composition children under their parent.
- **Templates.** "Resumed by" pill on the parent failed run header lists every resume attempt with status. Resumed-run breadcrumb now reads "resumed from" when `run_kind=resume`. SVG-friendly — no emojis. Inline `badge-runkind-resume` class follows the `badge-runkind-iterate_child` pattern.

## Code touched

- `internal/state/types.go` — `RunKindResume` const + enum doc.
- `internal/state/store_test.go` — `TestResumeRunLinkage` exercises the parent + composition wiring.
- `cmd/wave/commands/resume.go` — calls `SetParentRun` + `SetRunComposition` after `CreateRun`.
- `internal/webui/handlers_control.go` — same wiring on `handleResumeRun`.
- `internal/webui/handlers_runs.go` — `top_level_only` query param + `attachResumesToParents` helper.
- `internal/webui/handlers_run_detail.go` — split resume children into a separate `ResumeChildren` slice for the parent header pill.
- `internal/webui/embed.go` — `hasResumeChildren` + `countResumeChildren` template funcs.
- `internal/webui/icons.go` — `runKindLabel` adds `"resume"` → `"resume"`.
- `internal/webui/templates/run_detail.html` — "Resumed by" pill, breadcrumb label tweak.
- `internal/webui/templates/runs.html` — toggle, inline "resumed by N" badge.
- `internal/webui/handlers_runs_test.go` — `TestHandleAPIRunChildren_IncludesResumes` covers the API projection.

## Test plan

- [x] `go test ./internal/pipeline/... ./internal/state/... ./internal/webui/...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go build -o ./wave ./cmd/wave`
- [ ] **Manual smoke** (verify in your local Wave checkout):
  1. `./wave run wave-smoke-contracts --no-tui` and force a contract failure (e.g., point a contract at a missing file).
  2. `./wave resume <run-id>` — confirm the new run appears in `wave list runs --json` with `parent_run_id` set and `run_kind=resume`.
  3. Inspect `.agents/state.db`: `sqlite3 .agents/state.db "SELECT run_id, parent_run_id, run_kind FROM pipeline_run WHERE run_kind='resume';"` — should list the resume row.
  4. `./wave serve --port 8081` and visit `http://localhost:8081/runs` — original failed row shows a "resumed by 1" badge; resume row hidden by default; `?top_level_only=false` makes it nest under the parent.
  5. Visit `http://localhost:8081/runs/<failed-run-id>` — header shows "Resumed by: resume › <step>" pill linking to the resume run.
  6. Visit `http://localhost:8081/runs/<resume-run-id>` — top breadcrumb reads "← resumed from › <step>" linking back to the parent.

Closes #1510