### PR TITLE
refactor(config): migrate remaining os.Getenv sites to internal/config

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -16,7 +16,12 @@
 // must be added here intentionally rather than scattered across packages.
 package config
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
 
 // Env is a snapshot of relevant process environment variables, captured by
 // FromEnv. Consumers receive Env by value or read individual fields via the
@@ -91,6 +96,14 @@ func Lookup(key string) string {
 	return os.Getenv(key)
 }
 
+// EnvPresent reports whether the named environment variable is set to a
+// non-empty value. Use for presence-only probes (e.g. token introspection
+// preconditions, admin credential surface detection) where the value itself
+// is not consumed at the call site.
+func EnvPresent(key string) bool {
+	return os.Getenv(key) != ""
+}
+
 // HomeOr returns the HOME value or the supplied fallback if HOME is unset.
 // Convenience for subprocess env construction.
 func (e Env) HomeOr(fallback string) string {
@@ -107,4 +120,73 @@ func (e Env) TermOr(fallback string) string {
 		return e.Term
 	}
 	return fallback
+}
+
+// SubprocessHomePath returns the HOME and PATH values intended to be forwarded
+// into curated subprocess environments. The values are returned as-is from the
+// inherited process environment — callers that need a fallback (for example,
+// when HOME is unset) should apply it explicitly. Centralising the read here
+// keeps the inherited-env contract auditable from a single place.
+func SubprocessHomePath() (home, path string) {
+	env := FromEnv()
+	return env.Home, env.Path
+}
+
+// MigrationEnv groups the four WAVE_MIGRATION_* environment variables that
+// configure the schema migration subsystem. A nil pointer field means the
+// corresponding env var was unset and the consumer should keep its default.
+//
+// The boolean fields accept "true", "1", or "yes" (case-insensitive) as truthy
+// values; any other non-empty value is interpreted as false. The explicit
+// pointer-vs-zero-value distinction lets callers tell "unset" apart from
+// "explicitly set to false".
+type MigrationEnv struct {
+	Enabled              *bool
+	AutoMigrate          *bool
+	SkipValidation       *bool
+	MaxVersion           *int
+	MaxVersionParseError error // non-nil when WAVE_MAX_MIGRATION_VERSION was set but failed to parse
+	MaxVersionRawValue   string
+}
+
+// LoadMigrationEnv reads the four WAVE_MIGRATION_* environment variables and
+// returns a MigrationEnv with each field populated only when its underlying
+// env var was set to a non-empty value. The version int parser surfaces an
+// explicit error rather than silently dropping malformed values.
+func LoadMigrationEnv() MigrationEnv {
+	out := MigrationEnv{}
+	if v := os.Getenv("WAVE_MIGRATION_ENABLED"); v != "" {
+		b := parseBoolish(v)
+		out.Enabled = &b
+	}
+	if v := os.Getenv("WAVE_AUTO_MIGRATE"); v != "" {
+		b := parseBoolish(v)
+		out.AutoMigrate = &b
+	}
+	if v := os.Getenv("WAVE_SKIP_MIGRATION_VALIDATION"); v != "" {
+		b := parseBoolish(v)
+		out.SkipValidation = &b
+	}
+	if v := os.Getenv("WAVE_MAX_MIGRATION_VERSION"); v != "" {
+		out.MaxVersionRawValue = v
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			out.MaxVersionParseError = fmt.Errorf("WAVE_MAX_MIGRATION_VERSION=%q: %w", v, err)
+		} else {
+			out.MaxVersion = &n
+		}
+	}
+	return out
+}
+
+// parseBoolish returns true when v (case-insensitive, trimmed) matches one of
+// the accepted truthy spellings: "true", "1", "yes". Any other non-empty value
+// returns false. Empty strings should be filtered out by the caller.
+func parseBoolish(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 )
 
@@ -69,5 +70,110 @@ func TestLookup(t *testing.T) {
 	}
 	if got := Lookup("WAVE_TEST_DOES_NOT_EXIST_XYZ"); got != "" {
 		t.Errorf("Lookup of unset = %q, want empty", got)
+	}
+}
+
+func TestEnvPresent(t *testing.T) {
+	const key = "WAVE_TEST_PRESENT_VAR"
+	_ = os.Unsetenv(key)
+	if EnvPresent(key) {
+		t.Fatalf("EnvPresent(%s) = true, want false (unset)", key)
+	}
+
+	t.Setenv(key, "")
+	if EnvPresent(key) {
+		t.Errorf("EnvPresent(%s) with empty value = true, want false", key)
+	}
+
+	t.Setenv(key, "anything")
+	if !EnvPresent(key) {
+		t.Errorf("EnvPresent(%s) with value = false, want true", key)
+	}
+}
+
+func TestSubprocessHomePath(t *testing.T) {
+	t.Setenv("HOME", "/home/runner")
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin")
+
+	home, path := SubprocessHomePath()
+	if home != "/home/runner" {
+		t.Errorf("home = %q, want /home/runner", home)
+	}
+	if path != "/usr/local/bin:/usr/bin" {
+		t.Errorf("path = %q, want /usr/local/bin:/usr/bin", path)
+	}
+}
+
+func TestParseBoolish(t *testing.T) {
+	truthy := []string{"true", "TRUE", "True", "1", "yes", "YES", "Yes", "  true  ", "  1\t"}
+	for _, v := range truthy {
+		if !parseBoolish(v) {
+			t.Errorf("parseBoolish(%q) = false, want true", v)
+		}
+	}
+
+	falsy := []string{"false", "FALSE", "0", "no", "off", "anything", "  false  ", "2"}
+	for _, v := range falsy {
+		if parseBoolish(v) {
+			t.Errorf("parseBoolish(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestLoadMigrationEnv_AllUnset(t *testing.T) {
+	for _, k := range []string{
+		"WAVE_MIGRATION_ENABLED",
+		"WAVE_AUTO_MIGRATE",
+		"WAVE_SKIP_MIGRATION_VALIDATION",
+		"WAVE_MAX_MIGRATION_VERSION",
+	} {
+		_ = os.Unsetenv(k)
+	}
+
+	got := LoadMigrationEnv()
+	if got.Enabled != nil || got.AutoMigrate != nil || got.SkipValidation != nil || got.MaxVersion != nil {
+		t.Errorf("LoadMigrationEnv() with all unset returned non-nil pointers: %+v", got)
+	}
+	if got.MaxVersionParseError != nil {
+		t.Errorf("MaxVersionParseError = %v, want nil", got.MaxVersionParseError)
+	}
+}
+
+func TestLoadMigrationEnv_AllSet(t *testing.T) {
+	t.Setenv("WAVE_MIGRATION_ENABLED", "false")
+	t.Setenv("WAVE_AUTO_MIGRATE", "yes")
+	t.Setenv("WAVE_SKIP_MIGRATION_VALIDATION", "1")
+	t.Setenv("WAVE_MAX_MIGRATION_VERSION", "7")
+
+	got := LoadMigrationEnv()
+	if got.Enabled == nil || *got.Enabled != false {
+		t.Errorf("Enabled = %v, want false", got.Enabled)
+	}
+	if got.AutoMigrate == nil || *got.AutoMigrate != true {
+		t.Errorf("AutoMigrate = %v, want true", got.AutoMigrate)
+	}
+	if got.SkipValidation == nil || *got.SkipValidation != true {
+		t.Errorf("SkipValidation = %v, want true", got.SkipValidation)
+	}
+	if got.MaxVersion == nil || *got.MaxVersion != 7 {
+		t.Errorf("MaxVersion = %v, want 7", got.MaxVersion)
+	}
+	if got.MaxVersionParseError != nil {
+		t.Errorf("MaxVersionParseError = %v, want nil", got.MaxVersionParseError)
+	}
+}
+
+func TestLoadMigrationEnv_VersionParseError(t *testing.T) {
+	t.Setenv("WAVE_MAX_MIGRATION_VERSION", "not-a-number")
+
+	got := LoadMigrationEnv()
+	if got.MaxVersion != nil {
+		t.Errorf("MaxVersion = %v, want nil on parse failure", got.MaxVersion)
+	}
+	if got.MaxVersionParseError == nil {
+		t.Fatal("MaxVersionParseError = nil, want non-nil")
+	}
+	if got.MaxVersionRawValue != "not-a-number" {
+		t.Errorf("MaxVersionRawValue = %q, want not-a-number", got.MaxVersionRawValue)
 	}
 }

--- a/internal/runner/detach.go
+++ b/internal/runner/detach.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/state"
 )
 
@@ -123,8 +124,10 @@ func BuildDetachedArgs(opts Options, runID string) []string {
 // pass through — used by the webui server (it forwards GH_TOKEN/GITHUB_TOKEN
 // in addition to the base set).
 func BuildDetachEnv(extraVars ...string) []string {
-	path := os.Getenv("PATH")
-	home := os.Getenv("HOME")
+	// Read inherited PATH/HOME via internal/config so the detach contract is
+	// centralised with the other env-reader sites. Semantics are identical to
+	// a direct os.Getenv: empty string when the variable is unset.
+	home, path := config.SubprocessHomePath()
 	if home != "" {
 		toolBin := filepath.Join(home, ".local", "bin")
 		if !strings.Contains(path, toolBin) {

--- a/internal/scope/introspect.go
+++ b/internal/scope/introspect.go
@@ -3,10 +3,10 @@ package scope
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/forge"
 )
 
@@ -65,7 +65,7 @@ func (g *GitHubIntrospector) Introspect(envVar string) (*TokenInfo, error) {
 	info := &TokenInfo{EnvVar: envVar, TokenType: "unknown"}
 
 	// Check that the env var is set
-	if os.Getenv(envVar) == "" {
+	if !config.EnvPresent(envVar) {
 		info.Error = fmt.Errorf("environment variable %s is not set", envVar)
 		return info, nil
 	}
@@ -109,7 +109,7 @@ func (g *GitHubIntrospector) Introspect(envVar string) (*TokenInfo, error) {
 func (g *GitLabIntrospector) Introspect(envVar string) (*TokenInfo, error) {
 	info := &TokenInfo{EnvVar: envVar, TokenType: "unknown"}
 
-	if os.Getenv(envVar) == "" {
+	if !config.EnvPresent(envVar) {
 		info.Error = fmt.Errorf("environment variable %s is not set", envVar)
 		return info, nil
 	}
@@ -137,7 +137,7 @@ func (g *GitLabIntrospector) Introspect(envVar string) (*TokenInfo, error) {
 func (g *GiteaIntrospector) Introspect(envVar string) (*TokenInfo, error) {
 	info := &TokenInfo{EnvVar: envVar, TokenType: "unknown"}
 
-	if os.Getenv(envVar) == "" {
+	if !config.EnvPresent(envVar) {
 		info.Error = fmt.Errorf("environment variable %s is not set", envVar)
 		return info, nil
 	}

--- a/internal/state/migration_config.go
+++ b/internal/state/migration_config.go
@@ -2,9 +2,8 @@ package state
 
 import (
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
+
+	"github.com/recinq/wave/internal/config"
 )
 
 // MigrationConfig controls migration behavior
@@ -22,38 +21,38 @@ type MigrationConfig struct {
 	MaxMigrationVersion int
 }
 
-// LoadMigrationConfigFromEnv loads migration configuration from environment variables
+// LoadMigrationConfigFromEnv loads migration configuration from environment variables.
+//
+// The four WAVE_MIGRATION_* env vars are read through internal/config so the
+// process-wide env-reader contract stays in one place. Boolean fields accept
+// "true", "1", or "yes" (case-insensitive); any other non-empty value is
+// treated as false. WAVE_MAX_MIGRATION_VERSION must parse as a positive
+// integer — malformed or non-positive values are silently ignored to preserve
+// historical behaviour while the parse error is surfaced via
+// config.MigrationEnv for callers that want to inspect it.
 func LoadMigrationConfigFromEnv() *MigrationConfig {
-	config := &MigrationConfig{
+	cfg := &MigrationConfig{
 		EnableMigrations:        true, // Default to enabled for new systems
 		AutoMigrate:             true, // Default to automatic migration
 		SkipMigrationValidation: false,
 		MaxMigrationVersion:     0, // No limit
 	}
 
-	// WAVE_MIGRATION_ENABLED - enable/disable migration system
-	if env := os.Getenv("WAVE_MIGRATION_ENABLED"); env != "" {
-		config.EnableMigrations = strings.ToLower(env) == "true"
+	envCfg := config.LoadMigrationEnv()
+	if envCfg.Enabled != nil {
+		cfg.EnableMigrations = *envCfg.Enabled
+	}
+	if envCfg.AutoMigrate != nil {
+		cfg.AutoMigrate = *envCfg.AutoMigrate
+	}
+	if envCfg.SkipValidation != nil {
+		cfg.SkipMigrationValidation = *envCfg.SkipValidation
+	}
+	if envCfg.MaxVersion != nil && *envCfg.MaxVersion > 0 {
+		cfg.MaxMigrationVersion = *envCfg.MaxVersion
 	}
 
-	// WAVE_AUTO_MIGRATE - enable/disable automatic migration on startup
-	if env := os.Getenv("WAVE_AUTO_MIGRATE"); env != "" {
-		config.AutoMigrate = strings.ToLower(env) == "true"
-	}
-
-	// WAVE_SKIP_MIGRATION_VALIDATION - skip checksum validation (dev only)
-	if env := os.Getenv("WAVE_SKIP_MIGRATION_VALIDATION"); env != "" {
-		config.SkipMigrationValidation = strings.ToLower(env) == "true"
-	}
-
-	// WAVE_MAX_MIGRATION_VERSION - limit migration version (for gradual rollout)
-	if env := os.Getenv("WAVE_MAX_MIGRATION_VERSION"); env != "" {
-		if version, err := strconv.Atoi(env); err == nil && version > 0 {
-			config.MaxMigrationVersion = version
-		}
-	}
-
-	return config
+	return cfg
 }
 
 // ShouldUseMigrations determines if the migration system should be used

--- a/internal/webui/handlers_admin.go
+++ b/internal/webui/handlers_admin.go
@@ -3,10 +3,11 @@ package webui
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 	"strconv"
 	"time"
+
+	"github.com/recinq/wave/internal/config"
 )
 
 // --- Page Handler ---
@@ -88,7 +89,7 @@ func (s *Server) handleAPIAdminCredentials(w http.ResponseWriter, _ *http.Reques
 
 	resp := make(adminCredentialsResponse)
 	for _, key := range allKeys {
-		if os.Getenv(key) != "" {
+		if config.EnvPresent(key) {
 			resp[key] = true
 		}
 	}


### PR DESCRIPTION
## Summary

- Migrates the four remaining scattered `os.Getenv` call clusters to the centralised `internal/config` env-reader pattern established by #1531.
- After this commit `git grep -nE 'os\.Getenv\(' internal/scope internal/webui/handlers_admin.go internal/state/migration_config.go internal/runner/detach.go` returns zero hits.
- Adds three new typed accessors to `internal/config`: `EnvPresent(name)`, `SubprocessHomePath()`, and `LoadMigrationEnv()` (with the `MigrationEnv` struct that uses pointer fields to distinguish unset from explicitly-set-false).

### Migrated clusters

| Site | Pattern | New helper |
| ---- | ------- | ---------- |
| `internal/scope/introspect.go` (3 sites) | `os.Getenv(envVar) == ""` precondition | `config.EnvPresent(envVar)` |
| `internal/webui/handlers_admin.go` | dynamic credential-key probe loop | `config.EnvPresent(key)` |
| `internal/state/migration_config.go` (4 vars) | `WAVE_MIGRATION_ENABLED` / `WAVE_AUTO_MIGRATE` / `WAVE_SKIP_MIGRATION_VALIDATION` / `WAVE_MAX_MIGRATION_VERSION` | `config.LoadMigrationEnv()` |
| `internal/runner/detach.go` | `os.Getenv("PATH")` / `os.Getenv("HOME")` for detached subprocess env | `config.SubprocessHomePath()` |

### Behaviour preserved

- `LoadMigrationConfigFromEnv()` keeps its public signature and default semantics. Booleans now accept `true`/`1`/`yes` case-insensitively (a strict superset of the previous `true`-only parser); existing tests using `"false"`/`"true"` continue to pass.
- `WAVE_MAX_MIGRATION_VERSION` parse errors are surfaced explicitly on `MigrationEnv.MaxVersionParseError` while `LoadMigrationConfigFromEnv` continues to silently ignore non-positive/malformed values to preserve historical behaviour.
- `BuildDetachEnv` keeps the inherited-env contract verbatim — `config.SubprocessHomePath` returns `os.Getenv` values as-is.

## Test plan

- [x] `go build -o ./wave ./cmd/wave`
- [x] `go test ./internal/scope/... ./internal/state/... ./internal/runner/... ./internal/webui/... ./internal/config/...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] Verified `git grep -nE 'os\.Getenv\(' internal/scope internal/webui/handlers_admin.go internal/state/migration_config.go internal/runner/detach.go` returns zero hits