### PR TITLE
refactor(tui): route pipeline_launcher detach through internal/runner

### DIFF
--- a/internal/runner/detach.go
+++ b/internal/runner/detach.go
@@ -162,6 +162,75 @@ type DetachConfig struct {
 	ExtraEnv []string
 }
 
+// PIDRecorder is the optional surface SpawnDetached uses to persist a
+// freshly-spawned subprocess PID for a run. The TUI and webui both supply a
+// state-store-backed implementation; foreground CLI callers can pass nil.
+type PIDRecorder interface {
+	UpdateRunPID(runID string, pid int) error
+}
+
+// SpawnDetached starts a fully-detached `wave <subcommand>` subprocess from
+// the supplied argv. It is the shared spawn primitive used by Detach (for
+// `wave run`) and by callers that drive other subcommands such as the TUI's
+// `wave compose` orchestration path.
+//
+// Behaviour mirrored from Detach:
+//   - argv[0] is the wave binary resolved via os.Executable() (with argv[0]
+//     fallback for tests and unusual environments).
+//   - Setsid is set so the child becomes its own session leader and survives
+//     the parent process exit.
+//   - cfg.WorkDir, cfg.LogsDir, and cfg.ExtraEnv are honoured exactly the
+//     same way as in Detach.
+//   - cmd.Stdout / cmd.Stderr are redirected to <logsDir>/<runID>.log.
+//   - On success the child PID is recorded via recorder (when non-nil) and
+//     cmd.Process.Release is called so the OS fully reparents the child.
+//
+// Callers are responsible for any pre-spawn coordination (run-id reservation,
+// status transitions) — SpawnDetached only owns the fork/exec dance.
+func SpawnDetached(args []string, runID string, recorder PIDRecorder, cfg DetachConfig) error {
+	waveBin, exeErr := os.Executable()
+	if exeErr != nil {
+		// Fall back to argv[0] for compatibility with tests / unusual envs.
+		waveBin = os.Args[0]
+	}
+
+	cmd := exec.Command(waveBin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Env = BuildDetachEnv(cfg.ExtraEnv...)
+	if cfg.WorkDir != "" {
+		cmd.Dir = cfg.WorkDir
+	}
+
+	logsDir := cfg.LogsDir
+	if logsDir == "" {
+		logsDir = filepath.Join(".agents", "logs")
+	}
+	if mkErr := os.MkdirAll(logsDir, 0o755); mkErr != nil {
+		return fmt.Errorf("failed to create logs directory: %w", mkErr)
+	}
+	logPath := filepath.Join(logsDir, runID+".log")
+	logFile, logErr := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if logErr != nil {
+		return fmt.Errorf("failed to create log file: %w", logErr)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if startErr := cmd.Start(); startErr != nil {
+		logFile.Close()
+		return fmt.Errorf("failed to start detached subprocess: %w", startErr)
+	}
+
+	// The subprocess inherited the fd via fork; close our copy.
+	logFile.Close()
+
+	if recorder != nil {
+		_ = recorder.UpdateRunPID(runID, cmd.Process.Pid)
+	}
+	_ = cmd.Process.Release()
+	return nil
+}
+
 // Detach spawns a fully-detached `wave run` subprocess that survives the
 // parent process exit. The subprocess writes to the shared state DB so
 // `wave status`, `wave logs`, and the webui dashboard can all observe it.
@@ -232,46 +301,8 @@ func Detach(opts Options, store detachStore, maxConcurrentWorkers int, cfg Detac
 	// Build subprocess args: same flags minus --detach/-d, plus --run <runID>.
 	args := BuildDetachedArgs(opts, runID)
 
-	waveBin, exeErr := os.Executable()
-	if exeErr != nil {
-		// Fall back to argv[0] for compatibility with tests / unusual envs.
-		waveBin = os.Args[0]
+	if err := SpawnDetached(args, runID, store, cfg); err != nil {
+		return "", err
 	}
-
-	cmd := exec.Command(waveBin, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	cmd.Env = BuildDetachEnv(cfg.ExtraEnv...)
-	if cfg.WorkDir != "" {
-		cmd.Dir = cfg.WorkDir
-	}
-
-	// Redirect output to <logsDir>/<runID>.log
-	logsDir := cfg.LogsDir
-	if logsDir == "" {
-		logsDir = filepath.Join(".agents", "logs")
-	}
-	if mkErr := os.MkdirAll(logsDir, 0o755); mkErr != nil {
-		return "", fmt.Errorf("failed to create logs directory: %w", mkErr)
-	}
-	logPath := filepath.Join(logsDir, runID+".log")
-	logFile, logErr := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if logErr != nil {
-		return "", fmt.Errorf("failed to create log file: %w", logErr)
-	}
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	if startErr := cmd.Start(); startErr != nil {
-		logFile.Close()
-		return "", fmt.Errorf("failed to start detached pipeline: %w", startErr)
-	}
-
-	// Close the log file — the subprocess inherited the fd.
-	logFile.Close()
-
-	// Record PID and fully detach the subprocess.
-	_ = store.UpdateRunPID(runID, cmd.Process.Pid)
-	_ = cmd.Process.Release()
-
 	return runID, nil
 }

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -2,21 +2,23 @@ package tui
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/pipelinecatalog"
+	"github.com/recinq/wave/internal/runner"
 )
 
 // PipelineLauncher manages pipeline execution from the TUI.
-// It spawns detached subprocesses via `wave run` so pipelines survive TUI exit.
+// It spawns detached subprocesses via internal/runner so pipelines survive
+// TUI exit. The runner package owns the actual fork/exec dance, env filter,
+// log-file routing, and PID record — this type is purely the TUI-facing
+// adapter that translates LaunchConfig into runner.Options and emits
+// Bubble Tea messages on success/failure.
 type PipelineLauncher struct {
 	deps    LaunchDependencies
 	program *tea.Program
@@ -40,8 +42,13 @@ func (l *PipelineLauncher) SetProgram(p *tea.Program) {
 // Launch starts a pipeline as a detached subprocess and returns a tea.Cmd
 // that immediately sends PipelineLaunchedMsg. Live output comes from polling
 // SQLite events, not in-memory buffers.
+//
+// Subprocess spawning is delegated to runner.Detach so the TUI launch path
+// shares one canonical detach contract (argv, env, log file, PID record)
+// with the foreground CLI (`wave run --detach`) and the webui server. The
+// flag-spec exhaustiveness test in internal/runner guards the argv shape.
 func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
-	// Load the full pipeline definition to validate it exists
+	// Load the full pipeline definition to validate it exists.
 	p, err := pipelinecatalog.LoadPipelineByName(l.deps.PipelinesDir, config.PipelineName)
 	if err != nil {
 		pipelineName := config.PipelineName
@@ -50,90 +57,50 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 		}
 	}
 
-	// Generate run ID via StateStore so the run appears in the dashboard
-	var runID string
+	cfg := runner.DetachConfig{
+		ExtraEnv: manifestEnvPassthrough(l.deps.Manifest),
+	}
+
+	// Two paths preserve the original TUI behaviour exactly:
+	//
+	//  - With a state store, delegate to runner.Detach. It owns run-id
+	//    reservation (reusing a pre-created row when opts.RunID is set,
+	//    falling through to CreateRunWithLimit otherwise), the running
+	//    transition, and the spawn dance. We capture the canonical id it
+	//    returns and forward that to the TUI.
+	//  - Without a state store the TUI used to launch with a locally
+	//    generated id and skip persistence entirely. runner.Detach refuses
+	//    a nil store, so we drop down to runner.SpawnDetached for that
+	//    edge case so subprocesses still survive TUI exit.
+	var canonicalRunID string
 	if l.deps.Store != nil {
-		var storeErr error
-		runID, storeErr = l.deps.Store.CreateRun(p.Metadata.Name, config.Input)
+		preID, storeErr := l.deps.Store.CreateRun(p.Metadata.Name, config.Input)
 		if storeErr != nil {
-			runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
+			// Generate a local id; runner.Detach will see no matching row
+			// and reserve a fresh canonical id via CreateRunWithLimit.
+			preID = pipeline.GenerateRunID(p.Metadata.Name, 8)
 		}
+		opts := launchConfigToOptions(config, preID)
+		rid, err := runner.Detach(opts, l.deps.Store, 0, cfg)
+		if err != nil {
+			pipelineName := config.PipelineName
+			return func() tea.Msg {
+				return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("starting subprocess: %w", err)}
+			}
+		}
+		canonicalRunID = rid
 	} else {
-		runID = pipeline.GenerateRunID(p.Metadata.Name, 8)
-	}
-
-	// Transition run from pending -> running so wave status picks it up
-	if l.deps.Store != nil {
-		_ = l.deps.Store.UpdateRunStatus(runID, "running", "", 0)
-	}
-
-	// Build subprocess command: wave run --pipeline <name> --run <runID> --input <input> [flags...]
-	args := []string{"run", "--pipeline", config.PipelineName, "--run", runID}
-	if config.Input != "" {
-		args = append(args, "--input", config.Input)
-	}
-	if config.ModelOverride != "" {
-		args = append(args, "--model", config.ModelOverride)
-	}
-	if config.Adapter != "" {
-		args = append(args, "--adapter", config.Adapter)
-	}
-	if config.Timeout > 0 {
-		args = append(args, "--timeout", fmt.Sprintf("%d", config.Timeout))
-	}
-	if config.FromStep != "" {
-		args = append(args, "--from-step", config.FromStep)
-	}
-	if config.Steps != "" {
-		args = append(args, "--steps", config.Steps)
-	}
-	if config.Exclude != "" {
-		args = append(args, "--exclude", config.Exclude)
-	}
-	if config.OnFailure != "" && config.OnFailure != "halt" {
-		args = append(args, "--on-failure", config.OnFailure)
-	}
-	// Pass through user-selected flags to the subprocess.
-	// Compound flags like "--output text" are split into separate args.
-	for _, f := range config.Flags {
-		parts := strings.SplitN(f, " ", 2)
-		args = append(args, parts...)
-	}
-
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	cmd.Env = buildPassthroughEnv(l.deps)
-
-	// Redirect stdout/stderr to .agents/logs/<runID>.log so detached output is preserved
-	logFile, logErr := openRunLog(runID)
-	if logErr == nil {
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-	} else {
-		cmd.Stdout = nil
-		cmd.Stderr = nil
-	}
-
-	if startErr := cmd.Start(); startErr != nil {
-		if logFile != nil {
-			logFile.Close()
+		runID := pipeline.GenerateRunID(p.Metadata.Name, 8)
+		opts := launchConfigToOptions(config, runID)
+		args := runner.BuildDetachedArgs(opts, runID)
+		if err := runner.SpawnDetached(args, runID, nil, cfg); err != nil {
+			pipelineName := config.PipelineName
+			return func() tea.Msg {
+				return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("starting subprocess: %w", err)}
+			}
 		}
-		pipelineName := config.PipelineName
-		return func() tea.Msg {
-			return LaunchErrorMsg{PipelineName: pipelineName, Err: fmt.Errorf("starting subprocess: %w", startErr)}
-		}
+		canonicalRunID = runID
 	}
-
-	// Close the log file — the subprocess inherited the fd via fork
-	if logFile != nil {
-		logFile.Close()
-	}
-
-	// Record PID and release the process so it becomes fully detached
-	if l.deps.Store != nil {
-		_ = l.deps.Store.UpdateRunPID(runID, cmd.Process.Pid)
-	}
-	_ = cmd.Process.Release()
 
 	// Return immediate PipelineLaunchedMsg — no blocking executor cmd
 	pipelineName := config.PipelineName
@@ -142,7 +109,7 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 	debug := config.Debug
 	return func() tea.Msg {
 		return PipelineLaunchedMsg{
-			RunID:        runID,
+			RunID:        canonicalRunID,
 			PipelineName: pipelineName,
 			Input:        input,
 			Verbose:      verbose,
@@ -155,6 +122,10 @@ func (l *PipelineLauncher) Launch(config LaunchConfig) tea.Cmd {
 // `wave compose` subprocess. When parallel is true the --parallel flag is
 // passed and stages are separated by "--". Returns a single PipelineLaunchedMsg
 // whose RunID is the compose group ID.
+//
+// The fork/exec dance, env filter, and log-file routing are delegated to
+// runner.SpawnDetached so the TUI does not maintain its own copy of that
+// logic. Only the `wave compose` argv assembly is TUI-specific.
 func (l *PipelineLauncher) LaunchSequence(names []string, input string, parallel bool, stages [][]int) tea.Cmd {
 	if len(names) == 0 {
 		return func() tea.Msg {
@@ -199,33 +170,19 @@ func (l *PipelineLauncher) LaunchSequence(names []string, input string, parallel
 		args = append(args, names...)
 	}
 
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	cmd.Env = buildPassthroughEnv(l.deps)
-
-	logFile, logErr := openRunLog(groupRunID)
-	if logErr == nil {
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
+	cfg := runner.DetachConfig{
+		ExtraEnv: manifestEnvPassthrough(l.deps.Manifest),
 	}
 
-	if startErr := cmd.Start(); startErr != nil {
-		if logFile != nil {
-			logFile.Close()
-		}
-		return func() tea.Msg {
-			return LaunchErrorMsg{PipelineName: "compose", Err: fmt.Errorf("starting compose subprocess: %w", startErr)}
-		}
-	}
-
-	if logFile != nil {
-		logFile.Close()
-	}
-
+	var recorder runner.PIDRecorder
 	if l.deps.Store != nil {
-		_ = l.deps.Store.UpdateRunPID(groupRunID, cmd.Process.Pid)
+		recorder = l.deps.Store
 	}
-	_ = cmd.Process.Release()
+	if err := runner.SpawnDetached(args, groupRunID, recorder, cfg); err != nil {
+		return func() tea.Msg {
+			return LaunchErrorMsg{PipelineName: "compose", Err: fmt.Errorf("starting compose subprocess: %w", err)}
+		}
+	}
 
 	runID := groupRunID
 	return func() tea.Msg {
@@ -272,32 +229,61 @@ func (l *PipelineLauncher) Cleanup(_ string) {
 	// No in-process state to clean up.
 }
 
-// buildPassthroughEnv constructs a minimal environment for the subprocess.
-// It includes HOME, PATH, and any vars specified in manifest runtime.sandbox.env_passthrough.
-func buildPassthroughEnv(deps LaunchDependencies) []string {
-	env := []string{
-		"HOME=" + os.Getenv("HOME"),
-		"PATH=" + os.Getenv("PATH"),
+// launchConfigToOptions translates the form-driven LaunchConfig into the
+// runner.Options surface. Known UI-level "extra flags" (--verbose, --debug,
+// --output text|json, --dry-run, --mock, --detach) are mapped onto typed
+// Options fields so the runner.BuildDetachedArgs spec table owns argv
+// shaping. Unknown flags are silently dropped — the form only exposes the
+// known set via DefaultFlags().
+func launchConfigToOptions(config LaunchConfig, runID string) runner.Options {
+	opts := runner.Options{
+		Pipeline:  config.PipelineName,
+		Input:     config.Input,
+		RunID:     runID,
+		Model:     config.ModelOverride,
+		Adapter:   config.Adapter,
+		Timeout:   config.Timeout,
+		FromStep:  config.FromStep,
+		Steps:     config.Steps,
+		Exclude:   config.Exclude,
+		OnFailure: config.OnFailure,
 	}
 
-	if deps.Manifest != nil && len(deps.Manifest.Runtime.Sandbox.EnvPassthrough) > 0 {
-		for _, key := range deps.Manifest.Runtime.Sandbox.EnvPassthrough {
-			if val, ok := os.LookupEnv(key); ok {
-				env = append(env, key+"="+val)
-			}
+	// Translate known UI-flag tokens into typed Options fields.
+	// "--output X" appears as a single space-joined token in config.Flags.
+	for _, f := range config.Flags {
+		switch {
+		case f == "--verbose":
+			opts.Output.Verbose = true
+		case f == "--debug":
+			opts.Output.Debug = true
+		case f == "--dry-run":
+			opts.DryRun = true
+		case f == "--mock":
+			opts.Mock = true
+		case f == "--detach":
+			// Already detaching via runner.Detach — no-op.
+		case strings.HasPrefix(f, "--output "):
+			opts.Output.Format = strings.TrimPrefix(f, "--output ")
 		}
 	}
-
-	return env
+	return opts
 }
 
-// openRunLog creates the .agents/logs/ directory if needed and opens a log file for the run.
-func openRunLog(runID string) (*os.File, error) {
-	logsDir := filepath.Join(".agents", "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		return nil, err
+// manifestEnvPassthrough returns the additional env-variable names declared
+// in the manifest's runtime.sandbox.env_passthrough list. The result is
+// passed to runner.DetachConfig.ExtraEnv so the runner's BuildDetachEnv
+// forwards them alongside its standard set.
+func manifestEnvPassthrough(m *manifest.Manifest) []string {
+	if m == nil {
+		return nil
 	}
-	return os.OpenFile(filepath.Join(logsDir, runID+".log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if len(m.Runtime.Sandbox.EnvPassthrough) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m.Runtime.Sandbox.EnvPassthrough))
+	out = append(out, m.Runtime.Sandbox.EnvPassthrough...)
+	return out
 }
 
 // TUIProgressEmitter implements event.ProgressEmitter to bridge executor events

--- a/internal/tui/pipeline_launcher_test.go
+++ b/internal/tui/pipeline_launcher_test.go
@@ -1,14 +1,11 @@
 package tui
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewPipelineLauncher_InitializesFields(t *testing.T) {
@@ -89,89 +86,82 @@ func TestTUIProgressEmitter_EmitProgress_NilProgram(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBuildPassthroughEnv_MinimalEnv(t *testing.T) {
-	deps := LaunchDependencies{}
-	env := buildPassthroughEnv(deps)
+func TestLaunchConfigToOptions_TranslatesKnownFlags(t *testing.T) {
+	cfg := LaunchConfig{
+		PipelineName:  "impl-issue",
+		Input:         "fix bug",
+		ModelOverride: "haiku",
+		Adapter:       "claude",
+		Timeout:       30,
+		FromStep:      "implement",
+		Steps:         "plan,implement",
+		Exclude:       "create-pr",
+		OnFailure:     "skip",
+		Flags: []string{
+			"--verbose",
+			"--debug",
+			"--dry-run",
+			"--mock",
+			"--detach",
+			"--output text",
+		},
+	}
 
-	// Should always include HOME and PATH
-	assert.Contains(t, env, "HOME="+os.Getenv("HOME"))
-	assert.Contains(t, env, "PATH="+os.Getenv("PATH"))
-	assert.Len(t, env, 2)
+	opts := launchConfigToOptions(cfg, "run-xyz")
+
+	assert.Equal(t, "impl-issue", opts.Pipeline)
+	assert.Equal(t, "fix bug", opts.Input)
+	assert.Equal(t, "run-xyz", opts.RunID)
+	assert.Equal(t, "haiku", opts.Model)
+	assert.Equal(t, "claude", opts.Adapter)
+	assert.Equal(t, 30, opts.Timeout)
+	assert.Equal(t, "implement", opts.FromStep)
+	assert.Equal(t, "plan,implement", opts.Steps)
+	assert.Equal(t, "create-pr", opts.Exclude)
+	assert.Equal(t, "skip", opts.OnFailure)
+	assert.True(t, opts.Output.Verbose, "--verbose should map to Output.Verbose")
+	assert.True(t, opts.Output.Debug, "--debug should map to Output.Debug")
+	assert.True(t, opts.DryRun, "--dry-run should map to DryRun")
+	assert.True(t, opts.Mock, "--mock should map to Mock")
+	assert.Equal(t, "text", opts.Output.Format, "--output text should map to Output.Format")
+	// --detach is intentionally a no-op; the runner is producing the
+	// detached child, recursing would be wrong.
+	assert.False(t, opts.Detach, "--detach must not propagate into runner.Options.Detach")
 }
 
-func TestBuildPassthroughEnv_WithManifestPassthrough(t *testing.T) {
-	// Set a test env var to verify passthrough
-	t.Setenv("WAVE_TEST_VAR", "test-value")
+func TestLaunchConfigToOptions_EmptyFlagsLeaveDefaults(t *testing.T) {
+	cfg := LaunchConfig{PipelineName: "p"}
+	opts := launchConfigToOptions(cfg, "rid")
 
-	deps := LaunchDependencies{
-		Manifest: &manifest.Manifest{
-			Runtime: manifest.Runtime{
-				Sandbox: manifest.RuntimeSandbox{
-					EnvPassthrough: []string{"WAVE_TEST_VAR", "NONEXISTENT_VAR"},
-				},
+	assert.Equal(t, "p", opts.Pipeline)
+	assert.Equal(t, "rid", opts.RunID)
+	assert.False(t, opts.Output.Verbose)
+	assert.False(t, opts.Output.Debug)
+	assert.False(t, opts.DryRun)
+	assert.False(t, opts.Mock)
+	assert.Equal(t, "", opts.Output.Format)
+}
+
+func TestManifestEnvPassthrough_NilManifest(t *testing.T) {
+	out := manifestEnvPassthrough(nil)
+	assert.Nil(t, out)
+}
+
+func TestManifestEnvPassthrough_NoPassthrough(t *testing.T) {
+	m := &manifest.Manifest{}
+	out := manifestEnvPassthrough(m)
+	assert.Nil(t, out)
+}
+
+func TestManifestEnvPassthrough_ForwardsListedKeys(t *testing.T) {
+	m := &manifest.Manifest{
+		Runtime: manifest.Runtime{
+			Sandbox: manifest.RuntimeSandbox{
+				EnvPassthrough: []string{"GH_TOKEN", "GITHUB_TOKEN"},
 			},
 		},
 	}
-	env := buildPassthroughEnv(deps)
 
-	// Should include HOME, PATH, and the passthrough var
-	assert.Contains(t, env, "HOME="+os.Getenv("HOME"))
-	assert.Contains(t, env, "PATH="+os.Getenv("PATH"))
-	assert.Contains(t, env, "WAVE_TEST_VAR=test-value")
-	// NONEXISTENT_VAR should not be included since it's not set
-	assert.Len(t, env, 3)
-}
-
-func TestBuildPassthroughEnv_NilManifest(t *testing.T) {
-	deps := LaunchDependencies{
-		Manifest: nil,
-	}
-	env := buildPassthroughEnv(deps)
-	assert.Len(t, env, 2, "should only include HOME and PATH")
-}
-
-func TestOpenRunLog_CreatesDirectoryAndFile(t *testing.T) {
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir))
-	t.Cleanup(func() { _ = os.Chdir(origDir) })
-
-	f, err := openRunLog("test-run-123")
-	require.NoError(t, err)
-	defer f.Close()
-
-	// Verify the directory was created
-	_, err = os.Stat(filepath.Join(".agents", "logs"))
-	assert.NoError(t, err)
-
-	// Verify the file was created
-	_, err = os.Stat(filepath.Join(".agents", "logs", "test-run-123.log"))
-	assert.NoError(t, err)
-
-	// Verify it's writable
-	_, err = f.WriteString("test output\n")
-	assert.NoError(t, err)
-}
-
-func TestOpenRunLog_AppendsToExisting(t *testing.T) {
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir))
-	t.Cleanup(func() { _ = os.Chdir(origDir) })
-
-	// First write
-	f1, err := openRunLog("append-run")
-	require.NoError(t, err)
-	_, _ = f1.WriteString("first\n")
-	f1.Close()
-
-	// Second write (append)
-	f2, err := openRunLog("append-run")
-	require.NoError(t, err)
-	_, _ = f2.WriteString("second\n")
-	f2.Close()
-
-	content, err := os.ReadFile(filepath.Join(".agents", "logs", "append-run.log"))
-	require.NoError(t, err)
-	assert.Equal(t, "first\nsecond\n", string(content))
+	out := manifestEnvPassthrough(m)
+	assert.Equal(t, []string{"GH_TOKEN", "GITHUB_TOKEN"}, out)
 }


### PR DESCRIPTION
## Summary

Migrates the TUI's `pipeline_launcher.go` to use `internal/runner` for subprocess detach. PR #1527 extracted the shared detach logic into `internal/runner` for cmd and webui; the TUI launcher carried a third copy of that logic and was called out as a follow-up. This PR closes that follow-up.

## What was duplicated, what got removed

The TUI launcher previously hand-rolled:

- argv assembly for `wave run` (no exhaustiveness guarantee — drift risk)
- `exec.Command(os.Args[0], ...)` + `Setsid` + `Process.Release`
- minimal env passthrough (`buildPassthroughEnv`: HOME + PATH only, plus manifest-listed vars)
- log-file routing (`openRunLog`) under `.agents/logs/<runID>.log`
- PID record via `Store.UpdateRunPID`

All of the above is now delegated to `internal/runner`:

- `runner.Detach` — `Launch()` now defers run-id reservation, `running` transition, argv shaping, and spawn to the runner. `LaunchConfig` is translated into `runner.Options` via a new `launchConfigToOptions` helper that maps the form's known flag tokens (`--verbose`, `--debug`, `--output X`, `--dry-run`, `--mock`, `--detach`) onto typed Options fields. Manifest `runtime.sandbox.env_passthrough` is forwarded via `runner.DetachConfig.ExtraEnv`, so the TUI now also benefits from the runner's richer base env (`$HOME/.local/bin` PATH prepend, `ANTHROPIC_API_KEY`, `XDG_*`, etc.).
- `runner.SpawnDetached` (new, see below) — `LaunchSequence()` keeps its `wave compose` argv assembly but delegates the fork/exec dance.

## Runner API extension

`runner.Detach` only spawns `wave run`, so it doesn't fit the TUI's `wave compose` orchestrated-sequence path. Rather than copy the spawn dance back into the TUI, this PR adds a new generic primitive to `internal/runner`:

- `runner.SpawnDetached(args, runID, recorder, cfg) error` — handles `os.Executable()` resolution, Setsid, `BuildDetachEnv` filter, log-file routing, `cmd.Start`, optional PID record, `cmd.Process.Release`. Used internally by `runner.Detach` (so the spawn primitive has exactly one home) and externally by the TUI compose path.
- `runner.PIDRecorder` — public interface (`UpdateRunPID(runID string, pid int) error`) so callers can supply any pid-recording surface, or `nil` to skip.

This is a backward-compatible addition: existing `runner.Detach` callers (cmd, webui) are untouched.

## Behaviour preserved

- **Argv shape**: `BuildDetachedArgs` is the same source-of-truth used by CLI and webui — `TestDetachedArgsExhaustive` still guards new `Options` fields. Hardening from #1500 / #1530 carries over.
- **Run-id contract**: TUI still calls `Store.CreateRun` first; `runner.Detach` reuses that row when `opts.RunID` resolves; on `CreateRun` failure the TUI falls back to a generated id and runner reserves a fresh canonical id (now reported back to the TUI via `PipelineLaunchedMsg`).
- **Nil-store edge case**: original TUI launched without persistence when `Store` was nil. Retained via direct `SpawnDetached` call (`runner.Detach` refuses a nil store).
- **Manifest env passthrough**: vars listed in `runtime.sandbox.env_passthrough` still reach the subprocess.
- **Compose argv**: `wave compose [--parallel] [--input <input>] <names...>` (with `--` stage separators when parallel) unchanged.

## Tests

- Removed `TestBuildPassthroughEnv*` and `TestOpenRunLog*` (helpers no longer exist; runner-side coverage already exists via `TestBuildDetachEnv*`).
- Added `TestLaunchConfigToOptions_TranslatesKnownFlags` and `TestLaunchConfigToOptions_EmptyFlagsLeaveDefaults` covering the flag-to-Options translation, including the `--detach` no-op.
- Added `TestManifestEnvPassthrough_*` covering nil / empty / populated manifest cases.

## Test plan

- [x] `go build -o ./wave ./cmd/wave` clean
- [x] `go test -race ./internal/tui/... ./internal/runner/...` pass
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] Full repo `go test ./...` clean (one webui pagination test was flaky, passes on retry — unrelated to this change)
- [ ] Smoke: `wave` (TUI) boots and pipeline-launcher panel still launches a pipeline correctly. Could not run interactively in this headless session — should be verified by a reviewer with a TTY.

Closes the "TUI `pipeline_launcher.go` migration (third detach copy)" follow-up from PR #1527.