### PR TITLE
fix(pipeline): add prepare to wave-smoke-gates verify dependencies

### DIFF
--- a/.agents/pipelines/wave-smoke-gates.yaml
+++ b/.agents/pipelines/wave-smoke-gates.yaml
@@ -39,7 +39,7 @@ steps:
 
   - id: verify
     type: command
-    dependencies: [approval-gate]
+    dependencies: [prepare, approval-gate]
     script: |
       if [ ! -f .agents/output/gate-marker.json ]; then
         echo "FAIL: gate-marker.json missing"


### PR DESCRIPTION
## Summary

Follow-up to #1542 (workspace pollution fix). The `verify` step in `wave-smoke-gates` listed only `approval-gate` as a dependency, so the auto-injected dep artifacts mechanism (#1452) didn't propagate `prepare`'s `gate-marker.json` into verify's workspace. Pre-#1542 behaviour masked this — both command steps collapsed to the project root via the empty-workspace CWD fallback, and the file was incidentally visible. With workspace isolation restored, verify needs `prepare` as an explicit dep.

## Test plan

- [x] `./wave run wave-smoke-gates --adapter claude --model cheapest` completes successfully (5.1s)
- [x] verify step's contract validates (gate-result.json written)
- [x] Both `prepare` and `approval-gate` correctly visible in dependency chain