### PR TITLE
refactor(webui): drop internal/pipeline import from handlers_control via narrow iface

### DIFF
--- a/internal/webui/gate_handler.go
+++ b/internal/webui/gate_handler.go
@@ -2,11 +2,26 @@ package webui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/recinq/wave/internal/pipeline"
+)
+
+// Sentinel errors returned by GateRegistry.ResolveChoice so HTTP handlers can
+// map registry-layer outcomes onto status codes without leaking pipeline types
+// into the transport layer.
+var (
+	// ErrGateNotPending indicates no gate is currently pending for the run.
+	ErrGateNotPending = errors.New("no pending gate for run")
+	// ErrGateStepMismatch indicates the request's step does not match the
+	// step that registered the pending gate.
+	ErrGateStepMismatch = errors.New("step mismatch for pending gate")
+	// ErrGateInvalidChoice indicates the supplied choice key is not present
+	// in the pending gate's choice list.
+	ErrGateInvalidChoice = errors.New("invalid choice for pending gate")
 )
 
 // pendingGate holds the state for a gate that is waiting for a human decision
@@ -62,6 +77,49 @@ func (r *GateRegistry) Resolve(runID string, decision *pipeline.GateDecision) er
 	delete(r.pending, runID)
 	pg.Response <- decision
 	return nil
+}
+
+// ResolveChoice validates a human's choice against the pending gate for the
+// given run and resolves it. It is the transport-friendly wrapper around
+// Resolve: callers supply only string fields (choiceKey, text) and a stepID
+// for verification. The pipeline.GateDecision construction is hidden inside
+// the registry so HTTP handlers can stay free of internal/pipeline imports.
+//
+// Returns the resolved choice key and label on success. On failure returns
+// one of the sentinel errors (ErrGateNotPending, ErrGateStepMismatch,
+// ErrGateInvalidChoice) wrapped with extra context, or any error returned
+// by Resolve (e.g. double-resolve).
+func (r *GateRegistry) ResolveChoice(runID, stepID, choiceKey, text string) (string, string, error) {
+	pendingStepID := r.GetPendingStepID(runID)
+	if pendingStepID == "" {
+		// No pending gate at all.
+		return "", "", ErrGateNotPending
+	}
+	if stepID != "" && pendingStepID != stepID {
+		return "", "", fmt.Errorf("%w: pending step %q, request step %q", ErrGateStepMismatch, pendingStepID, stepID)
+	}
+
+	gate := r.GetPending(runID)
+	if gate == nil {
+		// Gate disappeared between GetPendingStepID and GetPending (race).
+		return "", "", ErrGateNotPending
+	}
+
+	choice := gate.FindChoiceByKey(choiceKey)
+	if choice == nil {
+		return "", "", fmt.Errorf("%w: %q", ErrGateInvalidChoice, choiceKey)
+	}
+
+	decision := &pipeline.GateDecision{
+		Choice: choice.Key,
+		Label:  choice.Label,
+		Text:   text,
+		Target: choice.Target,
+	}
+	if err := r.Resolve(runID, decision); err != nil {
+		return "", "", err
+	}
+	return choice.Key, choice.Label, nil
 }
 
 // GetPending returns the pending gate config for a run, or nil if none.

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -2,11 +2,11 @@ package webui
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
 	"github.com/recinq/wave/internal/state"
 )
@@ -351,41 +351,30 @@ func (s *Server) handleGateApprove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gate := s.realtime.gateRegistry.GetPending(runID)
-	if gate == nil {
-		writeJSONError(w, http.StatusNotFound, "no pending gate for this run")
-		return
-	}
-
-	pendingStepID := s.realtime.gateRegistry.GetPendingStepID(runID)
-	if pendingStepID != "" && pendingStepID != stepID {
-		writeJSONError(w, http.StatusConflict,
-			fmt.Sprintf("step mismatch: pending gate is for step %q, not %q", pendingStepID, stepID))
-		return
-	}
-
-	choice := gate.FindChoiceByKey(req.Choice)
-	if choice == nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid choice key: "+req.Choice)
-		return
-	}
-
-	decision := &pipeline.GateDecision{
-		Choice: choice.Key,
-		Label:  choice.Label,
-		Text:   req.Text,
-		Target: choice.Target,
-	}
-
-	if err := s.realtime.gateRegistry.Resolve(runID, decision); err != nil {
-		writeJSONError(w, http.StatusConflict, err.Error())
+	// Resolve the gate via the narrow controlGateRegistry interface. The
+	// registry hides pipeline.GateDecision construction so this transport
+	// layer stays free of pipeline imports.
+	var registry controlGateRegistry = s.realtime.gateRegistry
+	choiceKey, label, err := registry.ResolveChoice(runID, stepID, req.Choice, req.Text)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrGateNotPending):
+			writeJSONError(w, http.StatusNotFound, "no pending gate for this run")
+		case errors.Is(err, ErrGateStepMismatch):
+			writeJSONError(w, http.StatusConflict, err.Error())
+		case errors.Is(err, ErrGateInvalidChoice):
+			writeJSONError(w, http.StatusBadRequest, "invalid choice key: "+req.Choice)
+		default:
+			// Double-resolve and similar registry-level failures.
+			writeJSONError(w, http.StatusConflict, err.Error())
+		}
 		return
 	}
 
 	writeJSON(w, http.StatusOK, GateApproveResponse{
 		RunID:  runID,
 		StepID: stepID,
-		Choice: choice.Key,
-		Label:  choice.Label,
+		Choice: choiceKey,
+		Label:  label,
 	})
 }

--- a/internal/webui/runtime.go
+++ b/internal/webui/runtime.go
@@ -1,0 +1,26 @@
+package webui
+
+// controlGateRegistry is the narrow gate-registry contract that the HTTP
+// handlers in handlers_control.go depend on. Defining the interface here
+// (rather than reaching for *GateRegistry directly) keeps the handler file
+// free of any internal/pipeline imports: every method on this interface
+// trades only in primitive types or webui-local error sentinels.
+//
+// The concrete *GateRegistry (gate_handler.go) satisfies this interface;
+// see the compile-time guard below. Other webui files still hold a
+// *GateRegistry via serverRealtime — the interface is intentionally
+// scoped to handlers_control.go's surface and not threaded through the
+// Server struct. Broader cleanup of the webui→pipeline import seam will
+// land in follow-up PRs (issue #1498 sub-tasks).
+type controlGateRegistry interface {
+	// ResolveChoice validates a human's gate decision and resolves the
+	// pending gate for the run. It returns the resolved choice key and
+	// label on success, or one of the sentinel errors (ErrGateNotPending,
+	// ErrGateStepMismatch, ErrGateInvalidChoice) on failure.
+	ResolveChoice(runID, stepID, choiceKey, text string) (key, label string, err error)
+}
+
+// Compile-time guard: *GateRegistry must satisfy controlGateRegistry. If a
+// future change to GateRegistry breaks this contract, the package will fail
+// to build and the handler can be updated alongside.
+var _ controlGateRegistry = (*GateRegistry)(nil)


### PR DESCRIPTION
## Summary

`internal/webui/handlers_control.go` no longer imports `internal/pipeline`. The only direct usage was a `pipeline.GateDecision` construction inside `handleGateApprove`; that construction now lives behind a transport-friendly `GateRegistry.ResolveChoice` method, and the handler maps registry-layer outcomes onto HTTP status codes via webui-local sentinel errors.

This is sub-task B of issue #1498 (webui → pipeline layer-inversion cleanup). Sibling PRs already in flight: #1540 split the `Server` struct into composed sub-structs; #1527 extracted `internal/runner` for shared detach/launch logic.

## What changed

**`internal/webui/runtime.go` (new)** — narrow contract handlers_control.go depends on:

```go
type controlGateRegistry interface {
    ResolveChoice(runID, stepID, choiceKey, text string) (key, label string, err error)
}

var _ controlGateRegistry = (*GateRegistry)(nil)
```

**`internal/webui/gate_handler.go`** — adds `ResolveChoice` plus three sentinel errors:

- `ErrGateNotPending`     → handler maps to 404
- `ErrGateStepMismatch`   → handler maps to 409
- `ErrGateInvalidChoice`  → handler maps to 400
- (anything else, e.g. double-resolve) → handler maps to 409

`ResolveChoice` does the full pending+step+choice validation under one lock-window-friendly call, builds the `pipeline.GateDecision` internally, and resolves it. The webui transport layer never names a `pipeline.*` type.

**`internal/webui/handlers_control.go`** — `handleGateApprove` collapses ~30 lines of step-by-step validation into one `ResolveChoice` call + an `errors.Is` switch. Drops the `pipeline` import.

## Files touched

- `internal/webui/handlers_control.go` (only this handler file in scope)
- `internal/webui/gate_handler.go` (extension only — adds `ResolveChoice` + sentinels)
- `internal/webui/runtime.go` (new)

## Behaviour preserved

Status codes, response payloads, decision-channel semantics, and CSRF check are unchanged. All existing tests pass without modification — verified via `go test ./internal/webui/...`.

## Leftover webui→pipeline import sites (follow-up PRs)

These files still import `internal/pipeline` and are intentionally out of scope here:

- `internal/webui/gate_handler.go` — `*pipeline.GateConfig`/`*pipeline.GateDecision` are part of the registry's stored state and the `WebUIGateHandler` adapter that satisfies `pipeline.GateHandler`. Cleaning these up requires moving the gate-config/decision shapes into a neutral package.
- `internal/webui/server_launcher.go` — `*pipeline.Pipeline` parameter, `pipeline.GateHandler` interface.
- `internal/webui/server_helpers.go` — `loadPipelineYAML` returns `*pipeline.Pipeline`; `pipeline.YAMLPipelineLoader` is concrete.
- `internal/webui/types.go` — DTO struct fields likely typed against pipeline.
- `internal/webui/handlers_compose.go`, `handlers_fork.go`, `handlers_pipelines.go`, `handlers_skills.go` — additional handlers that consume `*pipeline.Pipeline`.
- `internal/webui/handlers_gate_test.go` — uses `pipeline.GateConfig`/`pipeline.GateDecision` directly to register and resolve gates in unit tests.

Each will get its own narrow-iface PR per the sub-task plan.

## Test plan

- [x] `go build -o ./wave ./cmd/wave`
- [x] `go vet ./...`
- [x] `go test ./internal/webui/... ./internal/pipeline/... ./internal/runner/...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Boot smoke: `./wave serve --port 8085` then `curl -sf http://localhost:8085/api/runs` → `{"runs":[],"has_more":false}` (HTTP 200)
- [x] `git grep -nE "internal/pipeline" internal/webui/handlers_control.go` → zero matches