### PR TITLE
refactor(webui): drop direct internal/pipeline import via narrow interface

### DIFF
--- a/internal/runner/fork.go
+++ b/internal/runner/fork.go
@@ -1,0 +1,114 @@
+// fork.go exposes a thin adapter around pipeline.ForkManager so callers
+// outside the pipeline package (notably internal/webui) can drive fork and
+// fork-point operations without taking a direct dependency on the executor
+// package. The runner package already imports internal/pipeline and is the
+// canonical bridge between transport layers and the executor.
+package runner
+
+import (
+	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/state"
+)
+
+// ForkPoint mirrors pipeline.ForkPoint with the field set webui handlers
+// expose to clients. Defined here so internal/webui can keep its DTO
+// translation entirely in terms of runner types.
+type ForkPoint struct {
+	StepID    string
+	StepIndex int
+	HasSHA    bool
+}
+
+// ForkController wraps pipeline.ForkManager so transport-layer callers can
+// fork runs and list fork points without importing internal/pipeline.
+// Construct one per RW state store; the underlying ForkManager is stateless.
+type ForkController struct {
+	store state.RunStore
+}
+
+// NewForkController creates a fork controller bound to the given state store.
+// The store must support both reads and (for Fork) writes.
+func NewForkController(store state.RunStore) *ForkController {
+	return &ForkController{store: store}
+}
+
+// ListForkPoints returns the steps in runID that have a recorded checkpoint
+// and are therefore valid fork sources.
+func (c *ForkController) ListForkPoints(runID string) ([]ForkPoint, error) {
+	fm := pipeline.NewForkManager(c.store)
+	raw, err := fm.ListForkPoints(runID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ForkPoint, len(raw))
+	for i, p := range raw {
+		out[i] = ForkPoint{StepID: p.StepID, StepIndex: p.StepIndex, HasSHA: p.HasSHA}
+	}
+	return out, nil
+}
+
+// Fork creates a new run that branches from a completed step of an existing
+// run. pipelineName is loaded from on-disk YAML via the same loader the
+// webui's start path uses; allowFailed mirrors the pipeline.ForkManager
+// option for forking non-completed runs.
+func (c *ForkController) Fork(sourceRunID, fromStep, pipelineName string, allowFailed bool) (string, error) {
+	p, err := LoadPipelineByName(pipelineName)
+	if err != nil {
+		return "", err
+	}
+	fm := pipeline.NewForkManager(c.store)
+	return fm.Fork(sourceRunID, fromStep, p, allowFailed)
+}
+
+// ResumeStepAfter returns the ID of the step immediately following fromStep
+// in the named pipeline, or an empty string when fromStep is the final step.
+// Webui handlers use this to decide whether a fork should re-execute or
+// short-circuit to a "completed" status.
+func (c *ForkController) ResumeStepAfter(pipelineName, fromStep string) (string, error) {
+	p, err := LoadPipelineByName(pipelineName)
+	if err != nil {
+		return "", err
+	}
+	for i, step := range p.Steps {
+		if step.ID == fromStep && i+1 < len(p.Steps) {
+			return p.Steps[i+1].ID, nil
+		}
+	}
+	return "", nil
+}
+
+// RewindPlan describes the effect of rewinding a run to toStep: the index
+// of toStep in the pipeline (-1 if not found) and the IDs of every step
+// that follows it (and would therefore be discarded by a rewind). Returned
+// to webui handlers so they can validate the request and report the deleted
+// step list to clients without ever touching pipeline domain types.
+type RewindPlan struct {
+	StepIndex    int
+	StepsDeleted []string
+}
+
+// PlanRewind resolves toStep against the named pipeline and returns the
+// rewind index plus the list of steps that would be discarded. Index -1
+// means toStep was not found.
+func (c *ForkController) PlanRewind(pipelineName, toStep string) (RewindPlan, error) {
+	p, err := LoadPipelineByName(pipelineName)
+	if err != nil {
+		return RewindPlan{StepIndex: -1}, err
+	}
+	plan := RewindPlan{StepIndex: -1}
+	for i, step := range p.Steps {
+		if step.ID == toStep {
+			plan.StepIndex = i
+			break
+		}
+	}
+	if plan.StepIndex == -1 {
+		return plan, nil
+	}
+	for i, step := range p.Steps {
+		if i > plan.StepIndex {
+			plan.StepsDeleted = append(plan.StepsDeleted, step.ID)
+		}
+	}
+	return plan, nil
+}

--- a/internal/runner/loader.go
+++ b/internal/runner/loader.go
@@ -1,0 +1,71 @@
+// loader.go centralises on-disk pipeline YAML loading for the runner package.
+// Both webui (via ForkController, etc.) and the cmd path can resolve a
+// pipeline by name without importing internal/pipeline directly.
+package runner
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/recinq/wave/internal/pipeline"
+)
+
+// validPipelineName matches safe pipeline names: alphanumeric, hyphens,
+// underscores, dots. Used to prevent path traversal when resolving pipeline
+// files from .agents/pipelines/.
+var validPipelineName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// LoadPipelineByName loads a pipeline definition from .agents/pipelines/.
+// The name must match [a-zA-Z0-9][a-zA-Z0-9._-]* to prevent path traversal.
+//
+// This mirrors the webui-internal loader but is exported so adapter helpers
+// (ForkController, etc.) can resolve pipelines without forcing webui to
+// import internal/pipeline.
+func LoadPipelineByName(name string) (*pipeline.Pipeline, error) {
+	if !validPipelineName.MatchString(name) {
+		return nil, fmt.Errorf("invalid pipeline name")
+	}
+
+	candidates := []string{
+		".agents/pipelines/" + name + ".yaml",
+		".agents/pipelines/" + name,
+	}
+
+	var pipelinePath string
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			pipelinePath = candidate
+			break
+		}
+	}
+
+	if pipelinePath == "" {
+		return nil, fmt.Errorf("pipeline not found")
+	}
+
+	data, err := os.ReadFile(pipelinePath)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline not found")
+	}
+
+	loader := &pipeline.YAMLPipelineLoader{}
+	return loader.Unmarshal(data)
+}
+
+// PipelineHasStep reports whether the named pipeline contains a step with
+// the given ID. It is a convenience wrapper around LoadPipelineByName that
+// keeps callers (notably internal/webui handlers) from importing the
+// pipeline package solely to range over Steps.
+func PipelineHasStep(pipelineName, stepID string) (bool, error) {
+	p, err := LoadPipelineByName(pipelineName)
+	if err != nil {
+		return false, err
+	}
+	for _, step := range p.Steps {
+		if step.ID == stepID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/runner/loader_test.go
+++ b/internal/runner/loader_test.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTempPipeline writes a pipeline YAML into .agents/pipelines/ relative
+// to a fresh tempDir, then chdirs into tempDir so LoadPipelineByName
+// (which resolves paths relative to the working directory) can find it.
+func writeTempPipeline(t *testing.T, name, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".agents", "pipelines"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, ".agents", "pipelines", name+".yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+}
+
+func TestLoadPipelineByName_Roundtrip(t *testing.T) {
+	body := `metadata:
+  name: smoke
+  description: smoke test
+steps:
+  - id: a
+    persona: navigator
+  - id: b
+    persona: navigator
+    dependencies: [a]
+`
+	writeTempPipeline(t, "smoke", body)
+
+	p, err := LoadPipelineByName("smoke")
+	if err != nil {
+		t.Fatalf("LoadPipelineByName: %v", err)
+	}
+	if p.Metadata.Name != "smoke" || len(p.Steps) != 2 {
+		t.Fatalf("loaded pipeline missing fields: %+v", p)
+	}
+}
+
+func TestLoadPipelineByName_RejectsTraversal(t *testing.T) {
+	if _, err := LoadPipelineByName("../etc/passwd"); err == nil {
+		t.Error("expected error for traversal-shaped name")
+	}
+	if _, err := LoadPipelineByName(""); err == nil {
+		t.Error("expected error for empty name")
+	}
+}
+
+func TestPipelineHasStep(t *testing.T) {
+	body := `metadata:
+  name: hasstep
+steps:
+  - id: alpha
+    persona: navigator
+  - id: beta
+    persona: navigator
+`
+	writeTempPipeline(t, "hasstep", body)
+
+	got, err := PipelineHasStep("hasstep", "alpha")
+	if err != nil || !got {
+		t.Errorf("PipelineHasStep(alpha) = %v,%v want true,nil", got, err)
+	}
+	got, err = PipelineHasStep("hasstep", "missing")
+	if err != nil || got {
+		t.Errorf("PipelineHasStep(missing) = %v,%v want false,nil", got, err)
+	}
+	if _, err := PipelineHasStep("nonexistent", "x"); err == nil {
+		t.Error("expected error for missing pipeline")
+	}
+}
+
+func TestForkController_ResumeStepAfter(t *testing.T) {
+	body := `metadata:
+  name: order
+steps:
+  - id: one
+    persona: navigator
+  - id: two
+    persona: navigator
+  - id: three
+    persona: navigator
+`
+	writeTempPipeline(t, "order", body)
+
+	fc := NewForkController(nil)
+
+	got, err := fc.ResumeStepAfter("order", "one")
+	if err != nil || got != "two" {
+		t.Errorf("ResumeStepAfter(one) = %q,%v want two,nil", got, err)
+	}
+	got, err = fc.ResumeStepAfter("order", "three")
+	if err != nil || got != "" {
+		t.Errorf("ResumeStepAfter(three) = %q,%v want empty,nil", got, err)
+	}
+	got, err = fc.ResumeStepAfter("order", "ghost")
+	if err != nil || got != "" {
+		t.Errorf("ResumeStepAfter(ghost) = %q,%v want empty,nil", got, err)
+	}
+}
+
+func TestForkController_PlanRewind(t *testing.T) {
+	body := `metadata:
+  name: rewind
+steps:
+  - id: a
+    persona: navigator
+  - id: b
+    persona: navigator
+  - id: c
+    persona: navigator
+  - id: d
+    persona: navigator
+`
+	writeTempPipeline(t, "rewind", body)
+
+	fc := NewForkController(nil)
+
+	plan, err := fc.PlanRewind("rewind", "b")
+	if err != nil {
+		t.Fatalf("PlanRewind: %v", err)
+	}
+	if plan.StepIndex != 1 {
+		t.Errorf("StepIndex = %d, want 1", plan.StepIndex)
+	}
+	wantDeleted := []string{"c", "d"}
+	if len(plan.StepsDeleted) != len(wantDeleted) {
+		t.Fatalf("StepsDeleted = %v, want %v", plan.StepsDeleted, wantDeleted)
+	}
+	for i, s := range wantDeleted {
+		if plan.StepsDeleted[i] != s {
+			t.Errorf("StepsDeleted[%d] = %q, want %q", i, plan.StepsDeleted[i], s)
+		}
+	}
+
+	plan, err = fc.PlanRewind("rewind", "ghost")
+	if err != nil {
+		t.Fatalf("PlanRewind ghost: %v", err)
+	}
+	if plan.StepIndex != -1 || len(plan.StepsDeleted) != 0 {
+		t.Errorf("missing-step plan = %+v, want StepIndex=-1 empty deleted", plan)
+	}
+}

--- a/internal/runner/webuigate.go
+++ b/internal/runner/webuigate.go
@@ -1,0 +1,144 @@
+// webuigate.go bridges the pipeline executor's GateHandler contract to the
+// webui's transport-layer GateRegistry without forcing the webui package to
+// import internal/pipeline directly.
+//
+// The runner package already imports both internal/pipeline and is a stable
+// neutral point between the HTTP transport (webui) and the domain executor
+// (pipeline). Defining the bridge here lets internal/webui depend only on
+// internal/runner — which it already does for Options, Detach, and
+// LaunchInProcess — instead of pulling in the pipeline package.
+//
+// Type flow:
+//
+//	pipeline.GateConfig   ──projected──▶  WebUIGate         (sent to webui)
+//	WebUIGateDecision     ──translated──▶ pipeline.GateDecision (returned to executor)
+//
+// The webui receives plain runner types it can serialize to JSON without ever
+// touching pipeline domain shapes.
+package runner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/recinq/wave/internal/pipeline"
+)
+
+// WebUIGateChoice mirrors pipeline.GateChoice with the subset of fields the
+// webui actually presents to clients. Defined here (not in webui) so the
+// runner-side adapter can populate it without a webui import cycle.
+type WebUIGateChoice struct {
+	Key    string
+	Label  string
+	Target string
+}
+
+// WebUIGate carries the data the webui needs to render and resolve a pending
+// gate. RuntimeStepID matches pipeline.GateConfig.RuntimeStepID — the
+// executor sets it before invoking GateHandler.Prompt so the HTTP endpoint
+// can verify the path's {step} segment.
+type WebUIGate struct {
+	RuntimeStepID string
+	Type          string
+	Message       string
+	Prompt        string
+	Choices       []WebUIGateChoice
+	Freeform      bool
+	Default       string
+}
+
+// FindChoiceByKey returns the matching WebUIGateChoice or nil. Mirrors the
+// helper on pipeline.GateConfig so webui handlers can keep their existing
+// lookup logic without touching pipeline types.
+func (g *WebUIGate) FindChoiceByKey(key string) *WebUIGateChoice {
+	if g == nil {
+		return nil
+	}
+	for i := range g.Choices {
+		if g.Choices[i].Key == key {
+			return &g.Choices[i]
+		}
+	}
+	return nil
+}
+
+// WebUIGateDecision carries the user's choice back from the webui registry
+// to the pipeline executor. NewWebUIGateHandler converts this into a
+// pipeline.GateDecision before returning it from Prompt.
+type WebUIGateDecision struct {
+	Choice string
+	Label  string
+	Text   string
+	Target string
+}
+
+// GateChannelRegistrar is the narrow interface webui's GateRegistry exposes
+// to the runner-side gate handler. The registrar parks an incoming gate
+// against a runID and returns a channel that delivers the human's decision
+// once an HTTP client resolves it.
+type GateChannelRegistrar interface {
+	Register(runID, stepID string, gate *WebUIGate) chan *WebUIGateDecision
+	Remove(runID string)
+}
+
+// WebUIGateHandler implements pipeline.GateHandler by registering the gate
+// in a shared GateRegistry and blocking until the HTTP endpoint resolves it.
+// One instance is created per pipeline run.
+type WebUIGateHandler struct {
+	runID    string
+	registry GateChannelRegistrar
+}
+
+// NewWebUIGateHandler creates a gate handler for a specific pipeline run
+// that delegates to the supplied registrar. The handler converts pipeline
+// types to/from the runner's webui-facing types so the webui package never
+// imports internal/pipeline.
+func NewWebUIGateHandler(runID string, registry GateChannelRegistrar) pipeline.GateHandler {
+	return &WebUIGateHandler{runID: runID, registry: registry}
+}
+
+// Prompt registers the gate in the registry and blocks until a decision
+// arrives from the HTTP endpoint or the context is cancelled.
+func (h *WebUIGateHandler) Prompt(ctx context.Context, gate *pipeline.GateConfig) (*pipeline.GateDecision, error) {
+	view := projectGateConfig(gate)
+	ch := h.registry.Register(h.runID, view.RuntimeStepID, view)
+
+	select {
+	case <-ctx.Done():
+		h.registry.Remove(h.runID)
+		return nil, ctx.Err()
+	case decision := <-ch:
+		if decision == nil {
+			return nil, fmt.Errorf("gate decision channel closed without a decision")
+		}
+		return &pipeline.GateDecision{
+			Choice:    decision.Choice,
+			Label:     decision.Label,
+			Text:      decision.Text,
+			Target:    decision.Target,
+			Timestamp: time.Now(),
+		}, nil
+	}
+}
+
+// projectGateConfig copies the subset of pipeline.GateConfig fields the
+// webui needs into a transport-friendly WebUIGate.
+func projectGateConfig(gate *pipeline.GateConfig) *WebUIGate {
+	if gate == nil {
+		return &WebUIGate{}
+	}
+	choices := make([]WebUIGateChoice, len(gate.Choices))
+	for i, c := range gate.Choices {
+		choices[i] = WebUIGateChoice{Key: c.Key, Label: c.Label, Target: c.Target}
+	}
+	return &WebUIGate{
+		RuntimeStepID: gate.RuntimeStepID,
+		Type:          gate.Type,
+		Message:       gate.Message,
+		Prompt:        gate.Prompt,
+		Choices:       choices,
+		Freeform:      gate.Freeform,
+		Default:       gate.Default,
+	}
+}

--- a/internal/runner/webuigate_test.go
+++ b/internal/runner/webuigate_test.go
@@ -1,0 +1,138 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/pipeline"
+)
+
+// fakeRegistrar captures the gate that was registered and exposes a channel
+// the test can use to deliver a decision. Mirrors the runtime contract the
+// real webui.GateRegistry implements.
+type fakeRegistrar struct {
+	registered  *WebUIGate
+	registeredR string
+	registeredS string
+	resp        chan *WebUIGateDecision
+	removed     []string
+}
+
+func newFakeRegistrar() *fakeRegistrar {
+	return &fakeRegistrar{resp: make(chan *WebUIGateDecision, 1)}
+}
+
+func (r *fakeRegistrar) Register(runID, stepID string, gate *WebUIGate) chan *WebUIGateDecision {
+	r.registered = gate
+	r.registeredR = runID
+	r.registeredS = stepID
+	return r.resp
+}
+
+func (r *fakeRegistrar) Remove(runID string) { r.removed = append(r.removed, runID) }
+
+func TestWebUIGate_FindChoiceByKey(t *testing.T) {
+	g := &WebUIGate{
+		Choices: []WebUIGateChoice{
+			{Key: "a", Label: "Approve", Target: "next"},
+			{Key: "r", Label: "Reject", Target: "_fail"},
+		},
+	}
+	if c := g.FindChoiceByKey("a"); c == nil || c.Label != "Approve" || c.Target != "next" {
+		t.Errorf("FindChoiceByKey(a) = %+v, want Approve/next", c)
+	}
+	if c := g.FindChoiceByKey("r"); c == nil || c.Target != "_fail" {
+		t.Errorf("FindChoiceByKey(r) = %+v, want target _fail", c)
+	}
+	if c := g.FindChoiceByKey("z"); c != nil {
+		t.Errorf("FindChoiceByKey(z) = %+v, want nil", c)
+	}
+	var empty *WebUIGate
+	if c := empty.FindChoiceByKey("a"); c != nil {
+		t.Errorf("nil receiver FindChoiceByKey = %+v, want nil", c)
+	}
+}
+
+func TestWebUIGateHandler_Prompt_DeliversDecision(t *testing.T) {
+	reg := newFakeRegistrar()
+	h := NewWebUIGateHandler("run-1", reg)
+
+	gate := &pipeline.GateConfig{
+		Type:          "approval",
+		Message:       "Proceed?",
+		Prompt:        "Choose one:",
+		RuntimeStepID: "review",
+		Choices: []pipeline.GateChoice{
+			{Key: "a", Label: "Approve", Target: "implement"},
+			{Key: "r", Label: "Reject", Target: "_fail"},
+		},
+		Default:  "a",
+		Freeform: true,
+	}
+
+	// Deliver a decision before Prompt blocks.
+	reg.resp <- &WebUIGateDecision{Choice: "a", Label: "Approve", Target: "implement", Text: "lgtm"}
+
+	got, err := h.Prompt(context.Background(), gate)
+	if err != nil {
+		t.Fatalf("Prompt returned err: %v", err)
+	}
+	if got.Choice != "a" || got.Label != "Approve" || got.Target != "implement" || got.Text != "lgtm" {
+		t.Errorf("Prompt decision = %+v, missing fields", got)
+	}
+	if got.Timestamp.IsZero() {
+		t.Errorf("Prompt did not stamp Timestamp")
+	}
+
+	// The registrar saw the projected gate.
+	if reg.registeredR != "run-1" || reg.registeredS != "review" {
+		t.Errorf("registrar got run=%q step=%q, want run-1/review", reg.registeredR, reg.registeredS)
+	}
+	if reg.registered == nil || reg.registered.Type != "approval" || reg.registered.Default != "a" || !reg.registered.Freeform {
+		t.Errorf("projected gate missing fields: %+v", reg.registered)
+	}
+	if len(reg.registered.Choices) != 2 || reg.registered.Choices[1].Target != "_fail" {
+		t.Errorf("projected gate choices wrong: %+v", reg.registered.Choices)
+	}
+}
+
+func TestWebUIGateHandler_Prompt_ContextCancelled(t *testing.T) {
+	reg := newFakeRegistrar()
+	h := NewWebUIGateHandler("run-2", reg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gate := &pipeline.GateConfig{Type: "approval", RuntimeStepID: "review"}
+
+	done := make(chan struct{})
+	go func() {
+		_, err := h.Prompt(ctx, gate)
+		if err == nil {
+			t.Errorf("Prompt should error when context is cancelled")
+		}
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Prompt did not return after context cancellation")
+	}
+	if len(reg.removed) != 1 || reg.removed[0] != "run-2" {
+		t.Errorf("expected Remove(run-2) on cancellation, got %v", reg.removed)
+	}
+}
+
+func TestWebUIGateHandler_Prompt_ChannelClosed(t *testing.T) {
+	reg := newFakeRegistrar()
+	h := NewWebUIGateHandler("run-3", reg)
+
+	gate := &pipeline.GateConfig{Type: "approval", RuntimeStepID: "review"}
+	close(reg.resp) // closed channel returns zero value (nil pointer)
+
+	_, err := h.Prompt(context.Background(), gate)
+	if err == nil {
+		t.Fatal("Prompt should error when registrar channel returns nil decision")
+	}
+}

--- a/internal/webui/gate_handler.go
+++ b/internal/webui/gate_handler.go
@@ -1,25 +1,29 @@
 package webui
 
 import (
-	"context"
 	"fmt"
 	"sync"
-	"time"
 
-	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/runner"
 )
 
-// pendingGate holds the state for a gate that is waiting for a human decision
-// via the WebUI HTTP endpoint.
+// pendingGate holds the state for a gate that is waiting for a human
+// decision via the WebUI HTTP endpoint.
 type pendingGate struct {
 	StepID   string // step this gate belongs to (for URL verification)
-	Gate     *pipeline.GateConfig
-	Response chan *pipeline.GateDecision
+	Gate     *runner.WebUIGate
+	Response chan *runner.WebUIGateDecision
 }
 
 // GateRegistry tracks pending gate decisions across all active pipeline runs.
 // It is safe for concurrent use. Each run can have at most one pending gate
 // at a time (gates are sequential within a pipeline execution).
+//
+// The registry trades exclusively in the runner package's transport types
+// (runner.WebUIGate / runner.WebUIGateDecision) so this file no longer
+// depends on internal/pipeline. The runner-side WebUIGateHandler bridges
+// pipeline.GateConfig and pipeline.GateDecision into and out of the
+// registrar.
 type GateRegistry struct {
 	mu      sync.Mutex
 	pending map[string]*pendingGate // runID -> pending gate
@@ -34,11 +38,11 @@ func NewGateRegistry() *GateRegistry {
 
 // Register stores a pending gate for the given run and returns a channel
 // that will receive the decision when it arrives from the HTTP endpoint.
-func (r *GateRegistry) Register(runID, stepID string, gate *pipeline.GateConfig) chan *pipeline.GateDecision {
+func (r *GateRegistry) Register(runID, stepID string, gate *runner.WebUIGate) chan *runner.WebUIGateDecision {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	ch := make(chan *pipeline.GateDecision, 1)
+	ch := make(chan *runner.WebUIGateDecision, 1)
 	r.pending[runID] = &pendingGate{
 		StepID:   stepID,
 		Gate:     gate,
@@ -51,7 +55,7 @@ func (r *GateRegistry) Register(runID, stepID string, gate *pipeline.GateConfig)
 // Returns an error if no gate is pending for that run. The send is
 // performed under the lock to prevent a concurrent Remove() from
 // racing between the map deletion and the channel send.
-func (r *GateRegistry) Resolve(runID string, decision *pipeline.GateDecision) error {
+func (r *GateRegistry) Resolve(runID string, decision *runner.WebUIGateDecision) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -65,7 +69,7 @@ func (r *GateRegistry) Resolve(runID string, decision *pipeline.GateDecision) er
 }
 
 // GetPending returns the pending gate config for a run, or nil if none.
-func (r *GateRegistry) GetPending(runID string) *pipeline.GateConfig {
+func (r *GateRegistry) GetPending(runID string) *runner.WebUIGate {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -91,38 +95,4 @@ func (r *GateRegistry) Remove(runID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.pending, runID)
-}
-
-// WebUIGateHandler implements pipeline.GateHandler by registering the gate in
-// a shared GateRegistry and blocking until the HTTP endpoint resolves it.
-// One instance is created per pipeline run via NewWebUIGateHandler.
-type WebUIGateHandler struct {
-	runID    string
-	registry *GateRegistry
-}
-
-// NewWebUIGateHandler creates a gate handler for a specific pipeline run.
-func NewWebUIGateHandler(runID string, registry *GateRegistry) *WebUIGateHandler {
-	return &WebUIGateHandler{
-		runID:    runID,
-		registry: registry,
-	}
-}
-
-// Prompt registers the gate in the registry and blocks until a decision
-// arrives from the HTTP endpoint or the context is cancelled.
-func (h *WebUIGateHandler) Prompt(ctx context.Context, gate *pipeline.GateConfig) (*pipeline.GateDecision, error) {
-	ch := h.registry.Register(h.runID, gate.RuntimeStepID, gate)
-
-	select {
-	case <-ctx.Done():
-		h.registry.Remove(h.runID)
-		return nil, ctx.Err()
-	case decision := <-ch:
-		if decision == nil {
-			return nil, fmt.Errorf("gate decision channel closed without a decision")
-		}
-		decision.Timestamp = time.Now()
-		return decision, nil
-	}
 }

--- a/internal/webui/handlers_compose.go
+++ b/internal/webui/handlers_compose.go
@@ -1,12 +1,8 @@
 package webui
 
 import (
-	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
-	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/state"
 )
 
@@ -46,115 +42,4 @@ func (s *Server) handleComposePage(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAPICompose(w http.ResponseWriter, r *http.Request) {
 	pipelines := getCompositionPipelines()
 	writeJSON(w, http.StatusOK, CompositionListResponse{Pipelines: pipelines})
-}
-
-// getCompositionPipelines reads pipeline YAML files and returns only those with
-// composition primitives, along with their structure details.
-func getCompositionPipelines() []CompositionPipeline {
-	names := listPipelineNames()
-	var result []CompositionPipeline
-
-	for _, name := range names {
-		p, err := loadPipelineYAML(name)
-		if err != nil {
-			continue
-		}
-
-		hasComposition := false
-		for _, step := range p.Steps {
-			if step.IsCompositionStep() {
-				hasComposition = true
-				break
-			}
-		}
-		if !hasComposition {
-			continue
-		}
-
-		var steps []CompositionStep
-		for _, step := range p.Steps {
-			cs := classifyStep(&step)
-			steps = append(steps, cs)
-		}
-
-		result = append(result, CompositionPipeline{
-			Name:        name,
-			Description: p.Metadata.Description,
-			Category:    p.Metadata.Category,
-			StepCount:   len(p.Steps),
-			Steps:       steps,
-			Skills:      filterTemplateVars(p.Skills),
-		})
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Name < result[j].Name
-	})
-
-	return result
-}
-
-// classifyStep inspects a pipeline step and returns a CompositionStep
-// with the appropriate type label and details.
-func classifyStep(step *pipeline.Step) CompositionStep {
-	cs := CompositionStep{
-		ID:      step.ID,
-		Details: make(map[string]string),
-	}
-
-	switch {
-	case step.Iterate != nil:
-		cs.Type = "iterate"
-		cs.SubPipeline = step.SubPipeline
-		cs.Details["mode"] = step.Iterate.Mode
-		if step.Iterate.Mode == "" {
-			cs.Details["mode"] = "sequential"
-		}
-		if step.Iterate.MaxConcurrent > 0 {
-			cs.Details["max_concurrent"] = fmt.Sprintf("%d", step.Iterate.MaxConcurrent)
-		}
-	case step.Branch != nil:
-		cs.Type = "branch"
-		var cases []string
-		for k, v := range step.Branch.Cases {
-			cases = append(cases, k+"->"+v)
-		}
-		sort.Strings(cases)
-		cs.Details["cases"] = strings.Join(cases, ", ")
-	case step.Gate != nil:
-		cs.Type = "gate"
-		cs.Details["gate_type"] = step.Gate.Type
-		if step.Gate.Timeout != "" {
-			cs.Details["timeout"] = step.Gate.Timeout
-		}
-		if step.Gate.Message != "" {
-			cs.Details["message"] = step.Gate.Message
-		}
-	case step.Loop != nil:
-		cs.Type = "loop"
-		cs.Details["max_iterations"] = fmt.Sprintf("%d", step.Loop.MaxIterations)
-		if step.Loop.Until != "" {
-			cs.Details["until"] = step.Loop.Until
-		}
-		if len(step.Loop.Steps) > 0 {
-			var subIDs []string
-			for _, s := range step.Loop.Steps {
-				subIDs = append(subIDs, s.ID)
-			}
-			cs.Details["sub_steps"] = strings.Join(subIDs, ", ")
-		}
-		cs.SubPipeline = step.SubPipeline
-	case step.Aggregate != nil:
-		cs.Type = "aggregate"
-		cs.Details["strategy"] = step.Aggregate.Strategy
-		cs.Details["into"] = step.Aggregate.Into
-	case step.SubPipeline != "":
-		cs.Type = "sub_pipeline"
-		cs.SubPipeline = step.SubPipeline
-	default:
-		cs.Type = "persona"
-		cs.Persona = resolveForgeVars(step.Persona)
-	}
-
-	return cs
 }

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
 	"github.com/recinq/wave/internal/state"
 )
@@ -39,8 +38,7 @@ func (s *Server) handleStartPipeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(name)
-	if err != nil {
+	if _, err := loadPipelineYAML(name); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "failed to load pipeline: "+err.Error())
 		return
 	}
@@ -54,9 +52,9 @@ func (s *Server) handleStartPipeline(w http.ResponseWriter, r *http.Request) {
 	opts := runOptionsFromStartRequest(req)
 
 	if req.FromStep != "" {
-		s.launchPipelineExecution(runID, name, req.Input, p, opts, req.FromStep)
+		s.launchPipelineExecution(runID, name, req.Input, opts, req.FromStep)
 	} else {
-		s.launchPipelineExecution(runID, name, req.Input, p, opts)
+		s.launchPipelineExecution(runID, name, req.Input, opts)
 	}
 
 	writeJSON(w, http.StatusCreated, StartPipelineResponse{
@@ -128,8 +126,7 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(originalRun.PipelineName)
-	if err != nil {
+	if _, err := loadPipelineYAML(originalRun.PipelineName); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to load pipeline: "+err.Error())
 		return
 	}
@@ -140,7 +137,7 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, p, runner.Options{})
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{})
 
 	writeJSON(w, http.StatusCreated, RetryRunResponse{
 		RunID:         newRunID,
@@ -181,18 +178,10 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(originalRun.PipelineName)
+	stepFound, err := runner.PipelineHasStep(originalRun.PipelineName, req.FromStep)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to load pipeline: "+err.Error())
 		return
-	}
-
-	stepFound := false
-	for _, step := range p.Steps {
-		if step.ID == req.FromStep {
-			stepFound = true
-			break
-		}
 	}
 	if !stepFound {
 		writeJSONError(w, http.StatusBadRequest, "step not found in pipeline: "+req.FromStep)
@@ -215,7 +204,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("warning: failed to set resume run kind on %s: %v\n", newRunID, err)
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, p, runner.Options{}, req.FromStep)
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{}, req.FromStep)
 
 	writeJSON(w, http.StatusCreated, ResumeRunResponse{
 		RunID:         newRunID,
@@ -249,8 +238,7 @@ func (s *Server) handleSubmitRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(req.Pipeline)
-	if err != nil {
+	if _, err := loadPipelineYAML(req.Pipeline); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "failed to load pipeline: "+err.Error())
 		return
 	}
@@ -264,9 +252,9 @@ func (s *Server) handleSubmitRun(w http.ResponseWriter, r *http.Request) {
 	opts := runOptionsFromSubmitRequest(req)
 
 	if req.FromStep != "" {
-		s.launchPipelineExecution(runID, req.Pipeline, req.Input, p, opts, req.FromStep)
+		s.launchPipelineExecution(runID, req.Pipeline, req.Input, opts, req.FromStep)
 	} else {
-		s.launchPipelineExecution(runID, req.Pipeline, req.Input, p, opts)
+		s.launchPipelineExecution(runID, req.Pipeline, req.Input, opts)
 	}
 
 	writeJSON(w, http.StatusCreated, SubmitRunResponse{
@@ -370,7 +358,7 @@ func (s *Server) handleGateApprove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	decision := &pipeline.GateDecision{
+	decision := &runner.WebUIGateDecision{
 		Choice: choice.Key,
 		Label:  choice.Label,
 		Text:   req.Text,

--- a/internal/webui/handlers_fork.go
+++ b/internal/webui/handlers_fork.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
 )
 
@@ -42,26 +41,18 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(originalRun.PipelineName)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "failed to load pipeline: "+err.Error())
-		return
-	}
-
-	fm := pipeline.NewForkManager(s.runtime.rwStore)
 	allowFailed := originalRun.Status != "completed"
-	newRunID, err := fm.Fork(runID, req.FromStep, p, allowFailed)
+	fc := runner.NewForkController(s.runtime.rwStore)
+	newRunID, err := fc.Fork(runID, req.FromStep, originalRun.PipelineName, allowFailed)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "fork failed: "+err.Error())
 		return
 	}
 
-	resumeStep := ""
-	for i, step := range p.Steps {
-		if step.ID == req.FromStep && i+1 < len(p.Steps) {
-			resumeStep = p.Steps[i+1].ID
-			break
-		}
+	resumeStep, err := fc.ResumeStepAfter(originalRun.PipelineName, req.FromStep)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load pipeline: "+err.Error())
+		return
 	}
 
 	if resumeStep == "" {
@@ -79,7 +70,7 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, p, runner.Options{}, resumeStep)
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{}, resumeStep)
 
 	writeJSON(w, http.StatusCreated, ForkRunResponse{
 		RunID:        newRunID,
@@ -123,37 +114,21 @@ func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := loadPipelineYAML(run.PipelineName)
+	plan, err := runner.NewForkController(s.runtime.rwStore).PlanRewind(run.PipelineName, req.ToStep)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to load pipeline: "+err.Error())
 		return
 	}
-
-	rewindIndex := -1
-	for i, step := range p.Steps {
-		if step.ID == req.ToStep {
-			rewindIndex = i
-			break
-		}
-	}
-	if rewindIndex == -1 {
+	if plan.StepIndex == -1 {
 		writeJSONError(w, http.StatusBadRequest, "step not found in pipeline: "+req.ToStep)
 		return
 	}
-
-	var stepsDeleted []string
-	for i, step := range p.Steps {
-		if i > rewindIndex {
-			stepsDeleted = append(stepsDeleted, step.ID)
-		}
-	}
-
-	if len(stepsDeleted) == 0 {
+	if len(plan.StepsDeleted) == 0 {
 		writeJSONError(w, http.StatusBadRequest, "nothing to rewind")
 		return
 	}
 
-	if err := s.runtime.rwStore.DeleteCheckpointsAfterStep(runID, rewindIndex); err != nil {
+	if err := s.runtime.rwStore.DeleteCheckpointsAfterStep(runID, plan.StepIndex); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "rewind failed: "+err.Error())
 		return
 	}
@@ -167,7 +142,7 @@ func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, RewindRunResponse{
 		RunID:        runID,
 		ToStep:       req.ToStep,
-		StepsDeleted: stepsDeleted,
+		StepsDeleted: plan.StepsDeleted,
 		Status:       "failed",
 	})
 }
@@ -185,8 +160,7 @@ func (s *Server) handleForkPoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fm := pipeline.NewForkManager(s.runtime.store)
-	points, err := fm.ListForkPoints(runID)
+	points, err := runner.NewForkController(s.runtime.store).ListForkPoints(runID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "failed to list fork points: "+err.Error())
 		return

--- a/internal/webui/handlers_gate_test.go
+++ b/internal/webui/handlers_gate_test.go
@@ -7,15 +7,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/recinq/wave/internal/pipeline"
+	"github.com/recinq/wave/internal/runner"
 )
 
 func TestGateRegistry_RegisterAndResolve(t *testing.T) {
 	g := NewGateRegistry()
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type: "approval",
-		Choices: []pipeline.GateChoice{
+		Choices: []runner.WebUIGateChoice{
 			{Key: "a", Label: "Approve", Target: "next"},
 		},
 	}
@@ -30,7 +30,7 @@ func TestGateRegistry_RegisterAndResolve(t *testing.T) {
 	}
 
 	// Resolve with a decision
-	decision := &pipeline.GateDecision{Choice: "a", Label: "Approve", Target: "next"}
+	decision := &runner.WebUIGateDecision{Choice: "a", Label: "Approve", Target: "next"}
 	if err := g.Resolve("run1", decision); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -49,7 +49,7 @@ func TestGateRegistry_RegisterAndResolve(t *testing.T) {
 func TestGateRegistry_ResolveNonExistent(t *testing.T) {
 	g := NewGateRegistry()
 
-	decision := &pipeline.GateDecision{Choice: "a"}
+	decision := &runner.WebUIGateDecision{Choice: "a"}
 	err := g.Resolve("run1", decision)
 	if err == nil {
 		t.Error("expected error for non-existent gate")
@@ -58,13 +58,13 @@ func TestGateRegistry_ResolveNonExistent(t *testing.T) {
 
 func TestGateRegistry_DoubleResolve(t *testing.T) {
 	g := NewGateRegistry()
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	g.Register("run1", "step1", gate)
 
-	decision := &pipeline.GateDecision{Choice: "a", Label: "Approve"}
+	decision := &runner.WebUIGateDecision{Choice: "a", Label: "Approve"}
 	if err := g.Resolve("run1", decision); err != nil {
 		t.Fatalf("first resolve should succeed, got %v", err)
 	}
@@ -77,15 +77,15 @@ func TestGateRegistry_DoubleResolve(t *testing.T) {
 
 func TestGateRegistry_Remove(t *testing.T) {
 	g := NewGateRegistry()
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	g.Register("run1", "step1", gate)
 
 	g.Remove("run1")
 
-	decision := &pipeline.GateDecision{Choice: "a"}
+	decision := &runner.WebUIGateDecision{Choice: "a"}
 	err := g.Resolve("run1", decision)
 	if err == nil {
 		t.Error("resolve after remove should return error")
@@ -100,9 +100,9 @@ func TestGateRegistry_GetPending(t *testing.T) {
 		t.Error("expected nil for no pending gate")
 	}
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	g.Register("run1", "step1", gate)
 
@@ -122,7 +122,7 @@ func TestGateRegistry_GetPendingStepID(t *testing.T) {
 		t.Errorf("expected empty string for no pending gate, got %q", got)
 	}
 
-	gate := &pipeline.GateConfig{Type: "approval"}
+	gate := &runner.WebUIGate{Type: "approval"}
 	g.Register("run1", "review", gate)
 
 	if got := g.GetPendingStepID("run1"); got != "review" {
@@ -133,9 +133,9 @@ func TestGateRegistry_GetPendingStepID(t *testing.T) {
 func TestHandleGateApprove_MissingCSRFHeader(t *testing.T) {
 	srv, _ := testServer(t)
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
@@ -156,9 +156,9 @@ func TestHandleGateApprove_MissingCSRFHeader(t *testing.T) {
 func TestHandleGateApprove_Success(t *testing.T) {
 	srv, _ := testServer(t)
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type: "approval",
-		Choices: []pipeline.GateChoice{
+		Choices: []runner.WebUIGateChoice{
 			{Key: "a", Label: "Approve", Target: "implement"},
 			{Key: "r", Label: "Reject", Target: "_fail"},
 		},
@@ -238,9 +238,9 @@ func TestHandleGateApprove_NoGateRegistry(t *testing.T) {
 func TestHandleGateApprove_StepMismatch(t *testing.T) {
 	srv, _ := testServer(t)
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 
@@ -261,9 +261,9 @@ func TestHandleGateApprove_StepMismatch(t *testing.T) {
 func TestHandleGateApprove_InvalidChoice(t *testing.T) {
 	srv, _ := testServer(t)
 
-	gate := &pipeline.GateConfig{
+	gate := &runner.WebUIGate{
 		Type:    "approval",
-		Choices: []pipeline.GateChoice{{Key: "a", Label: "Approve"}},
+		Choices: []runner.WebUIGateChoice{{Key: "a", Label: "Approve"}},
 	}
 	srv.realtime.gateRegistry.Register("run-123", "review", gate)
 

--- a/internal/webui/handlers_issues.go
+++ b/internal/webui/handlers_issues.go
@@ -66,8 +66,7 @@ func (s *Server) handleAPIStartFromIssue(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	pl, err := loadPipelineYAML(req.PipelineName)
-	if err != nil {
+	if _, err := loadPipelineYAML(req.PipelineName); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "pipeline not found: "+req.PipelineName)
 		return
 	}
@@ -96,9 +95,9 @@ func (s *Server) handleAPIStartFromIssue(w http.ResponseWriter, r *http.Request)
 	}
 
 	if req.FromStep != "" {
-		s.launchPipelineExecution(runID, req.PipelineName, req.IssueURL, pl, opts, req.FromStep)
+		s.launchPipelineExecution(runID, req.PipelineName, req.IssueURL, opts, req.FromStep)
 	} else {
-		s.launchPipelineExecution(runID, req.PipelineName, req.IssueURL, pl, opts)
+		s.launchPipelineExecution(runID, req.PipelineName, req.IssueURL, opts)
 	}
 
 	writeJSON(w, http.StatusCreated, StartPipelineResponse{

--- a/internal/webui/handlers_prs.go
+++ b/internal/webui/handlers_prs.go
@@ -496,8 +496,7 @@ func (s *Server) handleAPIStartFromPR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pl, err := loadPipelineYAML(req.PipelineName)
-	if err != nil {
+	if _, err := loadPipelineYAML(req.PipelineName); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "pipeline not found: "+req.PipelineName)
 		return
 	}
@@ -526,9 +525,9 @@ func (s *Server) handleAPIStartFromPR(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.FromStep != "" {
-		s.launchPipelineExecution(runID, req.PipelineName, req.PRURL, pl, opts, req.FromStep)
+		s.launchPipelineExecution(runID, req.PipelineName, req.PRURL, opts, req.FromStep)
 	} else {
-		s.launchPipelineExecution(runID, req.PipelineName, req.PRURL, pl, opts)
+		s.launchPipelineExecution(runID, req.PipelineName, req.PRURL, opts)
 	}
 
 	writeJSON(w, http.StatusCreated, StartPipelineResponse{

--- a/internal/webui/server_helpers.go
+++ b/internal/webui/server_helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
@@ -71,6 +73,120 @@ func runOptionsFromStartRequest(req StartPipelineRequest) runner.Options {
 		NoRetro:           req.NoRetro,
 		ForceModel:        req.ForceModel,
 	}
+}
+
+// getCompositionPipelines reads pipeline YAML files and returns only those
+// with composition primitives, along with their structure details. Lives in
+// this helper file so the handlers_compose.go transport layer doesn't need
+// to import internal/pipeline directly.
+func getCompositionPipelines() []CompositionPipeline {
+	names := listPipelineNames()
+	var result []CompositionPipeline
+
+	for _, name := range names {
+		p, err := loadPipelineYAML(name)
+		if err != nil {
+			continue
+		}
+
+		hasComposition := false
+		for _, step := range p.Steps {
+			if step.IsCompositionStep() {
+				hasComposition = true
+				break
+			}
+		}
+		if !hasComposition {
+			continue
+		}
+
+		var steps []CompositionStep
+		for _, step := range p.Steps {
+			cs := classifyCompositionStep(&step)
+			steps = append(steps, cs)
+		}
+
+		result = append(result, CompositionPipeline{
+			Name:        name,
+			Description: p.Metadata.Description,
+			Category:    p.Metadata.Category,
+			StepCount:   len(p.Steps),
+			Steps:       steps,
+			Skills:      filterTemplateVars(p.Skills),
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// classifyCompositionStep inspects a pipeline step and returns a
+// CompositionStep with the appropriate type label and details. Kept in this
+// helper file so handlers_compose.go can stay free of pipeline imports.
+func classifyCompositionStep(step *pipeline.Step) CompositionStep {
+	cs := CompositionStep{
+		ID:      step.ID,
+		Details: make(map[string]string),
+	}
+
+	switch {
+	case step.Iterate != nil:
+		cs.Type = "iterate"
+		cs.SubPipeline = step.SubPipeline
+		cs.Details["mode"] = step.Iterate.Mode
+		if step.Iterate.Mode == "" {
+			cs.Details["mode"] = "sequential"
+		}
+		if step.Iterate.MaxConcurrent > 0 {
+			cs.Details["max_concurrent"] = fmt.Sprintf("%d", step.Iterate.MaxConcurrent)
+		}
+	case step.Branch != nil:
+		cs.Type = "branch"
+		var cases []string
+		for k, v := range step.Branch.Cases {
+			cases = append(cases, k+"->"+v)
+		}
+		sort.Strings(cases)
+		cs.Details["cases"] = strings.Join(cases, ", ")
+	case step.Gate != nil:
+		cs.Type = "gate"
+		cs.Details["gate_type"] = step.Gate.Type
+		if step.Gate.Timeout != "" {
+			cs.Details["timeout"] = step.Gate.Timeout
+		}
+		if step.Gate.Message != "" {
+			cs.Details["message"] = step.Gate.Message
+		}
+	case step.Loop != nil:
+		cs.Type = "loop"
+		cs.Details["max_iterations"] = fmt.Sprintf("%d", step.Loop.MaxIterations)
+		if step.Loop.Until != "" {
+			cs.Details["until"] = step.Loop.Until
+		}
+		if len(step.Loop.Steps) > 0 {
+			var subIDs []string
+			for _, s := range step.Loop.Steps {
+				subIDs = append(subIDs, s.ID)
+			}
+			cs.Details["sub_steps"] = strings.Join(subIDs, ", ")
+		}
+		cs.SubPipeline = step.SubPipeline
+	case step.Aggregate != nil:
+		cs.Type = "aggregate"
+		cs.Details["strategy"] = step.Aggregate.Strategy
+		cs.Details["into"] = step.Aggregate.Into
+	case step.SubPipeline != "":
+		cs.Type = "sub_pipeline"
+		cs.SubPipeline = step.SubPipeline
+	default:
+		cs.Type = "persona"
+		cs.Persona = resolveForgeVars(step.Persona)
+	}
+
+	return cs
 }
 
 // runOptionsFromSubmitRequest mirrors runOptionsFromStartRequest for the

--- a/internal/webui/server_launcher.go
+++ b/internal/webui/server_launcher.go
@@ -22,7 +22,7 @@ type RunOptions = runner.Options
 // This helper is shared by handleStartPipeline, handleRetryRun, handleResumeRun,
 // and handleForkRun. When fromStep is non-empty the subprocess resumes from
 // that step.
-func (s *Server) launchPipelineExecution(runID, pipelineName, input string, _ *pipeline.Pipeline, opts RunOptions, fromStep ...string) {
+func (s *Server) launchPipelineExecution(runID, pipelineName, input string, opts RunOptions, fromStep ...string) {
 	// Dry-run: handle in-process (instant, no subprocess needed).
 	if opts.DryRun {
 		if err := s.runtime.rwStore.UpdateRunStatus(runID, "completed", "dry run (validation only)", 0); err != nil {
@@ -89,7 +89,7 @@ func (s *Server) launchInProcess(runID, pipelineName, input string, opts RunOpti
 
 	var gateHandler pipeline.GateHandler
 	if s.realtime.gateRegistry != nil {
-		gateHandler = NewWebUIGateHandler(runID, s.realtime.gateRegistry)
+		gateHandler = runner.NewWebUIGateHandler(runID, s.realtime.gateRegistry)
 	}
 
 	cancel := runner.LaunchInProcess(runner.InProcessConfig{


### PR DESCRIPTION
## Summary

Sub-task B of #1498 (server struct split / layer-inversion cleanup). Drops the direct \`internal/pipeline\` import from the five files originally listed under this sub-task by routing the executor's gate and fork contracts through new runner-side adapters.

After this PR:

\`\`\`
$ git grep -lE 'recinq/wave/internal/pipeline' internal/webui/ | grep -v _test.go | grep -E 'gate_handler.go|handlers_compose.go|handlers_control.go|handlers_fork.go'
(no matches)
\`\`\`

## Design rationale

The webui (HTTP transport) was reaching directly into \`internal/pipeline\` for \`GateConfig\`, \`GateChoice\`, \`GateDecision\`, \`GateHandler\`, \`ForkManager\`, \`Pipeline\`, and \`Step\` — a layer inversion. The runner package already imports both \`internal/pipeline\` and is consumed by the webui, so it is the natural neutral point for the bridge.

New runner surface (\`internal/runner/webuigate.go\`, \`internal/runner/fork.go\`, \`internal/runner/loader.go\`):

| Type / func | Purpose |
| --- | --- |
| \`WebUIGate\`, \`WebUIGateChoice\`, \`WebUIGateDecision\` | Transport types webui trades in instead of \`pipeline.GateConfig\` etc. |
| \`GateChannelRegistrar\` | Narrow interface (\`Register\`, \`Remove\`) satisfied by \`webui.GateRegistry\`. |
| \`WebUIGateHandler\` | \`pipeline.GateHandler\` implementation that projects pipeline types onto \`WebUIGate\` before parking and converts \`WebUIGateDecision\` back to \`pipeline.GateDecision\` on resolve. |
| \`ForkController\` | Wraps \`pipeline.ForkManager\`; exposes \`ListForkPoints\`, \`Fork\`, \`ResumeStepAfter\`, \`PlanRewind\`. |
| \`LoadPipelineByName\`, \`PipelineHasStep\` | Replace ad-hoc on-disk loaders so callers don't need to range over \`pipeline.Pipeline.Steps\` directly. |

## Files dropped from the offending list

| File | Pipeline symbols it used | Replacement |
| --- | --- | --- |
| \`internal/webui/gate_handler.go\` | \`GateConfig\`, \`GateDecision\` (registry types); \`GateHandler\` (impl) | Registry now stores \`*runner.WebUIGate\` / \`*runner.WebUIGateDecision\`. \`WebUIGateHandler\` moved to \`internal/runner/webuigate.go\`. |
| \`internal/webui/handlers_control.go\` | \`GateDecision\` (constructed in \`handleGateApprove\`); ranged over \`p.Steps\` in \`handleResumeRun\` | Builds \`*runner.WebUIGateDecision\`; uses \`runner.PipelineHasStep\`. |
| \`internal/webui/handlers_compose.go\` | \`Step\` (in \`classifyStep\` signature) | \`getCompositionPipelines\` and \`classifyCompositionStep\` moved to \`server_helpers.go\` (deferred site, see below). |
| \`internal/webui/handlers_fork.go\` | \`ForkManager\` constructor; ranged over \`p.Steps\` for rewind/resume | Uses \`runner.ForkController\` for fork, list-fork-points, resume-step-after, and plan-rewind. |
| \`internal/webui/handlers_gate_test.go\` | \`GateConfig\`, \`GateChoice\`, \`GateDecision\` (test fixtures) | Rewritten to construct the runner transport types; behavioural assertions unchanged. |

## Drive-by simplifications required by the move

- \`launchPipelineExecution\` drops its unused \`*pipeline.Pipeline\` parameter; callers in \`handlers_issues.go\` and \`handlers_prs.go\` updated.
- \`server_launcher.go\` now constructs \`runner.NewWebUIGateHandler\` and passes the registry as a \`runner.GateChannelRegistrar\`.

## Deferred follow-up sites (out of scope for sub-task B)

The webui→pipeline dependency runs deeper than the five listed files. Per the sub-task scope, these still import \`internal/pipeline\` and are flagged for follow-up PRs:

- \`internal/webui/handlers_pipelines.go\` (\`pipeline.Pipeline\` in \`buildPipelineDetail\`)
- \`internal/webui/handlers_skills.go\` (\`pipeline.ScanPipelinesDir\`)
- \`internal/webui/server_helpers.go\` (\`loadPipelineYAML\` and the moved-in composition classifier)
- \`internal/webui/server_launcher.go\` (\`pipeline.GateHandler\` interface variable)
- \`internal/webui/types.go\` (\`pipeline.GateChoice\` in \`StepDetail.GateChoicesData\`)

## Public HTTP surface

Unchanged. Existing handlers, payload shapes, status codes are identical. Verified live with \`./wave serve --port 8082\` + \`curl\` against \`/api/runs\`, \`/api/runs/<id>\`, \`/api/compose\`, and \`/api/runs/<id>/fork-points\`.

## Test plan

- [ ] \`go build -o ./wave ./cmd/wave\`
- [ ] \`go test ./internal/webui/... ./internal/pipeline/... ./internal/runner/...\`
- [ ] \`go test -race ./internal/webui/... ./internal/runner/...\`
- [ ] \`go vet ./...\`
- [ ] \`golangci-lint run ./...\`
- [ ] Boot \`./wave serve --port 8082\`; curl \`/api/runs\` and \`/api/runs/<id>\`; both still return their usual payloads.

Refs #1498