### PR TITLE
feat(pipelines/wave-self): every wave-* pipeline ends with visible outcome (PR or report)

### DIFF
--- a/.agents/pipelines/wave-audit.yaml
+++ b/.agents/pipelines/wave-audit.yaml
@@ -39,9 +39,13 @@ chat_context:
     - "Remediation actions and issue creation"
 
 pipeline_outputs:
-  report:
+  publish:
     step: publish
     artifact: publish-result
+    type: findings_report
+  report:
+    step: report
+    artifact: wave-audit-report
     type: findings_report
 
 steps:
@@ -507,3 +511,83 @@ steps:
         extract_from: .agents/output/publish-result.json
         json_path: .issues_created[].url
         label: "Audit Remediation Issue"
+
+  - id: report
+    persona: summarizer
+    model: cheapest
+    dependencies: [publish]
+    memory:
+      inject_artifacts:
+        - step: compose-triage
+          artifact: triage-report
+          as: triage_report
+        - step: publish
+          artifact: publish-result
+          as: publish_result
+    exec:
+      type: prompt
+      source: |
+        OBJECTIVE:
+        Produce a single, operator-facing markdown report summarising the wave-audit run.
+        Anyone reading this file in a browser or editor must immediately see what was
+        audited, what the audit found, which remediation issues were filed, and where to
+        click next. Without this report the operator only has a JSON blob and a list of
+        new issues — not a digest.
+
+        CONTEXT:
+        Two artifacts are injected: `triage_report` (the categorised, prioritised
+        findings) and `publish_result` (the JSON record of created/failed/skipped issues
+        from the publish step). All issue creation has already happened — your job is
+        purely to render a human-readable summary, not to take any new actions.
+
+        REQUIREMENTS:
+        1. Read both artifacts completely.
+        2. Render a markdown report at the configured output path with these sections, in
+           order:
+           - `# Wave Audit Report`
+           - `## Run Metadata` — repository, scope, timestamp, total items audited.
+           - `## Health Snapshot` — counts and percentages per fidelity category from
+             `triage_report.summary` (verified, partial, regressed, obsolete,
+             unverifiable) plus the overall health score.
+           - `## Remediation Issues Filed` — table with columns Source Item, Category,
+             New Issue, URL. One row per entry in `publish_result.issues_created`. URLs
+             must be rendered as live markdown links so the operator can click them.
+           - `## Failed Issue Creations` — same table shape but for
+             `publish_result.issues_failed`. If empty, write `_None._`.
+           - `## Top Findings` — bullet list of the 5 highest-priority items from
+             `triage_report.prioritized_actions` (priority, item number, action
+             description, estimated effort, link to the original item URL).
+           - `## Next Steps` — short paragraph telling the operator what to do (review
+             the filed issues, run `wave run impl-issue` against the highest priority
+             one, etc.). No emojis; use plain prose or HTML entities if any glyphs are
+             needed.
+        3. Citations must be clickable — every URL becomes a markdown link. Include the
+           source item URL and the new issue URL for every remediation row.
+
+        CONSTRAINTS AND ANTI-PATTERNS:
+        - Do NOT fabricate data not present in the injected artifacts.
+        - Do NOT take any side effects (no `gh` calls, no commits, no edits to other
+          files). This step is a pure renderer.
+        - Do NOT include emojis. Use plain text, markdown tables, or HTML entities only.
+        - Do NOT skip the report when there are zero actionable findings — instead write
+          a clear `## Health Snapshot` section noting that no remediation was required
+          and a `## Next Steps` section pointing to the verified items so the operator
+          knows the run completed cleanly.
+
+        QUALITY BAR:
+        A good report is one a maintainer can paste into Slack or a release note and have
+        the team understand the audit outcome without opening any other artifact. A bad
+        report restates the JSON without links, omits the issue URLs, or buries the
+        health snapshot below the fold.
+    output_artifacts:
+      - name: wave-audit-report
+        path: .agents/output/wave-audit-report.md
+        type: markdown
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: non_empty_file
+        source: .agents/output/wave-audit-report.md
+        on_failure: warn

--- a/.agents/pipelines/wave-test-hardening.yaml
+++ b/.agents/pipelines/wave-test-hardening.yaml
@@ -37,6 +37,10 @@ pipeline_outputs:
     step: analyze-coverage
     artifact: coverage-analysis
     type: findings_report
+  pr:
+    step: create-pr
+    artifact: pr-result
+    type: pr_ref
 
 steps:
   - id: analyze-coverage
@@ -58,10 +62,11 @@ steps:
         FOCUS: {{ input }}
 
         CONTEXT:
-        You are the first step in a four-step test hardening pipeline (analyze-coverage,
-        harden, run-tests, gate with loop). Your analysis will be consumed by a craftsman
-        persona who will add tests to cover the identified gaps. The pipeline loops: if
-        new tests fail, the harden step is re-visited. This is a Wave self-evolution
+        You are the first step in a five-step test hardening pipeline (analyze-coverage,
+        harden, run-tests, gate with loop, create-pr). Your analysis will be consumed by
+        a craftsman persona who will add tests to cover the identified gaps. The pipeline
+        loops: if new tests fail, the harden step is re-visited; on success the run ends
+        with a pull request opened by the create-pr step. This is a Wave self-evolution
         pipeline that always targets Wave's own Go codebase. You have read-only access
         to the project.
 
@@ -166,10 +171,8 @@ steps:
           artifact: coverage-analysis
           as: findings
     workspace:
-      mount:
-        - source: ./
-          target: /project
-          mode: readwrite
+      type: worktree
+      branch: "{{ pipeline_id }}"
     exec:
       type: prompt
       source: |
@@ -181,11 +184,12 @@ steps:
         CONTEXT:
         You are the second step in the test hardening pipeline. The coverage analysis
         artifact (injected as "findings") contains a prioritized list of test gaps with
-        package names, function names, gap types, and difficulty ratings. You have
-        read-write access to the project codebase. This step may be visited up to 3 times
-        if the test suite fails (the pipeline loops through run-tests and back to this step).
-        If this is a re-visit, focus on fixing the specific test failures from the previous
-        run rather than adding more new tests.
+        package names, function names, gap types, and difficulty ratings. You are running
+        in an isolated git worktree on a feature branch ({{ pipeline_id }}); commit your
+        changes here so the create-pr step can push the branch and open a pull request.
+        This step may be visited up to 3 times if the test suite fails (the pipeline loops
+        through run-tests and back to this step). If this is a re-visit, focus on fixing
+        the specific test failures from the previous run rather than adding more new tests.
 
         REQUIREMENTS:
         1. Read the findings artifact to get the prioritized list of test gaps. Start with
@@ -222,6 +226,12 @@ steps:
            - Fix those failures first before adding any new tests
         5. Aim to address at least 5 gaps per visit, prioritizing critical and high-priority
            items. If time/context allows, continue to medium-priority items.
+        6. Commit your changes on the current branch so the create-pr step has something
+           to push. Stage only the files you actually modified (test files and any source
+           files you fixed); never use `git add -A` because Wave-managed artifact and
+           output directories must stay out of the commit. Use a conventional commit
+           message such as `test(<package>): cover <gap-id> ...`. If a re-visit only
+           tweaks existing changes, amend or add follow-up commits as appropriate.
 
         CONSTRAINTS AND ANTI-PATTERNS:
         - Do NOT use t.Skip() without a linked issue number explaining why the test
@@ -263,12 +273,126 @@ steps:
   - id: run-tests
     type: command
     dependencies: [harden]
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
     script: "{{ project.contract_test_command }}"
 
   - id: gate
     type: conditional
     dependencies: [run-tests]
     edges:
-      - target: _complete
+      - target: create-pr
         condition: "outcome=success"
       - target: harden
+
+  - id: create-pr
+    persona: "{{ forge.type }}-commenter"
+    model: cheapest
+    contexts: [delivery]
+    dependencies: [gate]
+    memory:
+      inject_artifacts:
+        - step: analyze-coverage
+          artifact: coverage-analysis
+          as: coverage_findings
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source: |
+        OBJECTIVE:
+        Open a pull request for the test hardening commits produced by the harden step.
+        The PR is the operator-facing deliverable for this pipeline run — without it the
+        added tests sit unreviewed on a feature branch.
+
+        FOCUS: {{ input }}
+
+        CONTEXT:
+        You are running in an isolated git worktree on branch `{{ pipeline_id }}` shared
+        with the harden + run-tests steps. The harden step has already committed new test
+        files (and any minimal source fixes) to this branch and the test suite passes.
+        Your job is to push the branch and open a pull request with a summary that
+        references the coverage gaps addressed in this run. The injected
+        `coverage_findings` artifact contains the prioritized list of gaps and metadata.
+
+        SAFETY: Do NOT run `git checkout`, `git stash`, `git reset --hard`, or any command
+        that switches the current branch. The worktree is already on the right branch.
+
+        REQUIREMENTS:
+        1. Verify there is at least one commit ahead of the base branch:
+           ```bash
+           git log --oneline origin/main..HEAD
+           ```
+           The harden step's `must_pass: true` test_suite contract guarantees commits
+           exist on this branch — if the log is empty, fail the step with a clear
+           message rather than fabricating a PR.
+        2. Detect the repository owner/repo:
+           ```bash
+           gh repo view --json nameWithOwner --jq .nameWithOwner
+           ```
+        3. Push the feature branch (retry over HTTPS if SSH fails):
+           ```bash
+           git push -u origin "{{ pipeline_id }}" \
+             || GIT_SSH_COMMAND="ssh -F /dev/null" git push -u origin "{{ pipeline_id }}"
+           ```
+        4. Create the pull request. Read `coverage_findings` to extract the focus area and
+           the highest-priority gap IDs that were addressed. Build a summary:
+           ```bash
+           gh pr create \
+             --repo <OWNER/REPO> \
+             --head "{{ pipeline_id }}" \
+             --title "test(wave): harden coverage for <focus area>" \
+             --body "$(cat <<'EOF'
+        ## Summary
+        Test hardening run produced by the `wave-test-hardening` pipeline.
+
+        - Focus area: <from coverage_findings.focus>
+        - Gaps addressed: <comma-separated GAP-### ids from the coverage findings>
+        - Test suite: green at HEAD ({{ project.contract_test_command }})
+
+        ## Coverage Notes
+        <2-4 bullets describing which packages and functions gained coverage>
+
+        ## Test Plan
+        - [x] `{{ project.contract_test_command }}` passes locally on this branch
+        - [ ] Reviewer spot-checks the new tests for table-driven structure and edge case coverage
+        EOF
+        )"
+           ```
+        5. Capture the resulting PR number and URL from the `gh` output and write the
+           `pr-result` JSON. If PR creation fails for an already-existing branch, fall
+           back to `gh pr view --head "{{ pipeline_id }}" --json number,url` to recover
+           the existing PR reference.
+
+        CONSTRAINTS AND ANTI-PATTERNS:
+        - Do NOT include Co-Authored-By trailers or AI attribution in the PR body or
+          commits.
+        - Do NOT stage or commit anything new in this step. The harden step already did
+          the work; you only push and open the PR.
+        - Do NOT switch branches under any circumstances.
+        - Do NOT fabricate the PR URL. If `gh pr create` fails, record the error in the
+          `pr-result` artifact instead of inventing a URL.
+
+        OUTPUT FORMAT:
+        Produce a `pr-result` JSON matching the schema injected by the contract block.
+        Required fields: `pr_url`, `pr_number`, `branch`, `summary`.
+    output_artifacts:
+      - name: pr-result
+        path: .agents/output/pr-result.json
+        type: json
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/pr-result.json
+        schema_path: .agents/contracts/pr-result.schema.json
+        on_failure: warn
+    outcomes:
+      - type: pr
+        extract_from: .agents/output/pr-result.json
+        json_path: .pr_url
+        label: "Pull Request"


### PR DESCRIPTION
## Summary

Addresses the user request: _"as a user i expect something as a visible clickable readable outcome"_ from every `wave-*` self-evolution pipeline.

Before this change, several `wave-*` pipelines finished without an operator-facing artifact: files sat in a workspace, an exit code was returned, and that was it. Now every `wave-*` pipeline ends with a single clickable + readable deliverable — either a real pull request or a structured markdown report linked from `pipeline_outputs`.

## Outcome Shape per Pipeline

| Pipeline | Tree mutation | Outcome shape | Where it lands | Why |
|---|---|---|---|---|
| `wave-test-hardening` | readwrite | **Pull Request** (`create-pr` step) | `pr-result.json` validated against `.agents/contracts/pr-result.schema.json`, declared as `pipeline_outputs.pr` (`type: pr_ref`); `outcomes.type: pr` extracts the URL | Modifies the project tree by adding tests; canonical pattern from `impl-issue` create-pr step ensures a real PR with the new tests is opened on the worktree-isolated branch. |
| `wave-audit` | read-only on tree (creates GH issues) | **Markdown report** (`report` step) + existing GH issue creation | `wave-audit-report.md` (declared as `pipeline_outputs.report`) plus the existing `publish-result.json` (kept for `inception-harden` consumers) | The audit already creates clickable GitHub issues, but the operator deserves a digest that links each filed issue, surfaces the health snapshot, and lists the top prioritized actions. |
| `wave-validate` | read-only | **Markdown report** (existing `generate-report` step) | `validation-report.md` with `llm_judge` contract, declared as `pipeline_outputs.report` | Already correct — confirmed it is the last step's `output_artifact` and properly declared. |
| `wave-security-audit` | read-only | **Markdown report** (existing `verify` step) | `security-report.md` with `non_empty_file` contract, declared as `pipeline_outputs.report` | Already correct — confirmed declared and contracted. |
| `wave-scope-audit` | read-only on tree (creates GH issues) | **Markdown report** (existing `create-issues` step) | `created-issues.md` with `non_empty_file` contract, declared as `pipeline_outputs.issues` | Already correct — terminal markdown summary linking every created issue. |
| `wave-smoke-contracts` | n/a | `contract-check.json` (untouched) | Existing | Smoke test only, left as-is per spec. |
| `wave-smoke-gates` | n/a | `gate-result.json` (untouched) | Existing | Smoke test only, left as-is per spec. |

## Not Found

The spec asked to check for `wave-evolve.yaml`, `wave-bugfix.yaml`, and `wave-review.yaml`. None of these exist under `.agents/pipelines/` in this repository, so they were not modified. The full `wave-*` fleet covered above is the complete set.

## Implementation Notes

- `wave-test-hardening` `harden` and `run-tests` steps were converted from a `mode: readwrite` mount to `type: worktree` (shared `branch: "{{ pipeline_id }}"`). This matches the canonical `impl-issue` pattern and gives the new `create-pr` step a real branch to push. The `harden` prompt was updated to commit changes (no `git add -A`, conventional commit messages, no Co-Authored-By).
- `wave-test-hardening` `gate` conditional now routes to `create-pr` on success (instead of `_complete`), preserving the existing failure loop back to `harden`.
- `wave-audit` keeps its existing `publish-result.json` (still consumed by `inception-harden`) and adds a `report` step using `summarizer` persona at `model: cheapest`, producing `wave-audit-report.md` with markdown tables, clickable issue URLs, and a `Next Steps` section. Contract: `non_empty_file`, `on_failure: warn`.
- No emojis added anywhere (CLAUDE.md / spec rule). Plain markdown / HTML entities only.
- No Co-Authored-By trailers in commits or PR bodies.

## Test Plan

- [x] `go build -o ./wave ./cmd/wave` succeeds
- [x] `go test ./...` passes on this branch
- [x] `./wave list pipelines` parses cleanly and shows the new step counts (`wave-audit [5 steps]`, `wave-test-hardening [5 steps]`)
- [x] `./wave validate --pipeline <each-changed-pipeline>` succeeds
- [x] `./wave validate --all` succeeds
- [ ] Reviewer spot-checks that the canonical `create-pr` pattern (forge-aware persona, `pr-result.json`, `pr-result.schema.json`, `outcomes.type: pr`) was mirrored faithfully from `impl-issue`
- [ ] Reviewer confirms no `wave-*` pipeline still terminates without a clickable PR or readable markdown report