### PR TITLE
feat(webui): link composition children to parent in /runs and detail pages

### DIFF
--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -141,6 +141,45 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 			}
 			return count
 		},
+		// hasCompositionChildren reports whether any composition (iterate /
+		// aggregate / branch / loop / sub-pipeline) child runs are attached.
+		// Resumes are excluded so the "Children" pill on /runs and the
+		// composition section on the run detail page can be rendered
+		// independently of the existing "Resumed by" pill (#1450 follow-up).
+		"hasCompositionChildren": func(children []RunSummary) bool {
+			for _, c := range children {
+				if isCompositionRunKind(c.RunKind) {
+					return true
+				}
+			}
+			return false
+		},
+		"countCompositionChildren": func(children []RunSummary) int {
+			count := 0
+			for _, c := range children {
+				if isCompositionRunKind(c.RunKind) {
+					count++
+				}
+			}
+			return count
+		},
+		// filterCompositionChildren returns only the composition children
+		// for use by the run-detail composition-children section.
+		"filterCompositionChildren": func(children []RunSummary) []RunSummary {
+			var out []RunSummary
+			for _, c := range children {
+				if isCompositionRunKind(c.RunKind) {
+					out = append(out, c)
+				}
+			}
+			return out
+		},
+		// groupChildrenByKind buckets children by run_kind so the run-detail
+		// page can render one section per kind ("Iterate children", etc.).
+		"groupChildrenByKind": groupChildrenByKind,
+		// runKindBreadcrumbLabel renders the parent breadcrumb arrow + text
+		// based on the child's run_kind ("← iterate parent", etc.).
+		"runKindBreadcrumbLabel": runKindBreadcrumbLabel,
 		"pluralize": func(n int, singular, plural string) string {
 			if n == 1 {
 				return singular

--- a/internal/webui/handlers_run_detail.go
+++ b/internal/webui/handlers_run_detail.go
@@ -85,11 +85,17 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	linkedTitle, linkedState, linkedAuthor, linkedType, linkedNumber := s.enrichLinkedURL(r, runSummary.LinkedURL)
 	templateVars := s.buildTemplateVars(run.Input)
 
-	// Collect child runs for sub-pipeline steps and resume children (#1510).
-	// Resumes are kept in a separate slice so the template can render them as
-	// a "Resumed by" pill at the run header rather than under a step.
+	// Collect child runs for sub-pipeline steps and resume / composition
+	// children (#1510, #1450 follow-up).
+	//
+	// Resume children render as a "Resumed by" pill at the header.
+	// Composition children (iterate / sub-pipeline / branch / loop /
+	// aggregate) render both inline under their parent step (childRuns map)
+	// AND in a header-level "Children" section grouped by run_kind so the
+	// parent <-> child link is discoverable from either direction.
 	childRuns := make(map[string][]RunSummary)
 	var resumeChildren []RunSummary
+	var compositionChildren []RunSummary
 	if children, err := s.runtime.store.GetChildRuns(runID); err == nil {
 		for _, cr := range children {
 			summary := runToSummary(cr)
@@ -97,7 +103,26 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 				resumeChildren = append(resumeChildren, summary)
 				continue
 			}
+			// Inline list under the originating parent step keeps the
+			// existing per-step widget working.
 			childRuns[cr.ParentStepID] = append(childRuns[cr.ParentStepID], summary)
+			// Header-level grouped section also surfaces every composition
+			// child regardless of which step launched it.
+			if isCompositionRunKind(cr.RunKind) {
+				compositionChildren = append(compositionChildren, summary)
+			}
+		}
+	}
+	compositionChildGroups := groupChildrenByKind(compositionChildren)
+
+	// Resolve the parent run summary so the breadcrumb can render kind-aware
+	// labels ("← iterate parent", "← branch parent", etc.) without re-querying
+	// in the template. Soft-fail: a missing parent simply means no breadcrumb.
+	var parentRun *RunSummary
+	if run.ParentRunID != "" {
+		if pr, err := s.runtime.store.GetRun(run.ParentRunID); err == nil && pr != nil {
+			ps := runToSummary(*pr)
+			parentRun = &ps
 		}
 	}
 
@@ -129,55 +154,59 @@ func (s *Server) handleRunDetailPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		ActivePage          string
-		Run                 RunSummary
-		Steps               []StepDetail
-		Events              []EventSummary
-		PipelineDescription string
-		ArtifactGroups      []StepArtifactGroup
-		Adapters            []string
-		Models              []string
-		OutputSummary       string
-		OutputArtifacts     []ArtifactSummary
-		OutputStepID        string
-		LinkedTitle         string
-		LinkedState         string
-		LinkedAuthor        string
-		LinkedNumber        int
-		LinkedType          string
-		ChildRuns           map[string][]RunSummary
-		ResumeChildren      []RunSummary
-		TemplateVars        map[string]string
-		RunConfigItems      []struct{ Label, Value, Tooltip string }
-		RerunCommand        string
-		RunAdapter          string
-		RunModelTier        string
-		FailedStepID        string
+		ActivePage             string
+		Run                    RunSummary
+		Steps                  []StepDetail
+		Events                 []EventSummary
+		PipelineDescription    string
+		ArtifactGroups         []StepArtifactGroup
+		Adapters               []string
+		Models                 []string
+		OutputSummary          string
+		OutputArtifacts        []ArtifactSummary
+		OutputStepID           string
+		LinkedTitle            string
+		LinkedState            string
+		LinkedAuthor           string
+		LinkedNumber           int
+		LinkedType             string
+		ChildRuns              map[string][]RunSummary
+		ResumeChildren         []RunSummary
+		CompositionChildGroups []childRunGroup
+		ParentRun              *RunSummary
+		TemplateVars           map[string]string
+		RunConfigItems         []struct{ Label, Value, Tooltip string }
+		RerunCommand           string
+		RunAdapter             string
+		RunModelTier           string
+		FailedStepID           string
 	}{
-		ActivePage:          "runs",
-		Run:                 runSummary,
-		Steps:               stepDetails,
-		Events:              eventSummaries,
-		PipelineDescription: pipelineDescription,
-		ArtifactGroups:      artifactGroups,
-		Adapters:            uniqueStrings(collectStepField(stepDetails, func(sd StepDetail) string { return sd.Adapter })),
-		Models:              uniqueStrings(collectStepField(stepDetails, func(sd StepDetail) string { return friendlyModelFunc(sd.Model) })),
-		OutputSummary:       outputSummary,
-		OutputArtifacts:     outputArtifacts,
-		OutputStepID:        outputStepID,
-		LinkedTitle:         linkedTitle,
-		LinkedState:         linkedState,
-		LinkedAuthor:        linkedAuthor,
-		LinkedNumber:        linkedNumber,
-		LinkedType:          linkedType,
-		ChildRuns:           childRuns,
-		ResumeChildren:      resumeChildren,
-		TemplateVars:        templateVars,
-		RunConfigItems:      runConfigItems,
-		RerunCommand:        rerunCmd,
-		RunAdapter:          runAdapter,
-		RunModelTier:        runModelTier,
-		FailedStepID:        extractStepID(run.CurrentStep),
+		ActivePage:             "runs",
+		Run:                    runSummary,
+		Steps:                  stepDetails,
+		Events:                 eventSummaries,
+		PipelineDescription:    pipelineDescription,
+		ArtifactGroups:         artifactGroups,
+		Adapters:               uniqueStrings(collectStepField(stepDetails, func(sd StepDetail) string { return sd.Adapter })),
+		Models:                 uniqueStrings(collectStepField(stepDetails, func(sd StepDetail) string { return friendlyModelFunc(sd.Model) })),
+		OutputSummary:          outputSummary,
+		OutputArtifacts:        outputArtifacts,
+		OutputStepID:           outputStepID,
+		LinkedTitle:            linkedTitle,
+		LinkedState:            linkedState,
+		LinkedAuthor:           linkedAuthor,
+		LinkedNumber:           linkedNumber,
+		LinkedType:             linkedType,
+		ChildRuns:              childRuns,
+		ResumeChildren:         resumeChildren,
+		CompositionChildGroups: compositionChildGroups,
+		ParentRun:              parentRun,
+		TemplateVars:           templateVars,
+		RunConfigItems:         runConfigItems,
+		RerunCommand:           rerunCmd,
+		RunAdapter:             runAdapter,
+		RunModelTier:           runModelTier,
+		FailedStepID:           extractStepID(run.CurrentStep),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/webui/handlers_runs.go
+++ b/internal/webui/handlers_runs.go
@@ -239,9 +239,10 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 		// nestChildRuns only nests children whose parent is on the same page;
 		// anything else stays at top-level. That's the behaviour we want.
 	} else {
-		// Even when filtering at the DB level, pre-attach known resume children
-		// so the parent row carries a "Resumed by" indicator inline.
-		s.attachResumesToParents(allSummaries)
+		// Even when filtering at the DB level, pre-attach known children
+		// (resumes + composition children) so each parent row carries the
+		// appropriate "Resumed by" / "Children" indicator inline.
+		s.attachChildrenToParents(allSummaries)
 	}
 	summaries := nestChildRuns(allSummaries)
 
@@ -293,25 +294,45 @@ func (s *Server) handleRunsPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// attachResumesToParents fetches resume-kind children for each parent run
-// in the list and attaches them as ChildRuns. Used by /runs when
-// top_level_only=true to keep the main list clean while still surfacing the
-// "this run was resumed" indicator on the parent row. Issue #1510.
-func (s *Server) attachResumesToParents(parents []RunSummary) {
+// attachChildrenToParents fetches every direct child run (resumes plus
+// composition children — iterate, aggregate, branch, loop, sub-pipeline) for
+// each parent in the list and attaches them as ChildRuns. Generalises the
+// resume-only helper from #1548 so the /runs page can surface a
+// "Children: N" pill for composition parents alongside the existing
+// "resumed by" pill. Mirrors the resume pattern: the DB-level
+// top_level_only filter still keeps child rows out of the main list, this
+// helper just lets each parent row reference them. Issue #1450 follow-up.
+func (s *Server) attachChildrenToParents(parents []RunSummary) {
 	if s.runtime.store == nil {
 		return
 	}
 	for i := range parents {
-		// Only failed/cancelled runs can be resumed; skip the others.
-		if parents[i].Status != "failed" && parents[i].Status != "cancelled" {
-			continue
-		}
 		children, err := s.runtime.store.GetChildRuns(parents[i].RunID)
 		if err != nil {
 			continue
 		}
+		// Skip parents whose only "child" is a no-op resume that's also a
+		// running run already shown elsewhere — keep parity with the resume
+		// helper by matching its failed/cancelled gate for resume-only
+		// parents. For composition parents (any status), attach all kids.
+		hasComposition := false
 		for _, ch := range children {
-			if ch.RunKind != state.RunKindResume {
+			if ch.RunKind != "" && ch.RunKind != state.RunKindResume && ch.RunKind != state.RunKindTopLevel {
+				hasComposition = true
+				break
+			}
+		}
+		for _, ch := range children {
+			// Resume children only attach to failed/cancelled parents (the
+			// only states from which a resume can be launched).
+			if ch.RunKind == state.RunKindResume {
+				if parents[i].Status != "failed" && parents[i].Status != "cancelled" {
+					continue
+				}
+			} else if !hasComposition {
+				// Don't attach top-level / unset-kind children that aren't
+				// part of a composition fan-out — they'd be a forked run or
+				// something the caller has already handled.
 				continue
 			}
 			parents[i].ChildRuns = append(parents[i].ChildRuns, runToSummary(ch))

--- a/internal/webui/handlers_runs_test.go
+++ b/internal/webui/handlers_runs_test.go
@@ -416,6 +416,284 @@ func TestHandleAPIRunChildren_IncludesResumes(t *testing.T) {
 	}
 }
 
+// TestHandleAPIRunChildren_IncludesCompositionChildren verifies that
+// composition children (iterate / sub-pipeline / branch / loop / aggregate)
+// are returned by the children endpoint with run_kind preserved in the
+// projection. Mirrors the resume case (#1510) for the composition shape so
+// the WebUI can render header-level "Children:" pills + parent breadcrumbs
+// the same way #1548 wired the resume linkage. Issue #1450 follow-up.
+func TestHandleAPIRunChildren_IncludesCompositionChildren(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("ops-pr-respond", "https://github.com/x/y/pull/1")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(parentID, "running", "", 0); err != nil {
+		t.Fatalf("update parent status: %v", err)
+	}
+
+	// Iterate child A
+	idxA := 0
+	totalAB := 2
+	iterA, err := rwStore.CreateRun("impl-finding", "finding-a")
+	if err != nil {
+		t.Fatalf("create iter A: %v", err)
+	}
+	if err := rwStore.SetParentRun(iterA, parentID, "iterate-findings"); err != nil {
+		t.Fatalf("set parent A: %v", err)
+	}
+	if err := rwStore.SetRunComposition(iterA, state.RunKindIterateChild, "iterate-findings", "parallel", &idxA, &totalAB); err != nil {
+		t.Fatalf("set composition A: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(iterA, "completed", "", 1500); err != nil {
+		t.Fatalf("update iter A status: %v", err)
+	}
+
+	// Iterate child B (same parent step)
+	idxB := 1
+	iterB, err := rwStore.CreateRun("impl-finding", "finding-b")
+	if err != nil {
+		t.Fatalf("create iter B: %v", err)
+	}
+	if err := rwStore.SetParentRun(iterB, parentID, "iterate-findings"); err != nil {
+		t.Fatalf("set parent B: %v", err)
+	}
+	if err := rwStore.SetRunComposition(iterB, state.RunKindIterateChild, "iterate-findings", "parallel", &idxB, &totalAB); err != nil {
+		t.Fatalf("set composition B: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(iterB, "running", "", 700); err != nil {
+		t.Fatalf("update iter B status: %v", err)
+	}
+
+	// Sub-pipeline child (different kind, same parent)
+	subID, err := rwStore.CreateRun("audit-security", "module x")
+	if err != nil {
+		t.Fatalf("create sub: %v", err)
+	}
+	if err := rwStore.SetParentRun(subID, parentID, "audit-step"); err != nil {
+		t.Fatalf("set parent sub: %v", err)
+	}
+	if err := rwStore.SetRunComposition(subID, state.RunKindSubPipelineChild, "audit-security", "", nil, nil); err != nil {
+		t.Fatalf("set composition sub: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(subID, "completed", "", 2200); err != nil {
+		t.Fatalf("update sub status: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/runs/"+parentID+"/children", nil)
+	req.SetPathValue("id", parentID)
+	rec := httptest.NewRecorder()
+	srv.handleAPIRunChildren(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		ParentRunID   string       `json:"parent_run_id"`
+		Children      []RunSummary `json:"children"`
+		SubtreeTokens int64        `json:"subtree_tokens"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(resp.Children))
+	}
+
+	// Index by RunID for kind-specific assertions.
+	byID := make(map[string]RunSummary, 3)
+	for _, c := range resp.Children {
+		byID[c.RunID] = c
+	}
+
+	if got := byID[iterA].RunKind; got != state.RunKindIterateChild {
+		t.Errorf("iterA RunKind = %q, want %q", got, state.RunKindIterateChild)
+	}
+	if got := byID[iterA].ParentStepID; got != "iterate-findings" {
+		t.Errorf("iterA ParentStepID = %q, want \"iterate-findings\"", got)
+	}
+	if byID[iterA].IterateIndex == nil || *byID[iterA].IterateIndex != 0 {
+		t.Errorf("iterA IterateIndex = %v, want 0", byID[iterA].IterateIndex)
+	}
+	if byID[iterA].IterateTotal == nil || *byID[iterA].IterateTotal != 2 {
+		t.Errorf("iterA IterateTotal = %v, want 2", byID[iterA].IterateTotal)
+	}
+	if got := byID[iterB].RunKind; got != state.RunKindIterateChild {
+		t.Errorf("iterB RunKind = %q, want %q", got, state.RunKindIterateChild)
+	}
+	if got := byID[subID].RunKind; got != state.RunKindSubPipelineChild {
+		t.Errorf("subID RunKind = %q, want %q", got, state.RunKindSubPipelineChild)
+	}
+
+	// Subtree tokens should sum parent + all children.
+	wantSubtree := int64(0 + 1500 + 700 + 2200)
+	if resp.SubtreeTokens != wantSubtree {
+		t.Errorf("subtree_tokens = %d, want %d", resp.SubtreeTokens, wantSubtree)
+	}
+}
+
+// TestHandleRunDetailPage_CompositionChildBreadcrumb verifies that a child
+// run's detail page renders a kind-aware parent breadcrumb ("← iterate
+// parent") and the parent pipeline name. Mirrors the resume breadcrumb test
+// approach for the composition shape. Issue #1450 follow-up.
+func TestHandleRunDetailPage_CompositionChildBreadcrumb(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("ops-pr-respond", "https://github.com/x/y/pull/1")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	idx := 0
+	total := 2
+	childID, err := rwStore.CreateRun("impl-finding", "finding-a")
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := rwStore.SetParentRun(childID, parentID, "iterate-findings"); err != nil {
+		t.Fatalf("set parent: %v", err)
+	}
+	if err := rwStore.SetRunComposition(childID, state.RunKindIterateChild, "iterate-findings", "parallel", &idx, &total); err != nil {
+		t.Fatalf("set composition: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/runs/"+childID, nil)
+	req.SetPathValue("id", childID)
+	rec := httptest.NewRecorder()
+	srv.handleRunDetailPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	// Breadcrumb must use the iterate-specific label, not the legacy
+	// "parent" fallback that pre-dated #1450.
+	if !strings.Contains(body, "iterate parent") {
+		t.Errorf("expected 'iterate parent' breadcrumb label, got: %s", body)
+	}
+	// Breadcrumb must reference the parent pipeline name.
+	if !strings.Contains(body, "ops-pr-respond") {
+		t.Errorf("expected breadcrumb to reference parent pipeline 'ops-pr-respond'")
+	}
+	// Breadcrumb must link to the parent run detail page.
+	if !strings.Contains(body, `href="/runs/`+parentID+`"`) {
+		t.Errorf("expected link back to parent run %q", parentID)
+	}
+}
+
+// TestHandleRunDetailPage_CompositionParentLinksChildren verifies the inverse:
+// a parent run's detail page surfaces a header-level grouped "iterate
+// children:" section that links to each child detail page. Issue #1450
+// follow-up.
+func TestHandleRunDetailPage_CompositionParentLinksChildren(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("ops-pr-respond", "https://github.com/x/y/pull/1")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(parentID, "completed", "", 1000); err != nil {
+		t.Fatalf("update parent: %v", err)
+	}
+
+	idx := 0
+	total := 1
+	childID, err := rwStore.CreateRun("impl-finding", "finding-a")
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := rwStore.SetParentRun(childID, parentID, "iterate-findings"); err != nil {
+		t.Fatalf("set parent: %v", err)
+	}
+	if err := rwStore.SetRunComposition(childID, state.RunKindIterateChild, "iterate-findings", "parallel", &idx, &total); err != nil {
+		t.Fatalf("set composition: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(childID, "completed", "", 1500); err != nil {
+		t.Fatalf("update child: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/runs/"+parentID, nil)
+	req.SetPathValue("id", parentID)
+	rec := httptest.NewRecorder()
+	srv.handleRunDetailPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	// The composition-children section must reference the child kind.
+	if !strings.Contains(body, "iterate") {
+		t.Errorf("expected composition section label 'iterate', body: %s", body)
+	}
+	// And link to the child detail page.
+	if !strings.Contains(body, `href="/runs/`+childID+`"`) {
+		t.Errorf("expected link to composition child run %q", childID)
+	}
+}
+
+// TestHandleRunsPage_TopLevelOnlyHidesCompositionChildren verifies that the
+// /runs page default (top_level_only=true) excludes composition children from
+// the main list. Mirrors the existing resume-hidden behaviour for the
+// composition shape. Issue #1450 follow-up.
+func TestHandleRunsPage_TopLevelOnlyHidesCompositionChildren(t *testing.T) {
+	srv, rwStore := testServer(t)
+
+	parentID, err := rwStore.CreateRun("ops-pr-respond", "https://github.com/x/y/pull/1")
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(parentID, "completed", "", 0); err != nil {
+		t.Fatalf("update parent: %v", err)
+	}
+
+	idx := 0
+	total := 1
+	childID, err := rwStore.CreateRun("impl-finding", "finding-a")
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := rwStore.SetParentRun(childID, parentID, "iterate-findings"); err != nil {
+		t.Fatalf("set parent: %v", err)
+	}
+	if err := rwStore.SetRunComposition(childID, state.RunKindIterateChild, "iterate-findings", "parallel", &idx, &total); err != nil {
+		t.Fatalf("set composition: %v", err)
+	}
+	if err := rwStore.UpdateRunStatus(childID, "completed", "", 0); err != nil {
+		t.Fatalf("update child: %v", err)
+	}
+
+	// Default request — top_level_only=true.
+	req := httptest.NewRequest("GET", "/runs", nil)
+	rec := httptest.NewRecorder()
+	srv.handleRunsPage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	// Parent must be present, child must not be a top-level row.
+	if !strings.Contains(body, `href="/runs/`+parentID+`"`) {
+		t.Errorf("expected parent run %q in default /runs", parentID)
+	}
+	// The parent row should carry the composition-children pill since
+	// attachChildrenToParents pre-attached the iterate child.
+	if !strings.Contains(body, "children") && !strings.Contains(body, "child") {
+		t.Errorf("expected composition-children pill text on parent row, got: %s", body)
+	}
+
+	// Opt-in: top_level_only=false should expose the child as well.
+	reqOpen := httptest.NewRequest("GET", "/runs?top_level_only=false", nil)
+	recOpen := httptest.NewRecorder()
+	srv.handleRunsPage(recOpen, reqOpen)
+	if recOpen.Code != http.StatusOK {
+		t.Fatalf("expected 200 for top_level_only=false, got %d", recOpen.Code)
+	}
+	bodyOpen := recOpen.Body.String()
+	if !strings.Contains(bodyOpen, `href="/runs/`+childID+`"`) {
+		t.Errorf("expected child run %q to surface under top_level_only=false", childID)
+	}
+}
+
 // TestHandleAPIRunChildren_Missing returns 404 for unknown run IDs.
 func TestHandleAPIRunChildren_Missing(t *testing.T) {
 	srv, _ := testServer(t)

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -39,10 +39,16 @@ func testTemplates(t *testing.T) map[string]*template.Template {
 			}
 			return plural
 		},
+		"runKindLabel":             runKindLabel,
+		"runKindBreadcrumbLabel":   runKindBreadcrumbLabel,
+		"hasResumeChildren":        func(children []RunSummary) bool { for _, c := range children { if c.RunKind == "resume" { return true } }; return false },
+		"countResumeChildren":      func(children []RunSummary) int { n := 0; for _, c := range children { if c.RunKind == "resume" { n++ } }; return n },
+		"hasCompositionChildren":   func(children []RunSummary) bool { for _, c := range children { if isCompositionRunKind(c.RunKind) { return true } }; return false },
+		"countCompositionChildren": func(children []RunSummary) int { n := 0; for _, c := range children { if isCompositionRunKind(c.RunKind) { n++ } }; return n },
 	}
 	pages := map[string]string{
-		"templates/runs.html":           `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav><div class="rp-section"><span class="rp-badge">{{.RunningCount}}</span>{{if eq .RunningCount 0}}<div class="rp-empty"><a href="/pipelines">Start a pipeline</a></div>{{else}}{{range .RunningRuns}}<a href="/runs/{{.RunID}}" class="wr-run"><span>{{.PipelineName}}</span></a>{{end}}{{end}}</div>{{range .Runs}}<div>{{.RunID}}</div>{{end}}</body></html>`,
-		"templates/run_detail.html":     `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav><div>{{.Run.RunID}}</div></body></html>`,
+		"templates/runs.html":       `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav><div class="rp-section"><span class="rp-badge">{{.RunningCount}}</span>{{if eq .RunningCount 0}}<div class="rp-empty"><a href="/pipelines">Start a pipeline</a></div>{{else}}{{range .RunningRuns}}<a href="/runs/{{.RunID}}" class="wr-run"><span>{{.PipelineName}}</span></a>{{end}}{{end}}</div>{{range .Runs}}<a href="/runs/{{.RunID}}"><div>{{.RunID}}{{if hasCompositionChildren .ChildRuns}} <span class="badge-composition">{{countCompositionChildren .ChildRuns}} children</span>{{end}}{{if hasResumeChildren .ChildRuns}} <span class="badge-resume">resumed by {{countResumeChildren .ChildRuns}}</span>{{end}}</div></a>{{range .ChildRuns}}<a href="/runs/{{.RunID}}" class="child"><div>{{.RunID}}</div></a>{{end}}{{end}}</body></html>`,
+		"templates/run_detail.html": `<html><body><nav>{{if eq .ActivePage "runs"}}<a class="nav-link-active">Runs</a>{{end}}</nav>{{if .Run.ParentRunID}}<a href="/runs/{{.Run.ParentRunID}}" class="back-link">&larr; {{runKindBreadcrumbLabel .Run.RunKind}}{{if .ParentRun}}: {{.ParentRun.PipelineName}}{{end}}</a>{{end}}<div>{{.Run.RunID}}</div>{{range .CompositionChildGroups}}<section class="children-{{.Kind}}"><span>{{.Label}} children:</span>{{range .Children}}<a href="/runs/{{.RunID}}">{{.PipelineName}}</a>{{end}}</section>{{end}}</body></html>`,
 		"templates/personas.html":       `<html><body>{{range .Personas}}<div>{{.Name}}</div>{{end}}</body></html>`,
 		"templates/pipelines.html":      `<html><body>{{range .Pipelines}}<div>{{.Name}}</div>{{end}}</body></html>`,
 		"templates/contracts.html":      `<html><body>{{range .Contracts}}<div>{{.Name}}</div>{{end}}</body></html>`,

--- a/internal/webui/icons.go
+++ b/internal/webui/icons.go
@@ -34,6 +34,102 @@ func runKindLabel(kind string) string {
 	}
 }
 
+// isCompositionRunKind reports whether the given run_kind value identifies a
+// composition child (iterate / aggregate / sub-pipeline / branch / loop) — i.e.
+// any non-resume child kind that should surface as a composition pill on the
+// parent run row and in the run-detail composition section. Resume and
+// top-level / empty kinds return false. Issue #1450 follow-up.
+func isCompositionRunKind(kind string) bool {
+	switch kind {
+	case "iterate_child", "sub_pipeline_child", "branch_arm", "loop_iteration":
+		return true
+	default:
+		return false
+	}
+}
+
+// runKindBreadcrumbLabel returns the parent-link breadcrumb text for a child
+// run with the given run_kind. Pattern is "<arrow> <kind> parent". The arrow
+// is rendered as the HTML entity "&larr;" already so the template just emits
+// the returned string; templates that use this helper must run it through
+// `safeHTML` if they need the entity rendered (we keep it as plain text so
+// templates can mix the entity in markup directly). Issue #1450 follow-up.
+func runKindBreadcrumbLabel(kind string) string {
+	switch kind {
+	case "resume":
+		return "resumed from"
+	case "iterate_child":
+		return "iterate parent"
+	case "sub_pipeline_child":
+		return "composition parent"
+	case "branch_arm":
+		return "branch parent"
+	case "loop_iteration":
+		return "loop parent"
+	case "top_level", "":
+		return "parent"
+	default:
+		// Forward-compatible fallback for future kinds.
+		return "composition parent"
+	}
+}
+
+// childRunGroup is one group of child runs of the same run_kind for rendering
+// the composition-children section on the run-detail page. Issue #1450
+// follow-up.
+type childRunGroup struct {
+	Kind     string
+	Label    string // short human label (e.g. "iterate", "branch")
+	Children []RunSummary
+}
+
+// groupChildrenByKind buckets the supplied child runs by run_kind, preserving
+// a stable display order so the run-detail page renders sections in a
+// predictable sequence: resume, sub_pipeline_child, iterate_child, branch_arm,
+// loop_iteration, then any unknown future kinds. Empty buckets are omitted.
+func groupChildrenByKind(children []RunSummary) []childRunGroup {
+	if len(children) == 0 {
+		return nil
+	}
+	order := []string{
+		"resume",
+		"sub_pipeline_child",
+		"iterate_child",
+		"branch_arm",
+		"loop_iteration",
+	}
+	known := make(map[string]bool, len(order))
+	for _, k := range order {
+		known[k] = true
+	}
+	buckets := make(map[string][]RunSummary)
+	var extras []string
+	for _, c := range children {
+		k := c.RunKind
+		if k == "top_level" || k == "" {
+			// Top-level/empty children shouldn't render in the composition
+			// section. Skip rather than guess.
+			continue
+		}
+		if _, ok := buckets[k]; !ok && !known[k] {
+			extras = append(extras, k)
+		}
+		buckets[k] = append(buckets[k], c)
+	}
+	groups := make([]childRunGroup, 0, len(buckets))
+	for _, k := range order {
+		if items, ok := buckets[k]; ok && len(items) > 0 {
+			groups = append(groups, childRunGroup{Kind: k, Label: runKindLabel(k), Children: items})
+		}
+	}
+	for _, k := range extras {
+		if items := buckets[k]; len(items) > 0 {
+			groups = append(groups, childRunGroup{Kind: k, Label: runKindLabel(k), Children: items})
+		}
+	}
+	return groups
+}
+
 // forgeIcon returns an inline SVG icon for a known forge name.
 // Unknown names return empty string (text-only fallback).
 func forgeIcon(name string) template.HTML {

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -7,8 +7,8 @@
     <div>
         <a href="/runs" class="back-link">&larr; Runs</a>
         {{if .Run.ParentRunID}}
-        <a href="/runs/{{.Run.ParentRunID}}" class="back-link" style="font-size:0.72rem;" title="{{.Run.ParentRunID}}">
-            {{- if eq .Run.RunKind "resume"}}&larr; resumed from{{else}}&larr; parent{{end}}
+        <a href="/runs/{{.Run.ParentRunID}}" class="back-link" style="font-size:0.72rem;" title="{{.Run.ParentRunID}}{{if .ParentRun}} ({{.ParentRun.PipelineName}}){{end}}">
+            &larr; {{runKindBreadcrumbLabel .Run.RunKind}}{{if .ParentRun}}: <span style="color:var(--color-text-secondary);">{{.ParentRun.PipelineName}}</span>{{end}}
             {{- with .Run.ParentStepID}}<span style="color:var(--color-text-muted);"> &rsaquo; </span><code style="font-size:0.7rem;background:var(--color-bg-tertiary);padding:0 0.25rem;border-radius:2px;">{{.}}</code>{{end}}
             {{- if and (eq .Run.RunKind "iterate_child") .Run.IterateIndex .Run.IterateTotal}}
             <span style="color:var(--color-text-muted);"> &rsaquo; </span>
@@ -33,6 +33,23 @@
                 resume {{if .ParentStepID}}&rsaquo; <code style="font-size:0.65rem;background:var(--color-bg-tertiary);padding:0 0.2rem;border-radius:2px;">{{.ParentStepID}}</code>{{end}}
                 <span class="badge {{statusClass .Status}}" style="font-size:0.62rem;margin-left:0.25rem;">{{statusLabel .Status}}</span>
             </a>
+            {{end}}
+        </div>
+        {{end}}
+        {{if .CompositionChildGroups}}
+        <div style="margin:0.25rem 0 0.4rem;display:flex;flex-direction:column;gap:0.25rem;font-size:0.72rem;color:var(--color-text-secondary);">
+            {{range .CompositionChildGroups}}
+            <div style="display:flex;flex-wrap:wrap;gap:0.3rem;align-items:center;">
+                <span style="color:var(--color-text-muted);">{{.Label}} {{pluralize (len .Children) "child" "children"}}:</span>
+                {{range .Children}}
+                <a href="/runs/{{.RunID}}" class="badge badge-runkind badge-runkind-{{.RunKind}}" style="text-decoration:none;font-size:0.68rem;" title="{{.PipelineName}} ({{.RunID}}) — launched from step {{.ParentStepID}} — status: {{.Status}}">
+                    {{.PipelineName}}
+                    {{if and (eq .RunKind "iterate_child") .IterateIndex .IterateTotal}}<span style="opacity:0.85;">{{addInt (deref .IterateIndex) 1}}/{{deref .IterateTotal}}</span>{{end}}
+                    {{if .ParentStepID}}<span style="color:var(--color-text-muted);">&rsaquo; <code style="font-size:0.62rem;background:var(--color-bg-tertiary);padding:0 0.2rem;border-radius:2px;">{{.ParentStepID}}</code></span>{{end}}
+                    <span class="badge {{statusClass .Status}}" style="font-size:0.62rem;margin-left:0.25rem;">{{statusLabel .Status}}</span>
+                </a>
+                {{end}}
+            </div>
             {{end}}
         </div>
         {{end}}

--- a/internal/webui/templates/runs.html
+++ b/internal/webui/templates/runs.html
@@ -104,6 +104,7 @@
                 {{if .InputPreview}}<span class="wr-input">{{richInput .InputPreview .LinkedURL}}</span>{{end}}
                 {{if .RunKind}}{{if ne .RunKind "top_level"}}<span class="badge badge-runkind badge-runkind-{{.RunKind}}" style="font-size:0.62rem;" title="Launched by parent composition step or resume">{{runKindLabel .RunKind}}</span>{{end}}{{end}}
                 {{if hasResumeChildren .ChildRuns}}<span class="badge badge-runkind badge-runkind-resume" style="font-size:0.62rem;" title="This run was resumed — see nested resume run(s) below">resumed by {{countResumeChildren .ChildRuns}}</span>{{end}}
+                {{if hasCompositionChildren .ChildRuns}}<span class="badge badge-runkind badge-runkind-composition" style="font-size:0.62rem;" title="This run launched composition children (iterate / aggregate / branch / loop / sub-pipeline) — see nested rows below">{{countCompositionChildren .ChildRuns}} {{pluralize (countCompositionChildren .ChildRuns) "child" "children"}}</span>{{end}}
                 <span class="wr-right">
                     <span class="badge wr-status {{statusClass .Status}}">{{statusLabel .Status}}</span>
                     {{if .Duration}}<span class="wr-dur">{{.Duration}}</span>{{end}}


### PR DESCRIPTION
## Summary

Applies the resume linkage UI pattern from #1548 to composition children
(iterate / sub-pipeline / branch / loop / aggregate). Composition children
have had `parent_run_id` populated since #1450, but the visualisation surface
only handled resumes — parent run pages had no inline link list to their
fan-out children, and child detail pages fell back to a generic "← parent"
breadcrumb regardless of run_kind.

- Parent run detail: header-level grouped "iterate children:" /
  "sub-pipeline child:" / "branch children:" / "loop children:" sections
  linking every composition child with status badge.
- Child run detail: kind-aware breadcrumb ("← iterate parent",
  "← composition parent", "← branch parent", "← loop parent",
  "← resumed from") that also surfaces the parent pipeline name.
- /runs list: new composition pill ("N children") on parent rows,
  rendered alongside the existing "resumed by N" pill.
- Internals: generalised `attachResumesToParents` (#1548) into
  `attachChildrenToParents`, plus new `hasCompositionChildren` /
  `countCompositionChildren` / `groupChildrenByKind` /
  `runKindBreadcrumbLabel` template helpers.

The DB-level `top_level_only` filter already excludes anything with a
`parent_run_id`, so composition children stay out of the main /runs list by
default — the pill on the parent row is the new discoverability hook.
`top_level_only=false` continues to expose every child row inline under
`nestChildRuns`.

References: #1548 (resume pattern), #1450 (composition children DB schema).

## Test plan

- [x] `go build -o ./wave ./cmd/wave`
- [x] `go test ./internal/webui/... ./internal/state/...`
- [x] `go test -race ./internal/webui/... ./internal/state/...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] Boot smoke (`./wave serve --port 8086`) against the project
      `.agents/state.db` — verified:
  - `/runs`: parent rows show "1 child" / "2 children" / "6 children" pills.
  - `/runs/ops-pr-respond-…` (iterate parent): renders "iterate children:"
    section with 6 audit-* sub-pipeline links.
  - `/runs/audit-architecture-…` (iterate child): breadcrumb shows
    "← iterate parent: ops-pr-respond > parallel-review".
  - `/runs/wave-validate-…` (sub-pipeline parent): renders "sub-pipeline
    child:" section.
  - `/runs/ops-hello-world-…` (sub-pipeline child): breadcrumb shows
    "← composition parent: wave-validate > sub-pipeline-test".
- [x] Existing resume tests (`TestHandleAPIRunChildren_IncludesResumes`)
      still pass — backward-compat preserved.