### PR TITLE
feat(state,webui,cmd): distinguish design-rejection from runtime failure

### DIFF
--- a/.agents/pipelines/impl-issue-core.yaml
+++ b/.agents/pipelines/impl-issue-core.yaml
@@ -70,7 +70,14 @@ steps:
         source: .agents/output/issue-assessment.json
         schema_path: .agents/contracts/issue-assessment.schema.json
         must_pass: true
-        on_failure: fail
+        # The schema's `implementable: { const: true }` rule deliberately
+        # rejects assessments where the persona reports `implementable:
+        # false` (issue already implemented, superseded, no real bug).
+        # Surface this as a distinct `rejected` terminal state rather than
+        # a runtime `failed` so operators don't see a red banner for what
+        # was actually a correct, intentional verdict. The CLI exits 0 and
+        # the webui renders a yellow no-op badge for rejected runs.
+        on_failure: rejected
 
   - id: plan
     persona: implementer

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -256,6 +256,18 @@ func runRun(opts RunOptions, debug bool) error {
 	execErr := runOnce(ctx, executor, opts, &m, p, store, runID)
 
 	if execErr != nil {
+		// Design rejection: contract with on_failure: rejected fired. The
+		// persona reported the work is non-actionable (e.g. issue already
+		// implemented, no real bug, superseded). Render with a distinct
+		// non-red banner and exit 0 — this was a legitimate verdict, not
+		// a runtime failure. Stop the TUI first so the banner reaches a
+		// clean terminal.
+		var rejectionErr *pipeline.ContractRejectionError
+		if errors.As(execErr, &rejectionErr) {
+			res.Close()
+			printRejectionSummary(opts, p, rejectionErr, time.Since(pipelineStart), emitter, runID)
+			return nil
+		}
 		return formatRecoveryError(execErr, opts, p, runID, wsRoot, emitter)
 	}
 

--- a/cmd/wave/commands/run_stages.go
+++ b/cmd/wave/commands/run_stages.go
@@ -439,10 +439,16 @@ func runOnce(ctx context.Context, executor *pipeline.DefaultPipelineExecutor, op
 	// Update the pipeline_run record so the dashboard reflects final status
 	if store != nil {
 		tokens := executor.GetTotalTokens()
+		var rejectionErr *pipeline.ContractRejectionError
 		switch {
 		case ctx.Err() != nil:
 			_ = store.UpdateRunStatus(runID, "cancelled", "pipeline cancelled", tokens)
 			_ = store.ClearCancellation(runID)
+		case execErr != nil && errors.As(execErr, &rejectionErr):
+			// Design rejection: persona output deliberately reported the
+			// work is non-actionable (e.g. `implementable: false`). This
+			// is a legitimate terminal verdict, not a runtime failure.
+			_ = store.UpdateRunStatus(runID, "rejected", execErr.Error(), tokens)
 		case execErr != nil:
 			_ = store.UpdateRunStatus(runID, "failed", execErr.Error(), tokens)
 		default:
@@ -606,6 +612,48 @@ func formatRecoveryError(execErr error, opts RunOptions, p *pipeline.Pipeline, r
 // modes print the green "completed" banner plus an indented outcome
 // breakdown to stderr; JSON mode emits a final "completed" event with the
 // structured outcomes payload. Quiet mode is intentionally silent.
+// printRejectionSummary renders the post-run banner for a design-rejection
+// terminal state. It is the rejection sibling of printSummary — the run was
+// halted because a contract with `on_failure: rejected` fired (e.g. an issue
+// assessment returned `implementable: false`). The banner uses a yellow
+// "rejected" colour rather than red, the CLI exits 0, and JSON consumers
+// receive a `state: "rejected"` event so dashboards can route it to the
+// dedicated rejected status.
+//
+// Banner sample (text mode):
+//
+//	! Pipeline 'inception-bugfix' rejected (1.5s) — no implementable issue
+//	  step "fetch-assess": value must be true at /implementable
+func printRejectionSummary(opts RunOptions, p *pipeline.Pipeline, rejectionErr *pipeline.ContractRejectionError, elapsed time.Duration, emitter event.EventEmitter, runID string) {
+	if opts.Output.Format == OutputFormatJSON {
+		emitter.Emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: runID,
+			StepID:     rejectionErr.StepID,
+			State:      "rejected",
+			DurationMs: elapsed.Milliseconds(),
+			Message:    rejectionErr.Error(),
+		})
+		return
+	}
+	if opts.Output.Format != OutputFormatAuto && opts.Output.Format != OutputFormatText {
+		return
+	}
+	// Yellow ANSI bang glyph keeps the run visually distinct from a green
+	// completion (✓) or red failure (✕). The colour code is the same one
+	// `display.FormatStateBadge` uses for warning-class signals.
+	const yellow = "\033[33m"
+	const reset = "\033[0m"
+	fmt.Fprintf(os.Stderr, "\n  %s!%s Pipeline '%s' rejected (%.1fs) — no implementable result\n",
+		yellow, reset, p.Metadata.Name, elapsed.Seconds())
+	if rejectionErr.StepID != "" {
+		fmt.Fprintf(os.Stderr, "    step %q: %s\n", rejectionErr.StepID, rejectionErr.Reason)
+	} else if rejectionErr.Reason != "" {
+		fmt.Fprintf(os.Stderr, "    %s\n", rejectionErr.Reason)
+	}
+	fmt.Fprintf(os.Stderr, "    This is not a runtime failure — the pipeline declared the work non-actionable by design.\n\n")
+}
+
 func printSummary(opts RunOptions, executor *pipeline.DefaultPipelineExecutor, p *pipeline.Pipeline, runID string, elapsed time.Duration, emitter event.EventEmitter) {
 	// Show human summary only in auto/text modes — json and quiet stay clean
 	if opts.Output.Format == OutputFormatAuto || opts.Output.Format == OutputFormatText {

--- a/internal/defaults/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/pipelines/impl-issue-core.yaml
@@ -69,7 +69,14 @@ steps:
         source: .agents/output/issue-assessment.json
         schema_path: .agents/contracts/issue-assessment.schema.json
         must_pass: true
-        on_failure: fail
+        # The schema's `implementable: { const: true }` rule deliberately
+        # rejects assessments where the persona reports `implementable:
+        # false` (issue already implemented, superseded, no real bug).
+        # Surface this as a distinct `rejected` terminal state rather than
+        # a runtime `failed` so operators don't see a red banner for what
+        # was actually a correct, intentional verdict. The CLI exits 0 and
+        # the webui renders a yellow no-op badge for rejected runs.
+        on_failure: rejected
 
   - id: plan
     persona: implementer

--- a/internal/event/emitter.go
+++ b/internal/event/emitter.go
@@ -117,6 +117,17 @@ const (
 	StateRetrying       = "retrying"
 	StateSkipped        = "skipped"
 	StateReworking      = "reworking"
+	// StateRejected is a terminal state distinct from StateFailed. It signals
+	// that a step (or run) was halted by an *intentional design rejection*: a
+	// contract with on_failure: rejected fired because the upstream
+	// assessment declared the work non-actionable (e.g. fetch-assess setting
+	// `implementable: false` because the issue is already implemented or
+	// superseded). Pipeline authors opt in to this signal via
+	// `on_failure: rejected` on the gating contract; downstream UIs render
+	// it with a distinct, non-red badge so operators don't conflate
+	// design rejections with runtime failures. See feat: distinguish
+	// design-rejection from runtime failure (issue tracking the UX gap).
+	StateRejected = "rejected"
 
 	// Progress tracking states
 	StateStepProgress       = "step_progress"       // Step is making progress (with percentage)

--- a/internal/pipeline/contract_integration_test.go
+++ b/internal/pipeline/contract_integration_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1437,4 +1438,190 @@ func contractTestIndexOf(slice []string, item string) int {
 		}
 	}
 	return -1
+}
+
+// ============================================================================
+// Test: Contract on_failure: rejected routes to design-rejection terminal state
+// ============================================================================
+//
+// Regression for the UX bug where impl-issue-core's fetch-assess step,
+// when correctly determining `implementable: false` for an
+// already-implemented or superseded issue, would surface as a generic red
+// "failed" run. The contract opt-in `on_failure: rejected` now routes
+// these cases to the dedicated `rejected` terminal state with:
+//
+//   - Pipeline status = "rejected" (distinct from "failed").
+//   - Step state = "rejected" (distinct from "failed").
+//   - The returned error implements ContractRejectionError so callers
+//     (CLI runOnce, webui handlers) can branch to non-red rendering.
+//   - A `rejected` event in the event log for SSE consumers.
+
+func TestContractIntegration_DesignRejectionTerminalState(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Schema mirrors issue-assessment.schema.json's `implementable` rule —
+	// const: true means a `false` value is a deliberate, schema-encoded
+	// rejection signal, not a missing-field bug.
+	schemaDir := filepath.Join(tmpDir, ".agents", "contracts")
+	require.NoError(t, os.MkdirAll(schemaDir, 0755))
+	schema := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["implementable"],
+		"properties": {
+			"implementable": { "type": "boolean", "const": true },
+			"reason": { "type": "string" }
+		}
+	}`
+	schemaPath := filepath.Join(schemaDir, "assess.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0644))
+
+	// Persona output: deliberately reports `implementable: false`. This
+	// is the "design rejection" signal — the issue cannot/should not be
+	// worked on. The schema's const:true rejects this value.
+	rejectionArtifact := `{"implementable": false, "reason": "issue already implemented in commit abc123"}`
+	mockAdapter := newContractTestArtifactWritingAdapter(map[string]string{
+		"fetch-assess": rejectionArtifact,
+	})
+
+	collector := testutil.NewEventCollector()
+	executor := NewDefaultPipelineExecutor(mockAdapter,
+		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
+	)
+
+	m := testutil.CreateTestManifest(tmpDir)
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "design-rejection-test"},
+		Steps: []Step{
+			{
+				ID:      "fetch-assess",
+				Persona: "navigator",
+				Exec:    ExecConfig{Source: "Assess whether this issue is implementable"},
+				OutputArtifacts: []ArtifactDef{
+					{Name: "assessment", Path: ".agents/artifact.json"},
+				},
+				Handover: HandoverConfig{
+					Contract: ContractConfig{
+						Type:       "json_schema",
+						SchemaPath: schemaPath,
+						MustPass:   true,
+						OnFailure:  OnFailureRejected,
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.Error(t, err, "Execute should propagate the rejection error so callers can branch")
+
+	// The error must be a ContractRejectionError (possibly wrapped in
+	// StepExecutionError) so cmd/wave/commands/run_stages.go and the
+	// webui can detect it via errors.As and route to the rejected
+	// terminal state instead of treating it as a runtime failure.
+	var rejectionErr *ContractRejectionError
+	require.True(t, errors.As(err, &rejectionErr),
+		"error must unwrap to *ContractRejectionError so CLI/webui can detect design rejection (got: %T)", err)
+	assert.Equal(t, "fetch-assess", rejectionErr.StepID, "rejection error should carry the step ID")
+	assert.Equal(t, "json_schema", rejectionErr.ContractType, "rejection error should carry the contract type")
+
+	// Event log should contain a `rejected` state event (not just `failed`)
+	// so SSE clients and the webui timeline render the run distinctly.
+	events := collector.GetEvents()
+	hasRejected := false
+	hasFailed := false
+	for _, e := range events {
+		switch e.State {
+		case "rejected":
+			hasRejected = true
+		case "failed":
+			// Only count failed events that aren't from sub-step retry
+			// fingerprinting (those are emitted regardless).
+			if e.StepID == "fetch-assess" {
+				hasFailed = true
+			}
+		}
+	}
+	assert.True(t, hasRejected, "should emit at least one `rejected` state event")
+	assert.False(t, hasFailed, "should NOT emit a `failed` state event for the fetch-assess step — that would be the very bug this test guards against")
+}
+
+// TestContractIntegration_OnFailureFailStillRejectsBrokenSchema confirms
+// that `on_failure: fail` (the default) is unchanged by the rejection
+// patch — schema breakage, runtime panics, and other genuine errors must
+// continue to surface as red `failed` runs. The rejection opt-in must not
+// mask real bugs.
+func TestContractIntegration_OnFailureFailStillFailsRun(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	schemaDir := filepath.Join(tmpDir, ".agents", "contracts")
+	require.NoError(t, os.MkdirAll(schemaDir, 0755))
+	schema := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["implementable"],
+		"properties": {
+			"implementable": { "type": "boolean", "const": true }
+		}
+	}`
+	schemaPath := filepath.Join(schemaDir, "assess.schema.json")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0644))
+
+	// Same `implementable: false` payload, but the contract uses the
+	// default `on_failure: fail` (no explicit value). The run must still
+	// surface as a regular failure — backward compatibility for pipelines
+	// that have not opted into the rejection signal.
+	rejectionArtifact := `{"implementable": false}`
+	mockAdapter := newContractTestArtifactWritingAdapter(map[string]string{
+		"step1": rejectionArtifact,
+	})
+
+	collector := testutil.NewEventCollector()
+	executor := NewDefaultPipelineExecutor(mockAdapter,
+		WithEmitter(collector),
+		WithOntologyService(ontology.NoOp{}),
+	)
+
+	m := testutil.CreateTestManifest(tmpDir)
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "fail-default-test"},
+		Steps: []Step{
+			{
+				ID:      "step1",
+				Persona: "navigator",
+				Exec:    ExecConfig{Source: "Generate"},
+				OutputArtifacts: []ArtifactDef{
+					{Name: "out", Path: ".agents/artifact.json"},
+				},
+				Handover: HandoverConfig{
+					Contract: ContractConfig{
+						Type:       "json_schema",
+						SchemaPath: schemaPath,
+						MustPass:   true,
+						// no on_failure set — defaults to "fail"
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := executor.Execute(ctx, p, m, "test")
+	require.Error(t, err)
+
+	// Must NOT be classified as a rejection — pipelines must explicitly
+	// opt in via `on_failure: rejected`. Otherwise we'd silently change
+	// the semantics of every `const`/`enum` schema check across the
+	// codebase.
+	var rejectionErr *ContractRejectionError
+	assert.False(t, errors.As(err, &rejectionErr),
+		"default on_failure: fail must NOT trigger the rejection path")
 }

--- a/internal/pipeline/dag.go
+++ b/internal/pipeline/dag.go
@@ -134,10 +134,10 @@ func (v *DAGValidator) ValidateDAG(p *Pipeline) error {
 			// Validate contract-level on_failure enum
 			if c.OnFailure != "" {
 				switch c.OnFailure {
-				case OnFailureFail, OnFailureSkip, OnFailureContinue, OnFailureRework, OnFailureWarn:
+				case OnFailureFail, OnFailureSkip, OnFailureContinue, OnFailureRework, OnFailureWarn, OnFailureRejected:
 					// valid
 				default:
-					return fmt.Errorf("step %q: agent_review contract has invalid on_failure value %q (must be fail, skip, continue, rework, or warn)",
+					return fmt.Errorf("step %q: agent_review contract has invalid on_failure value %q (must be fail, skip, continue, rework, warn, or rejected)",
 						step.ID, c.OnFailure)
 				}
 			}

--- a/internal/pipeline/errors.go
+++ b/internal/pipeline/errors.go
@@ -18,6 +18,30 @@ func (e *StepExecutionError) Unwrap() error {
 	return e.Err
 }
 
+// ContractRejectionError signals a *design rejection* — a contract with
+// on_failure: rejected fired because the persona output deliberately marked
+// the work as non-actionable (e.g. fetch-assess setting `implementable:
+// false` because the issue is already implemented or superseded).
+//
+// This is structurally a step failure (the contract did not pass), but
+// semantically it is the persona telling the orchestrator "there is no work
+// here." Callers up the stack (the executor, the CLI's runOnce, the webui
+// status renderer) detect this error via errors.As and route it to the
+// dedicated `rejected` terminal state instead of `failed`. The CLI exits 0
+// because there was no malfunction — the answer was simply "no".
+type ContractRejectionError struct {
+	StepID       string
+	ContractType string
+	Reason       string // human-readable summary of the rejection (validator error message)
+}
+
+func (e *ContractRejectionError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("step %q rejected by contract (%s): %s", e.StepID, e.ContractType, e.Reason)
+	}
+	return fmt.Sprintf("step %q rejected by contract (%s)", e.StepID, e.ContractType)
+}
+
 // gateAbortError is returned when a gate step selects a choice targeting _fail,
 // signaling that the pipeline should abort.
 type gateAbortError struct {

--- a/internal/pipeline/executor_contract.go
+++ b/internal/pipeline/executor_contract.go
@@ -198,6 +198,55 @@ func (e *DefaultPipelineExecutor) applyContractOnFailure(
 		)
 		return false, fmt.Errorf("contract validation failed: %w", cErr)
 
+	case OnFailureRejected:
+		// Design rejection: contract failed because the persona output
+		// deliberately signalled no-op (e.g. `implementable: false`). This
+		// is NOT a runtime failure — the run terminates in the dedicated
+		// `rejected` state and the CLI exits 0. Mark step state as
+		// rejected so step-level UIs render it distinctly.
+		execution.mu.Lock()
+		execution.States[step.ID] = stateRejected
+		execution.mu.Unlock()
+		e.emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: pipelineID,
+			StepID:     step.ID,
+			State:      stateRejected,
+			Message:    fmt.Sprintf("design rejection: %s contract reported non-actionable result (%s)", c.Type, cErr.Error()),
+		})
+		if e.logger != nil {
+			e.logger.LogContractResult(pipelineID, step.ID, c.Type, "rejected")
+			_ = e.logger.LogStepEnd(pipelineID, step.ID, stateRejected, time.Since(stepStart), result.ExitCode, 0, result.TokensUsed, "design rejection: "+cErr.Error())
+		}
+		if e.store != nil {
+			completedAt := time.Now()
+			// A rejection is not a runtime failure; treat it as a
+			// successful no-op for performance metrics so dashboards
+			// don't double-count it as a failure.
+			e.store.RecordPerformanceMetric(&state.PerformanceMetricRecord{
+				RunID:        pipelineID,
+				StepID:       step.ID,
+				PipelineName: execution.Status.PipelineName,
+				Persona:      resolvedPersona,
+				StartedAt:    stepStart,
+				CompletedAt:  &completedAt,
+				DurationMs:   time.Since(stepStart).Milliseconds(),
+				TokensUsed:   result.TokensUsed,
+				Success:      true,
+				ErrorMessage: "design rejection: " + cErr.Error(),
+			})
+		}
+		e.recordDecision(pipelineID, step.ID, "contract",
+			fmt.Sprintf("contract reported design rejection for step %s", step.ID),
+			fmt.Sprintf("on_failure is 'rejected' — pipeline halted with non-actionable verdict: %s", cErr.Error()),
+			map[string]interface{}{"contract_type": c.Type, "error": cErr.Error()},
+		)
+		return false, &ContractRejectionError{
+			StepID:       step.ID,
+			ContractType: c.Type,
+			Reason:       cErr.Error(),
+		}
+
 	case OnFailureSkip:
 		// Halt contract processing; the step is treated as passing (return nil upstream)
 		e.emit(event.Event{

--- a/internal/pipeline/executor_lifecycle.go
+++ b/internal/pipeline/executor_lifecycle.go
@@ -535,6 +535,37 @@ func (e *DefaultPipelineExecutor) runSchedulingLoop(ctx context.Context, executi
 				}
 				continue
 			}
+			// Design rejection: a step's contract with on_failure: rejected
+			// fired. Halt the pipeline in the dedicated `rejected` terminal
+			// state — distinct from `failed` so UIs render it without the
+			// red "this is broken" signal. The error is preserved so callers
+			// (CLI runOnce, webui) can inspect it via errors.As.
+			var rejectionErr *ContractRejectionError
+			if errors.As(err, &rejectionErr) {
+				execution.Status.State = stateRejected
+				rejectedStepID := rejectionErr.StepID
+				if rejectedStepID == "" && len(ready) > 0 {
+					rejectedStepID = ready[0].ID
+				}
+				if rejectedStepID != "" {
+					execution.Status.FailedSteps = append(execution.Status.FailedSteps, rejectedStepID)
+				}
+				if e.store != nil {
+					_ = e.store.SavePipelineState(pipelineID, stateRejected, execution.Input)
+				}
+				e.emit(event.Event{
+					Timestamp:  time.Now(),
+					PipelineID: pipelineID,
+					StepID:     rejectedStepID,
+					State:      stateRejected,
+					Message:    err.Error(),
+				})
+				if e.retroGenerator != nil {
+					e.retroGenerator.Generate(pipelineID, execution.Pipeline.Metadata.Name)
+				}
+				e.cleanupCompletedPipeline(pipelineID)
+				return 0, &StepExecutionError{StepID: rejectedStepID, Err: err}
+			}
 			execution.Status.State = stateFailed
 			// Identify which step(s) failed from the batch
 			var failedStepID string

--- a/internal/pipeline/executor_steps.go
+++ b/internal/pipeline/executor_steps.go
@@ -513,6 +513,24 @@ func (e *DefaultPipelineExecutor) executeStep(ctx context.Context, execution *Pi
 		if err != nil {
 			lastErr = err
 
+			// Design rejection short-circuit: a contract with on_failure:
+			// rejected fired because the persona output deliberately
+			// signalled no-op. This is NOT a retryable failure — the work
+			// being non-actionable is the *answer*, not a bug. Skip retries
+			// and route directly to the rejected terminal state. The
+			// executor's States map is already set by applyContractOnFailure;
+			// we just need to short-circuit the loop, persist state, and
+			// propagate the typed error so callers (run.go, webui) can
+			// render the run with the dedicated rejected status.
+			var rejectionErr *ContractRejectionError
+			if errors.As(err, &rejectionErr) {
+				if e.store != nil {
+					_ = e.store.SaveStepState(pipelineID, step.ID, state.StateRejected, err.Error())
+				}
+				e.recordStepOntologyUsage(execution, step, stateRejected)
+				return err
+			}
+
 			// Classify the failure for intelligent retry decisions.
 			// Use stepCtx (watchdog-derived) so stall cancellation is detected.
 			failureClass := ClassifyStepFailure(err, nil, stepCtx.Err())

--- a/internal/pipeline/iotypes.go
+++ b/internal/pipeline/iotypes.go
@@ -170,9 +170,11 @@ func TypedWiringCheck(p *Pipeline, childLoader SubPipelineLoader, pipelinesDir s
 // Violation categories (ADR-011 rules):
 //
 //   - Rule 5: contract `on_failure: retry` — deterministic on_failure values
-//     must be fail/skip/continue/rework (+rework_step)/warn. `retry` is
-//     forbidden because retries belong to the step-level retry policy, not
-//     contracts.
+//     must be fail/skip/continue/rework (+rework_step)/warn/rejected.
+//     `retry` is forbidden because retries belong to the step-level retry
+//     policy, not contracts. `rejected` is a terminal "design rejection"
+//     outcome where the persona deliberately reports a non-actionable
+//     verdict (e.g. issue already implemented).
 //   - Rule 3: pipeline_outputs entries without an explicit `type:` — every
 //     declared output must carry a semantic type so consumers can type-check
 //     cross-pipeline wiring at load time.
@@ -200,7 +202,7 @@ func CollectWLPLoadErrors(p *Pipeline) []string {
 		for i, c := range step.Handover.EffectiveContracts() {
 			if c.OnFailure == OnFailureRetry {
 				warnings = append(warnings,
-					fmt.Sprintf("pipeline %q step %q contract[%d] (%s): on_failure=%q is deprecated — use step-level retry.max_attempts for retries, or a deterministic contract outcome (fail, skip, continue, rework, warn). See ADR-011 rule 5.",
+					fmt.Sprintf("pipeline %q step %q contract[%d] (%s): on_failure=%q is deprecated — use step-level retry.max_attempts for retries, or a deterministic contract outcome (fail, skip, continue, rework, warn, rejected). See ADR-011 rule 5.",
 						p.Metadata.Name, step.ID, i, c.Type, OnFailureRetry))
 			}
 		}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -23,6 +23,7 @@ const (
 	stateRetrying       = string(state.StateRetrying)
 	stateSkipped        = string(state.StateSkipped)
 	stateReworking      = string(state.StateReworking)
+	stateRejected       = string(state.StateRejected)
 )
 
 // OnFailure policy constants for contract and step failure handling.
@@ -33,6 +34,13 @@ const (
 	OnFailureRework   = "rework"
 	OnFailureWarn     = "warn"
 	OnFailureRetry    = "retry"
+	// OnFailureRejected marks a contract failure as an *intentional design
+	// rejection* rather than a runtime error. The pipeline halts and the run
+	// terminates in the dedicated `rejected` state (distinct from `failed`).
+	// Used by gating contracts where the upstream persona is expected to
+	// declare a no-op result (e.g. `implementable: false` in fetch-assess).
+	// CLI exits 0 and webui renders a non-red badge.
+	OnFailureRejected = "rejected"
 )
 
 // Fidelity constants control how much prior thread context a step receives.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -28,6 +28,12 @@ const (
 	StateRetrying       StepState = event.StateRetrying
 	StateSkipped        StepState = event.StateSkipped
 	StateReworking      StepState = event.StateReworking
+	// StateRejected marks a terminal "design rejection" — a contract with
+	// on_failure: rejected fired because the persona output deliberately
+	// signalled the work is non-actionable (e.g. issue already implemented).
+	// It is not a runtime failure; UIs render it distinctly from
+	// StateFailed. See internal/event for the canonical definition.
+	StateRejected StepState = event.StateRejected
 )
 
 // PipelineStateRecord holds persisted pipeline state.

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -258,6 +258,10 @@ func statusIcon(status string) string {
 		return "●"
 	case "failed":
 		return "✕"
+	case "rejected":
+		// Bang glyph signals "stop, take a look" without the red-cross
+		// "this broke" connotation of failure. Used by run_row + run_detail.
+		return "!"
 	case "cancelled":
 		return "○"
 	case "pending":
@@ -278,6 +282,11 @@ func statusClass(status string) string {
 		return "status-running"
 	case "failed":
 		return "status-failed"
+	case "rejected":
+		// Rejected = design-rejection terminal state (e.g. fetch-assess
+		// reported `implementable: false`). Distinct from `failed` so the
+		// UI doesn't misrepresent a legitimate verdict as a runtime bug.
+		return "status-rejected"
 	case "cancelled":
 		return "status-cancelled"
 	case "pending":
@@ -300,6 +309,11 @@ func statusLabel(status string) string {
 	switch status {
 	case "completed_empty":
 		return "No Changes"
+	case "rejected":
+		// "rejected" alone reads ambiguously in tables — be explicit about
+		// the design-rejection meaning so operators don't confuse it with
+		// PR/issue rejection vocabulary.
+		return "rejected (no-op)"
 	default:
 		return status
 	}

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -414,6 +414,12 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
 .status-completed-empty { background: var(--color-completed-empty-bg); color: var(--color-completed-empty); }
 .badge.status-running, .status-running { background: var(--color-running-bg); color: var(--color-running) !important; }
 .status-failed { background: var(--color-failed-bg); color: var(--color-failed); }
+/* Design rejection: deliberate non-actionable verdict (e.g. fetch-assess
+   reported `implementable: false`). Yellow signals "stop, look" without
+   the red "this broke" connotation of a runtime failure. Reuses
+   --color-pending so the design tokens stay consistent across the run
+   row, run detail header, and step badges. */
+.status-rejected { background: var(--color-pending-bg); color: var(--color-pending); }
 .status-cancelled { background: var(--color-cancelled-bg); color: var(--color-cancelled); }
 .status-pending { background: var(--color-pending-bg); color: var(--color-pending); }
 .status-warning { background: var(--color-pending-bg); color: var(--color-pending); }
@@ -723,6 +729,7 @@ a:focus-visible, button:focus-visible, select:focus-visible, input:focus-visible
 .step-card.status-completed { box-shadow: inset 3px 0 0 0 var(--color-completed); }
 .step-card.status-completed-empty { box-shadow: inset 3px 0 0 0 var(--color-completed-empty); }
 .step-card.status-failed { box-shadow: inset 3px 0 0 0 var(--color-failed); }
+.step-card.status-rejected { box-shadow: inset 3px 0 0 0 var(--color-pending); }
 .step-card.status-pending { box-shadow: inset 3px 0 0 0 var(--color-pending); }
 .step-card.status-cancelled { box-shadow: inset 3px 0 0 0 var(--color-cancelled); }
 .step-header {

--- a/internal/webui/templates/partials/run_row.html
+++ b/internal/webui/templates/partials/run_row.html
@@ -5,11 +5,12 @@
             {{if eq .Status "running"}}<span class="spinner spinner-sm" aria-label="Running" role="status"></span>
             {{else if eq .Status "completed"}}<span class="status-check">&#10003;</span>
             {{else if eq .Status "failed"}}<span class="status-cross">&#10007;</span>
+            {{else if eq .Status "rejected"}}<span class="status-bang" aria-label="Design rejection — no implementable result">&#33;</span>
             {{else if eq .Status "cancelled"}}<span class="status-dash">&#9644;</span>
             {{else}}<span class="status-dot">&#9679;</span>
             {{end}}
         </span>
-        <span class="badge {{statusClass .Status}}">{{.Status}}</span>
+        <span class="badge {{statusClass .Status}}" title="{{if eq .Status "rejected"}}Pipeline halted because a contract reported the work is non-actionable (design rejection — not a runtime failure){{end}}">{{statusLabel .Status}}</span>
     </td>
     <td class="wrap">
         <div class="run-pipeline-name">

--- a/internal/webui/templates/run_detail.html
+++ b/internal/webui/templates/run_detail.html
@@ -21,20 +21,14 @@
         {{end}}
         <h1>
             <a href="/pipelines/{{.Run.PipelineName}}">{{.Run.PipelineName}}</a>
-            <span class="badge {{statusClass .Run.Status}}">{{statusLabel .Run.Status}}</span>
+            <span class="badge {{statusClass .Run.Status}}"{{if eq .Run.Status "rejected"}} title="Pipeline halted because a contract reported the work is non-actionable (design rejection — not a runtime failure)"{{end}}>{{statusLabel .Run.Status}}</span>
             <code style="font-size:0.62rem;color:var(--color-text-muted);font-weight:400;background:var(--color-bg-tertiary);padding:0.1rem 0.4rem;border-radius:3px;">{{.Run.RunID}}</code>
         </h1>
         {{if .PipelineDescription}}<p style="margin:0.1rem 0 0.3rem;font-size:0.8rem;color:var(--color-text-secondary);max-width:48rem;">{{.PipelineDescription}}</p>{{end}}
-        {{if .ResumeChildren}}
-        <div style="margin:0.25rem 0 0.4rem;display:flex;flex-wrap:wrap;gap:0.3rem;align-items:center;font-size:0.72rem;color:var(--color-text-secondary);">
-            <span style="color:var(--color-text-muted);">Resumed by:</span>
-            {{range .ResumeChildren}}
-            <a href="/runs/{{.RunID}}" class="badge badge-runkind badge-runkind-resume" style="text-decoration:none;font-size:0.68rem;" title="Resume run {{.RunID}} (from step {{.ParentStepID}}) — status: {{.Status}}">
-                resume {{if .ParentStepID}}&rsaquo; <code style="font-size:0.65rem;background:var(--color-bg-tertiary);padding:0 0.2rem;border-radius:2px;">{{.ParentStepID}}</code>{{end}}
-                <span class="badge {{statusClass .Status}}" style="font-size:0.62rem;margin-left:0.25rem;">{{statusLabel .Status}}</span>
-            </a>
-            {{end}}
-        </div>
+        {{if eq .Run.Status "rejected"}}
+        <p style="margin:0.4rem 0 0;padding:0.4rem 0.6rem;background:var(--color-pending-bg);color:var(--color-pending);border-left:3px solid var(--color-pending);border-radius:3px;font-size:0.78rem;max-width:48rem;">
+            <strong>Design rejection.</strong> Step {{if .FailedStepID}}<code style="background:transparent;color:var(--color-pending);">{{.FailedStepID}}</code> {{end}}reported the work is non-actionable (e.g. issue already implemented, superseded, or no real bug). This is not a runtime failure — the pipeline correctly declared "no work to do here."
+        </p>
         {{end}}
         {{if .CompositionChildGroups}}
         <div style="margin:0.25rem 0 0.4rem;display:flex;flex-direction:column;gap:0.25rem;font-size:0.72rem;color:var(--color-text-secondary);">
@@ -296,12 +290,13 @@
 </div>
 
 <!-- OUTPUT -->
-<div class="ws {{if eq .Run.Status "completed"}}st-completed{{else if eq .Run.Status "failed"}}st-failed{{else if eq .Run.Status "running"}}st-running{{else}}st-pending{{end}}" style="margin-top:1rem;">
+<div class="ws {{if eq .Run.Status "completed"}}st-completed{{else if eq .Run.Status "failed"}}st-failed{{else if eq .Run.Status "rejected"}}st-rejected{{else if eq .Run.Status "running"}}st-running{{else}}st-pending{{end}}" style="margin-top:1rem;">
     <div class="ws-content">
     <div class="ws-row1">
         <span class="ws-name">Output</span>
         {{if eq .Run.Status "completed"}}<span style="color:var(--color-completed);">&#10003;</span>
         {{else if eq .Run.Status "failed"}}<span style="color:var(--color-failed);">&#10007;</span>
+        {{else if eq .Run.Status "rejected"}}<span style="color:var(--color-pending);" title="Design rejection — pipeline halted because the assessment reported no actionable work">&#33;</span>
         {{else if eq .Run.Status "running"}}<span class="spinner spinner-sm" style="vertical-align:middle;margin-left:0.35rem;"></span>{{end}}
         {{if eq .Run.Status "failed"}}
         <button class="btn btn-sm" style="margin-left:auto;font-size:0.72rem;border-color:rgba(239,68,68,0.3);color:var(--color-failed);" onclick="retryRun('{{.Run.RunID}}',this)">Retry</button>


### PR DESCRIPTION
## Summary

When `inception-bugfix` (or any pipeline composing `impl-issue-core`) ran `fetch-assess` against an issue that was already implemented or superseded, the persona correctly emitted `implementable: false`, the schema's `const: true` rule rejected it, and the run surfaced as a generic red `failed` at 33% — misleading operators into thinking the orchestrator broke when in fact the orchestrator was correctly declaring "no work to do here."

This PR adds a dedicated `rejected` terminal state that pipelines opt into via `on_failure: rejected` on a gating contract. Distinct from `failed` everywhere it matters:

- CLI exits **0** with a **yellow** "rejected (no implementable result)" banner instead of the red "Pipeline execution failed" recovery block.
- Webui run rows render a yellow `!` badge with a tooltip explaining design rejection; the run-detail page shows a callout banner.
- The state machine still records the underlying step state as `rejected` so dashboards can filter for them, and downstream composition steps see a distinct error type (`ContractRejectionError`) rather than guessing from string contents.

`fetch-assess` in `impl-issue-core.yaml` (both `.agents/` and `internal/defaults/`) now opts in. Every other pipeline keeps its current `on_failure: fail` semantics.

## Design choice

Considered three options:

- **A — new state value only.** Cleanest UX but provides no opt-in mechanism — every `const`/`enum` schema check across the codebase would silently change semantics. Rejected.
- **B — keep `failed`, tag with `failure_kind: design_rejection`.** Least invasive but conflates the structural state machine with a tag the renderer has to special-case in N places. Operators still see red badges by default until every renderer is taught about the tag.
- **C — `on_failure: rejected` + new state value (this PR).** Explicit YAML opt-in (so the assessment contract documents intent) PLUS a structurally distinct terminal state (so the state machine and every renderer that consumes it stay coherent). Backward compatible: any pipeline that doesn't opt in keeps current behaviour.

Option C wins because the rejection signal is **the persona's verdict**, not an inference the orchestrator can derive automatically. Pipeline authors who want this UX must declare it; everyone else is unchanged.

## What changed

- `internal/event/emitter.go` — canonical `StateRejected` const.
- `internal/state/store.go` — re-exported `StateRejected`.
- `internal/pipeline/types.go` — `OnFailureRejected` const + matching `stateRejected` step alias.
- `internal/pipeline/errors.go` — new `ContractRejectionError` typed error carrying `StepID`, `ContractType`, `Reason`.
- `internal/pipeline/executor_contract.go` — `applyContractOnFailure` handles the rejection policy: emits a `rejected` event, marks step state `rejected`, records a non-failure performance metric, returns `ContractRejectionError`.
- `internal/pipeline/executor_steps.go` — short-circuits the retry loop when it sees a rejection (rejection is the answer, not a bug to retry).
- `internal/pipeline/executor_lifecycle.go` — scheduling loop maps the rejection error to pipeline state `rejected` (not `failed`), still saves a retro for diagnostic continuity.
- `internal/pipeline/dag.go` + `iotypes.go` — accepts `rejected` in contract `on_failure` enum.
- `cmd/wave/commands/run_stages.go` — `runOnce` writes `rejected` to the run record when it sees `ContractRejectionError`; new `printRejectionSummary` renders the yellow banner with the reason.
- `cmd/wave/commands/run.go` — branches before `formatRecoveryError` so rejection runs skip the red recovery block, exit 0.
- `internal/webui/embed.go` — `statusClass`, `statusLabel`, `statusIcon` know about `rejected`.
- `internal/webui/static/style.css` — `.status-rejected` (badge + step-card) reusing the yellow `--color-pending` design token.
- `internal/webui/templates/partials/run_row.html` — yellow bang icon, tooltip, `statusLabel` rendering.
- `internal/webui/templates/run_detail.html` — yellow callout banner explaining the verdict.
- `.agents/pipelines/impl-issue-core.yaml` + `internal/defaults/pipelines/impl-issue-core.yaml` — `fetch-assess` now `on_failure: rejected` with comment explaining why.
- `internal/pipeline/contract_integration_test.go` — two regression tests:
  - `TestContractIntegration_DesignRejectionTerminalState`: drives a stub fetch-assess returning `implementable: false`, asserts run lands in `rejected` state with `ContractRejectionError`, no `failed` event for the rejected step.
  - `TestContractIntegration_OnFailureFailStillFailsRun`: same payload with default `on_failure: fail` must still fail — guards against silent semantic change.

## Test plan

- [x] `go build -o ./wave ./cmd/wave`
- [x] `go test ./internal/contract/... ./internal/pipeline/... ./internal/state/... ./internal/webui/... ./cmd/wave/...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/pipeline/... ./internal/event/... ./internal/state/... ./internal/webui/... ./cmd/wave/...` — 0 issues
- [x] New regression tests pass: `TestContractIntegration_DesignRejectionTerminalState`, `TestContractIntegration_OnFailureFailStillFailsRun`
- [ ] Live smoke: run `inception-bugfix` against a known already-fixed issue and confirm the run surfaces as yellow `rejected (no-op)` in `wave list runs` and the webui run detail page (covered by regression tests in this PR; live run gated on having a non-self repo to point at, per the no-external-posts rule)

## Before / after

**Before**
```
✕ Pipeline 'inception-bugfix' failed at 33% (50% steps)
  step "fetch-assess": contract validation failed [json_schema] (attempt 2/2): JSON schema validation failed (must_pass: true)
  ...
```
Run row: red `failed` badge.

**After**
```
! Pipeline 'inception-bugfix' rejected (1.5s) — no implementable result
  step "fetch-assess": contract validation failed [json_schema] (attempt 2/2): value must be true at /implementable
  This is not a runtime failure — the pipeline declared the work non-actionable by design.
```
Run row: yellow `rejected (no-op)` badge with tooltip "Pipeline halted because a contract reported the work is non-actionable (design rejection — not a runtime failure)". Run detail page shows a yellow callout banner.