### PR TITLE
refactor(config): lift runner.Options to config.RuntimeConfig

### DIFF
--- a/cmd/wave/commands/output.go
+++ b/cmd/wave/commands/output.go
@@ -7,28 +7,28 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/forge"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/runner"
 	"github.com/spf13/cobra"
 )
 
-// Output format constants — aliased from internal/runner to keep a single
+// Output format constants — aliased from internal/config to keep a single
 // source of truth shared with the webui launch path.
 const (
-	OutputFormatAuto  = runner.OutputFormatAuto
-	OutputFormatJSON  = runner.OutputFormatJSON
-	OutputFormatText  = runner.OutputFormatText
-	OutputFormatQuiet = runner.OutputFormatQuiet
+	OutputFormatAuto  = config.OutputFormatAuto
+	OutputFormatJSON  = config.OutputFormatJSON
+	OutputFormatText  = config.OutputFormatText
+	OutputFormatQuiet = config.OutputFormatQuiet
 )
 
-// OutputConfig is aliased from internal/runner so the cmd and webui layers
+// OutputConfig is aliased from internal/config so the cmd and webui layers
 // share an identical shape; cmd-only consumers continue to reference
 // commands.OutputConfig without churn.
-type OutputConfig = runner.OutputConfig
+type OutputConfig = config.OutputConfig
 
 // resolvedFlagsKey is the context key for storing ResolvedFlags.
 type resolvedFlagsKey struct{}

--- a/cmd/wave/commands/run.go
+++ b/cmd/wave/commands/run.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
@@ -17,11 +18,12 @@ import (
 	"golang.org/x/term"
 )
 
-// RunOptions is aliased from internal/runner — the canonical struct lives
-// there so the webui launch path consumes the exact same fields without a
-// translation layer. The exhaustiveness test (TestDetachedArgsExhaustive)
-// also lives in internal/runner alongside the spec table it guards.
-type RunOptions = runner.Options
+// RunOptions is aliased from internal/config — the canonical struct lives
+// there (alongside the env snapshot) so the webui launch path consumes the
+// exact same fields without a translation layer. The exhaustiveness test
+// (TestDetachedArgsExhaustive) lives in internal/runner alongside the spec
+// table it guards.
+type RunOptions = config.RuntimeConfig
 
 func NewRunCmd() *cobra.Command {
 	var opts RunOptions

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -1,20 +1,14 @@
-// Package runner is the single source of truth for launching pipeline runs —
-// either in-process (LaunchInProcess) or as a fully-detached subprocess
-// (Detach). It is shared by cmd/wave/commands and internal/webui so the two
-// paths produce identical runtime behaviour.
+package config
+
+// This file holds the per-run configuration snapshot that mirrors the
+// `wave run` CLI flag set. RuntimeConfig is consumed by both the foreground
+// CLI path (cmd/wave/commands) and the webui launch path (internal/webui)
+// so the two surfaces produce identical runtime behaviour.
 //
-// The package intentionally exposes a small surface:
-//
-//	Options       — every CLI-parity input (mirror of `wave run` flags)
-//	OutputConfig  — verbose/format selection for the run
-//	Detach        — spawn a `wave run` subprocess (Setsid + Process.Release)
-//	LaunchInProcess — wire up DefaultPipelineExecutor and run a goroutine
-//
-// The detach flag-spec table (DetachFlagSpecs / DetachFlagSkippedFields) lives
-// in detach.go and is exercised by TestDetachedArgsExhaustive — adding a new
-// Options field requires registering it (or explicitly skipping it) in that
-// table, otherwise the test fails.
-package runner
+// Lifting the struct into internal/config keeps it next to Env (the process
+// environment snapshot) so a single package owns runtime-configuration
+// types. A future EffectiveConfig will overlay manifest defaults with
+// RuntimeConfig and Env to produce the resolved view used by the executor.
 
 // Output format constants — the canonical set used by `wave run` and shared
 // with the cmd layer via type aliases.
@@ -35,12 +29,12 @@ type OutputConfig struct {
 	Debug   bool
 }
 
-// Options captures every CLI-parity input accepted by `wave run`. The cmd
-// layer aliases this type as RunOptions for backwards compatibility; the
-// webui layer constructs Options directly. Field order is preserved from the
-// original cmd RunOptions so the reflection-based exhaustiveness test keeps
-// its existing assumptions.
-type Options struct {
+// RuntimeConfig captures every CLI-parity input accepted by `wave run`. The
+// cmd layer aliases this type as RunOptions for local naming hygiene; the
+// webui layer constructs RuntimeConfig directly. Field order is preserved
+// from the original cmd RunOptions so the reflection-based exhaustiveness
+// test keeps its existing assumptions.
+type RuntimeConfig struct {
 	Pipeline          string
 	Input             string
 	DryRun            bool

--- a/internal/runner/detach.go
+++ b/internal/runner/detach.go
@@ -14,29 +14,29 @@ import (
 	"github.com/recinq/wave/internal/state"
 )
 
-// detachFlagSpec mirrors a single Options field into the argv of a detached
-// `wave run` subprocess. emit appends "--flag" or "--flag value" tokens to
-// args when the field warrants forwarding (skipping zero/default values).
-// Together DetachFlagSpecs forms the single source of truth for the argv
-// rebuilder. TestDetachedArgsExhaustive guards against new Options fields
-// being silently dropped — every field must be registered here or in
-// DetachFlagSkippedFields.
+// detachFlagSpec mirrors a single config.RuntimeConfig field into the argv
+// of a detached `wave run` subprocess. emit appends "--flag" or "--flag
+// value" tokens to args when the field warrants forwarding (skipping
+// zero/default values). Together DetachFlagSpecs forms the single source of
+// truth for the argv rebuilder. TestDetachedArgsExhaustive guards against
+// new RuntimeConfig fields being silently dropped — every field must be
+// registered here or in DetachFlagSkippedFields.
 type detachFlagSpec struct {
-	field string // Options struct field name (matched by exhaustiveness test)
+	field string // RuntimeConfig struct field name (matched by exhaustiveness test)
 	flag  string // CLI flag name without leading dashes
-	emit  func(opts Options, args []string) []string
+	emit  func(opts config.RuntimeConfig, args []string) []string
 }
 
-// FlagSpecField returns the Options field name registered with a spec.
+// FlagSpecField returns the RuntimeConfig field name registered with a spec.
 // Exposed so out-of-package tests can introspect the spec list.
 func (s detachFlagSpec) FlagSpecField() string { return s.field }
 
 // FlagSpecFlag returns the CLI flag (without leading dashes) for a spec.
 func (s detachFlagSpec) FlagSpecFlag() string { return s.flag }
 
-// DetachFlagSkippedFields lists Options fields that intentionally do NOT
-// flow through to the detached subprocess. Update this list (with a reason)
-// when adding a new field that should not be mirrored.
+// DetachFlagSkippedFields lists RuntimeConfig fields that intentionally do
+// NOT flow through to the detached subprocess. Update this list (with a
+// reason) when adding a new field that should not be mirrored.
 var DetachFlagSkippedFields = map[string]string{
 	"Pipeline": "always emitted explicitly as --pipeline before spec processing",
 	"RunID":    "always emitted explicitly as --run with the freshly created runID",
@@ -46,8 +46,8 @@ var DetachFlagSkippedFields = map[string]string{
 }
 
 // boolFlag emits "--<flag>" when get(o) is true.
-func boolFlag(field, flag string, get func(Options) bool) detachFlagSpec {
-	return detachFlagSpec{field: field, flag: flag, emit: func(o Options, a []string) []string {
+func boolFlag(field, flag string, get func(config.RuntimeConfig) bool) detachFlagSpec {
+	return detachFlagSpec{field: field, flag: flag, emit: func(o config.RuntimeConfig, a []string) []string {
 		if get(o) {
 			return append(a, "--"+flag)
 		}
@@ -56,8 +56,8 @@ func boolFlag(field, flag string, get func(Options) bool) detachFlagSpec {
 }
 
 // strFlag emits "--<flag> <value>" when get(o) is non-empty and not equal to skip.
-func strFlag(field, flag, skip string, get func(Options) string) detachFlagSpec {
-	return detachFlagSpec{field: field, flag: flag, emit: func(o Options, a []string) []string {
+func strFlag(field, flag, skip string, get func(config.RuntimeConfig) string) detachFlagSpec {
+	return detachFlagSpec{field: field, flag: flag, emit: func(o config.RuntimeConfig, a []string) []string {
 		v := get(o)
 		if v != "" && v != skip {
 			return append(a, "--"+flag, v)
@@ -67,8 +67,8 @@ func strFlag(field, flag, skip string, get func(Options) string) detachFlagSpec 
 }
 
 // intFlag emits "--<flag> <value>" when get(o) > 0.
-func intFlag(field, flag string, get func(Options) int) detachFlagSpec {
-	return detachFlagSpec{field: field, flag: flag, emit: func(o Options, a []string) []string {
+func intFlag(field, flag string, get func(config.RuntimeConfig) int) detachFlagSpec {
+	return detachFlagSpec{field: field, flag: flag, emit: func(o config.RuntimeConfig, a []string) []string {
 		if v := get(o); v > 0 {
 			return append(a, "--"+flag, fmt.Sprintf("%d", v))
 		}
@@ -79,32 +79,32 @@ func intFlag(field, flag string, get func(Options) int) detachFlagSpec {
 // DetachFlagSpecs is the single source of truth for argv mirroring.
 // Adding a new pass-through flag means adding ONE entry here.
 var DetachFlagSpecs = []detachFlagSpec{
-	strFlag("Input", "input", "", func(o Options) string { return o.Input }),
-	strFlag("FromStep", "from-step", "", func(o Options) string { return o.FromStep }),
-	boolFlag("Force", "force", func(o Options) bool { return o.Force }),
-	intFlag("Timeout", "timeout", func(o Options) int { return o.Timeout }),
-	strFlag("Manifest", "manifest", "wave.yaml", func(o Options) string { return o.Manifest }),
-	boolFlag("Mock", "mock", func(o Options) bool { return o.Mock }),
-	strFlag("Model", "model", "", func(o Options) string { return o.Model }),
-	strFlag("Adapter", "adapter", "", func(o Options) string { return o.Adapter }),
-	boolFlag("PreserveWorkspace", "preserve-workspace", func(o Options) bool { return o.PreserveWorkspace }),
-	strFlag("Steps", "steps", "", func(o Options) string { return o.Steps }),
-	strFlag("Exclude", "exclude", "", func(o Options) string { return o.Exclude }),
-	boolFlag("Continuous", "continuous", func(o Options) bool { return o.Continuous }),
-	strFlag("Source", "source", "", func(o Options) string { return o.Source }),
-	intFlag("MaxIterations", "max-iterations", func(o Options) int { return o.MaxIterations }),
-	strFlag("Delay", "delay", "0s", func(o Options) string { return o.Delay }),
-	strFlag("OnFailure", "on-failure", "halt", func(o Options) string { return o.OnFailure }),
-	boolFlag("AutoApprove", "auto-approve", func(o Options) bool { return o.AutoApprove }),
-	boolFlag("NoRetro", "no-retro", func(o Options) bool { return o.NoRetro }),
-	boolFlag("ForceModel", "force-model", func(o Options) bool { return o.ForceModel }),
+	strFlag("Input", "input", "", func(o config.RuntimeConfig) string { return o.Input }),
+	strFlag("FromStep", "from-step", "", func(o config.RuntimeConfig) string { return o.FromStep }),
+	boolFlag("Force", "force", func(o config.RuntimeConfig) bool { return o.Force }),
+	intFlag("Timeout", "timeout", func(o config.RuntimeConfig) int { return o.Timeout }),
+	strFlag("Manifest", "manifest", "wave.yaml", func(o config.RuntimeConfig) string { return o.Manifest }),
+	boolFlag("Mock", "mock", func(o config.RuntimeConfig) bool { return o.Mock }),
+	strFlag("Model", "model", "", func(o config.RuntimeConfig) string { return o.Model }),
+	strFlag("Adapter", "adapter", "", func(o config.RuntimeConfig) string { return o.Adapter }),
+	boolFlag("PreserveWorkspace", "preserve-workspace", func(o config.RuntimeConfig) bool { return o.PreserveWorkspace }),
+	strFlag("Steps", "steps", "", func(o config.RuntimeConfig) string { return o.Steps }),
+	strFlag("Exclude", "exclude", "", func(o config.RuntimeConfig) string { return o.Exclude }),
+	boolFlag("Continuous", "continuous", func(o config.RuntimeConfig) bool { return o.Continuous }),
+	strFlag("Source", "source", "", func(o config.RuntimeConfig) string { return o.Source }),
+	intFlag("MaxIterations", "max-iterations", func(o config.RuntimeConfig) int { return o.MaxIterations }),
+	strFlag("Delay", "delay", "0s", func(o config.RuntimeConfig) string { return o.Delay }),
+	strFlag("OnFailure", "on-failure", "halt", func(o config.RuntimeConfig) string { return o.OnFailure }),
+	boolFlag("AutoApprove", "auto-approve", func(o config.RuntimeConfig) bool { return o.AutoApprove }),
+	boolFlag("NoRetro", "no-retro", func(o config.RuntimeConfig) bool { return o.NoRetro }),
+	boolFlag("ForceModel", "force-model", func(o config.RuntimeConfig) bool { return o.ForceModel }),
 }
 
 // BuildDetachedArgs constructs argv for a detached `wave run` subprocess from
-// the parent Options plus the freshly created runID. Pipeline and run id
-// are always emitted; all other fields flow through DetachFlagSpecs so adding
-// a new pass-through flag requires editing exactly one spec list.
-func BuildDetachedArgs(opts Options, runID string) []string {
+// the parent RuntimeConfig plus the freshly created runID. Pipeline and run
+// id are always emitted; all other fields flow through DetachFlagSpecs so
+// adding a new pass-through flag requires editing exactly one spec list.
+func BuildDetachedArgs(opts config.RuntimeConfig, runID string) []string {
 	args := []string{"run", "--pipeline", opts.Pipeline, "--run", runID}
 	for _, spec := range DetachFlagSpecs {
 		args = spec.emit(opts, args)
@@ -254,7 +254,7 @@ type detachStore interface {
 
 // On success the returned runID is the canonical ID for the spawned run and
 // the subprocess has already been fully released (cmd.Process.Release).
-func Detach(opts Options, store detachStore, maxConcurrentWorkers int, cfg DetachConfig) (runID string, err error) {
+func Detach(opts config.RuntimeConfig, store detachStore, maxConcurrentWorkers int, cfg DetachConfig) (runID string, err error) {
 	if store == nil {
 		return "", fmt.Errorf("Detach: state store is required")
 	}

--- a/internal/runner/detach_args_test.go
+++ b/internal/runner/detach_args_test.go
@@ -3,15 +3,18 @@ package runner
 import (
 	"reflect"
 	"testing"
+
+	"github.com/recinq/wave/internal/config"
 )
 
-// TestBuildDetachedArgsAllFlagsPresent constructs an Options value with every
-// non-zero field, runs the argv builder, and asserts that every flag declared
-// in DetachFlagSpecs appears in the produced argv. This is the regression
-// test for issue #1500 — Continuous, Source, MaxIterations, Delay, OnFailure,
-// and NoRetro were silently dropped from the detached subprocess invocation.
+// TestBuildDetachedArgsAllFlagsPresent constructs a RuntimeConfig value with
+// every non-zero field, runs the argv builder, and asserts that every flag
+// declared in DetachFlagSpecs appears in the produced argv. This is the
+// regression test for issue #1500 — Continuous, Source, MaxIterations, Delay,
+// OnFailure, and NoRetro were silently dropped from the detached subprocess
+// invocation.
 func TestBuildDetachedArgsAllFlagsPresent(t *testing.T) {
-	opts := Options{
+	opts := config.RuntimeConfig{
 		Pipeline:          "impl-issue",
 		Input:             "fix login bug",
 		FromStep:          "implement",
@@ -66,10 +69,10 @@ func TestBuildDetachedArgsAllFlagsPresent(t *testing.T) {
 	mustContainFlag(t, args, "--no-retro")
 }
 
-// TestBuildDetachedArgsZeroValuesOmitted asserts that a near-empty Options
-// (just pipeline + runID) does not emit conditional flags.
+// TestBuildDetachedArgsZeroValuesOmitted asserts that a near-empty
+// RuntimeConfig (just pipeline + runID) does not emit conditional flags.
 func TestBuildDetachedArgsZeroValuesOmitted(t *testing.T) {
-	opts := Options{Pipeline: "impl-issue", Manifest: "wave.yaml"}
+	opts := config.RuntimeConfig{Pipeline: "impl-issue", Manifest: "wave.yaml"}
 	args := BuildDetachedArgs(opts, "run-xyz")
 
 	mustContainPair(t, args, "--pipeline", "impl-issue")
@@ -78,31 +81,31 @@ func TestBuildDetachedArgsZeroValuesOmitted(t *testing.T) {
 	// None of the conditional flags should appear.
 	for _, spec := range DetachFlagSpecs {
 		if containsFlag(args, "--"+spec.flag) {
-			t.Errorf("zero-value Options still emitted --%s", spec.flag)
+			t.Errorf("zero-value RuntimeConfig still emitted --%s", spec.flag)
 		}
 	}
 	if containsFlag(args, "--verbose") {
-		t.Errorf("zero-value Options still emitted --verbose")
+		t.Errorf("zero-value RuntimeConfig still emitted --verbose")
 	}
 }
 
 // TestBuildDetachedArgsManifestDefaultOmitted verifies that a manifest set to
 // the default "wave.yaml" is not forwarded — matches the legacy behaviour.
 func TestBuildDetachedArgsManifestDefaultOmitted(t *testing.T) {
-	opts := Options{Pipeline: "p", Manifest: "wave.yaml"}
+	opts := config.RuntimeConfig{Pipeline: "p", Manifest: "wave.yaml"}
 	args := BuildDetachedArgs(opts, "rid")
 	if containsFlag(args, "--manifest") {
 		t.Errorf("default manifest 'wave.yaml' should not be forwarded; got %v", args)
 	}
 }
 
-// TestDetachedArgsExhaustive walks the Options struct via reflection and
-// asserts that every field is either:
+// TestDetachedArgsExhaustive walks the RuntimeConfig struct via reflection
+// and asserts that every field is either:
 //   - registered in DetachFlagSpecs by name, or
 //   - explicitly skipped via DetachFlagSkippedFields with a reason.
 //
-// This guards against future Options fields silently dropping out of the
-// detached subprocess invocation (the original bug in #1500).
+// This guards against future RuntimeConfig fields silently dropping out of
+// the detached subprocess invocation (the original bug in #1500).
 func TestDetachedArgsExhaustive(t *testing.T) {
 	registered := make(map[string]bool, len(DetachFlagSpecs))
 	for _, spec := range DetachFlagSpecs {
@@ -112,7 +115,7 @@ func TestDetachedArgsExhaustive(t *testing.T) {
 		registered[spec.field] = true
 	}
 
-	rt := reflect.TypeOf(Options{})
+	rt := reflect.TypeOf(config.RuntimeConfig{})
 	for i := 0; i < rt.NumField(); i++ {
 		name := rt.Field(i).Name
 		if registered[name] {
@@ -121,16 +124,16 @@ func TestDetachedArgsExhaustive(t *testing.T) {
 		if _, skipped := DetachFlagSkippedFields[name]; skipped {
 			continue
 		}
-		t.Errorf("Options field %q is neither registered in DetachFlagSpecs "+
+		t.Errorf("RuntimeConfig field %q is neither registered in DetachFlagSpecs "+
 			"nor listed in DetachFlagSkippedFields — add it to one of them so "+
 			"Detach forwards (or explicitly drops) the flag", name)
 	}
 
-	// Inverse check: skipped fields must actually exist on Options, so
+	// Inverse check: skipped fields must actually exist on RuntimeConfig, so
 	// stale entries surface as failures during refactors.
 	for name := range DetachFlagSkippedFields {
 		if _, ok := rt.FieldByName(name); !ok {
-			t.Errorf("DetachFlagSkippedFields references unknown Options field %q", name)
+			t.Errorf("DetachFlagSkippedFields references unknown RuntimeConfig field %q", name)
 		}
 	}
 }

--- a/internal/runner/doc.go
+++ b/internal/runner/doc.go
@@ -1,0 +1,17 @@
+// Package runner is the single source of truth for launching pipeline runs —
+// either in-process (LaunchInProcess) or as a fully-detached subprocess
+// (Detach). It is shared by cmd/wave/commands and internal/webui so the two
+// paths produce identical runtime behaviour.
+//
+// The package intentionally exposes a small surface:
+//
+//	config.RuntimeConfig — every CLI-parity input (mirror of `wave run` flags),
+//	                       defined in internal/config alongside the env snapshot
+//	Detach               — spawn a `wave run` subprocess (Setsid + Process.Release)
+//	LaunchInProcess      — wire up DefaultPipelineExecutor and run a goroutine
+//
+// The detach flag-spec table (DetachFlagSpecs / DetachFlagSkippedFields) lives
+// in detach.go and is exercised by TestDetachedArgsExhaustive — adding a new
+// config.RuntimeConfig field requires registering it (or explicitly skipping
+// it) in that table, otherwise the test fails.
+package runner

--- a/internal/runner/inprocess.go
+++ b/internal/runner/inprocess.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/audit"
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/ontology"
@@ -51,7 +52,7 @@ type InProcessConfig struct {
 	FromStep string
 
 	// Options carries the CLI-parity flags (model/adapter/timeout/filters etc.).
-	Options Options
+	Options config.RuntimeConfig
 
 	// OnComplete is invoked from the launched goroutine after the run finishes
 	// (success or failure). It runs after the run status update so callers can

--- a/internal/tui/pipeline_launcher.go
+++ b/internal/tui/pipeline_launcher.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/pipeline"
@@ -17,7 +18,7 @@ import (
 // It spawns detached subprocesses via internal/runner so pipelines survive
 // TUI exit. The runner package owns the actual fork/exec dance, env filter,
 // log-file routing, and PID record — this type is purely the TUI-facing
-// adapter that translates LaunchConfig into runner.Options and emits
+// adapter that translates LaunchConfig into config.RuntimeConfig and emits
 // Bubble Tea messages on success/failure.
 type PipelineLauncher struct {
 	deps    LaunchDependencies
@@ -230,28 +231,28 @@ func (l *PipelineLauncher) Cleanup(_ string) {
 }
 
 // launchConfigToOptions translates the form-driven LaunchConfig into the
-// runner.Options surface. Known UI-level "extra flags" (--verbose, --debug,
-// --output text|json, --dry-run, --mock, --detach) are mapped onto typed
-// Options fields so the runner.BuildDetachedArgs spec table owns argv
-// shaping. Unknown flags are silently dropped — the form only exposes the
-// known set via DefaultFlags().
-func launchConfigToOptions(config LaunchConfig, runID string) runner.Options {
-	opts := runner.Options{
-		Pipeline:  config.PipelineName,
-		Input:     config.Input,
+// config.RuntimeConfig surface. Known UI-level "extra flags" (--verbose,
+// --debug, --output text|json, --dry-run, --mock, --detach) are mapped onto
+// typed RuntimeConfig fields so the runner.BuildDetachedArgs spec table owns
+// argv shaping. Unknown flags are silently dropped — the form only exposes
+// the known set via DefaultFlags().
+func launchConfigToOptions(lc LaunchConfig, runID string) config.RuntimeConfig {
+	opts := config.RuntimeConfig{
+		Pipeline:  lc.PipelineName,
+		Input:     lc.Input,
 		RunID:     runID,
-		Model:     config.ModelOverride,
-		Adapter:   config.Adapter,
-		Timeout:   config.Timeout,
-		FromStep:  config.FromStep,
-		Steps:     config.Steps,
-		Exclude:   config.Exclude,
-		OnFailure: config.OnFailure,
+		Model:     lc.ModelOverride,
+		Adapter:   lc.Adapter,
+		Timeout:   lc.Timeout,
+		FromStep:  lc.FromStep,
+		Steps:     lc.Steps,
+		Exclude:   lc.Exclude,
+		OnFailure: lc.OnFailure,
 	}
 
-	// Translate known UI-flag tokens into typed Options fields.
-	// "--output X" appears as a single space-joined token in config.Flags.
-	for _, f := range config.Flags {
+	// Translate known UI-flag tokens into typed RuntimeConfig fields.
+	// "--output X" appears as a single space-joined token in lc.Flags.
+	for _, f := range lc.Flags {
 		switch {
 		case f == "--verbose":
 			opts.Output.Verbose = true

--- a/internal/tui/pipeline_launcher_test.go
+++ b/internal/tui/pipeline_launcher_test.go
@@ -126,7 +126,7 @@ func TestLaunchConfigToOptions_TranslatesKnownFlags(t *testing.T) {
 	assert.Equal(t, "text", opts.Output.Format, "--output text should map to Output.Format")
 	// --detach is intentionally a no-op; the runner is producing the
 	// detached child, recursing would be wrong.
-	assert.False(t, opts.Detach, "--detach must not propagate into runner.Options.Detach")
+	assert.False(t, opts.Detach, "--detach must not propagate into config.RuntimeConfig.Detach")
 }
 
 func TestLaunchConfigToOptions_EmptyFlagsLeaveDefaults(t *testing.T) {

--- a/internal/webui/handlers_control.go
+++ b/internal/webui/handlers_control.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/runner"
 	"github.com/recinq/wave/internal/state"
 )
@@ -137,7 +138,7 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{})
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, config.RuntimeConfig{})
 
 	writeJSON(w, http.StatusCreated, RetryRunResponse{
 		RunID:         newRunID,
@@ -204,7 +205,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("warning: failed to set resume run kind on %s: %v\n", newRunID, err)
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{}, req.FromStep)
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, config.RuntimeConfig{}, req.FromStep)
 
 	writeJSON(w, http.StatusCreated, ResumeRunResponse{
 		RunID:         newRunID,

--- a/internal/webui/handlers_fork.go
+++ b/internal/webui/handlers_fork.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/runner"
 )
 
@@ -70,7 +71,7 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, runner.Options{}, resumeStep)
+	s.launchPipelineExecution(newRunID, originalRun.PipelineName, originalRun.Input, config.RuntimeConfig{}, resumeStep)
 
 	writeJSON(w, http.StatusCreated, ForkRunResponse{
 		RunID:        newRunID,

--- a/internal/webui/server_helpers.go
+++ b/internal/webui/server_helpers.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/pipeline"
-	"github.com/recinq/wave/internal/runner"
 )
 
 // validPipelineName matches safe pipeline names: alphanumeric, hyphens, underscores, dots.
@@ -49,10 +49,10 @@ func loadPipelineYAML(name string) (*pipeline.Pipeline, error) {
 }
 
 // runOptionsFromStartRequest projects an HTTP StartPipelineRequest onto the
-// shared runner.Options struct so the launch path is identical regardless of
-// which handler triggered the run.
-func runOptionsFromStartRequest(req StartPipelineRequest) runner.Options {
-	return runner.Options{
+// shared config.RuntimeConfig struct so the launch path is identical
+// regardless of which handler triggered the run.
+func runOptionsFromStartRequest(req StartPipelineRequest) config.RuntimeConfig {
+	return config.RuntimeConfig{
 		Model:             req.Model,
 		Adapter:           req.Adapter,
 		DryRun:            req.DryRun,
@@ -191,8 +191,8 @@ func classifyCompositionStep(step *pipeline.Step) CompositionStep {
 
 // runOptionsFromSubmitRequest mirrors runOptionsFromStartRequest for the
 // /api/runs submit endpoint.
-func runOptionsFromSubmitRequest(req SubmitRunRequest) runner.Options {
-	return runner.Options{
+func runOptionsFromSubmitRequest(req SubmitRunRequest) config.RuntimeConfig {
+	return config.RuntimeConfig{
 		Model:             req.Model,
 		Adapter:           req.Adapter,
 		DryRun:            req.DryRun,

--- a/internal/webui/server_launcher.go
+++ b/internal/webui/server_launcher.go
@@ -3,16 +3,17 @@ package webui
 import (
 	"log"
 
+	"github.com/recinq/wave/internal/config"
 	"github.com/recinq/wave/internal/event"
 	"github.com/recinq/wave/internal/pipeline"
 	"github.com/recinq/wave/internal/runner"
 )
 
 // RunOptions is the CLI-parity option set forwarded from the webui start
-// form to internal/runner. Aliased so webui handlers and request DTOs keep
-// their existing field names while sharing one canonical shape with the cmd
-// path.
-type RunOptions = runner.Options
+// form to internal/runner. Aliased to config.RuntimeConfig so webui handlers
+// and request DTOs keep their existing field names while sharing one
+// canonical shape with the cmd path.
+type RunOptions = config.RuntimeConfig
 
 // launchPipelineExecution starts pipeline execution as a detached subprocess
 // via internal/runner. The subprocess is fully independent of the server


### PR DESCRIPTION
## Summary

PR-1 of internal task #61 (Config struct sprawl consolidation).

`internal/runner/Options` is misnamed — it isn't runner-specific, it's the
runtime config snapshot consumed by both runner and webui launch paths.
This PR lifts it into `internal/config` next to `config.Env` so a single
package owns runtime configuration types. **Rename + relocation only — no
semantics change, no field splits, no manifest churn.**

### What moved
- `internal/runner/options.go` → `internal/config/runtime.go`
- `runner.Options` → `config.RuntimeConfig`
- `runner.OutputConfig` → `config.OutputConfig`
- `runner.OutputFormat{Auto,JSON,Text,Quiet}` → `config.OutputFormat*`

### What stayed
- All field names (the reflection-driven `TestDetachedArgsExhaustive`
  needs no edits — same field set, same names).
- Manifest types — out of scope for this PR.
- `cmd/wave/commands.RunOptions` keeps its name; it now aliases
  `config.RuntimeConfig` so flag-binding sites stay local.
- `internal/webui.RunOptions` keeps its name; same alias rationale.

### What's next (PR-2)
Add `config.Effective` = manifest defaults overlaid by
`config.RuntimeConfig` overlaid by `config.Env`. That's where merging,
precedence, and caller migration land.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` all green (incl. `TestDetachedArgsExhaustive`
      which now introspects `config.RuntimeConfig`)
- [x] `golangci-lint run ./...` 0 issues
- [x] Smoke: `wave run --pipeline wave-smoke-contracts --adapter claude
      --model cheapest` — pipeline completes successfully (validate step
      ran end-to-end, contract artefact produced)