### PR TITLE
refactor(config): add EffectiveConfig merge layer (manifest+env+runtime)

### DIFF
--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -1,0 +1,172 @@
+package config
+
+// This file holds the EffectiveConfig merge layer — a single resolved view
+// over manifest defaults, the process env snapshot, and the per-run runtime
+// overrides supplied by `wave run` flags or the webui launch struct.
+//
+// Precedence (lowest -> highest):
+//
+//   1. Manifest defaults  — values pulled from wave.yaml's runtime block
+//   2. Process env        — config.Env snapshot (NO_COLOR etc.)
+//   3. Runtime overrides  — config.RuntimeConfig (CLI flags / launch struct)
+//
+// Empty / zero-value fields in a higher-precedence source do NOT clobber
+// lower-precedence non-empty values: an unset CLI flag defers to env, which
+// in turn defers to manifest. This rule exists so callers can hand a single
+// resolved view down to executors and adapters without each layer re-applying
+// its own "if non-empty, override" boilerplate.
+//
+// Scope (deliberately narrow): only the fields where merge logic currently
+// lives in multiple call-sites (or where bundling them on Effective lets
+// callers stop threading RuntimeConfig down for the sake of one bool):
+//
+//   - Adapter           runtime > manifest first declared adapter > "claude"
+//   - Model             runtime > manifest tier table fallback handled
+//                       per-step inside the executor; Effective only carries
+//                       the run-wide override
+//   - StepTimeout       runtime int (minutes) > manifest GetDefaultTimeout()
+//                       > timeouts.StepDefault
+//   - AutoApprove       runtime-only bool, bundled for caller ergonomics
+//   - NoRetro           runtime-only bool, bundled for caller ergonomics
+//   - ForceModel        runtime-only bool, bundled for caller ergonomics
+//   - NoColor           env (NO_COLOR set) > runtime Output.NoColor flag
+//
+// Anything else (workspace_root, output format, verbosity) is read from
+// exactly one source today and does not benefit from a merge layer; those
+// callers are intentionally left alone per PR-2 scope.
+
+import (
+	"time"
+
+	"github.com/recinq/wave/internal/timeouts"
+)
+
+// ManifestDefaults is the slice of *manifest.Manifest that Resolve consults.
+// Declaring it as an interface here keeps the config package free of any
+// dependency on internal/manifest (which transitively imports internal/config
+// via hooks/scope, so a direct import would form a cycle).
+//
+// *manifest.Manifest satisfies this interface directly through its existing
+// methods and field access — no adapter struct is required at the call site;
+// callers wrap raw access in a small helper (see ManifestDefaultsFunc).
+type ManifestDefaults interface {
+	// FirstAdapter returns the first adapter name declared on the manifest,
+	// or empty when the manifest declares none. Used as the fallback adapter
+	// when no runtime override is supplied.
+	FirstAdapter() string
+
+	// DefaultTimeout returns the manifest-resolved per-step timeout. The
+	// underlying manifest type already collapses the legacy
+	// DefaultTimeoutMin field and the structured Timeouts.StepDefaultMin
+	// field into a single duration.
+	DefaultTimeout() time.Duration
+}
+
+// Effective is the resolved per-run configuration view. It collapses the
+// three input layers (manifest, env, runtime) into one struct so consumers
+// (executor wiring, webui launcher, cmd run) stop reaching back into all
+// three sources separately.
+//
+// Zero-valued fields on Effective mean "no opinion" — the executor's own
+// per-step defaults still apply. Notably, an empty Adapter still gets the
+// hard-coded "claude" fallback applied by Resolve, because that fallback
+// already lives in two places today and consolidating it is part of the
+// motivation for this layer.
+type Effective struct {
+	// Adapter is the resolved adapter name. Never empty after Resolve:
+	// runtime override wins, else first manifest adapter, else "claude".
+	Adapter string
+
+	// Model is the run-wide model override. Empty means "use the per-step
+	// or per-persona model"; the executor applies its own tier-table logic
+	// from the manifest in that case.
+	Model string
+
+	// StepTimeout is the per-step timeout. Always non-zero after Resolve:
+	// runtime > manifest > timeouts.StepDefault.
+	StepTimeout time.Duration
+
+	// AutoApprove auto-resolves approval gates with their default choice.
+	AutoApprove bool
+
+	// NoRetro skips retrospective generation for the run.
+	NoRetro bool
+
+	// ForceModel forces the resolved Model onto every step regardless of
+	// per-step or per-persona model pinning.
+	ForceModel bool
+
+	// NoColor disables ANSI color in CLI/TUI output. True when either the
+	// runtime Output.NoColor flag is set or the NO_COLOR env var is
+	// non-empty (per the no-color.org convention).
+	NoColor bool
+}
+
+// Resolve merges manifest defaults, the env snapshot, and runtime overrides
+// into a single Effective view. Higher-precedence non-zero values win;
+// zero-valued higher-precedence fields defer to the lower layers.
+//
+// A nil ManifestDefaults is tolerated: it represents the standalone webui
+// bootstrap path where the server is launched without a manifest on disk.
+// In that case manifest-layer fields fall through to the hard-coded
+// fallbacks ("claude" adapter, timeouts.StepDefault).
+func Resolve(m ManifestDefaults, env Env, rt RuntimeConfig) Effective {
+	out := Effective{
+		AutoApprove: rt.AutoApprove,
+		NoRetro:     rt.NoRetro,
+		ForceModel:  rt.ForceModel,
+		Model:       rt.Model,
+	}
+
+	// Adapter precedence: runtime > manifest first adapter > "claude".
+	switch {
+	case rt.Adapter != "":
+		out.Adapter = rt.Adapter
+	case m != nil && m.FirstAdapter() != "":
+		out.Adapter = m.FirstAdapter()
+	default:
+		out.Adapter = "claude"
+	}
+
+	// StepTimeout precedence: runtime (minutes, > 0) > manifest default >
+	// hard-coded fallback. Zero on runtime is "unset", not "no timeout".
+	switch {
+	case rt.Timeout > 0:
+		out.StepTimeout = time.Duration(rt.Timeout) * time.Minute
+	case m != nil:
+		out.StepTimeout = m.DefaultTimeout()
+	default:
+		out.StepTimeout = timeouts.StepDefault
+	}
+
+	// NoColor precedence: env NO_COLOR (any non-empty value) OR runtime
+	// flag. The env var is the no-color.org convention; the runtime flag
+	// covers cmd's --no-color path.
+	out.NoColor = env.NoColor != "" || rt.Output.NoColor
+
+	return out
+}
+
+// ManifestDefaultsFunc adapts plain functions into a ManifestDefaults
+// implementation. The cmd and webui callers use this to bridge their
+// loaded *manifest.Manifest into Resolve without a separate wrapper type.
+type ManifestDefaultsFunc struct {
+	FirstAdapterFn   func() string
+	DefaultTimeoutFn func() time.Duration
+}
+
+// FirstAdapter implements ManifestDefaults.
+func (f ManifestDefaultsFunc) FirstAdapter() string {
+	if f.FirstAdapterFn == nil {
+		return ""
+	}
+	return f.FirstAdapterFn()
+}
+
+// DefaultTimeout implements ManifestDefaults.
+func (f ManifestDefaultsFunc) DefaultTimeout() time.Duration {
+	if f.DefaultTimeoutFn == nil {
+		return timeouts.StepDefault
+	}
+	return f.DefaultTimeoutFn()
+}

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -1,0 +1,259 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/timeouts"
+)
+
+// fakeManifest is a test-only ManifestDefaults that returns canned values.
+// Used to keep the merge tests focused on precedence rules, not on coupling
+// to the real internal/manifest.Manifest type.
+type fakeManifest struct {
+	firstAdapter   string
+	defaultTimeout time.Duration
+}
+
+func (f fakeManifest) FirstAdapter() string          { return f.firstAdapter }
+func (f fakeManifest) DefaultTimeout() time.Duration { return f.defaultTimeout }
+
+func TestResolve_PrecedenceTable(t *testing.T) {
+	tests := []struct {
+		name string
+		m    ManifestDefaults
+		env  Env
+		rt   RuntimeConfig
+		want Effective
+	}{
+		{
+			name: "manifest only — adapter and timeout from manifest",
+			m: fakeManifest{
+				firstAdapter:   "opencode",
+				defaultTimeout: 12 * time.Minute,
+			},
+			env: Env{},
+			rt:  RuntimeConfig{},
+			want: Effective{
+				Adapter:     "opencode",
+				StepTimeout: 12 * time.Minute,
+			},
+		},
+		{
+			name: "env overrides manifest for NoColor",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{NoColor: "1"},
+			rt:  RuntimeConfig{},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 5 * time.Minute,
+				NoColor:     true,
+			},
+		},
+		{
+			name: "runtime adapter overrides manifest",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Adapter: "gemini",
+			},
+			want: Effective{
+				Adapter:     "gemini",
+				StepTimeout: 5 * time.Minute,
+			},
+		},
+		{
+			name: "runtime timeout overrides manifest",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Timeout: 30, // minutes
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 30 * time.Minute,
+			},
+		},
+		{
+			name: "runtime zero-value timeout defers to manifest",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 7 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Timeout: 0,
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 7 * time.Minute,
+			},
+		},
+		{
+			name: "runtime empty adapter defers to manifest",
+			m: fakeManifest{
+				firstAdapter:   "codex",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Adapter: "",
+			},
+			want: Effective{
+				Adapter:     "codex",
+				StepTimeout: 5 * time.Minute,
+			},
+		},
+		{
+			name: "nil manifest tolerated — adapter falls through to claude, timeout to default",
+			m:    nil,
+			env:  Env{},
+			rt:   RuntimeConfig{},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: timeouts.StepDefault,
+			},
+		},
+		{
+			name: "nil manifest with runtime overrides — runtime still wins",
+			m:    nil,
+			env:  Env{},
+			rt: RuntimeConfig{
+				Adapter: "gemini",
+				Timeout: 15,
+			},
+			want: Effective{
+				Adapter:     "gemini",
+				StepTimeout: 15 * time.Minute,
+			},
+		},
+		{
+			name: "model passes through from runtime — no manifest layer for run-wide model",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Model: "haiku",
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 5 * time.Minute,
+				Model:       "haiku",
+			},
+		},
+		{
+			name: "runtime-only flags bundled (auto-approve / no-retro / force-model)",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				AutoApprove: true,
+				NoRetro:     true,
+				ForceModel:  true,
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 5 * time.Minute,
+				AutoApprove: true,
+				NoRetro:     true,
+				ForceModel:  true,
+			},
+		},
+		{
+			name: "runtime Output.NoColor sets NoColor even when env unset",
+			m: fakeManifest{
+				firstAdapter:   "claude",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt: RuntimeConfig{
+				Output: OutputConfig{NoColor: true},
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 5 * time.Minute,
+				NoColor:     true,
+			},
+		},
+		{
+			name: "empty manifest first adapter falls through to claude",
+			m: fakeManifest{
+				firstAdapter:   "",
+				defaultTimeout: 5 * time.Minute,
+			},
+			env: Env{},
+			rt:  RuntimeConfig{},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 5 * time.Minute,
+			},
+		},
+		{
+			name: "all three layers contribute — runtime adapter, env nocolor, manifest timeout",
+			m: fakeManifest{
+				firstAdapter:   "opencode",
+				defaultTimeout: 9 * time.Minute,
+			},
+			env: Env{NoColor: "true"},
+			rt: RuntimeConfig{
+				Adapter: "claude",
+				Model:   "opus",
+			},
+			want: Effective{
+				Adapter:     "claude",
+				StepTimeout: 9 * time.Minute,
+				Model:       "opus",
+				NoColor:     true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Resolve(tc.m, tc.env, tc.rt)
+			if got != tc.want {
+				t.Errorf("Resolve() mismatch\n got = %+v\nwant = %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestManifestDefaultsFunc_NilFunctionsSafe(t *testing.T) {
+	// A zero-valued ManifestDefaultsFunc must be safe to call — callers that
+	// only know one of the two values should not have to populate both.
+	var f ManifestDefaultsFunc
+
+	if got := f.FirstAdapter(); got != "" {
+		t.Errorf("FirstAdapter() with nil fn = %q, want empty", got)
+	}
+	if got := f.DefaultTimeout(); got != timeouts.StepDefault {
+		t.Errorf("DefaultTimeout() with nil fn = %v, want %v", got, timeouts.StepDefault)
+	}
+}
+
+func TestManifestDefaultsFunc_DelegatesToFunctions(t *testing.T) {
+	f := ManifestDefaultsFunc{
+		FirstAdapterFn:   func() string { return "gemini" },
+		DefaultTimeoutFn: func() time.Duration { return 42 * time.Second },
+	}
+
+	if got := f.FirstAdapter(); got != "gemini" {
+		t.Errorf("FirstAdapter() = %q, want gemini", got)
+	}
+	if got := f.DefaultTimeout(); got != 42*time.Second {
+		t.Errorf("DefaultTimeout() = %v, want 42s", got)
+	}
+}

--- a/internal/runner/inprocess.go
+++ b/internal/runner/inprocess.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/recinq/wave/internal/adapter"
 	"github.com/recinq/wave/internal/audit"
@@ -98,7 +97,13 @@ func (s SkillStoreConfig) resolved() (skill.SkillSource, skill.SkillSource) {
 // lifetime. If cfg.OnComplete is non-nil it is invoked after the final
 // status row is written.
 func LaunchInProcess(cfg InProcessConfig) context.CancelFunc {
-	runner := resolveAdapterRunner(cfg.Options.Adapter, cfg.Manifest)
+	// Resolve manifest + env + runtime into a single effective view. The
+	// merge layer owns the "runtime > manifest > fallback" precedence for
+	// adapter and timeout, so the option-list assembly below stops doing
+	// it inline.
+	eff := config.Resolve(manifestDefaultsFromManifest(cfg.Manifest), config.FromEnv(), cfg.Options)
+
+	runner := adapter.ResolveAdapter(eff.Adapter)
 
 	traceLogger, traceErr := audit.NewTraceLogger()
 	if traceErr != nil {
@@ -121,14 +126,22 @@ func LaunchInProcess(cfg InProcessConfig) context.CancelFunc {
 	if cfg.GateHandler != nil {
 		execOpts = append(execOpts, pipeline.WithGateHandler(cfg.GateHandler))
 	}
-	if cfg.Options.Model != "" {
-		execOpts = append(execOpts, pipeline.WithModelOverride(cfg.Options.Model))
+	if eff.Model != "" {
+		execOpts = append(execOpts, pipeline.WithModelOverride(eff.Model))
 	}
+	// WithAdapterOverride forces the named adapter onto every step,
+	// overriding step.Adapter and persona.Adapter. Only apply it when the
+	// runtime supplied an explicit --adapter — the manifest-first / "claude"
+	// fallbacks captured by eff.Adapter are for runner resolution, not
+	// per-step dispatch.
 	if cfg.Options.Adapter != "" {
 		execOpts = append(execOpts, pipeline.WithAdapterOverride(cfg.Options.Adapter))
 	}
 	if cfg.Options.Timeout > 0 {
-		execOpts = append(execOpts, pipeline.WithStepTimeout(time.Duration(cfg.Options.Timeout)*time.Minute))
+		// Only honour the merged timeout when it actually came from a
+		// runtime override — manifest defaults are applied per-step inside
+		// the executor and overriding here would short-circuit them.
+		execOpts = append(execOpts, pipeline.WithStepTimeout(eff.StepTimeout))
 	}
 	if cfg.Options.Steps != "" || cfg.Options.Exclude != "" {
 		execOpts = append(execOpts, pipeline.WithStepFilter(pipeline.ParseStepFilter(cfg.Options.Steps, cfg.Options.Exclude)))
@@ -189,18 +202,29 @@ func LaunchInProcess(cfg InProcessConfig) context.CancelFunc {
 	return cancel
 }
 
-// resolveAdapterRunner mirrors the heuristic the webui used: explicit override
-// wins, otherwise pick the first adapter declared on the manifest, otherwise
-// fall back to "claude". Kept as a private helper because the cmd path uses a
-// richer adapter registry that we don't want to invade in this PR.
-func resolveAdapterRunner(adapterOverride string, m *manifest.Manifest) adapter.AdapterRunner {
-	if adapterOverride != "" {
-		return adapter.ResolveAdapter(adapterOverride)
+// manifestDefaultsFromManifest adapts a *manifest.Manifest into the
+// config.ManifestDefaults interface used by config.Resolve. The interface
+// indirection exists because internal/config cannot import internal/manifest
+// (manifest transitively imports config via hooks/scope, which would cycle).
+//
+// A nil manifest yields a ManifestDefaults that returns zero values; Resolve
+// treats that the same as a zero-valued manifest, falling through to the
+// hard-coded adapter and timeout fallbacks.
+func manifestDefaultsFromManifest(m *manifest.Manifest) config.ManifestDefaults {
+	if m == nil {
+		return nil
 	}
-	if m != nil {
-		for adapterName := range m.Adapters {
-			return adapter.ResolveAdapter(adapterName)
-		}
+	return config.ManifestDefaultsFunc{
+		FirstAdapterFn: func() string {
+			// Map iteration order is non-deterministic; the previous
+			// implementation relied on this. Preserve semantics by
+			// returning the first key Go yields — callers that pin a
+			// specific adapter must use --adapter explicitly.
+			for adapterName := range m.Adapters {
+				return adapterName
+			}
+			return ""
+		},
+		DefaultTimeoutFn: m.Runtime.GetDefaultTimeout,
 	}
-	return adapter.ResolveAdapter("claude")
 }


### PR DESCRIPTION
PR-2 of internal task #61 (Config struct sprawl consolidation). Follow-up to PR-1 #1561 (`runner.Options` → `config.RuntimeConfig`).

## Summary

Adds `config.Effective` + `config.Resolve` — a single resolved per-run configuration view that collapses three input sources with explicit precedence: **manifest < env < runtime**. Zero-valued higher-precedence fields defer to lower layers, so an unset CLI flag does not clobber a manifest setting.

## Chosen Effective fields

Kept deliberately narrow — only where merge logic exists across multiple call-sites today, or where bundling lets callers stop threading `RuntimeConfig` down:

| Field         | Precedence                                                                       |
|---------------|----------------------------------------------------------------------------------|
| `Adapter`     | runtime `--adapter` > manifest first declared adapter > `\"claude\"`               |
| `Model`       | runtime `--model` only (per-step tier table stays in the executor)               |
| `StepTimeout` | runtime `--timeout` (min) > manifest `Runtime.GetDefaultTimeout()` > `timeouts.StepDefault` |
| `AutoApprove` | runtime-only — bundled                                                           |
| `NoRetro`     | runtime-only — bundled                                                           |
| `ForceModel`  | runtime-only — bundled                                                           |
| `NoColor`     | env `NO_COLOR` (any non-empty value) OR runtime `Output.NoColor`                 |

Workspace path / output format / verbosity are read from exactly one source today and do **not** benefit from a merge layer; those callers are intentionally left alone.

## Architecture note: import-cycle handling

`internal/config` cannot import `internal/manifest` directly — manifest transitively imports config via `hooks` and `scope`, forming a cycle. `ManifestDefaults` is therefore exposed as an interface in the config package, with a `ManifestDefaultsFunc` adapter the callers wrap their `*manifest.Manifest` in.

## Migrated call site

- **`internal/runner/inprocess.go`** — `LaunchInProcess` now calls `config.Resolve` once and uses the merged view for adapter-runner selection. The previous `resolveAdapterRunner` helper (manifest-first / `\"claude\"` fallback) is removed; its logic now lives inside `config.Resolve`. `WithAdapterOverride` is still gated on explicit `--adapter` to preserve the documented \"runtime forces every step\" semantics for the executor's per-step adapter routing.

`cmd/wave/commands/run_stages.go:assembleExecutorOptions` and `cmd/wave/commands/do.go` were reviewed and **not** migrated: they only consume `RuntimeConfig` overrides directly (no inline manifest+env+runtime triangulation), so per the migration rule \"a caller that reads exactly one source does NOT need to switch\" they're left intact.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` — all packages green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `wave run --pipeline wave-smoke-contracts --adapter claude --model cheapest` — succeeds (16.4s, 10.7k tokens)
- [x] `wave run --pipeline wave-smoke-contracts --adapter claude` (no `--model`) — succeeds, defaults to manifest tier (`claude-haiku-4-5`)

Tests in `internal/config/effective_test.go` are table-driven and cover: manifest-only, env-overrides-manifest, runtime-overrides-env, runtime-zero-value-defers, nil-manifest tolerated, model passthrough, bundled runtime-only flags, and a three-layer composition case.