### PR TITLE
feat(state): add 5 tables for evolution + worksource + schedule (PRE-5)

### DIFF
--- a/internal/state/evolution.go
+++ b/internal/state/evolution.go
@@ -1,0 +1,449 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PipelineEvalRecord captures the per-run signal aggregation that drives the
+// evolution loop: judge score, contract pass/fail, retry count, failure class,
+// human override flag, duration, and cost. Inserted at run completion (Phase 3
+// of the onboarding-as-session epic).
+type PipelineEvalRecord struct {
+	PipelineName  string
+	RunID         string
+	JudgeScore    *float64
+	ContractPass  *bool
+	RetryCount    *int
+	FailureClass  string
+	HumanOverride *bool
+	DurationMs    *int64
+	CostDollars   *float64
+	RecordedAt    time.Time
+}
+
+// PipelineVersionRecord pins a sha256+yaml_path tuple per (pipeline_name,
+// version). Exactly one row per pipeline is active at a time; activation
+// flips happen in CreatePipelineVersion (active=true) or ActivateVersion.
+type PipelineVersionRecord struct {
+	PipelineName string
+	Version      int
+	SHA256       string
+	YAMLPath     string
+	Active       bool
+	CreatedAt    time.Time
+}
+
+// EvolutionProposalStatus enumerates the lifecycle states of an evolution
+// proposal awaiting human review.
+type EvolutionProposalStatus string
+
+const (
+	ProposalProposed   EvolutionProposalStatus = "proposed"
+	ProposalApproved   EvolutionProposalStatus = "approved"
+	ProposalRejected   EvolutionProposalStatus = "rejected"
+	ProposalSuperseded EvolutionProposalStatus = "superseded"
+)
+
+// EvolutionProposalRecord is one row from evolution_proposal. The diff lives
+// on disk at DiffPath; the SignalSummary is opaque JSON the producer chose.
+type EvolutionProposalRecord struct {
+	ID             int64
+	PipelineName   string
+	VersionBefore  int
+	VersionAfter   int
+	DiffPath       string
+	Reason         string
+	SignalSummary  string
+	Status         EvolutionProposalStatus
+	ProposedAt     time.Time
+	DecidedAt      *time.Time
+	DecidedBy      string
+}
+
+// EvolutionStore is the domain-scoped persistence surface for the evolution
+// loop. Consumers wiring evolution-only logic (e.g. internal/evolution) should
+// depend on this interface rather than the aggregate StateStore.
+type EvolutionStore interface {
+	RecordEval(rec PipelineEvalRecord) error
+	GetEvalsForPipeline(pipelineName string, limit int) ([]PipelineEvalRecord, error)
+
+	CreatePipelineVersion(rec PipelineVersionRecord) error
+	ActivateVersion(pipelineName string, version int) error
+	GetActiveVersion(pipelineName string) (*PipelineVersionRecord, error)
+	ListPipelineVersions(pipelineName string) ([]PipelineVersionRecord, error)
+
+	CreateProposal(rec EvolutionProposalRecord) (int64, error)
+	DecideProposal(id int64, status EvolutionProposalStatus, decidedBy string) error
+	GetProposal(id int64) (*EvolutionProposalRecord, error)
+	ListProposalsByStatus(status EvolutionProposalStatus, limit int) ([]EvolutionProposalRecord, error)
+}
+
+// RecordEval inserts a row into pipeline_eval. The (pipeline_name, run_id)
+// composite key prevents double-recording when the executor's terminal hook
+// fires more than once.
+func (s *stateStore) RecordEval(rec PipelineEvalRecord) error {
+	if rec.PipelineName == "" || rec.RunID == "" {
+		return errors.New("RecordEval: pipeline_name and run_id are required")
+	}
+	if rec.RecordedAt.IsZero() {
+		rec.RecordedAt = time.Now()
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO pipeline_eval
+			(pipeline_name, run_id, judge_score, contract_pass, retry_count,
+			 failure_class, human_override, duration_ms, cost_dollars, recorded_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.PipelineName, rec.RunID,
+		nullableFloat(rec.JudgeScore),
+		nullableBool(rec.ContractPass),
+		nullableInt(rec.RetryCount),
+		nullEmptyString(rec.FailureClass),
+		nullableBool(rec.HumanOverride),
+		nullableInt64(rec.DurationMs),
+		nullableFloat(rec.CostDollars),
+		rec.RecordedAt.Unix(),
+	)
+	return err
+}
+
+// GetEvalsForPipeline returns the most recent eval rows for a pipeline,
+// newest first. Limit ≤ 0 returns all rows.
+func (s *stateStore) GetEvalsForPipeline(pipelineName string, limit int) ([]PipelineEvalRecord, error) {
+	q := `SELECT pipeline_name, run_id, judge_score, contract_pass, retry_count,
+		failure_class, human_override, duration_ms, cost_dollars, recorded_at
+		FROM pipeline_eval WHERE pipeline_name = ? ORDER BY recorded_at DESC`
+	args := []any{pipelineName}
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PipelineEvalRecord
+	for rows.Next() {
+		var (
+			r            PipelineEvalRecord
+			judgeScore   sql.NullFloat64
+			contractPass sql.NullBool
+			retryCount   sql.NullInt64
+			failureClass sql.NullString
+			humanOver    sql.NullBool
+			durationMs   sql.NullInt64
+			costDollars  sql.NullFloat64
+			recordedAt   int64
+		)
+		if err := rows.Scan(&r.PipelineName, &r.RunID, &judgeScore, &contractPass, &retryCount,
+			&failureClass, &humanOver, &durationMs, &costDollars, &recordedAt); err != nil {
+			return nil, err
+		}
+		if judgeScore.Valid {
+			v := judgeScore.Float64
+			r.JudgeScore = &v
+		}
+		if contractPass.Valid {
+			v := contractPass.Bool
+			r.ContractPass = &v
+		}
+		if retryCount.Valid {
+			v := int(retryCount.Int64)
+			r.RetryCount = &v
+		}
+		if failureClass.Valid {
+			r.FailureClass = failureClass.String
+		}
+		if humanOver.Valid {
+			v := humanOver.Bool
+			r.HumanOverride = &v
+		}
+		if durationMs.Valid {
+			v := durationMs.Int64
+			r.DurationMs = &v
+		}
+		if costDollars.Valid {
+			v := costDollars.Float64
+			r.CostDollars = &v
+		}
+		r.RecordedAt = time.Unix(recordedAt, 0)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// CreatePipelineVersion inserts a new pipeline_version row. When rec.Active is
+// true, all other rows for the same pipeline_name are deactivated atomically.
+func (s *stateStore) CreatePipelineVersion(rec PipelineVersionRecord) error {
+	if rec.PipelineName == "" || rec.SHA256 == "" || rec.YAMLPath == "" {
+		return errors.New("CreatePipelineVersion: pipeline_name, sha256, yaml_path required")
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if rec.Active {
+		if _, err := tx.Exec(
+			`UPDATE pipeline_version SET active = 0 WHERE pipeline_name = ?`,
+			rec.PipelineName,
+		); err != nil {
+			return fmt.Errorf("deactivate prior versions: %w", err)
+		}
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO pipeline_version (pipeline_name, version, sha256, yaml_path, active, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		rec.PipelineName, rec.Version, rec.SHA256, rec.YAMLPath, rec.Active, rec.CreatedAt.Unix(),
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// ActivateVersion flips the active flag to the requested version, deactivating
+// all other versions of the same pipeline atomically.
+func (s *stateStore) ActivateVersion(pipelineName string, version int) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(
+		`UPDATE pipeline_version SET active = 0 WHERE pipeline_name = ?`,
+		pipelineName,
+	); err != nil {
+		return err
+	}
+	res, err := tx.Exec(
+		`UPDATE pipeline_version SET active = 1 WHERE pipeline_name = ? AND version = ?`,
+		pipelineName, version,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("ActivateVersion: pipeline %q version %d not found", pipelineName, version)
+	}
+	return tx.Commit()
+}
+
+// GetActiveVersion returns the row with active=1 for the pipeline, or nil if
+// no version is active.
+func (s *stateStore) GetActiveVersion(pipelineName string) (*PipelineVersionRecord, error) {
+	row := s.db.QueryRow(
+		`SELECT pipeline_name, version, sha256, yaml_path, active, created_at
+		 FROM pipeline_version WHERE pipeline_name = ? AND active = 1`,
+		pipelineName,
+	)
+	rec, err := scanPipelineVersion(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return rec, err
+}
+
+// ListPipelineVersions returns every version row for a pipeline, newest first.
+func (s *stateStore) ListPipelineVersions(pipelineName string) ([]PipelineVersionRecord, error) {
+	rows, err := s.db.Query(
+		`SELECT pipeline_name, version, sha256, yaml_path, active, created_at
+		 FROM pipeline_version WHERE pipeline_name = ? ORDER BY version DESC`,
+		pipelineName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PipelineVersionRecord
+	for rows.Next() {
+		var r PipelineVersionRecord
+		var createdAt int64
+		if err := rows.Scan(&r.PipelineName, &r.Version, &r.SHA256, &r.YAMLPath, &r.Active, &createdAt); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = time.Unix(createdAt, 0)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanPipelineVersion(row *sql.Row) (*PipelineVersionRecord, error) {
+	var r PipelineVersionRecord
+	var createdAt int64
+	if err := row.Scan(&r.PipelineName, &r.Version, &r.SHA256, &r.YAMLPath, &r.Active, &createdAt); err != nil {
+		return nil, err
+	}
+	r.CreatedAt = time.Unix(createdAt, 0)
+	return &r, nil
+}
+
+// CreateProposal inserts an evolution_proposal row in 'proposed' state and
+// returns the autoincrement id. ProposedAt defaults to time.Now() when zero.
+func (s *stateStore) CreateProposal(rec EvolutionProposalRecord) (int64, error) {
+	if rec.PipelineName == "" || rec.DiffPath == "" || rec.Reason == "" {
+		return 0, errors.New("CreateProposal: pipeline_name, diff_path, reason required")
+	}
+	if rec.Status == "" {
+		rec.Status = ProposalProposed
+	}
+	if rec.ProposedAt.IsZero() {
+		rec.ProposedAt = time.Now()
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO evolution_proposal
+			(pipeline_name, version_before, version_after, diff_path, reason,
+			 signal_summary, status, proposed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.PipelineName, rec.VersionBefore, rec.VersionAfter, rec.DiffPath,
+		rec.Reason, rec.SignalSummary, string(rec.Status), rec.ProposedAt.Unix(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// DecideProposal updates a proposal to a terminal status and records who
+// decided. Returns an error if the proposal is already terminal.
+func (s *stateStore) DecideProposal(id int64, status EvolutionProposalStatus, decidedBy string) error {
+	if status == ProposalProposed {
+		return errors.New("DecideProposal: cannot decide back to 'proposed'")
+	}
+	res, err := s.db.Exec(
+		`UPDATE evolution_proposal
+		 SET status = ?, decided_at = ?, decided_by = ?
+		 WHERE id = ? AND status = 'proposed'`,
+		string(status), time.Now().Unix(), decidedBy, id,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("DecideProposal: proposal %d not in 'proposed' state", id)
+	}
+	return nil
+}
+
+// GetProposal returns one proposal by id, or nil if not found.
+func (s *stateStore) GetProposal(id int64) (*EvolutionProposalRecord, error) {
+	row := s.db.QueryRow(
+		`SELECT id, pipeline_name, version_before, version_after, diff_path,
+			reason, signal_summary, status, proposed_at, decided_at, decided_by
+		 FROM evolution_proposal WHERE id = ?`,
+		id,
+	)
+	rec, err := scanProposal(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return rec, err
+}
+
+// ListProposalsByStatus returns proposals matching status, newest first.
+// Limit ≤ 0 returns all.
+func (s *stateStore) ListProposalsByStatus(status EvolutionProposalStatus, limit int) ([]EvolutionProposalRecord, error) {
+	q := `SELECT id, pipeline_name, version_before, version_after, diff_path,
+		reason, signal_summary, status, proposed_at, decided_at, decided_by
+		FROM evolution_proposal WHERE status = ? ORDER BY proposed_at DESC`
+	args := []any{string(status)}
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []EvolutionProposalRecord
+	for rows.Next() {
+		var (
+			r          EvolutionProposalRecord
+			decidedAt  sql.NullInt64
+			decidedBy  sql.NullString
+			proposedAt int64
+			statusStr  string
+		)
+		if err := rows.Scan(&r.ID, &r.PipelineName, &r.VersionBefore, &r.VersionAfter,
+			&r.DiffPath, &r.Reason, &r.SignalSummary, &statusStr, &proposedAt,
+			&decidedAt, &decidedBy); err != nil {
+			return nil, err
+		}
+		r.Status = EvolutionProposalStatus(statusStr)
+		r.ProposedAt = time.Unix(proposedAt, 0)
+		if decidedAt.Valid {
+			t := time.Unix(decidedAt.Int64, 0)
+			r.DecidedAt = &t
+		}
+		if decidedBy.Valid {
+			r.DecidedBy = decidedBy.String
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanProposal(row *sql.Row) (*EvolutionProposalRecord, error) {
+	var (
+		r          EvolutionProposalRecord
+		decidedAt  sql.NullInt64
+		decidedBy  sql.NullString
+		proposedAt int64
+		statusStr  string
+	)
+	if err := row.Scan(&r.ID, &r.PipelineName, &r.VersionBefore, &r.VersionAfter,
+		&r.DiffPath, &r.Reason, &r.SignalSummary, &statusStr, &proposedAt,
+		&decidedAt, &decidedBy); err != nil {
+		return nil, err
+	}
+	r.Status = EvolutionProposalStatus(statusStr)
+	r.ProposedAt = time.Unix(proposedAt, 0)
+	if decidedAt.Valid {
+		t := time.Unix(decidedAt.Int64, 0)
+		r.DecidedAt = &t
+	}
+	if decidedBy.Valid {
+		r.DecidedBy = decidedBy.String
+	}
+	return &r, nil
+}
+
+// nullable* helpers convert *T into a sql-friendly value (nil → NULL).
+func nullableFloat(p *float64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+func nullableBool(p *bool) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+func nullableInt(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+func nullableInt64(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+func nullEmptyString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/state/evolution_test.go
+++ b/internal/state/evolution_test.go
@@ -1,0 +1,144 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordEval_BasicInsert(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	score := 0.85
+	pass := true
+	retries := 1
+	dur := int64(12500)
+	cost := 0.42
+
+	rec := PipelineEvalRecord{
+		PipelineName: "impl-issue",
+		RunID:        "run-1",
+		JudgeScore:   &score,
+		ContractPass: &pass,
+		RetryCount:   &retries,
+		FailureClass: "",
+		DurationMs:   &dur,
+		CostDollars:  &cost,
+	}
+	require.NoError(t, store.RecordEval(rec))
+
+	got, err := store.GetEvalsForPipeline("impl-issue", 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "run-1", got[0].RunID)
+	assert.NotNil(t, got[0].JudgeScore)
+	assert.InDelta(t, 0.85, *got[0].JudgeScore, 1e-9)
+	assert.NotNil(t, got[0].ContractPass)
+	assert.True(t, *got[0].ContractPass)
+}
+
+func TestGetEvalsForPipeline_OrderingAndLimit(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	now := time.Now()
+	for i, runID := range []string{"r1", "r2", "r3"} {
+		rec := PipelineEvalRecord{
+			PipelineName: "p",
+			RunID:        runID,
+			RecordedAt:   now.Add(time.Duration(i) * time.Second),
+		}
+		require.NoError(t, store.RecordEval(rec))
+	}
+
+	all, err := store.GetEvalsForPipeline("p", 0)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	// Newest first
+	assert.Equal(t, "r3", all[0].RunID)
+	assert.Equal(t, "r1", all[2].RunID)
+
+	limited, err := store.GetEvalsForPipeline("p", 2)
+	require.NoError(t, err)
+	require.Len(t, limited, 2)
+}
+
+func TestPipelineVersion_CreateAndActivate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	v1 := PipelineVersionRecord{PipelineName: "p", Version: 1, SHA256: "abc", YAMLPath: ".agents/p.v1.yaml", Active: true}
+	require.NoError(t, store.CreatePipelineVersion(v1))
+
+	v2 := PipelineVersionRecord{PipelineName: "p", Version: 2, SHA256: "def", YAMLPath: ".agents/p.v2.yaml", Active: true}
+	require.NoError(t, store.CreatePipelineVersion(v2))
+
+	// Creating v2 with active=true should have deactivated v1.
+	active, err := store.GetActiveVersion("p")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, 2, active.Version)
+
+	// Roll back to v1.
+	require.NoError(t, store.ActivateVersion("p", 1))
+	active, err = store.GetActiveVersion("p")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, 1, active.Version)
+}
+
+func TestActivateVersion_NotFound(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	err := store.ActivateVersion("ghost", 99)
+	assert.Error(t, err)
+}
+
+func TestProposal_CreateDecideList(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	id, err := store.CreateProposal(EvolutionProposalRecord{
+		PipelineName:   "p",
+		VersionBefore:  1,
+		VersionAfter:   2,
+		DiffPath:       ".agents/proposals/1.diff",
+		Reason:         "judge_score below 0.80 over 10 runs",
+		SignalSummary:  `{"avg_judge":0.72}`,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, id)
+
+	listed, err := store.ListProposalsByStatus(ProposalProposed, 10)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, id, listed[0].ID)
+
+	require.NoError(t, store.DecideProposal(id, ProposalApproved, "nextlevelshit"))
+
+	got, err := store.GetProposal(id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ProposalApproved, got.Status)
+	require.NotNil(t, got.DecidedAt)
+	assert.Equal(t, "nextlevelshit", got.DecidedBy)
+
+	// Decide twice → second call must error (already terminal).
+	err = store.DecideProposal(id, ProposalRejected, "x")
+	assert.Error(t, err)
+}
+
+func TestProposal_DecideRejectsProposedTransition(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	id, err := store.CreateProposal(EvolutionProposalRecord{
+		PipelineName: "p", VersionBefore: 1, VersionAfter: 2,
+		DiffPath: "x", Reason: "y",
+	})
+	require.NoError(t, err)
+	err = store.DecideProposal(id, ProposalProposed, "x")
+	assert.Error(t, err, "decide → proposed must be rejected")
+}

--- a/internal/state/migration_definitions.go
+++ b/internal/state/migration_definitions.go
@@ -571,5 +571,98 @@ DROP INDEX IF EXISTS idx_ontology_usage_context;
 DROP TABLE IF EXISTS ontology_usage;`,
 			Down: "",
 		},
+		{
+			Version:     29,
+			Description: "Add pipeline_eval table for evolution signal aggregation (epic #1565 PRE-5)",
+			Up: `CREATE TABLE IF NOT EXISTS pipeline_eval (
+    pipeline_name TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    judge_score REAL,
+    contract_pass BOOLEAN,
+    retry_count INTEGER,
+    failure_class TEXT,
+    human_override BOOLEAN,
+    duration_ms INTEGER,
+    cost_dollars REAL,
+    recorded_at INTEGER NOT NULL,
+    PRIMARY KEY (pipeline_name, run_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pipeline_eval_recorded ON pipeline_eval(pipeline_name, recorded_at DESC);`,
+			Down: `DROP INDEX IF EXISTS idx_pipeline_eval_recorded;
+DROP TABLE IF EXISTS pipeline_eval;`,
+		},
+		{
+			Version:     30,
+			Description: "Add pipeline_version table for active-version tracking (epic #1565 PRE-5)",
+			Up: `CREATE TABLE IF NOT EXISTS pipeline_version (
+    pipeline_name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    yaml_path TEXT NOT NULL,
+    active BOOLEAN NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (pipeline_name, version)
+);
+CREATE INDEX IF NOT EXISTS idx_pipeline_version_active ON pipeline_version(pipeline_name) WHERE active = 1;`,
+			Down: `DROP INDEX IF EXISTS idx_pipeline_version_active;
+DROP TABLE IF EXISTS pipeline_version;`,
+		},
+		{
+			Version:     31,
+			Description: "Add evolution_proposal table for human-approve gate on auto-evolved pipelines (epic #1565 PRE-5)",
+			Up: `CREATE TABLE IF NOT EXISTS evolution_proposal (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pipeline_name TEXT NOT NULL,
+    version_before INTEGER NOT NULL,
+    version_after INTEGER NOT NULL,
+    diff_path TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    signal_summary TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('proposed','approved','rejected','superseded')),
+    proposed_at INTEGER NOT NULL,
+    decided_at INTEGER,
+    decided_by TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_evolution_proposal_status ON evolution_proposal(status, proposed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_evolution_proposal_pipeline ON evolution_proposal(pipeline_name);`,
+			Down: `DROP INDEX IF EXISTS idx_evolution_proposal_pipeline;
+DROP INDEX IF EXISTS idx_evolution_proposal_status;
+DROP TABLE IF EXISTS evolution_proposal;`,
+		},
+		{
+			Version:     32,
+			Description: "Add worksource_binding table for issue→pipeline dispatch (epic #1565 PRE-5)",
+			Up: `CREATE TABLE IF NOT EXISTS worksource_binding (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    forge TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    selector TEXT NOT NULL,
+    pipeline_name TEXT NOT NULL,
+    trigger TEXT NOT NULL CHECK (trigger IN ('on_demand','on_label','on_open','scheduled')),
+    config TEXT,
+    active BOOLEAN NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_worksource_binding_active ON worksource_binding(forge, repo) WHERE active = 1;`,
+			Down: `DROP INDEX IF EXISTS idx_worksource_binding_active;
+DROP TABLE IF EXISTS worksource_binding;`,
+		},
+		{
+			Version:     33,
+			Description: "Add schedule table for cron-driven pipeline runs (epic #1565 PRE-5)",
+			Up: `CREATE TABLE IF NOT EXISTS schedule (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pipeline_name TEXT NOT NULL,
+    cron_expr TEXT NOT NULL,
+    input_ref TEXT,
+    active BOOLEAN NOT NULL,
+    next_fire_at INTEGER,
+    last_run_id TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_schedule_due ON schedule(next_fire_at) WHERE active = 1;`,
+			Down: `DROP INDEX IF EXISTS idx_schedule_due;
+DROP TABLE IF EXISTS schedule;`,
+		},
 	}
 }

--- a/internal/state/migrations_test.go
+++ b/internal/state/migrations_test.go
@@ -465,7 +465,7 @@ func TestInitializeWithMigrations_ExistingDatabase(t *testing.T) {
 	manager := NewMigrationManager(db)
 	applied, err := manager.GetAppliedMigrations()
 	assert.NoError(t, err)
-	assert.Len(t, applied, 28) // All 28 defined migrations
+	assert.Len(t, applied, 33) // All 33 defined migrations
 }
 
 func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
@@ -496,11 +496,11 @@ func TestInitializeWithMigrations_NoAutoMigrate(t *testing.T) {
 func TestMigrationDefinitions(t *testing.T) {
 	migrations := GetAllMigrations()
 
-	// Should have 28 migrations based on our definition
-	assert.Len(t, migrations, 28)
+	// Should have 33 migrations based on our definition
+	assert.Len(t, migrations, 33)
 
 	// Check version sequence
-	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}
+	expectedVersions := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}
 	for i, migration := range migrations {
 		assert.Equal(t, expectedVersions[i], migration.Version)
 		assert.NotEmpty(t, migration.Description)

--- a/internal/state/schedule.go
+++ b/internal/state/schedule.go
@@ -1,0 +1,171 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ScheduleRecord is one cron-driven pipeline schedule. InputRef is opaque JSON
+// (a literal input, a worksource query selector, or empty for runs that take
+// no input). NextFireAt is what the scheduler tick loop reads to decide whose
+// turn it is; UpdateScheduleNextFire bumps it after a fire.
+type ScheduleRecord struct {
+	ID           int64
+	PipelineName string
+	CronExpr     string
+	InputRef     string
+	Active       bool
+	NextFireAt   *time.Time
+	LastRunID    string
+	CreatedAt    time.Time
+}
+
+// ScheduleStore is the domain-scoped persistence surface for cron-driven
+// pipeline runs. Phase 0 PRE-6 introduces the in-process scheduler that
+// consumes this table.
+type ScheduleStore interface {
+	CreateSchedule(rec ScheduleRecord) (int64, error)
+	UpdateScheduleNextFire(id int64, nextFireAt time.Time, lastRunID string) error
+	DeactivateSchedule(id int64) error
+	GetSchedule(id int64) (*ScheduleRecord, error)
+	ListSchedules() ([]ScheduleRecord, error)
+	ListDueSchedules(now time.Time) ([]ScheduleRecord, error)
+}
+
+func (s *stateStore) CreateSchedule(rec ScheduleRecord) (int64, error) {
+	if rec.PipelineName == "" || rec.CronExpr == "" {
+		return 0, errors.New("CreateSchedule: pipeline_name and cron_expr required")
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	var nextFire any
+	if rec.NextFireAt != nil {
+		nextFire = rec.NextFireAt.Unix()
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO schedule
+			(pipeline_name, cron_expr, input_ref, active, next_fire_at, last_run_id, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		rec.PipelineName, rec.CronExpr, nullEmptyString(rec.InputRef), rec.Active,
+		nextFire, nullEmptyString(rec.LastRunID), rec.CreatedAt.Unix(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// UpdateScheduleNextFire records that the schedule fired (LastRunID) and
+// advances NextFireAt to the next computed tick.
+func (s *stateStore) UpdateScheduleNextFire(id int64, nextFireAt time.Time, lastRunID string) error {
+	res, err := s.db.Exec(
+		`UPDATE schedule SET next_fire_at = ?, last_run_id = ? WHERE id = ?`,
+		nextFireAt.Unix(), nullEmptyString(lastRunID), id,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("UpdateScheduleNextFire: id %d not found", id)
+	}
+	return nil
+}
+
+func (s *stateStore) DeactivateSchedule(id int64) error {
+	res, err := s.db.Exec(`UPDATE schedule SET active = 0 WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("DeactivateSchedule: id %d not found", id)
+	}
+	return nil
+}
+
+func (s *stateStore) GetSchedule(id int64) (*ScheduleRecord, error) {
+	row := s.db.QueryRow(
+		`SELECT id, pipeline_name, cron_expr, input_ref, active, next_fire_at, last_run_id, created_at
+		 FROM schedule WHERE id = ?`,
+		id,
+	)
+	rec, err := scanSchedule(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return rec, err
+}
+
+// ListSchedules returns every schedule row, newest first.
+func (s *stateStore) ListSchedules() ([]ScheduleRecord, error) {
+	return s.querySchedules(
+		`SELECT id, pipeline_name, cron_expr, input_ref, active, next_fire_at, last_run_id, created_at
+		 FROM schedule ORDER BY created_at DESC`,
+	)
+}
+
+// ListDueSchedules returns active schedules whose next_fire_at is at or
+// before `now`, oldest-due first. The scheduler iterates these to fire runs.
+func (s *stateStore) ListDueSchedules(now time.Time) ([]ScheduleRecord, error) {
+	return s.querySchedules(
+		`SELECT id, pipeline_name, cron_expr, input_ref, active, next_fire_at, last_run_id, created_at
+		 FROM schedule WHERE active = 1 AND next_fire_at IS NOT NULL AND next_fire_at <= ?
+		 ORDER BY next_fire_at ASC`,
+		now.Unix(),
+	)
+}
+
+func (s *stateStore) querySchedules(q string, args ...any) ([]ScheduleRecord, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ScheduleRecord
+	for rows.Next() {
+		rec, err := scanScheduleRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *rec)
+	}
+	return out, rows.Err()
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanScheduleRow(row rowScanner) (*ScheduleRecord, error) {
+	var (
+		r          ScheduleRecord
+		inputRef   sql.NullString
+		nextFire   sql.NullInt64
+		lastRunID  sql.NullString
+		createdAt  int64
+	)
+	if err := row.Scan(&r.ID, &r.PipelineName, &r.CronExpr, &inputRef, &r.Active,
+		&nextFire, &lastRunID, &createdAt); err != nil {
+		return nil, err
+	}
+	if inputRef.Valid {
+		r.InputRef = inputRef.String
+	}
+	if nextFire.Valid {
+		t := time.Unix(nextFire.Int64, 0)
+		r.NextFireAt = &t
+	}
+	if lastRunID.Valid {
+		r.LastRunID = lastRunID.String
+	}
+	r.CreatedAt = time.Unix(createdAt, 0)
+	return &r, nil
+}
+
+func scanSchedule(row *sql.Row) (*ScheduleRecord, error) {
+	return scanScheduleRow(row)
+}

--- a/internal/state/schedule_test.go
+++ b/internal/state/schedule_test.go
@@ -1,0 +1,89 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedule_CreateGetList(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	next := time.Now().Add(1 * time.Hour)
+	id, err := store.CreateSchedule(ScheduleRecord{
+		PipelineName: "ops-bootstrap",
+		CronExpr:     "0 * * * *",
+		InputRef:     "{}",
+		Active:       true,
+		NextFireAt:   &next,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, id)
+
+	got, err := store.GetSchedule(id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "ops-bootstrap", got.PipelineName)
+	require.NotNil(t, got.NextFireAt)
+
+	all, err := store.ListSchedules()
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+}
+
+func TestSchedule_ListDueSchedules(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	now := time.Now()
+	due := now.Add(-1 * time.Minute)
+	future := now.Add(1 * time.Hour)
+
+	for _, s := range []ScheduleRecord{
+		{PipelineName: "due-active", CronExpr: "* * * * *", Active: true, NextFireAt: &due},
+		{PipelineName: "due-inactive", CronExpr: "* * * * *", Active: false, NextFireAt: &due},
+		{PipelineName: "future-active", CronExpr: "* * * * *", Active: true, NextFireAt: &future},
+		{PipelineName: "no-fire", CronExpr: "* * * * *", Active: true},
+	} {
+		_, err := store.CreateSchedule(s)
+		require.NoError(t, err)
+	}
+
+	dueRows, err := store.ListDueSchedules(now)
+	require.NoError(t, err)
+	require.Len(t, dueRows, 1, "only the active+past row should be returned")
+	assert.Equal(t, "due-active", dueRows[0].PipelineName)
+}
+
+func TestSchedule_UpdateNextFireAndDeactivate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	id, err := store.CreateSchedule(ScheduleRecord{
+		PipelineName: "p", CronExpr: "0 0 * * *", Active: true,
+	})
+	require.NoError(t, err)
+
+	next := time.Now().Add(24 * time.Hour)
+	require.NoError(t, store.UpdateScheduleNextFire(id, next, "run-abc"))
+
+	got, err := store.GetSchedule(id)
+	require.NoError(t, err)
+	require.NotNil(t, got.NextFireAt)
+	assert.Equal(t, "run-abc", got.LastRunID)
+
+	require.NoError(t, store.DeactivateSchedule(id))
+	got, err = store.GetSchedule(id)
+	require.NoError(t, err)
+	assert.False(t, got.Active)
+}
+
+func TestSchedule_UpdateMissing(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	err := store.UpdateScheduleNextFire(999, time.Now(), "x")
+	assert.Error(t, err)
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -73,6 +73,9 @@ type StateStore interface {
 	EventStore
 	WebhookStore
 	ChatStore
+	EvolutionStore
+	WorksourceStore
+	ScheduleStore
 
 	Close() error
 }

--- a/internal/state/worksource.go
+++ b/internal/state/worksource.go
@@ -1,0 +1,192 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// WorksourceTrigger enumerates how a worksource binding fires runs.
+type WorksourceTrigger string
+
+const (
+	TriggerOnDemand  WorksourceTrigger = "on_demand"
+	TriggerOnLabel   WorksourceTrigger = "on_label"
+	TriggerOnOpen    WorksourceTrigger = "on_open"
+	TriggerScheduled WorksourceTrigger = "scheduled"
+)
+
+// WorksourceBindingRecord maps a forge query (selector JSON) to a pipeline.
+// Selector and Config are stored as opaque JSON so the bindings table stays
+// schema-stable as the dispatch layer grows.
+type WorksourceBindingRecord struct {
+	ID           int64
+	Forge        string
+	Repo         string
+	Selector     string // JSON: { labels:[], state:'open', ... }
+	PipelineName string
+	Trigger      WorksourceTrigger
+	Config       string // JSON: cron, debounce, etc — may be empty
+	Active       bool
+	CreatedAt    time.Time
+}
+
+// WorksourceStore is the domain-scoped persistence surface for issue→pipeline
+// dispatch bindings. Phase 2 of the onboarding-as-session epic populates it.
+type WorksourceStore interface {
+	CreateBinding(rec WorksourceBindingRecord) (int64, error)
+	UpdateBinding(rec WorksourceBindingRecord) error
+	DeactivateBinding(id int64) error
+	GetBinding(id int64) (*WorksourceBindingRecord, error)
+	ListBindings(forge, repo string) ([]WorksourceBindingRecord, error)
+	ListActiveBindings() ([]WorksourceBindingRecord, error)
+}
+
+func (s *stateStore) CreateBinding(rec WorksourceBindingRecord) (int64, error) {
+	if rec.Forge == "" || rec.Repo == "" || rec.PipelineName == "" || rec.Trigger == "" {
+		return 0, errors.New("CreateBinding: forge, repo, pipeline_name, trigger required")
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	if rec.Selector == "" {
+		rec.Selector = "{}"
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO worksource_binding
+			(forge, repo, selector, pipeline_name, trigger, config, active, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.Forge, rec.Repo, rec.Selector, rec.PipelineName, string(rec.Trigger),
+		nullEmptyString(rec.Config), rec.Active, rec.CreatedAt.Unix(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// UpdateBinding rewrites all mutable fields of a binding by id. Returns an
+// error if the row does not exist.
+func (s *stateStore) UpdateBinding(rec WorksourceBindingRecord) error {
+	if rec.ID == 0 {
+		return errors.New("UpdateBinding: id required")
+	}
+	res, err := s.db.Exec(
+		`UPDATE worksource_binding
+		 SET forge = ?, repo = ?, selector = ?, pipeline_name = ?,
+			 trigger = ?, config = ?, active = ?
+		 WHERE id = ?`,
+		rec.Forge, rec.Repo, rec.Selector, rec.PipelineName, string(rec.Trigger),
+		nullEmptyString(rec.Config), rec.Active, rec.ID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("UpdateBinding: id %d not found", rec.ID)
+	}
+	return nil
+}
+
+// DeactivateBinding flips active to false. Bindings are not hard-deleted so
+// run history retains the binding context.
+func (s *stateStore) DeactivateBinding(id int64) error {
+	res, err := s.db.Exec(`UPDATE worksource_binding SET active = 0 WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("DeactivateBinding: id %d not found", id)
+	}
+	return nil
+}
+
+func (s *stateStore) GetBinding(id int64) (*WorksourceBindingRecord, error) {
+	row := s.db.QueryRow(
+		`SELECT id, forge, repo, selector, pipeline_name, trigger, config, active, created_at
+		 FROM worksource_binding WHERE id = ?`,
+		id,
+	)
+	rec, err := scanBinding(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return rec, err
+}
+
+// ListBindings returns bindings filtered by forge+repo. Empty filters match
+// all rows. Newest first.
+func (s *stateStore) ListBindings(forge, repo string) ([]WorksourceBindingRecord, error) {
+	q := `SELECT id, forge, repo, selector, pipeline_name, trigger, config, active, created_at
+		FROM worksource_binding WHERE 1 = 1`
+	var args []any
+	if forge != "" {
+		q += " AND forge = ?"
+		args = append(args, forge)
+	}
+	if repo != "" {
+		q += " AND repo = ?"
+		args = append(args, repo)
+	}
+	q += " ORDER BY created_at DESC"
+	return s.queryBindings(q, args...)
+}
+
+// ListActiveBindings returns every active binding across forges. Used by the
+// poller to know what to scan.
+func (s *stateStore) ListActiveBindings() ([]WorksourceBindingRecord, error) {
+	return s.queryBindings(
+		`SELECT id, forge, repo, selector, pipeline_name, trigger, config, active, created_at
+		 FROM worksource_binding WHERE active = 1 ORDER BY created_at DESC`,
+	)
+}
+
+func (s *stateStore) queryBindings(q string, args ...any) ([]WorksourceBindingRecord, error) {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []WorksourceBindingRecord
+	for rows.Next() {
+		var (
+			r         WorksourceBindingRecord
+			cfg       sql.NullString
+			trigger   string
+			createdAt int64
+		)
+		if err := rows.Scan(&r.ID, &r.Forge, &r.Repo, &r.Selector, &r.PipelineName,
+			&trigger, &cfg, &r.Active, &createdAt); err != nil {
+			return nil, err
+		}
+		r.Trigger = WorksourceTrigger(trigger)
+		if cfg.Valid {
+			r.Config = cfg.String
+		}
+		r.CreatedAt = time.Unix(createdAt, 0)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanBinding(row *sql.Row) (*WorksourceBindingRecord, error) {
+	var (
+		r         WorksourceBindingRecord
+		cfg       sql.NullString
+		trigger   string
+		createdAt int64
+	)
+	if err := row.Scan(&r.ID, &r.Forge, &r.Repo, &r.Selector, &r.PipelineName,
+		&trigger, &cfg, &r.Active, &createdAt); err != nil {
+		return nil, err
+	}
+	r.Trigger = WorksourceTrigger(trigger)
+	if cfg.Valid {
+		r.Config = cfg.String
+	}
+	r.CreatedAt = time.Unix(createdAt, 0)
+	return &r, nil
+}

--- a/internal/state/worksource_test.go
+++ b/internal/state/worksource_test.go
@@ -1,0 +1,83 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorksourceBinding_CreateGetUpdateDeactivate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	id, err := store.CreateBinding(WorksourceBindingRecord{
+		Forge:        "github",
+		Repo:         "re-cinq/wave",
+		Selector:     `{"labels":["bug"],"state":"open"}`,
+		PipelineName: "impl-issue",
+		Trigger:      TriggerOnLabel,
+		Active:       true,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, id)
+
+	got, err := store.GetBinding(id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "github", got.Forge)
+	assert.Equal(t, TriggerOnLabel, got.Trigger)
+	assert.True(t, got.Active)
+
+	got.PipelineName = "impl-issue-v2"
+	require.NoError(t, store.UpdateBinding(*got))
+
+	got2, err := store.GetBinding(id)
+	require.NoError(t, err)
+	assert.Equal(t, "impl-issue-v2", got2.PipelineName)
+
+	require.NoError(t, store.DeactivateBinding(id))
+	got3, err := store.GetBinding(id)
+	require.NoError(t, err)
+	assert.False(t, got3.Active)
+}
+
+func TestWorksourceBinding_ListByForgeRepo(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	for _, b := range []WorksourceBindingRecord{
+		{Forge: "github", Repo: "a/b", Selector: "{}", PipelineName: "p1", Trigger: TriggerOnDemand, Active: true},
+		{Forge: "gitea", Repo: "x/y", Selector: "{}", PipelineName: "p2", Trigger: TriggerOnDemand, Active: true},
+		{Forge: "github", Repo: "a/b", Selector: "{}", PipelineName: "p3", Trigger: TriggerOnDemand, Active: false},
+	} {
+		_, err := store.CreateBinding(b)
+		require.NoError(t, err)
+	}
+
+	github, err := store.ListBindings("github", "")
+	require.NoError(t, err)
+	assert.Len(t, github, 2)
+
+	repoAB, err := store.ListBindings("github", "a/b")
+	require.NoError(t, err)
+	assert.Len(t, repoAB, 2)
+
+	all, err := store.ListBindings("", "")
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	active, err := store.ListActiveBindings()
+	require.NoError(t, err)
+	assert.Len(t, active, 2)
+}
+
+func TestWorksourceBinding_UpdateMissing(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	err := store.UpdateBinding(WorksourceBindingRecord{
+		ID: 999, Forge: "x", Repo: "y", Selector: "{}",
+		PipelineName: "p", Trigger: TriggerOnDemand, Active: true,
+	})
+	assert.Error(t, err)
+}

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -588,13 +588,89 @@ func (m *MockStateStore) ListOrchestrationDecisionSummary(_ int) ([]state.Orches
 	return nil, nil
 }
 
+// EvolutionStore stubs (epic #1565 PRE-5). Tests that exercise eval/version/
+// proposal logic should swap in a real *stateStore via NewTestStateStore.
+func (m *MockStateStore) RecordEval(_ state.PipelineEvalRecord) error {
+	return nil
+}
+func (m *MockStateStore) GetEvalsForPipeline(_ string, _ int) ([]state.PipelineEvalRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) CreatePipelineVersion(_ state.PipelineVersionRecord) error {
+	return nil
+}
+func (m *MockStateStore) ActivateVersion(_ string, _ int) error {
+	return nil
+}
+func (m *MockStateStore) GetActiveVersion(_ string) (*state.PipelineVersionRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListPipelineVersions(_ string) ([]state.PipelineVersionRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) CreateProposal(_ state.EvolutionProposalRecord) (int64, error) {
+	return 0, nil
+}
+func (m *MockStateStore) DecideProposal(_ int64, _ state.EvolutionProposalStatus, _ string) error {
+	return nil
+}
+func (m *MockStateStore) GetProposal(_ int64) (*state.EvolutionProposalRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListProposalsByStatus(_ state.EvolutionProposalStatus, _ int) ([]state.EvolutionProposalRecord, error) {
+	return nil, nil
+}
+
+// WorksourceStore stubs (epic #1565 PRE-5).
+func (m *MockStateStore) CreateBinding(_ state.WorksourceBindingRecord) (int64, error) {
+	return 0, nil
+}
+func (m *MockStateStore) UpdateBinding(_ state.WorksourceBindingRecord) error {
+	return nil
+}
+func (m *MockStateStore) DeactivateBinding(_ int64) error {
+	return nil
+}
+func (m *MockStateStore) GetBinding(_ int64) (*state.WorksourceBindingRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListBindings(_, _ string) ([]state.WorksourceBindingRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListActiveBindings() ([]state.WorksourceBindingRecord, error) {
+	return nil, nil
+}
+
+// ScheduleStore stubs (epic #1565 PRE-5).
+func (m *MockStateStore) CreateSchedule(_ state.ScheduleRecord) (int64, error) {
+	return 0, nil
+}
+func (m *MockStateStore) UpdateScheduleNextFire(_ int64, _ time.Time, _ string) error {
+	return nil
+}
+func (m *MockStateStore) DeactivateSchedule(_ int64) error {
+	return nil
+}
+func (m *MockStateStore) GetSchedule(_ int64) (*state.ScheduleRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListSchedules() ([]state.ScheduleRecord, error) {
+	return nil, nil
+}
+func (m *MockStateStore) ListDueSchedules(_ time.Time) ([]state.ScheduleRecord, error) {
+	return nil, nil
+}
+
 // Compile-time assertions that *MockStateStore satisfies every domain-scoped
 // state interface as well as the aggregate StateStore. These guard against
 // drift if a method is added to one of the narrow interfaces and missed here.
 var (
-	_ state.RunStore     = (*MockStateStore)(nil)
-	_ state.EventStore   = (*MockStateStore)(nil)
-	_ state.WebhookStore = (*MockStateStore)(nil)
-	_ state.ChatStore    = (*MockStateStore)(nil)
-	_ state.StateStore    = (*MockStateStore)(nil)
+	_ state.RunStore        = (*MockStateStore)(nil)
+	_ state.EventStore      = (*MockStateStore)(nil)
+	_ state.WebhookStore    = (*MockStateStore)(nil)
+	_ state.ChatStore       = (*MockStateStore)(nil)
+	_ state.EvolutionStore  = (*MockStateStore)(nil)
+	_ state.WorksourceStore = (*MockStateStore)(nil)
+	_ state.ScheduleStore   = (*MockStateStore)(nil)
+	_ state.StateStore      = (*MockStateStore)(nil)
 )

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -168,6 +168,52 @@ func (b baseStateStore) ListOrchestrationDecisionSummary(int) ([]state.Orchestra
 	return nil, nil
 }
 
+// EvolutionStore stubs (epic #1565 PRE-5).
+func (b baseStateStore) RecordEval(state.PipelineEvalRecord) error { return nil }
+func (b baseStateStore) GetEvalsForPipeline(string, int) ([]state.PipelineEvalRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) CreatePipelineVersion(state.PipelineVersionRecord) error { return nil }
+func (b baseStateStore) ActivateVersion(string, int) error                       { return nil }
+func (b baseStateStore) GetActiveVersion(string) (*state.PipelineVersionRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) ListPipelineVersions(string) ([]state.PipelineVersionRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) CreateProposal(state.EvolutionProposalRecord) (int64, error) { return 0, nil }
+func (b baseStateStore) DecideProposal(int64, state.EvolutionProposalStatus, string) error {
+	return nil
+}
+func (b baseStateStore) GetProposal(int64) (*state.EvolutionProposalRecord, error) { return nil, nil }
+func (b baseStateStore) ListProposalsByStatus(state.EvolutionProposalStatus, int) ([]state.EvolutionProposalRecord, error) {
+	return nil, nil
+}
+
+// WorksourceStore stubs (epic #1565 PRE-5).
+func (b baseStateStore) CreateBinding(state.WorksourceBindingRecord) (int64, error) { return 0, nil }
+func (b baseStateStore) UpdateBinding(state.WorksourceBindingRecord) error          { return nil }
+func (b baseStateStore) DeactivateBinding(int64) error                              { return nil }
+func (b baseStateStore) GetBinding(int64) (*state.WorksourceBindingRecord, error)   { return nil, nil }
+func (b baseStateStore) ListBindings(string, string) ([]state.WorksourceBindingRecord, error) {
+	return nil, nil
+}
+func (b baseStateStore) ListActiveBindings() ([]state.WorksourceBindingRecord, error) {
+	return nil, nil
+}
+
+// ScheduleStore stubs (epic #1565 PRE-5).
+func (b baseStateStore) CreateSchedule(state.ScheduleRecord) (int64, error) { return 0, nil }
+func (b baseStateStore) UpdateScheduleNextFire(int64, time.Time, string) error {
+	return nil
+}
+func (b baseStateStore) DeactivateSchedule(int64) error                  { return nil }
+func (b baseStateStore) GetSchedule(int64) (*state.ScheduleRecord, error) { return nil, nil }
+func (b baseStateStore) ListSchedules() ([]state.ScheduleRecord, error)   { return nil, nil }
+func (b baseStateStore) ListDueSchedules(time.Time) ([]state.ScheduleRecord, error) {
+	return nil, nil
+}
+
 // Compile-time check: baseStateStore must satisfy state.StateStore.
 var _ state.StateStore = baseStateStore{}
 


### PR DESCRIPTION
Closes #1568. Phase 0 child of Epic #1565.

## What

Five additive tables + sub-interfaces for the onboarding-as-session epic:

| Table | Purpose | Phase |
|---|---|---|
| \`pipeline_eval\` | per-run signal aggregation | Phase 3 |
| \`pipeline_version\` | active-version tracking (sha256, yaml_path) | Phase 3 |
| \`evolution_proposal\` | human-approve gate on auto-evolved pipelines | Phase 3 |
| \`worksource_binding\` | issue→pipeline dispatch | Phase 2 |
| \`schedule\` | cron-driven runs | Phase 0 PRE-6 |

Migrations 29-33 (additive only, no existing column changes).

## Sub-interfaces

\`EvolutionStore\`, \`WorksourceStore\`, \`ScheduleStore\` — composed into \`StateStore\`. Existing consumers continue to satisfy the aggregate interface; mock stubs added in \`internal/testutil\` + \`internal/tui\` so satisfiers compile.

## Tests

- \`evolution_test.go\` — record + read evals, version create/activate flip, proposal lifecycle (proposed → terminal, double-decide rejected)
- \`worksource_test.go\` — binding CRUD, list filters, deactivate
- \`schedule_test.go\` — create, list-due (active + past next_fire only), update next-fire, deactivate
- Migration count assertion bumped 28 → 33

## Acceptance vs #1568

- [x] Migrations idempotent (CREATE TABLE IF NOT EXISTS, CREATE INDEX IF NOT EXISTS)
- [x] CRUD methods + tests for each table
- [x] Foreign-key relations match planning doc § PRE-5
- [x] No regression on existing migrations