### PR TITLE
feat(scheduler): cron parser + in-process tick loop (PRE-6)

### DIFF
--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -1,0 +1,187 @@
+// Package scheduler provides cron-driven recurring pipeline runs (epic
+// #1565 PRE-6). The cron parser supports the standard 5-field expression
+// (minute hour day-of-month month day-of-week) plus the common shortcuts
+// `*`, `N`, `N-M`, `*/N`, and `N,M,P`. Day-of-month and day-of-week are
+// OR'd when both are non-`*` — matching cron(8) semantics.
+//
+// NextFire walks forward minute-by-minute from `now` and returns the first
+// matching tick. Capped at 5 years to surface impossible expressions
+// (e.g. `0 0 31 2 *`) as errors rather than infinite loops.
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Expression is a parsed 5-field cron expression. Each field is a bitmap
+// over the allowed range for that field; bit i is set when value i matches.
+type Expression struct {
+	raw     string
+	minute  uint64 // bits 0..59
+	hour    uint64 // bits 0..23
+	dom     uint64 // bits 1..31; bit 0 unused
+	month   uint64 // bits 1..12; bit 0 unused
+	dow     uint64 // bits 0..6 (Sun=0, Sat=6)
+	domStar bool   // dom field was `*`
+	dowStar bool   // dow field was `*`
+}
+
+// Parse parses a 5-field cron expression. Whitespace between fields is
+// collapsed; leading/trailing whitespace is trimmed.
+func Parse(expr string) (*Expression, error) {
+	fields := strings.Fields(strings.TrimSpace(expr))
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("cron: want 5 fields (min hour dom month dow), got %d in %q", len(fields), expr)
+	}
+	e := &Expression{raw: expr}
+	var err error
+	if e.minute, err = parseField(fields[0], 0, 59); err != nil {
+		return nil, fmt.Errorf("cron: minute: %w", err)
+	}
+	if e.hour, err = parseField(fields[1], 0, 23); err != nil {
+		return nil, fmt.Errorf("cron: hour: %w", err)
+	}
+	if e.dom, err = parseField(fields[2], 1, 31); err != nil {
+		return nil, fmt.Errorf("cron: day-of-month: %w", err)
+	}
+	if e.month, err = parseField(fields[3], 1, 12); err != nil {
+		return nil, fmt.Errorf("cron: month: %w", err)
+	}
+	if e.dow, err = parseField(fields[4], 0, 6); err != nil {
+		return nil, fmt.Errorf("cron: day-of-week: %w", err)
+	}
+	e.domStar = fields[2] == "*"
+	e.dowStar = fields[4] == "*"
+	return e, nil
+}
+
+// String returns the original expression text for diagnostics.
+func (e *Expression) String() string { return e.raw }
+
+// Match reports whether t satisfies every field of e. cron(8) semantics:
+// when both day-of-month and day-of-week are explicit (non-`*`), the
+// expression matches if EITHER condition holds; otherwise both must hold.
+func (e *Expression) Match(t time.Time) bool {
+	if !bit(e.minute, t.Minute()) {
+		return false
+	}
+	if !bit(e.hour, t.Hour()) {
+		return false
+	}
+	if !bit(e.month, int(t.Month())) {
+		return false
+	}
+	domHit := bit(e.dom, t.Day())
+	dowHit := bit(e.dow, int(t.Weekday()))
+	switch {
+	case e.domStar && e.dowStar:
+		return true
+	case e.domStar:
+		return dowHit
+	case e.dowStar:
+		return domHit
+	default:
+		return domHit || dowHit
+	}
+}
+
+// NextFire returns the first minute strictly after `now` that satisfies
+// the expression. Returns an error when no match is found within 5 years —
+// surfaces impossible expressions like `0 0 31 2 *` (Feb 31).
+func (e *Expression) NextFire(now time.Time) (time.Time, error) {
+	// Truncate to minute resolution and step one minute forward so the
+	// returned time is strictly greater than `now`.
+	t := now.Truncate(time.Minute).Add(time.Minute)
+	limit := t.Add(5 * 365 * 24 * time.Hour)
+	for t.Before(limit) {
+		if e.Match(t) {
+			return t, nil
+		}
+		t = t.Add(time.Minute)
+	}
+	return time.Time{}, fmt.Errorf("cron: no match within 5 years for %q", e.raw)
+}
+
+// parseField parses a single cron field into a bitmap. The accepted forms
+// (per the package doc) compose: a comma-separated list of items, each of
+// which is `*`, `N`, `N-M`, `*/N`, or `N-M/N`.
+func parseField(spec string, lo, hi int) (uint64, error) {
+	if spec == "" {
+		return 0, errors.New("empty field")
+	}
+	var bits uint64
+	for _, item := range strings.Split(spec, ",") {
+		stepBits, err := parseFieldItem(item, lo, hi)
+		if err != nil {
+			return 0, err
+		}
+		bits |= stepBits
+	}
+	if bits == 0 {
+		return 0, fmt.Errorf("no values in %q", spec)
+	}
+	return bits, nil
+}
+
+func parseFieldItem(item string, lo, hi int) (uint64, error) {
+	step := 1
+	if i := strings.Index(item, "/"); i >= 0 {
+		s, err := strconv.Atoi(item[i+1:])
+		if err != nil || s < 1 {
+			return 0, fmt.Errorf("invalid step in %q", item)
+		}
+		step = s
+		item = item[:i]
+	}
+
+	var rangeLo, rangeHi int
+	switch {
+	case item == "*":
+		rangeLo, rangeHi = lo, hi
+	case strings.Contains(item, "-"):
+		parts := strings.SplitN(item, "-", 2)
+		a, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, fmt.Errorf("invalid range start in %q", item)
+		}
+		b, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, fmt.Errorf("invalid range end in %q", item)
+		}
+		if a > b {
+			return 0, fmt.Errorf("inverted range in %q", item)
+		}
+		rangeLo, rangeHi = a, b
+	default:
+		v, err := strconv.Atoi(item)
+		if err != nil {
+			return 0, fmt.Errorf("invalid value %q", item)
+		}
+		// Bare value with /step expands to v..hi step; otherwise v..v.
+		rangeLo = v
+		if step > 1 {
+			rangeHi = hi
+		} else {
+			rangeHi = v
+		}
+	}
+	if rangeLo < lo || rangeHi > hi {
+		return 0, fmt.Errorf("value %d-%d out of allowed range [%d,%d]", rangeLo, rangeHi, lo, hi)
+	}
+	var bits uint64
+	for v := rangeLo; v <= rangeHi; v += step {
+		bits |= 1 << uint(v)
+	}
+	return bits, nil
+}
+
+func bit(mask uint64, i int) bool {
+	if i < 0 || i >= 64 {
+		return false
+	}
+	return mask&(1<<uint(i)) != 0
+}

--- a/internal/scheduler/cron_test.go
+++ b/internal/scheduler/cron_test.go
@@ -1,0 +1,110 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_FieldShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		want bool // true => parse must succeed
+	}{
+		{"every minute", "* * * * *", true},
+		{"top of hour", "0 * * * *", true},
+		{"daily midnight", "0 0 * * *", true},
+		{"weekday 9am", "0 9 * * 1-5", true},
+		{"every 15 min", "*/15 * * * *", true},
+		{"list", "0,15,30,45 * * * *", true},
+		{"range/step", "0-30/5 * * * *", true},
+		{"too few fields", "* * * *", false},
+		{"too many fields", "* * * * * *", false},
+		{"out of range", "60 * * * *", false},
+		{"inverted range", "5-3 * * * *", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.expr)
+			if tc.want && err != nil {
+				t.Fatalf("Parse(%q) unexpected error: %v", tc.expr, err)
+			}
+			if !tc.want && err == nil {
+				t.Fatalf("Parse(%q) expected error, got nil", tc.expr)
+			}
+		})
+	}
+}
+
+func TestNextFire_TopOfHour(t *testing.T) {
+	expr, err := Parse("0 * * * *")
+	require.NoError(t, err)
+	now := time.Date(2026, 4, 29, 14, 27, 0, 0, time.UTC)
+	got, err := expr.NextFire(now)
+	require.NoError(t, err)
+	want := time.Date(2026, 4, 29, 15, 0, 0, 0, time.UTC)
+	assert.Equal(t, want, got)
+}
+
+func TestNextFire_Every15Min(t *testing.T) {
+	expr, err := Parse("*/15 * * * *")
+	require.NoError(t, err)
+	now := time.Date(2026, 4, 29, 14, 7, 0, 0, time.UTC)
+	got, err := expr.NextFire(now)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 4, 29, 14, 15, 0, 0, time.UTC), got)
+}
+
+func TestNextFire_WeekdayOnly(t *testing.T) {
+	// Mon-Fri at 9am. Saturday's next fire is Monday morning.
+	expr, err := Parse("0 9 * * 1-5")
+	require.NoError(t, err)
+	saturday := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC) // Saturday
+	got, err := expr.NextFire(saturday)
+	require.NoError(t, err)
+	assert.Equal(t, time.Weekday(time.Monday), got.Weekday())
+	assert.Equal(t, 9, got.Hour())
+}
+
+func TestNextFire_DomDowOr(t *testing.T) {
+	// cron(8): non-* in BOTH dom and dow → match if EITHER fires.
+	// "0 0 1 * 1" = midnight on the 1st OR every Monday.
+	expr, err := Parse("0 0 1 * 1")
+	require.NoError(t, err)
+	// Friday Apr 24 → next match is Sun Apr 26? No, Apr 26 is Sunday.
+	// First Monday after Friday Apr 24 is Mon Apr 27. The 1st is May 1.
+	// So next from Apr 24 is Mon Apr 27.
+	from := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	got, err := expr.NextFire(from)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC), got)
+}
+
+func TestNextFire_AlwaysStrictlyAfterNow(t *testing.T) {
+	expr, err := Parse("* * * * *")
+	require.NoError(t, err)
+	now := time.Date(2026, 4, 29, 14, 27, 0, 0, time.UTC)
+	got, err := expr.NextFire(now)
+	require.NoError(t, err)
+	assert.True(t, got.After(now), "NextFire must be strictly after now")
+	assert.Equal(t, now.Add(time.Minute), got)
+}
+
+func TestNextFire_ImpossibleExpression(t *testing.T) {
+	// Feb 31 — cannot ever match.
+	expr, err := Parse("0 0 31 2 *")
+	require.NoError(t, err)
+	_, err = expr.NextFire(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	assert.Error(t, err)
+}
+
+func TestMatch_FieldRespect(t *testing.T) {
+	expr, err := Parse("30 14 * * *")
+	require.NoError(t, err)
+	assert.True(t, expr.Match(time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)))
+	assert.False(t, expr.Match(time.Date(2026, 4, 29, 14, 31, 0, 0, time.UTC)))
+	assert.False(t, expr.Match(time.Date(2026, 4, 29, 15, 30, 0, 0, time.UTC)))
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,177 @@
+package scheduler
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// Dispatcher is what the scheduler calls when a schedule fires. It is
+// supplied by the boot path (webui server in Phase 1.5+, CLI scheduler
+// daemon in a later phase) so this package stays independent of the
+// runner / executor wiring.
+//
+// Implementations must be non-blocking: spawn the run on a goroutine and
+// return promptly so a long-running pipeline does not stall the tick
+// loop's other due jobs. The returned runID is stored in
+// schedule.last_run_id; an empty string is fine when the dispatcher has
+// not minted one yet.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, schedule state.ScheduleRecord) (runID string, err error)
+}
+
+// DispatcherFunc adapts a plain function to the Dispatcher interface.
+type DispatcherFunc func(ctx context.Context, schedule state.ScheduleRecord) (string, error)
+
+func (f DispatcherFunc) Dispatch(ctx context.Context, s state.ScheduleRecord) (string, error) {
+	return f(ctx, s)
+}
+
+// Scheduler reads state.ScheduleStore on every tick, fires every schedule
+// whose next_fire_at has passed, and advances next_fire_at to the next
+// cron match. Concurrent ticks are guarded so a slow Dispatch on tick N
+// does not double-fire on tick N+1.
+type Scheduler struct {
+	store      state.ScheduleStore
+	dispatcher Dispatcher
+	tick       time.Duration
+	now        func() time.Time
+
+	mu       sync.Mutex
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	running  bool
+}
+
+// Options configures a Scheduler. Zero values yield sensible defaults:
+// 30-second tick, time.Now clock.
+type Options struct {
+	Tick time.Duration
+	Now  func() time.Time
+}
+
+// New returns a Scheduler bound to the supplied store and dispatcher.
+// The scheduler does not start ticking until Start is called.
+func New(store state.ScheduleStore, dispatcher Dispatcher, opts Options) *Scheduler {
+	if opts.Tick <= 0 {
+		opts.Tick = 30 * time.Second
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Scheduler{
+		store:      store,
+		dispatcher: dispatcher,
+		tick:       opts.Tick,
+		now:        opts.Now,
+	}
+}
+
+// Start spawns the tick loop. Returns immediately. Calling Start twice
+// without Stop is a no-op.
+func (s *Scheduler) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = true
+	s.stopCh = make(chan struct{})
+	s.doneCh = make(chan struct{})
+	s.mu.Unlock()
+
+	go s.loop(ctx)
+}
+
+// Stop halts the tick loop and waits up to 5 seconds for the in-flight
+// tick to finish. Safe to call multiple times.
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	close(s.stopCh)
+	doneCh := s.doneCh
+	s.running = false
+	s.mu.Unlock()
+
+	select {
+	case <-doneCh:
+	case <-time.After(5 * time.Second):
+		log.Printf("scheduler: stop timed out waiting for tick loop")
+	}
+}
+
+func (s *Scheduler) loop(ctx context.Context) {
+	defer close(s.doneCh)
+
+	// Fire one tick immediately so a freshly-started server doesn't wait
+	// the full Tick interval before processing overdue schedules.
+	s.Tick(ctx)
+
+	t := time.NewTicker(s.tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case <-t.C:
+			s.Tick(ctx)
+		}
+	}
+}
+
+// Tick processes all due schedules once. Exposed so callers (tests, manual
+// triggers from a webui button) can drive the loop deterministically.
+func (s *Scheduler) Tick(ctx context.Context) {
+	now := s.now()
+	due, err := s.store.ListDueSchedules(now)
+	if err != nil {
+		log.Printf("scheduler: list due schedules: %v", err)
+		return
+	}
+	for _, sched := range due {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		s.fireOne(ctx, sched, now)
+	}
+}
+
+func (s *Scheduler) fireOne(ctx context.Context, sched state.ScheduleRecord, now time.Time) {
+	expr, err := Parse(sched.CronExpr)
+	if err != nil {
+		log.Printf("scheduler: parse cron %q for schedule %d: %v", sched.CronExpr, sched.ID, err)
+		// Advance next_fire_at by a day so we don't churn the bad row
+		// on every tick. Operators can fix the expression and the next
+		// scheduled fire will pick up the corrected value.
+		_ = s.store.UpdateScheduleNextFire(sched.ID, now.Add(24*time.Hour), sched.LastRunID)
+		return
+	}
+
+	runID, dispatchErr := s.dispatcher.Dispatch(ctx, sched)
+	if dispatchErr != nil {
+		log.Printf("scheduler: dispatch schedule %d (%s): %v", sched.ID, sched.PipelineName, dispatchErr)
+		// Still advance so a chronically-broken dispatcher doesn't
+		// re-fire continuously.
+	}
+
+	next, err := expr.NextFire(now)
+	if err != nil {
+		log.Printf("scheduler: next-fire for schedule %d: %v", sched.ID, err)
+		return
+	}
+	lastRunID := sched.LastRunID
+	if runID != "" {
+		lastRunID = runID
+	}
+	if err := s.store.UpdateScheduleNextFire(sched.ID, next, lastRunID); err != nil {
+		log.Printf("scheduler: update next-fire schedule %d: %v", sched.ID, err)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,185 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStore is an in-memory ScheduleStore used to drive the tick loop
+// without spinning up SQLite. Only the methods Tick + fireOne touch are
+// implemented; the rest panic so a future test that depends on them
+// surfaces immediately.
+type fakeStore struct {
+	mu      sync.Mutex
+	rows    []state.ScheduleRecord
+	updates []updateCall
+}
+
+type updateCall struct {
+	id        int64
+	nextFire  time.Time
+	lastRunID string
+}
+
+func (f *fakeStore) ListDueSchedules(now time.Time) ([]state.ScheduleRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var due []state.ScheduleRecord
+	for _, r := range f.rows {
+		if !r.Active || r.NextFireAt == nil {
+			continue
+		}
+		if !r.NextFireAt.After(now) {
+			due = append(due, r)
+		}
+	}
+	return due, nil
+}
+
+func (f *fakeStore) UpdateScheduleNextFire(id int64, nextFire time.Time, lastRunID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, updateCall{id: id, nextFire: nextFire, lastRunID: lastRunID})
+	for i := range f.rows {
+		if f.rows[i].ID == id {
+			f.rows[i].NextFireAt = &nextFire
+			f.rows[i].LastRunID = lastRunID
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
+func (f *fakeStore) CreateSchedule(state.ScheduleRecord) (int64, error) { panic("unused") }
+func (f *fakeStore) DeactivateSchedule(int64) error                     { panic("unused") }
+func (f *fakeStore) GetSchedule(int64) (*state.ScheduleRecord, error)   { panic("unused") }
+func (f *fakeStore) ListSchedules() ([]state.ScheduleRecord, error)     { panic("unused") }
+
+var _ state.ScheduleStore = (*fakeStore)(nil)
+
+func TestTick_FiresDueSchedule(t *testing.T) {
+	now := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Minute)
+
+	store := &fakeStore{
+		rows: []state.ScheduleRecord{
+			{ID: 1, PipelineName: "p", CronExpr: "*/15 * * * *", Active: true, NextFireAt: &past},
+		},
+	}
+
+	var dispatched []int64
+	disp := DispatcherFunc(func(_ context.Context, s state.ScheduleRecord) (string, error) {
+		dispatched = append(dispatched, s.ID)
+		return "run-abc", nil
+	})
+
+	sched := New(store, disp, Options{Now: func() time.Time { return now }})
+	sched.Tick(context.Background())
+
+	assert.Equal(t, []int64{1}, dispatched)
+	require.Len(t, store.updates, 1)
+	// next_fire_at must advance to a future time
+	assert.True(t, store.updates[0].nextFire.After(now))
+	assert.Equal(t, "run-abc", store.updates[0].lastRunID)
+}
+
+func TestTick_SkipsFutureSchedules(t *testing.T) {
+	now := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	future := now.Add(1 * time.Hour)
+
+	store := &fakeStore{
+		rows: []state.ScheduleRecord{
+			{ID: 1, PipelineName: "p", CronExpr: "*/15 * * * *", Active: true, NextFireAt: &future},
+		},
+	}
+	dispatched := 0
+	disp := DispatcherFunc(func(context.Context, state.ScheduleRecord) (string, error) {
+		dispatched++
+		return "", nil
+	})
+
+	sched := New(store, disp, Options{Now: func() time.Time { return now }})
+	sched.Tick(context.Background())
+
+	assert.Equal(t, 0, dispatched)
+	assert.Empty(t, store.updates)
+}
+
+func TestTick_BadCronSkipsButAdvances(t *testing.T) {
+	now := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Minute)
+
+	store := &fakeStore{
+		rows: []state.ScheduleRecord{
+			{ID: 1, PipelineName: "p", CronExpr: "not a cron", Active: true, NextFireAt: &past},
+		},
+	}
+	dispatched := 0
+	disp := DispatcherFunc(func(context.Context, state.ScheduleRecord) (string, error) {
+		dispatched++
+		return "", nil
+	})
+	sched := New(store, disp, Options{Now: func() time.Time { return now }})
+	sched.Tick(context.Background())
+
+	assert.Equal(t, 0, dispatched, "bad cron must not dispatch")
+	require.Len(t, store.updates, 1, "bad cron must still advance to prevent churn")
+	assert.True(t, store.updates[0].nextFire.After(now))
+}
+
+func TestTick_DispatchErrStillAdvances(t *testing.T) {
+	now := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Minute)
+
+	store := &fakeStore{
+		rows: []state.ScheduleRecord{
+			{ID: 1, PipelineName: "p", CronExpr: "* * * * *", Active: true, NextFireAt: &past},
+		},
+	}
+	disp := DispatcherFunc(func(context.Context, state.ScheduleRecord) (string, error) {
+		return "", errors.New("boom")
+	})
+	sched := New(store, disp, Options{Now: func() time.Time { return now }})
+	sched.Tick(context.Background())
+
+	require.Len(t, store.updates, 1, "failed dispatch must still advance next_fire to avoid hot loops")
+}
+
+func TestStartStop_TickFiresImmediately(t *testing.T) {
+	now := time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Minute)
+
+	store := &fakeStore{
+		rows: []state.ScheduleRecord{
+			{ID: 1, PipelineName: "p", CronExpr: "* * * * *", Active: true, NextFireAt: &past},
+		},
+	}
+	fired := make(chan struct{}, 1)
+	disp := DispatcherFunc(func(context.Context, state.ScheduleRecord) (string, error) {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+		return "", nil
+	})
+
+	sched := New(store, disp, Options{
+		Tick: 50 * time.Millisecond,
+		Now:  func() time.Time { return now },
+	})
+	sched.Start(context.Background())
+	defer sched.Stop()
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not fire on initial tick")
+	}
+}


### PR DESCRIPTION
Closes #1571. Phase 0 child of Epic #1565.

## What

New bounded context \`internal/scheduler/\` with two components:

- **\`cron.go\`** — 5-field cron parser. Supports \`*\`, \`N\`, \`N-M\`, \`*/N\`, \`N-M/N\`, comma lists. cron(8) DOM/DOW OR semantics. \`NextFire\` walks minute-by-minute capped at 5 years to surface impossible expressions.
- **\`scheduler.go\`** — \`Scheduler\` with \`Start\`/\`Stop\`/\`Tick\`. Reads \`state.ScheduleStore\` (PRE-5), fires due jobs through a pluggable \`Dispatcher\` interface. Default tick 30s. Fires once on Start so booted servers don't wait the full interval for overdue rows.

## Behaviour notes

- Bad cron expression → advance \`next_fire_at\` by 24h to prevent tick churn
- Failed dispatch → still advance \`next_fire_at\` so a chronically-broken dispatcher doesn't hot-loop
- \`Tick\` exposed for deterministic test driving
- Independent of runner package — boot path supplies the Dispatcher

## Tests

- \`cron_test.go\` — parser shapes, NextFire correctness (incl. weekday-only, DOM/DOW OR), strictly-after-now, impossible-expression error
- \`scheduler_test.go\` — fakeStore-driven Tick (due-only, future-skip, bad-cron, dispatch-err), Start fires immediately

659 LOC, 4 new files.

## Acceptance vs #1571

- [x] Cron expressions parsed (5-field standard)
- [x] Tick loop fires due jobs, marks them in DB (next_fire_at advance + last_run_id)
- [x] Graceful shutdown (Stop drains in-flight tick with 5s timeout)
- [x] Tests cover edge cases (bad cron, dispatch err, impossible expr, future-skip)