### PR TITLE
feat(forge): Gitea HTTP adapter (PRE-3)

### DIFF
--- a/internal/forge/detect.go
+++ b/internal/forge/detect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -255,8 +256,19 @@ func parseHTTPSPath(path string) (host, owner, repo string) {
 // classifyHost maps a hostname to a ForgeType.
 // When the hostname doesn't match known patterns, it falls back to
 // tea CLI detection and HTTP endpoint probing.
+//
+// Self-hosted Gitea/Forgejo hostnames that don't contain "gitea" or
+// "forgejo" cost a 3s HTTP probe on every classify. Operators can
+// short-circuit the probe by listing their hosts in the WAVE_GITEA_HOSTS
+// env (comma-separated). The same applies to WAVE_FORGEJO_HOSTS.
 func classifyHost(host string) ForgeType {
 	h := strings.ToLower(host)
+	if hostInEnvList(h, "WAVE_GITEA_HOSTS") {
+		return ForgeGitea
+	}
+	if hostInEnvList(h, "WAVE_FORGEJO_HOSTS") {
+		return ForgeForgejo
+	}
 	switch {
 	case h == "github.com" || strings.HasSuffix(h, ".github.com"):
 		return ForgeGitHub
@@ -270,11 +282,6 @@ func classifyHost(host string) ForgeType {
 		return ForgeForgejo
 	case h == "codeberg.org" || strings.HasSuffix(h, ".codeberg.org"):
 		return ForgeCodeberg
-	// Re-cinq-hosted Gitea instance — ship it explicitly so the boot path
-	// classifier doesn't pay the 3s HTTP probe on every wave init / wave
-	// run inside a librete.ch repo.
-	case h == "git.librete.ch":
-		return ForgeGitea
 	}
 
 	// Check if tea CLI knows about this host (registered Gitea/Forgejo instance).
@@ -386,6 +393,24 @@ func checkTeaCLI(host string) ForgeType {
 		}
 	}
 	return ForgeUnknown
+}
+
+// hostInEnvList reports whether host appears (case-insensitively) in the
+// comma-separated value of the named env. Empty/missing env returns false.
+// Used by classifyHost to let operators register self-hosted Gitea/Forgejo
+// hosts whose hostname doesn't contain "gitea"/"forgejo", avoiding the
+// 3s HTTP probe.
+func hostInEnvList(host, envKey string) bool {
+	v := os.Getenv(envKey)
+	if v == "" {
+		return false
+	}
+	for _, h := range strings.Split(v, ",") {
+		if strings.EqualFold(strings.TrimSpace(h), host) {
+			return true
+		}
+	}
+	return false
 }
 
 // hasForgePrefix checks if a pipeline name starts with any known forge prefix.

--- a/internal/forge/detect.go
+++ b/internal/forge/detect.go
@@ -270,6 +270,11 @@ func classifyHost(host string) ForgeType {
 		return ForgeForgejo
 	case h == "codeberg.org" || strings.HasSuffix(h, ".codeberg.org"):
 		return ForgeCodeberg
+	// Re-cinq-hosted Gitea instance — ship it explicitly so the boot path
+	// classifier doesn't pay the 3s HTTP probe on every wave init / wave
+	// run inside a librete.ch repo.
+	case h == "git.librete.ch":
+		return ForgeGitea
 	}
 
 	// Check if tea CLI knows about this host (registered Gitea/Forgejo instance).

--- a/internal/forge/gitea.go
+++ b/internal/forge/gitea.go
@@ -1,0 +1,439 @@
+package forge
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/recinq/wave/internal/httpx"
+)
+
+// GiteaClient implements forge.Client against the Gitea v1 HTTP API.
+// Works with vanilla Gitea, Forgejo (which serves the same /api/v1
+// surface), and Codeberg (a hosted Forgejo). Authentication is via the
+// `Authorization: token <TOKEN>` header.
+//
+// Self-hosted Gitea instances frequently use private CAs; the default
+// transport tolerates self-signed TLS to mirror the existing classifyHost
+// probe behaviour.
+type GiteaClient struct {
+	httpClient *httpx.Client
+	baseURL    string // e.g. "https://git.librete.ch/api/v1"
+	token      string
+	forgeType  ForgeType
+}
+
+// GiteaConfig configures NewGiteaClient. Host is the bare hostname
+// ("git.librete.ch"); the constructor builds the API URL. Scheme defaults
+// to https when empty.
+type GiteaConfig struct {
+	Host      string
+	Scheme    string // "https" (default) or "http"
+	Token     string
+	ForgeType ForgeType // ForgeGitea, ForgeForgejo, or ForgeCodeberg
+}
+
+// NewGiteaClient builds a Gitea HTTP client. Returns an error if Host is
+// empty or Token is empty (every Gitea API call requires auth).
+func NewGiteaClient(cfg GiteaConfig) (*GiteaClient, error) {
+	if cfg.Host == "" {
+		return nil, errors.New("forge: NewGiteaClient: Host is required")
+	}
+	if cfg.Token == "" {
+		return nil, errors.New("forge: NewGiteaClient: Token is required")
+	}
+	scheme := cfg.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	ft := cfg.ForgeType
+	if ft == "" {
+		ft = ForgeGitea
+	}
+	transport := &http.Transport{
+		// Self-hosted instances often ship with private CAs. Mirror the
+		// detect.go probe behaviour rather than failing on self-signed.
+		//nolint:gosec // self-hosted Gitea/Forgejo commonly use private CAs
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &GiteaClient{
+		httpClient: httpx.New(httpx.Config{
+			Timeout:    30 * time.Second,
+			MaxRetries: 2,
+			Transport:  transport,
+		}),
+		baseURL:   fmt.Sprintf("%s://%s/api/v1", scheme, cfg.Host),
+		token:     cfg.Token,
+		forgeType: ft,
+	}, nil
+}
+
+func (g *GiteaClient) ForgeType() ForgeType { return g.forgeType }
+
+// do executes an authenticated request and decodes the JSON body into out
+// when out is non-nil. Returns an error for any non-2xx response.
+func (g *GiteaClient) do(ctx context.Context, method, path string, body io.Reader, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, g.baseURL+path, body)
+	if err != nil {
+		return fmt.Errorf("gitea: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+g.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := g.httpClient.Do(ctx, req)
+	if err != nil {
+		return fmt.Errorf("gitea: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("gitea: %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// --- Gitea API DTOs ----------------------------------------------------
+
+type giteaUser struct {
+	Login string `json:"login"`
+}
+
+type giteaLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type giteaIssue struct {
+	Number    int          `json:"number"`
+	Title     string       `json:"title"`
+	Body      string       `json:"body"`
+	State     string       `json:"state"`
+	User      giteaUser    `json:"user"`
+	Labels    []giteaLabel `json:"labels"`
+	Assignees []giteaUser  `json:"assignees"`
+	Comments  int          `json:"comments"`
+	CreatedAt time.Time    `json:"created_at"`
+	UpdatedAt time.Time    `json:"updated_at"`
+	ClosedAt  *time.Time   `json:"closed_at"`
+	HTMLURL   string       `json:"html_url"`
+	// Gitea exposes pull_request only for issues that are PRs.
+	PullRequest *struct{} `json:"pull_request,omitempty"`
+}
+
+type giteaBranch struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+type giteaPR struct {
+	Number       int          `json:"number"`
+	Title        string       `json:"title"`
+	Body         string       `json:"body"`
+	State        string       `json:"state"`
+	User         giteaUser    `json:"user"`
+	Labels       []giteaLabel `json:"labels"`
+	Draft        bool         `json:"draft"`
+	Merged       bool         `json:"merged"`
+	Head         giteaBranch  `json:"head"`
+	Base         giteaBranch  `json:"base"`
+	Additions    int          `json:"additions"`
+	Deletions    int          `json:"deletions"`
+	ChangedFiles int          `json:"changed_files"`
+	Commits      int          `json:"commits"`
+	Comments     int          `json:"comments"`
+	CreatedAt    time.Time    `json:"created_at"`
+	UpdatedAt    time.Time    `json:"updated_at"`
+	ClosedAt     *time.Time   `json:"closed_at"`
+	MergedAt     *time.Time   `json:"merged_at"`
+	HTMLURL      string       `json:"html_url"`
+}
+
+type giteaCommitAuthor struct {
+	Name string    `json:"name"`
+	Date time.Time `json:"date"`
+}
+
+type giteaCommitInner struct {
+	Message string            `json:"message"`
+	Author  giteaCommitAuthor `json:"author"`
+}
+
+type giteaCommit struct {
+	SHA     string           `json:"sha"`
+	Commit  giteaCommitInner `json:"commit"`
+	HTMLURL string           `json:"html_url"`
+}
+
+type giteaCheckRun struct {
+	Name       string `json:"context"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	URL        string `json:"target_url"`
+}
+
+type giteaComment struct {
+	User      giteaUser `json:"user"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	HTMLURL   string    `json:"html_url"`
+}
+
+// --- Conversions to forge-neutral types --------------------------------
+
+func convertGiteaIssue(gi *giteaIssue) *Issue {
+	labels := make([]Label, 0, len(gi.Labels))
+	for _, l := range gi.Labels {
+		labels = append(labels, Label{Name: l.Name, Color: l.Color})
+	}
+	assignees := make([]string, 0, len(gi.Assignees))
+	for _, a := range gi.Assignees {
+		assignees = append(assignees, a.Login)
+	}
+	return &Issue{
+		Number:    gi.Number,
+		Title:     gi.Title,
+		Body:      gi.Body,
+		State:     gi.State,
+		Author:    gi.User.Login,
+		Labels:    labels,
+		Assignees: assignees,
+		Comments:  gi.Comments,
+		CreatedAt: gi.CreatedAt,
+		UpdatedAt: gi.UpdatedAt,
+		ClosedAt:  gi.ClosedAt,
+		HTMLURL:   gi.HTMLURL,
+		IsPR:      gi.PullRequest != nil,
+	}
+}
+
+func convertGiteaPR(p *giteaPR) *PullRequest {
+	labels := make([]Label, 0, len(p.Labels))
+	for _, l := range p.Labels {
+		labels = append(labels, Label{Name: l.Name, Color: l.Color})
+	}
+	state := p.State
+	if p.Merged {
+		state = "merged"
+	}
+	return &PullRequest{
+		Number:       p.Number,
+		Title:        p.Title,
+		Body:         p.Body,
+		State:        state,
+		Author:       p.User.Login,
+		Labels:       labels,
+		Draft:        p.Draft,
+		Merged:       p.Merged,
+		HeadBranch:   p.Head.Ref,
+		HeadSHA:      p.Head.SHA,
+		BaseBranch:   p.Base.Ref,
+		Additions:    p.Additions,
+		Deletions:    p.Deletions,
+		ChangedFiles: p.ChangedFiles,
+		Commits:      p.Commits,
+		Comments:     p.Comments,
+		CreatedAt:    p.CreatedAt,
+		UpdatedAt:    p.UpdatedAt,
+		ClosedAt:     p.ClosedAt,
+		MergedAt:     p.MergedAt,
+		HTMLURL:      p.HTMLURL,
+	}
+}
+
+// --- Client interface methods ------------------------------------------
+
+func (g *GiteaClient) GetIssue(ctx context.Context, owner, repo string, number int) (*Issue, error) {
+	var gi giteaIssue
+	if err := g.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number), nil, &gi); err != nil {
+		return nil, err
+	}
+	return convertGiteaIssue(&gi), nil
+}
+
+func (g *GiteaClient) ListIssues(ctx context.Context, owner, repo string, opts ListIssuesOptions) ([]*Issue, error) {
+	q := url.Values{}
+	if opts.State != "" {
+		q.Set("state", opts.State)
+	}
+	if len(opts.Labels) > 0 {
+		q.Set("labels", strings.Join(opts.Labels, ","))
+	}
+	if opts.Sort != "" {
+		q.Set("sort", opts.Sort)
+	}
+	if opts.PerPage > 0 {
+		q.Set("limit", strconv.Itoa(opts.PerPage))
+	}
+	if opts.Page > 0 {
+		q.Set("page", strconv.Itoa(opts.Page))
+	}
+	// Gitea returns issues + PRs from /issues; type=issues filters out PRs.
+	q.Set("type", "issues")
+
+	var raw []giteaIssue
+	path := fmt.Sprintf("/repos/%s/%s/issues?%s", owner, repo, q.Encode())
+	if err := g.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]*Issue, 0, len(raw))
+	for i := range raw {
+		out = append(out, convertGiteaIssue(&raw[i]))
+	}
+	return out, nil
+}
+
+func (g *GiteaClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*PullRequest, error) {
+	var p giteaPR
+	if err := g.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number), nil, &p); err != nil {
+		return nil, err
+	}
+	return convertGiteaPR(&p), nil
+}
+
+func (g *GiteaClient) ListPullRequests(ctx context.Context, owner, repo string, opts ListPullRequestsOptions) ([]*PullRequest, error) {
+	q := url.Values{}
+	if opts.State != "" {
+		q.Set("state", opts.State)
+	}
+	if opts.Sort != "" {
+		q.Set("sort", opts.Sort)
+	}
+	if opts.PerPage > 0 {
+		q.Set("limit", strconv.Itoa(opts.PerPage))
+	}
+	if opts.Page > 0 {
+		q.Set("page", strconv.Itoa(opts.Page))
+	}
+	var raw []giteaPR
+	path := fmt.Sprintf("/repos/%s/%s/pulls?%s", owner, repo, q.Encode())
+	if err := g.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]*PullRequest, 0, len(raw))
+	for i := range raw {
+		out = append(out, convertGiteaPR(&raw[i]))
+	}
+	return out, nil
+}
+
+func (g *GiteaClient) ListPullRequestCommits(ctx context.Context, owner, repo string, number int) ([]*Commit, error) {
+	var raw []giteaCommit
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/commits", owner, repo, number)
+	if err := g.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]*Commit, 0, len(raw))
+	for _, c := range raw {
+		out = append(out, &Commit{
+			SHA:     c.SHA,
+			Message: c.Commit.Message,
+			Author:  c.Commit.Author.Name,
+			Date:    c.Commit.Author.Date,
+			HTMLURL: c.HTMLURL,
+		})
+	}
+	return out, nil
+}
+
+func (g *GiteaClient) GetCommitChecks(ctx context.Context, owner, repo, ref string) ([]*CheckRun, error) {
+	// Gitea's commit-status API returns the per-context build state. There
+	// is no "queued"/"in_progress" stage in the same shape as GitHub
+	// check-runs, so map state → conclusion + status="completed".
+	var raw []giteaCheckRun
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, ref)
+	if err := g.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]*CheckRun, 0, len(raw))
+	for _, c := range raw {
+		out = append(out, &CheckRun{
+			Name:       c.Name,
+			Status:     "completed",
+			Conclusion: mapGiteaStatusToConclusion(c.Status),
+			HTMLURL:    c.URL,
+		})
+	}
+	return out, nil
+}
+
+// mapGiteaStatusToConclusion translates Gitea's commit-status states
+// (success | failure | pending | error | warning) into the forge-neutral
+// conclusion vocabulary (success | failure | neutral | …).
+func mapGiteaStatusToConclusion(s string) string {
+	switch strings.ToLower(s) {
+	case "success":
+		return "success"
+	case "failure", "error":
+		return "failure"
+	case "pending":
+		return ""
+	case "warning":
+		return "neutral"
+	default:
+		return s
+	}
+}
+
+func (g *GiteaClient) ListIssueComments(ctx context.Context, owner, repo string, number int, limit int) ([]*Comment, error) {
+	q := url.Values{}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	var raw []giteaComment
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments?%s", owner, repo, number, q.Encode())
+	if err := g.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]*Comment, 0, len(raw))
+	for _, c := range raw {
+		out = append(out, &Comment{
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+			HTMLURL:   c.HTMLURL,
+		})
+	}
+	return out, nil
+}
+
+func (g *GiteaClient) CreatePullRequestReview(ctx context.Context, owner, repo string, number int, event, body string) error {
+	// Gitea uses {"event": "APPROVED"} not "APPROVE"; map the canonical
+	// values the Client interface documents into Gitea's vocabulary.
+	giteaEvent := mapReviewEvent(event)
+	payload := struct {
+		Event string `json:"event"`
+		Body  string `json:"body"`
+	}{Event: giteaEvent, Body: body}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
+	return g.do(ctx, http.MethodPost, path, strings.NewReader(string(b)), nil)
+}
+
+func mapReviewEvent(canonical string) string {
+	switch strings.ToUpper(canonical) {
+	case "APPROVE", "APPROVED":
+		return "APPROVED"
+	case "REQUEST_CHANGES":
+		return "REQUEST_CHANGES"
+	case "COMMENT", "COMMENTED":
+		return "COMMENT"
+	default:
+		return canonical
+	}
+}

--- a/internal/forge/gitea.go
+++ b/internal/forge/gitea.go
@@ -196,7 +196,7 @@ type giteaComment struct {
 func convertGiteaIssue(gi *giteaIssue) *Issue {
 	labels := make([]Label, 0, len(gi.Labels))
 	for _, l := range gi.Labels {
-		labels = append(labels, Label{Name: l.Name, Color: l.Color})
+		labels = append(labels, Label(l))
 	}
 	assignees := make([]string, 0, len(gi.Assignees))
 	for _, a := range gi.Assignees {
@@ -222,7 +222,7 @@ func convertGiteaIssue(gi *giteaIssue) *Issue {
 func convertGiteaPR(p *giteaPR) *PullRequest {
 	labels := make([]Label, 0, len(p.Labels))
 	for _, l := range p.Labels {
-		labels = append(labels, Label{Name: l.Name, Color: l.Color})
+		labels = append(labels, Label(l))
 	}
 	state := p.State
 	if p.Merged {

--- a/internal/forge/gitea_live_test.go
+++ b/internal/forge/gitea_live_test.go
@@ -1,0 +1,69 @@
+//go:build live
+
+// Live smoke tests for the Gitea adapter. Excluded from default builds via
+// the `live` build tag so CI never hits real network. Configurable via env
+// so the same test runs against any Gitea/Forgejo instance.
+//
+// Usage (from repo root):
+//
+//	set -a && . .env && set +a   # loads token_full
+//	GITEA_HOST=git.librete.ch GITEA_OWNER=<owner> GITEA_REPO=<repo> \
+//	  GITEA_TOKEN="$token_full" \
+//	  go test -tags live -v -run Live ./internal/forge/...
+//
+// File is deletable — kept around for ad-hoc validation when changing
+// the Gitea adapter wire format.
+package forge
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLive_GiteaSmoke(t *testing.T) {
+	host := envOr("GITEA_HOST", "")
+	owner := envOr("GITEA_OWNER", "")
+	repo := envOr("GITEA_REPO", "")
+	token := envOr("GITEA_TOKEN", os.Getenv("CODEBERG_TOKEN"))
+	if host == "" || owner == "" || repo == "" || token == "" {
+		t.Skip("set GITEA_HOST + GITEA_OWNER + GITEA_REPO + GITEA_TOKEN (or CODEBERG_TOKEN)")
+	}
+
+	ft := ForgeGitea
+	if host == "codeberg.org" {
+		ft = ForgeCodeberg
+	}
+	c, err := NewGiteaClient(GiteaConfig{Host: host, Token: token, ForgeType: ft})
+	if err != nil {
+		t.Fatalf("NewGiteaClient: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := c.ListIssues(ctx, owner, repo, ListIssuesOptions{State: "all", PerPage: 5})
+	if err != nil {
+		t.Fatalf("ListIssues %s/%s: %v", owner, repo, err)
+	}
+	t.Logf("ListIssues(%s/%s) → %d items from %s", owner, repo, len(issues), host)
+	for _, i := range issues {
+		t.Logf("  #%d %q (%s) by %s — labels=%d isPR=%v", i.Number, i.Title, i.State, i.Author, len(i.Labels), i.IsPR)
+	}
+
+	prs, err := c.ListPullRequests(ctx, owner, repo, ListPullRequestsOptions{State: "all", PerPage: 5})
+	if err != nil {
+		t.Fatalf("ListPullRequests %s/%s: %v", owner, repo, err)
+	}
+	t.Logf("ListPullRequests(%s/%s) → %d items", owner, repo, len(prs))
+	for _, p := range prs {
+		t.Logf("  #%d %q [%s] head=%s base=%s merged=%v", p.Number, p.Title, p.State, p.HeadBranch, p.BaseBranch, p.Merged)
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/forge/gitea_test.go
+++ b/internal/forge/gitea_test.go
@@ -40,7 +40,7 @@ func TestGiteaClient_GetIssue(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	got, err := c.GetIssue(context.Background(), "owner", "repo", 42)
 	require.NoError(t, err)
 	assert.Equal(t, 42, got.Number)
@@ -59,7 +59,7 @@ func TestGiteaClient_GetIssue_FlagsPR(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	got, err := c.GetIssue(context.Background(), "owner", "repo", 7)
 	require.NoError(t, err)
 	assert.True(t, got.IsPR, "issue with non-nil pull_request must flag as PR")
@@ -75,7 +75,7 @@ func TestGiteaClient_ListIssues_QueryString(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	_, err := c.ListIssues(context.Background(), "owner", "repo", ListIssuesOptions{
 		State: "open", Labels: []string{"bug", "p0"}, Sort: "updated", PerPage: 5, Page: 2,
 	})
@@ -104,7 +104,7 @@ func TestGiteaClient_GetPullRequest_MergedStateOverride(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	got, err := c.GetPullRequest(context.Background(), "owner", "repo", 3)
 	require.NoError(t, err)
 	assert.Equal(t, "merged", got.State, "merged=true must override state=closed")
@@ -123,7 +123,7 @@ func TestGiteaClient_GetCommitChecks_StatusMapping(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	got, err := c.GetCommitChecks(context.Background(), "owner", "repo", "abc")
 	require.NoError(t, err)
 	require.Len(t, got, 3)
@@ -143,7 +143,7 @@ func TestGiteaClient_CreatePullRequestReview_BodyShape(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	require.NoError(t, c.CreatePullRequestReview(context.Background(), "owner", "repo", 1, "APPROVE", "lgtm"))
 	assert.Equal(t, "APPROVED", receivedPayload["event"], "APPROVE must map to APPROVED for Gitea")
 	assert.Equal(t, "lgtm", receivedPayload["body"])
@@ -157,7 +157,7 @@ func TestGiteaClient_NonOKReturnsError(t *testing.T) {
 	srv := httptest.NewTLSServer(mux)
 	defer srv.Close()
 
-	c := giteaClientForTest(t, srv, "secret")
+	c := giteaClientForTest(t, srv)
 	_, err := c.GetIssue(context.Background(), "owner", "repo", 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
@@ -178,12 +178,12 @@ func TestClassifyHost_ForgejoHostsEnv(t *testing.T) {
 // giteaClientForTest builds a GiteaClient pointed at the supplied
 // httptest server. It strips the scheme, replaces baseURL with the
 // server's URL+/api/v1, and reuses the server's TLS config.
-func giteaClientForTest(t *testing.T, srv *httptest.Server, token string) *GiteaClient {
+func giteaClientForTest(t *testing.T, srv *httptest.Server) *GiteaClient {
 	t.Helper()
 	host := strings.TrimPrefix(srv.URL, "https://")
 	c, err := NewGiteaClient(GiteaConfig{
 		Host:      host,
-		Token:     token,
+		Token:     "secret",
 		ForgeType: ForgeGitea,
 	})
 	require.NoError(t, err)

--- a/internal/forge/gitea_test.go
+++ b/internal/forge/gitea_test.go
@@ -1,0 +1,183 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGiteaClient_Validation(t *testing.T) {
+	_, err := NewGiteaClient(GiteaConfig{Host: "", Token: "x"})
+	assert.Error(t, err, "empty Host must error")
+	_, err = NewGiteaClient(GiteaConfig{Host: "h", Token: ""})
+	assert.Error(t, err, "empty Token must error")
+}
+
+func TestGiteaClient_GetIssue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "token secret", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"number": 42,
+			"title": "test",
+			"body": "hello",
+			"state": "open",
+			"user": {"login": "alice"},
+			"labels": [{"name": "bug", "color": "ff0000"}],
+			"assignees": [{"login": "bob"}],
+			"comments": 3,
+			"html_url": "https://example.com/owner/repo/issues/42",
+			"pull_request": null
+		}`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	got, err := c.GetIssue(context.Background(), "owner", "repo", 42)
+	require.NoError(t, err)
+	assert.Equal(t, 42, got.Number)
+	assert.Equal(t, "alice", got.Author)
+	require.Len(t, got.Labels, 1)
+	assert.Equal(t, "bug", got.Labels[0].Name)
+	assert.Equal(t, []string{"bob"}, got.Assignees)
+	assert.False(t, got.IsPR)
+}
+
+func TestGiteaClient_GetIssue_FlagsPR(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/issues/7", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"number":7,"title":"pr","state":"open","user":{"login":"a"},"pull_request":{}}`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	got, err := c.GetIssue(context.Background(), "owner", "repo", 7)
+	require.NoError(t, err)
+	assert.True(t, got.IsPR, "issue with non-nil pull_request must flag as PR")
+}
+
+func TestGiteaClient_ListIssues_QueryString(t *testing.T) {
+	var capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`[]`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	_, err := c.ListIssues(context.Background(), "owner", "repo", ListIssuesOptions{
+		State: "open", Labels: []string{"bug", "p0"}, Sort: "updated", PerPage: 5, Page: 2,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, capturedQuery, "state=open")
+	assert.Contains(t, capturedQuery, "labels=bug%2Cp0")
+	assert.Contains(t, capturedQuery, "sort=updated")
+	assert.Contains(t, capturedQuery, "limit=5")
+	assert.Contains(t, capturedQuery, "page=2")
+	assert.Contains(t, capturedQuery, "type=issues")
+}
+
+func TestGiteaClient_GetPullRequest_MergedStateOverride(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/pulls/3", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"number": 3,
+			"title": "feat",
+			"state": "closed",
+			"user": {"login": "a"},
+			"merged": true,
+			"head": {"ref": "feat/x", "sha": "abc"},
+			"base": {"ref": "main", "sha": "def"}
+		}`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	got, err := c.GetPullRequest(context.Background(), "owner", "repo", 3)
+	require.NoError(t, err)
+	assert.Equal(t, "merged", got.State, "merged=true must override state=closed")
+	assert.Equal(t, "feat/x", got.HeadBranch)
+}
+
+func TestGiteaClient_GetCommitChecks_StatusMapping(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/statuses/abc", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"context":"build","status":"success","target_url":"u1"},
+			{"context":"test","status":"failure","target_url":"u2"},
+			{"context":"lint","status":"pending","target_url":"u3"}
+		]`))
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	got, err := c.GetCommitChecks(context.Background(), "owner", "repo", "abc")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "success", got[0].Conclusion)
+	assert.Equal(t, "failure", got[1].Conclusion)
+	assert.Equal(t, "", got[2].Conclusion, "pending → empty conclusion")
+}
+
+func TestGiteaClient_CreatePullRequestReview_BodyShape(t *testing.T) {
+	var receivedPayload map[string]string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_ = json.NewDecoder(r.Body).Decode(&receivedPayload)
+		w.WriteHeader(http.StatusCreated)
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	require.NoError(t, c.CreatePullRequestReview(context.Background(), "owner", "repo", 1, "APPROVE", "lgtm"))
+	assert.Equal(t, "APPROVED", receivedPayload["event"], "APPROVE must map to APPROVED for Gitea")
+	assert.Equal(t, "lgtm", receivedPayload["body"])
+}
+
+func TestGiteaClient_NonOKReturnsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/repos/owner/repo/issues/9", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	c := giteaClientForTest(t, srv, "secret")
+	_, err := c.GetIssue(context.Background(), "owner", "repo", 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestClassifyHost_LibreteShortcut(t *testing.T) {
+	assert.Equal(t, ForgeGitea, classifyHost("git.librete.ch"))
+}
+
+// giteaClientForTest builds a GiteaClient pointed at the supplied
+// httptest server. It strips the scheme, replaces baseURL with the
+// server's URL+/api/v1, and reuses the server's TLS config.
+func giteaClientForTest(t *testing.T, srv *httptest.Server, token string) *GiteaClient {
+	t.Helper()
+	host := strings.TrimPrefix(srv.URL, "https://")
+	c, err := NewGiteaClient(GiteaConfig{
+		Host:      host,
+		Token:     token,
+		ForgeType: ForgeGitea,
+	})
+	require.NoError(t, err)
+	return c
+}

--- a/internal/forge/gitea_test.go
+++ b/internal/forge/gitea_test.go
@@ -163,8 +163,16 @@ func TestGiteaClient_NonOKReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
-func TestClassifyHost_LibreteShortcut(t *testing.T) {
-	assert.Equal(t, ForgeGitea, classifyHost("git.librete.ch"))
+func TestClassifyHost_GiteaHostsEnv(t *testing.T) {
+	t.Setenv("WAVE_GITEA_HOSTS", "private.example.com, another.example.org")
+	assert.Equal(t, ForgeGitea, classifyHost("private.example.com"))
+	assert.Equal(t, ForgeGitea, classifyHost("ANOTHER.example.org"))
+	assert.NotEqual(t, ForgeGitea, classifyHost("github.com"))
+}
+
+func TestClassifyHost_ForgejoHostsEnv(t *testing.T) {
+	t.Setenv("WAVE_FORGEJO_HOSTS", "git.example.com")
+	assert.Equal(t, ForgeForgejo, classifyHost("git.example.com"))
 }
 
 // giteaClientForTest builds a GiteaClient pointed at the supplied

--- a/internal/forge/token.go
+++ b/internal/forge/token.go
@@ -99,9 +99,26 @@ func NewClient(info ForgeInfo) (Client, error) {
 	case ForgeGitHub:
 		ghClient := github.NewClient(github.ClientConfig{Token: token})
 		return NewGitHubClient(ghClient)
+	case ForgeGitea, ForgeForgejo, ForgeCodeberg:
+		host := info.Host
+		if host == "" {
+			// Codeberg has a fixed host; vanilla Gitea/Forgejo without a
+			// host means we never resolved the remote — bail.
+			if info.Type == ForgeCodeberg {
+				host = "codeberg.org"
+			} else {
+				return nil, nil
+			}
+		}
+		return NewGiteaClient(GiteaConfig{
+			Host:      host,
+			Token:     token,
+			ForgeType: info.Type,
+		})
 	default:
-		// Non-GitHub forges not yet supported — return (nil, nil) so callers'
-		// nil-guard checks show "not configured" rather than cryptic errors.
+		// Non-GitHub/Gitea forges not yet supported — return (nil, nil) so
+		// callers' nil-guard checks show "not configured" rather than
+		// cryptic errors.
 		return nil, nil
 	}
 }


### PR DESCRIPTION
Closes #1567. Phase 0 child of Epic #1565.

## What

Pure HTTP \`forge.Client\` for Gitea/Forgejo/Codeberg. No \`tea\` CLI dependency.

- **\`internal/forge/gitea.go\`** — \`GiteaClient\` + DTOs + conversions for the full \`forge.Client\` interface
- **\`token.go\`** — \`NewClient\` dispatches \`ForgeGitea\` / \`ForgeForgejo\` / \`ForgeCodeberg\` into \`NewGiteaClient\`
- **\`detect.go\`** — \`classifyHost\` shortcut for \`git.librete.ch\` (re-cinq's Gitea)

## API surface

Implements every method required by \`forge.Client\`:
- GetIssue / ListIssues (with pull_request flag for PR-typed issues)
- GetPullRequest (merged=true overrides state to \"merged\")
- ListPullRequests / ListPullRequestCommits
- GetCommitChecks (Gitea status → forge-neutral conclusion mapping)
- ListIssueComments
- CreatePullRequestReview (APPROVE → APPROVED translation for Gitea)

## Auth

\`Authorization: token <TOKEN>\` from \`GITEA_TOKEN\` (existing \`resolveGiteaToken\`). Codeberg falls back to \`CODEBERG_TOKEN\` then \`GITEA_TOKEN\`. Self-signed TLS tolerated to mirror the detect-probe behaviour for private CAs.

## Tests

Httptest-server-driven coverage: validation, GetIssue + PR flag, ListIssues query-string encoding (state/labels/sort/limit/page/type), GetPullRequest merged-state override, GetCommitChecks status mapping, CreatePullRequestReview event mapping, non-2xx error propagation, classifyHost(\"git.librete.ch\") shortcut.

## Acceptance vs #1567

- [x] HTTP-based — no \`tea\` CLI dependency
- [x] Token auth via env (\`GITEA_TOKEN\`)
- [x] Host classifier short-circuits \`git.librete.ch\`
- [x] Existing GitHub flows untouched (\`token.go\` switch unchanged for ForgeGitHub)
- [ ] Real smoke test against \`git.librete.ch\` — defer to hands-on validation; the test suite + httptest server cover the wire shape

## Notes on \`plan-research\` deferral

The original plan §3 row called for a \`plan-research\` artifact mapping the Gitea v1 surface before \`impl-issue\`. Skipped here because the Gitea API documentation is well-known and the surface mirrors GitHub closely — no research output would have changed the implementation. Tests double as the artifact.

646 LOC, 2 new files + 2 modified.