### PR TITLE
feat(onboarding): add onboarder persona + onboard-project meta-pipeline (1.1)

### DIFF
--- a/.agents/contracts/detection.schema.json
+++ b/.agents/contracts/detection.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Project Detection",
+  "description": "Schema for the JSON shape produced by the onboarder persona during the detect step of the onboard-project meta-pipeline. Captures the project's flavour, build system, test command, and any signals that informed the detection.",
+  "type": "object",
+  "required": ["flavour", "signals"],
+  "additionalProperties": false,
+  "properties": {
+    "flavour": {
+      "type": "string",
+      "description": "Detected project flavour. Use 'unknown' when no signal is conclusive — downstream steps will degrade gracefully.",
+      "examples": ["go", "rust", "node", "bun", "deno", "python", "csharp", "java", "ruby", "unknown"]
+    },
+    "build_system": {
+      "type": ["string", "null"],
+      "description": "Build system associated with the flavour (e.g. go, cargo, npm, bun, pip, dotnet). Null when not determinable."
+    },
+    "test_command": {
+      "type": ["string", "null"],
+      "description": "Canonical test command for the project (e.g. 'go test ./...'). Null when not determinable."
+    },
+    "package_managers": {
+      "type": "array",
+      "description": "Package managers in use, ordered by precedence.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "signals": {
+      "type": "array",
+      "description": "Concrete files or markers that informed the detection (e.g. 'go.mod', 'package.json', 'Cargo.toml'). Each entry is a path relative to the project root.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additional_signals": {
+      "type": "object",
+      "description": "Free-form key/value pairs for unusual or composite signals not covered by the canonical fields. Use this rather than guessing at the canonical shape.",
+      "additionalProperties": true
+    },
+    "project_intent": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable summary of what the project does, derived from README / design docs."
+    },
+    "frameworks": {
+      "type": "array",
+      "description": "Frameworks or major libraries detected (e.g. 'react', 'gin', 'fastapi').",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/scope/onboarding-as-session-plan.md
+++ b/docs/scope/onboarding-as-session-plan.md
@@ -423,7 +423,7 @@ New canonical schema (per ADR-010): `internal/contract/schemas/shared/work_item_
 
 | # | Title | Files |
 |---|---|---|
-| 1.1 | Onboarder agent + meta-pipeline | new `.agents/personas/onboarder.md`, new `internal/defaults/pipelines/onboard-project.yaml` (assess → propose → write `.agents/*` → smoke-test) |
+| 1.1 ✅ | Onboarder agent + meta-pipeline | `internal/defaults/personas/onboarder.{md,yaml}`, `internal/defaults/pipelines/onboard-project.yaml` (detect → propose → generate → finalize), `internal/defaults/contracts/detection.schema.json`, `internal/defaults/prompts/onboard/{detect,propose,generate,finalize}.md` |
 | 1.2 | Webui driver | new `internal/webui/handlers_onboard.go`, new templates `onboard/start.html`, `onboard/step.html`, SSE stream |
 | 1.3 | CLI driver | `cmd/wave/commands/init.go` — call `OnboardingService.StartSession` via CLI UI |
 | 1.4 | Entry-page branch | `internal/webui/routes.go` — `/` checks `IsOnboarded`, redirects appropriately |

--- a/internal/defaults/contracts/detection.schema.json
+++ b/internal/defaults/contracts/detection.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Project Detection",
+  "description": "Schema for the JSON shape produced by the onboarder persona during the detect step of the onboard-project meta-pipeline. Captures the project's flavour, build system, test command, and any signals that informed the detection.",
+  "type": "object",
+  "required": ["flavour", "signals"],
+  "additionalProperties": false,
+  "properties": {
+    "flavour": {
+      "type": "string",
+      "description": "Detected project flavour. Use 'unknown' when no signal is conclusive — downstream steps will degrade gracefully.",
+      "examples": ["go", "rust", "node", "bun", "deno", "python", "csharp", "java", "ruby", "unknown"]
+    },
+    "build_system": {
+      "type": ["string", "null"],
+      "description": "Build system associated with the flavour (e.g. go, cargo, npm, bun, pip, dotnet). Null when not determinable."
+    },
+    "test_command": {
+      "type": ["string", "null"],
+      "description": "Canonical test command for the project (e.g. 'go test ./...'). Null when not determinable."
+    },
+    "package_managers": {
+      "type": "array",
+      "description": "Package managers in use, ordered by precedence.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "signals": {
+      "type": "array",
+      "description": "Concrete files or markers that informed the detection (e.g. 'go.mod', 'package.json', 'Cargo.toml'). Each entry is a path relative to the project root.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additional_signals": {
+      "type": "object",
+      "description": "Free-form key/value pairs for unusual or composite signals not covered by the canonical fields. Use this rather than guessing at the canonical shape.",
+      "additionalProperties": true
+    },
+    "project_intent": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable summary of what the project does, derived from README / design docs."
+    },
+    "frameworks": {
+      "type": "array",
+      "description": "Frameworks or major libraries detected (e.g. 'react', 'gin', 'fastapi').",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/internal/defaults/embed_test.go
+++ b/internal/defaults/embed_test.go
@@ -154,9 +154,9 @@ func TestGetPersonaConfigs_ReturnsAllPersonas(t *testing.T) {
 		t.Fatalf("GetPersonaConfigs() error: %v", err)
 	}
 
-	// Should have exactly 31 persona configs (all .md files minus base-protocol)
-	if len(configs) != 31 {
-		t.Errorf("expected 31 persona configs, got %d", len(configs))
+	// Should have exactly 32 persona configs (all .md files minus base-protocol)
+	if len(configs) != 32 {
+		t.Errorf("expected 32 persona configs, got %d", len(configs))
 	}
 
 	// Verify a few known personas exist

--- a/internal/defaults/onboarder_test.go
+++ b/internal/defaults/onboarder_test.go
@@ -1,0 +1,150 @@
+package defaults
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// TestOnboardProjectPipelineRegistered asserts the onboard-project pipeline
+// is embedded and discoverable via the defaults registry, including all the
+// prompts and the contract it depends on.
+func TestOnboardProjectPipelineRegistered(t *testing.T) {
+	pipelines, err := GetPipelines()
+	if err != nil {
+		t.Fatalf("GetPipelines() error: %v", err)
+	}
+	body, ok := pipelines["onboard-project.yaml"]
+	if !ok {
+		t.Fatal("expected onboard-project.yaml in default pipelines")
+	}
+
+	for _, want := range []string{
+		"name: onboard-project",
+		"persona: onboarder",
+		"source_path: .agents/prompts/onboard/detect.md",
+		"source_path: .agents/prompts/onboard/propose.md",
+		"source_path: .agents/prompts/onboard/generate.md",
+		"source_path: .agents/prompts/onboard/finalize.md",
+		"schema_path: .agents/contracts/detection.schema.json",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("onboard-project.yaml missing required reference %q", want)
+		}
+	}
+
+	prompts, err := GetPrompts()
+	if err != nil {
+		t.Fatalf("GetPrompts() error: %v", err)
+	}
+	for _, p := range []string{
+		"onboard/detect.md",
+		"onboard/propose.md",
+		"onboard/generate.md",
+		"onboard/finalize.md",
+	} {
+		if _, ok := prompts[p]; !ok {
+			t.Errorf("expected prompt %q to be embedded", p)
+		}
+	}
+
+	contracts, err := GetContracts()
+	if err != nil {
+		t.Fatalf("GetContracts() error: %v", err)
+	}
+	if _, ok := contracts["detection.schema.json"]; !ok {
+		t.Error("expected detection.schema.json in default contracts")
+	}
+}
+
+// TestOnboarderPersonaRegistered asserts both the markdown and yaml halves
+// of the onboarder persona are embedded.
+func TestOnboarderPersonaRegistered(t *testing.T) {
+	personas, err := GetPersonas()
+	if err != nil {
+		t.Fatalf("GetPersonas() error: %v", err)
+	}
+	if _, ok := personas["onboarder.md"]; !ok {
+		t.Fatal("expected onboarder.md in default personas")
+	}
+
+	configs, err := GetPersonaConfigs()
+	if err != nil {
+		t.Fatalf("GetPersonaConfigs() error: %v", err)
+	}
+	cfg, ok := configs["onboarder"]
+	if !ok {
+		t.Fatal("expected onboarder persona config")
+	}
+	if cfg.Description == "" {
+		t.Error("onboarder persona config missing description")
+	}
+	if len(cfg.Permissions.AllowedTools) == 0 {
+		t.Error("onboarder persona config missing allowed_tools")
+	}
+}
+
+// TestDetectionSchemaValidatesFixtures runs the schema against valid + invalid
+// fixtures to catch regressions in either the schema or the contract loader.
+func TestDetectionSchemaValidatesFixtures(t *testing.T) {
+	contracts, err := GetContracts()
+	if err != nil {
+		t.Fatalf("GetContracts() error: %v", err)
+	}
+	schemaText, ok := contracts["detection.schema.json"]
+	if !ok {
+		t.Fatal("detection.schema.json not embedded")
+	}
+
+	var schemaDoc interface{}
+	if err := json.Unmarshal([]byte(schemaText), &schemaDoc); err != nil {
+		t.Fatalf("schema not valid JSON: %v", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("detection.schema.json", schemaDoc); err != nil {
+		t.Fatalf("compiler.AddResource: %v", err)
+	}
+	schema, err := compiler.Compile("detection.schema.json")
+	if err != nil {
+		t.Fatalf("compiler.Compile: %v", err)
+	}
+
+	valid := []string{
+		`{"flavour":"go","build_system":"go","test_command":"go test ./...","signals":["go.mod"],"package_managers":["go"]}`,
+		`{"flavour":"node","signals":["package.json","package-lock.json"],"frameworks":["react"]}`,
+		`{"flavour":"unknown","signals":[],"additional_signals":{"hint":"empty repo"}}`,
+		`{"flavour":"rust","build_system":null,"test_command":null,"signals":["Cargo.toml"]}`,
+	}
+	for i, raw := range valid {
+		var doc interface{}
+		if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+			t.Fatalf("valid fixture %d: unmarshal: %v", i, err)
+		}
+		if err := schema.Validate(doc); err != nil {
+			t.Errorf("valid fixture %d failed validation: %v\nfixture: %s", i, err, raw)
+		}
+	}
+
+	invalid := []string{
+		// missing required flavour
+		`{"signals":["go.mod"]}`,
+		// missing required signals
+		`{"flavour":"go"}`,
+		// flavour wrong type
+		`{"flavour":1,"signals":[]}`,
+		// extra top-level property forbidden
+		`{"flavour":"go","signals":[],"unexpected":"nope"}`,
+	}
+	for i, raw := range invalid {
+		var doc interface{}
+		if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+			t.Fatalf("invalid fixture %d: unmarshal: %v", i, err)
+		}
+		if err := schema.Validate(doc); err == nil {
+			t.Errorf("invalid fixture %d unexpectedly passed validation: %s", i, raw)
+		}
+	}
+}

--- a/internal/defaults/personas/onboarder.md
+++ b/internal/defaults/personas/onboarder.md
@@ -1,0 +1,24 @@
+# Onboarder
+
+Workspace-scoped agent that surveys a project and writes its `.agents/*` overlay. Produces detection JSON, file manifests, and tailored personas, pipelines, and prompts for the project at hand.
+
+## Rules
+- Read the project before proposing or writing anything — actual files, not assumptions
+- Detection output must conform to `detection.schema.json`; emit `flavour: "unknown"` rather than guessing
+- Every generated `.agents/*` file must be tailored to the detected flavour, not boilerplate
+- Pipelines you generate must reference the personas and prompts you also generate — no dangling references
+- Always end the run by writing the sentinel `.agents/.onboarding-done`
+
+## Responsibilities
+- Inspect the project root and surface concrete signals (manifest files, lockfiles, framework markers)
+- Propose a `.agents/*` overlay manifest before writing — never go straight from detection to filesystem
+- Write only inside `.agents/`. Touching `wave.yaml`, source files, or anything outside `.agents/` is forbidden
+- Validate generated YAML/MD before exit; report and retry on failure rather than ignoring it
+- Keep generated content small and idiomatic — one tailored persona, one tailored pipeline, one prompt minimum
+
+## Constraints
+- NEVER write outside `.agents/`
+- NEVER overwrite a file that already exists in `.agents/` without a clear reason recorded in output
+- NEVER invent flavour signals — every entry in `signals[]` must point to a real file on disk
+- NEVER skip the sentinel write; the project is not onboarded until `.agents/.onboarding-done` exists
+- NEVER include language-specific commands in personas; keep personas flavour-agnostic and route flavour-specific commands through pipelines

--- a/internal/defaults/personas/onboarder.yaml
+++ b/internal/defaults/personas/onboarder.yaml
@@ -1,0 +1,6 @@
+description: "Project introspection and .agents/* overlay generation"
+temperature: 0.4
+permissions:
+  allowed_tools:
+    - "*"
+  deny: []

--- a/internal/defaults/personas_test.go
+++ b/internal/defaults/personas_test.go
@@ -94,7 +94,7 @@ func TestPersonaFilesMandatorySections(t *testing.T) {
 	}
 }
 
-// TestAllPersonasCovered verifies exactly 23 persona files exist (excluding
+// TestAllPersonasCovered verifies the expected persona files exist (excluding
 // base-protocol.md) with the expected names (SC-004).
 func TestAllPersonasCovered(t *testing.T) {
 	personas, err := GetPersonas()
@@ -126,6 +126,7 @@ func TestAllPersonasCovered(t *testing.T) {
 		"validator.md":        true,
 		"synthesizer.md":      true,
 		"supervisor.md":       true,
+		"onboarder.md":        true,
 	}
 
 	for name := range expected {
@@ -141,7 +142,7 @@ func TestAllPersonasCovered(t *testing.T) {
 			count++
 		}
 	}
-	if count != 31 {
-		t.Errorf("expected 31 persona files, got %d", count)
+	if count != 32 {
+		t.Errorf("expected 32 persona files, got %d", count)
 	}
 }

--- a/internal/defaults/pipelines/onboard-project.yaml
+++ b/internal/defaults/pipelines/onboard-project.yaml
@@ -1,0 +1,168 @@
+kind: WavePipeline
+metadata:
+  name: onboard-project
+  description: >-
+    Generate a tailored .agents/* overlay for an existing project. Surveys the
+    project to detect its flavour, proposes a manifest of personas, pipelines,
+    and prompts, writes them, validates the result, and marks the project as
+    onboarded by writing the .agents/.onboarding-done sentinel. Use this as the
+    first run on any project where Wave has not yet been onboarded.
+  release: true
+
+input:
+  source: cli
+  type: string
+  schema:
+    type: string
+    description: "Optional project description or intent hint (defaults to empty string)"
+  example: ""
+
+chat_context:
+  artifact_summaries:
+    - detection
+    - proposal
+    - generation
+  suggested_questions:
+    - "What flavour was detected?"
+    - "Which .agents/* files were generated?"
+    - "Did the sentinel get written?"
+  focus_areas:
+    - "Detection accuracy"
+    - "Generated overlay completeness"
+    - "Sentinel state"
+
+pipeline_outputs:
+  detection:
+    step: detect
+    artifact: detection
+    type: workspace_ref
+  proposal:
+    step: propose
+    artifact: proposal
+    type: workspace_ref
+
+steps:
+  - id: detect
+    persona: onboarder
+    model: cheapest
+    workspace:
+      mount:
+        - source: ./
+          target: /project
+          mode: readonly
+    exec:
+      type: prompt
+      source_path: .agents/prompts/onboard/detect.md
+    output_artifacts:
+      - name: detection
+        path: .agents/output/detection.json
+        type: json
+    retry:
+      policy: patient
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/detection.json
+        schema_path: .agents/contracts/detection.schema.json
+        must_pass: true
+        on_failure: fail
+
+  - id: propose
+    persona: onboarder
+    thread: onboard
+    model: cheapest
+    dependencies: [detect]
+    memory:
+      inject_artifacts:
+        - step: detect
+          artifact: detection
+          as: detection
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source_path: .agents/prompts/onboard/propose.md
+    output_artifacts:
+      - name: proposal
+        path: .agents/output/onboard-proposal.json
+        type: json
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: non_empty_file
+        source: .agents/output/onboard-proposal.json
+        must_pass: true
+        on_failure: warn
+
+  - id: generate
+    persona: onboarder
+    thread: onboard
+    model: cheapest
+    dependencies: [propose]
+    memory:
+      inject_artifacts:
+        - step: detect
+          artifact: detection
+          as: detection
+        - step: propose
+          artifact: proposal
+          as: proposal
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source_path: .agents/prompts/onboard/generate.md
+    output_artifacts:
+      - name: generation
+        path: .agents/output/onboard-generation.json
+        type: json
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: non_empty_file
+        source: .agents/output/onboard-generation.json
+        must_pass: true
+        on_failure: warn
+
+  - id: finalize
+    persona: craftsman
+    thread: onboard
+    model: cheapest
+    dependencies: [generate]
+    memory:
+      inject_artifacts:
+        - step: detect
+          artifact: detection
+          as: detection
+        - step: propose
+          artifact: proposal
+          as: proposal
+        - step: generate
+          artifact: generation
+          as: generation
+    workspace:
+      type: worktree
+      branch: "{{ pipeline_id }}"
+    exec:
+      type: prompt
+      source_path: .agents/prompts/onboard/finalize.md
+    output_artifacts:
+      - name: finalize-report
+        path: .agents/output/onboard-finalize.json
+        type: json
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: non_empty_file
+        source: .agents/output/onboard-finalize.json
+        must_pass: true
+        on_failure: fail

--- a/internal/defaults/prompts/onboard/detect.md
+++ b/internal/defaults/prompts/onboard/detect.md
@@ -1,0 +1,46 @@
+## Objective
+
+Survey the project mounted at `/project` and emit a structured detection JSON describing its flavour, build system, test command, and the concrete signals that informed the detection. The output is consumed by the next pipeline step (propose) — accuracy and completeness here decide whether the generated `.agents/*` overlay is useful or generic.
+
+## Context
+
+This is the first step of the `onboard-project` pipeline. You have read-only access to the project directory at `/project`. The project may be greenfield (almost empty), partially scaffolded, or a mature codebase with existing tooling. Your job is to look at what is actually on disk — not to guess from the directory name or a README alone.
+
+## Requirements
+
+Execute these steps in order:
+
+1. List the top two levels of the project directory: `ls /project` and `find /project -maxdepth 2 -type f`. Record every file path you'll cite as a signal.
+2. Read manifest and lockfile heads (first 50–100 lines each) for any of the following that exist:
+   - `go.mod`, `go.sum`
+   - `Cargo.toml`, `Cargo.lock`
+   - `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `deno.json`, `deno.lock`
+   - `pyproject.toml`, `setup.py`, `requirements.txt`, `Pipfile`
+   - `pom.xml`, `build.gradle`, `build.gradle.kts`
+   - `*.csproj`, `*.sln`
+   - `Gemfile`
+3. Read `wave.yaml` if present and extract `project.language`, `project.build_command`, `project.test_command`. These take precedence over inferred values.
+4. Read the README (any case) for project intent — capture a one-sentence summary in `project_intent` if available.
+5. Determine the flavour using this precedence:
+   1. `wave.yaml` `project.language` if explicitly set.
+   2. Manifest signal: `go.mod` → `go`; `Cargo.toml` → `rust`; `deno.json` → `deno`; `bun.lockb` → `bun`; `package.json` → `node`; `pyproject.toml` or `setup.py` → `python`; `*.csproj` / `*.sln` → `csharp`; `pom.xml` / `build.gradle*` → `java`; `Gemfile` → `ruby`.
+   3. If still ambiguous, emit `flavour: "unknown"` and capture the unusual evidence under `additional_signals`.
+6. Determine the canonical test command: prefer `wave.yaml` `project.test_command`; otherwise the flavour default (`go test ./...`, `cargo test`, `npm test`, `bun test`, `pytest`, `dotnet test`, `mvn test`, `gradle test`, `bundle exec rake test`).
+7. Detect frameworks only when there's a strong signal (e.g. a top-level dependency entry referencing the framework name).
+
+## Output Format
+
+Produce JSON matching `detection.schema.json`. Every entry in `signals[]` must be a real path you observed via `ls` / `find`. When a field cannot be determined honestly, use `null` (for nullable fields) or `unknown` (for `flavour`).
+
+Write the output to `.agents/output/detection.json`.
+
+## Constraints
+
+- Do NOT write any files outside `.agents/output/`.
+- Do NOT invent signals you didn't observe.
+- Do NOT pick a flavour to satisfy the schema — `unknown` is preferred over a wrong guess.
+- Do NOT read or modify files outside the `/project` mount.
+
+## Quality Bar
+
+Good detection cites at least one concrete signal per non-null field, picks the right flavour on the first try when manifest evidence exists, and degrades to `unknown` cleanly when it doesn't. Bad detection guesses, omits signals, or hallucinates a `test_command` the project doesn't actually support.

--- a/internal/defaults/prompts/onboard/finalize.md
+++ b/internal/defaults/prompts/onboard/finalize.md
@@ -1,0 +1,47 @@
+## Objective
+
+Validate the generated `.agents/*` overlay and write the onboarding sentinel. After this step exits, `wave init` and the webui driver must be able to detect the project as onboarded by checking `.agents/.onboarding-done`.
+
+## Context
+
+The generate step wrote files under `.agents/` according to the proposal manifest. Its report is available as the `generation` artifact at `.agents/artifacts/generation`, listing what was written, skipped, and any errors. The detection and proposal artifacts are also still available under `.agents/artifacts/`. You are in the project root in a worktree.
+
+## Requirements
+
+1. Read `.agents/artifacts/generation` and confirm `errors` is empty. If non-empty, abort and emit a clear failure note in `.agents/output/onboard-finalize.json`.
+2. Verify the on-disk overlay:
+   - At least one file exists under `.agents/personas/`
+   - At least one file exists under `.agents/pipelines/`
+   - At least one file exists under `.agents/prompts/`
+   Use `ls .agents/personas .agents/pipelines .agents/prompts` to confirm.
+3. Validate every generated YAML pipeline by running:
+   ```bash
+   wave validate .agents/pipelines/<file>.yaml
+   ```
+   for each `.yaml` under `.agents/pipelines/`. If `wave validate` is not on PATH, fall back to `go run ./cmd/wave validate <file>` from the project root if a `cmd/wave` source tree exists, otherwise skip with a recorded note.
+4. Validate every generated markdown file is non-empty and has a level-1 heading.
+5. Write the sentinel:
+   ```bash
+   mkdir -p .agents
+   : > .agents/.onboarding-done
+   ```
+   This produces the same end-state as `onboarding.MarkDoneAt` (a zero-byte file at the documented sentinel path).
+6. Emit a finalization report at `.agents/output/onboard-finalize.json`:
+   ```json
+   {
+     "validated": [".agents/pipelines/example.yaml"],
+     "warnings": [],
+     "sentinel_written": true
+   }
+   ```
+
+## Constraints
+
+- Do NOT modify generated files in this step. Validation is read-only — fix issues by failing the step, not by patching.
+- Do NOT write the sentinel before validation passes. A failed validation must leave the sentinel absent so the project re-runs onboarding.
+- Do NOT write outside `.agents/`.
+- Do NOT commit or push. The driver decides what to do with the worktree.
+
+## Quality Bar
+
+A good finalize step exits with the sentinel present, every generated YAML validated, and a clean report. A bad step writes the sentinel despite a validation failure, modifies generated files in place, or skips validation silently.

--- a/internal/defaults/prompts/onboard/generate.md
+++ b/internal/defaults/prompts/onboard/generate.md
@@ -1,0 +1,41 @@
+## Objective
+
+Materialise the proposal manifest into real files under `.agents/`. Read the proposal, write each file, and stop. No improvisation, no extra files, no edits outside `.agents/`.
+
+## Context
+
+The propose step wrote `onboard-proposal.json` and it has been injected as the `proposal` artifact at `.agents/artifacts/proposal`. The detect step's output is also still available at `.agents/artifacts/detection`. You are running in a worktree; the working directory is the project root.
+
+## Requirements
+
+1. Read the proposal manifest from `.agents/artifacts/proposal` and parse the `files` array.
+2. Read the detection artifact from `.agents/artifacts/detection` for context (flavour, test command, signals).
+3. For each entry in the proposal `files` array:
+   1. Verify the `path` starts with `.agents/`. If it does not, abort with a clear error — never write outside `.agents/`.
+   2. Skip the file if it already exists on disk and record a note in `.agents/output/onboard-generation.json`.
+   3. Create parent directories with `mkdir -p`.
+   4. Write the file with content tailored to the detected flavour:
+      - **Personas**: short markdown describing role, rules, responsibilities, constraints — no language-specific commands.
+      - **Pipelines**: valid Wave pipeline YAML referencing the personas and prompts defined elsewhere in the proposal. Use the detection `test_command` for any test-running step. Include the standard `kind: WavePipeline`, `metadata.name`, `metadata.description`, `steps[]` shape.
+      - **Prompts**: markdown with Objective / Context / Requirements / Output Format / Constraints / Quality Bar sections, mirroring the shape of the prompt you are reading now.
+4. After writing all files, emit a generation report at `.agents/output/onboard-generation.json`:
+   ```json
+   {
+     "written": [".agents/personas/example.md", ...],
+     "skipped": [".agents/pipelines/already-exists.yaml"],
+     "errors": []
+   }
+   ```
+5. Do NOT run any tests, builds, or validation commands here — that's the finalize step's job.
+
+## Constraints
+
+- Every write target MUST start with `.agents/`. Hard fail otherwise.
+- Do NOT modify `wave.yaml`, `go.mod`, `package.json`, source files, CI files, or anything outside `.agents/`.
+- Do NOT delete files. Skipping is the only valid response to a pre-existing file.
+- Do NOT include placeholder content like `TODO` or `// fill me in` — every file must be functional on first read.
+- Do NOT add Co-Authored-By or AI attribution lines to any generated file.
+
+## Quality Bar
+
+A good generation step writes exactly the files in the manifest, each tailored to the detected flavour, with no leakage outside `.agents/`. A bad step touches `wave.yaml`, writes generic boilerplate, or leaves dangling references because it skipped a referenced file silently.

--- a/internal/defaults/prompts/onboard/propose.md
+++ b/internal/defaults/prompts/onboard/propose.md
@@ -1,0 +1,40 @@
+## Objective
+
+Read the injected `detection` artifact and produce a manifest of `.agents/*` files that the next step (generate) will create. The proposal is the deterministic plan — once it is written, the generate step does not improvise additional files.
+
+## Context
+
+The previous detect step wrote `detection.json` (matching `detection.schema.json`) and it has been injected as the `detection` artifact. You can read it from `.agents/artifacts/detection`. You are still in the project root; later steps will write to `.agents/`. No `.agents/*` files exist yet beyond the injected artifact.
+
+## Requirements
+
+1. Load the detection artifact from `.agents/artifacts/detection` and parse it.
+2. Plan a minimal, tailored overlay that includes at least:
+   - One persona under `.agents/personas/` named after the flavour or project intent (e.g. `<project-slug>-implementer.md`). When `flavour` is `unknown`, name it after the project directory or a generic role.
+   - One pipeline under `.agents/pipelines/` whose steps reference real commands for the detected flavour (e.g. the canonical `test_command` from detection). The pipeline should perform a small, useful loop — for example, `lint → test → review` for an established project, or `bootstrap → smoke` for a greenfield one.
+   - At least one prompt file under `.agents/prompts/<pipeline-name>/` for the pipeline above.
+3. For each planned file, record:
+   - `path` — the full relative path under `.agents/`
+   - `purpose` — a one-sentence description of what the file does
+   - `references` — list of other planned paths it points to (used by generate to verify the graph)
+4. Verify the manifest is internally consistent — every `references` entry must appear elsewhere in the manifest. Fix any dangling references before emitting.
+5. Write the manifest to `.agents/output/onboard-proposal.json` as a JSON object of the shape:
+   ```json
+   {
+     "flavour": "go",
+     "files": [
+       {"path": ".agents/personas/example.md", "purpose": "...", "references": []}
+     ]
+   }
+   ```
+
+## Constraints
+
+- The manifest must list ONLY paths under `.agents/`.
+- Every pipeline you propose must reference at least one persona and at least one prompt that you also propose.
+- Do NOT propose files that already exist in `.agents/` (check `ls .agents` first).
+- Do NOT inflate the manifest with files unrelated to the detected flavour or intent.
+
+## Quality Bar
+
+A good proposal lists 3–6 files, all under `.agents/`, with a coherent reference graph and obvious tailoring to the detected flavour. A bad proposal is generic, dangling-reference-laden, or stuffs unrelated files into the manifest.

--- a/specs/1576-onboarder-meta-pipeline/plan.md
+++ b/specs/1576-onboarder-meta-pipeline/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan — Onboarder agent + onboard-project meta-pipeline
+
+## 1. Objective
+
+Ship a forge-agnostic, project-introspecting `onboard-project` meta-pipeline plus a dedicated `onboarder` persona. Running `wave run onboard-project` on any existing project must detect its flavour, propose a tailored `.agents/*` overlay (personas, pipelines, prompts), write those files, and mark the project onboarded via the existing sentinel.
+
+## 2. Approach
+
+Mirror the proven `ops-bootstrap` shape (assess → generate → commit), but flip the polarity from **scaffolding source code** to **scaffolding agent configuration**:
+
+1. **detect** (read-only) — `navigator` persona surveys the project, emits `detection.json` matching `detection.schema.json`.
+2. **propose** — `onboarder` persona reads `detection.json` and emits a manifest of `.agents/*` files to write (paths + intended purpose), allowing later steps to be deterministic about what gets generated.
+3. **generate** — `onboarder` persona writes the `.agents/*` files into the workspace based on the proposal. Includes at minimum one tailored persona, one tailored pipeline, and one prompt file referenced by that pipeline.
+4. **finalize** — `craftsman` persona validates the generated YAML/MD with `wave validate` (or equivalent), then writes the sentinel via Go helper invocation (`go run ./cmd/wave doctor` style) or directly via shell (`mkdir -p .agents && touch .agents/.onboarding-done`) — preserving the same end-state `MarkDoneAt` produces.
+
+Rationale for splitting **detect** from **propose**: forge-agnostic detection is reusable (also used by `wave init` non-interactive baseline); proposal is the LLM-creative step. Keeping them separate lets future steps cache detection output and re-run proposal cheaply.
+
+The pipeline ships in `internal/defaults/pipelines/` so it is embedded into the binary. Local overlays (`.agents/pipelines/onboard-project.yaml`) still take precedence per existing loader behaviour.
+
+## 3. File Mapping
+
+### Create
+
+| Path | Purpose |
+|------|---------|
+| `internal/defaults/personas/onboarder.md` | Persona spec for the onboarder agent — read-write, scoped to `.agents/*` and project introspection |
+| `internal/defaults/contracts/detection.schema.json` | JSON schema validating the detect-step output |
+| `internal/defaults/pipelines/onboard-project.yaml` | The 4-step meta-pipeline (detect → propose → generate → finalize) |
+| `internal/defaults/prompts/onboard/detect.md` | Detect-step prompt (project introspection → JSON) |
+| `internal/defaults/prompts/onboard/propose.md` | Propose-step prompt (detection JSON → file manifest) |
+| `internal/defaults/prompts/onboard/generate.md` | Generate-step prompt (file manifest → write files) |
+| `internal/defaults/prompts/onboard/finalize.md` | Finalize-step prompt (validate + sentinel) |
+| `specs/1576-onboarder-meta-pipeline/{spec,plan,tasks}.md` | This planning artefact set |
+
+### Modify
+
+| Path | Reason |
+|------|--------|
+| (none required at planning time) | Pipeline + persona + contract auto-discovered by existing embed-FS / registry mechanisms |
+
+If the pipeline registry or contract registry uses an explicit `embed.go` listing, that file will need adding to — to be confirmed during implementation.
+
+### Delete
+
+None.
+
+## 4. Architecture Decisions
+
+- **AD-1 — Four-step shape over three.** Splitting detect from propose makes the schema-validated handoff clean and lets the contract enforce structure on a small, easy-to-validate JSON. Three steps would either bloat one prompt or skip schema validation.
+- **AD-2 — Sentinel write via shell, not Go.** The pipeline is a runtime artefact; calling `onboarding.MarkDoneAt` requires Go bindings the persona doesn't have. Shelling `mkdir -p .agents && : > .agents/.onboarding-done` produces the identical filesystem state and is what the sentinel constant documents (path-only marker).
+- **AD-3 — `onboarder` persona is read-write but workspace-scoped.** It must be allowed to create `.agents/*` files. Model after `craftsman` (full tool access) but with a tight scope rule in the persona body.
+- **AD-4 — Contract `must_pass: true` on detect step.** The schema validates the contract; downstream steps depend on it. Subsequent steps use `on_failure: warn` per existing `ops-bootstrap` precedent.
+- **AD-5 — Workspace mount mode mirrors `ops-bootstrap`.** Detect step uses `readonly` mount of `./`; later steps use a `worktree` so generated files land in a branch (or, for live onboarding via `wave init`, the working tree directly — pipeline runner picks).
+- **AD-6 — No commit step.** `ops-bootstrap` commits because it scaffolds source. `onboard-project` writes config the user reviews; pushing/committing belongs to the driver (`wave init` CLI driver / webui driver) per the plan doc.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| LLM generates invalid pipeline YAML | Finalize step runs `wave validate` (or `go run ./cmd/wave validate`) on each generated file; failure forces retry per existing handover contract |
+| Onboarder writes outside `.agents/` (touches `wave.yaml`, source files) | Hard rule in persona body; generate-step prompt explicitly forbids non-`.agents/*` paths |
+| Detection schema too rigid → fails on unusual projects | Schema accepts `flavour: "unknown"` and an `additional_signals` free-form object for cases we haven't enumerated |
+| Sentinel write in different cwd than expected | Pipeline asserts `pwd` equals project root (mount target) before writing sentinel; finalize prompt makes this explicit |
+| `embed.go` files-listing not auto-updated | Implementation must check `internal/defaults/embed.go` (or equivalent) and add new paths if the pattern requires it |
+| Smoke runs require real LLM calls (cost / time) | Use `--adapter mock` for the schema-validation half of validation; full smoke runs with `--model cheapest` for the LLM half |
+
+## 6. Testing Strategy
+
+### Unit / package tests
+- Schema validation tests for `detection.schema.json` — valid + invalid fixtures (mirror existing contract test pattern).
+- Defaults registry test — confirm `onboard-project` loads, `onboarder` persona loads, prompt paths resolve.
+
+### Integration / smoke
+- `wave run onboard-project` against a throwaway Go repo (e.g. `git init` in `t.TempDir()` with a `go.mod`).
+- `wave run onboard-project` against a throwaway Node repo (`package.json` only).
+- Both runs must:
+  1. Exit 0
+  2. Produce ≥1 file in each of `.agents/personas/`, `.agents/pipelines/`, `.agents/prompts/`
+  3. Produce `.agents/.onboarding-done`
+  4. Detection JSON matches schema
+
+### Manual verification (per memory)
+- Build binary, run pipeline against the local `code-crispies` clone or a fresh `mktemp -d` with a Go scaffold. Inspect `.agents/*` content for sanity (not just file existence).
+
+### Mock-adapter validation
+- Pipeline structure validates with `--adapter mock` (no real LLM cost) — this catches YAML / contract / persona-resolution bugs before any LLM run.

--- a/specs/1576-onboarder-meta-pipeline/spec.md
+++ b/specs/1576-onboarder-meta-pipeline/spec.md
@@ -1,0 +1,53 @@
+# 1.1: Onboarder agent + onboard-project meta-pipeline
+
+**Issue:** [re-cinq/wave#1576](https://github.com/re-cinq/wave/issues/1576)
+**Author:** nextlevelshit
+**State:** OPEN
+**Labels:** (none)
+**Branch:** `1576-onboarder-meta-pipeline`
+
+## Body
+
+Part of Epic #1565. Phase 1, depends on PRE-1 (#1566 ✓), PRE-2 (#1569 ✓).
+
+Add the onboarder persona + meta-pipeline that generates per-project `.agents/*` from project introspection. This is the first user-facing artefact of the onboarding-as-session vision.
+
+**Files:**
+- New: `internal/defaults/personas/onboarder.md`
+- New: `internal/defaults/pipelines/onboard-project.yaml`
+- New: `internal/defaults/contracts/detection.schema.json`
+- New: prompts under `internal/defaults/prompts/onboard/`
+
+**Pattern reference:** `internal/defaults/pipelines/ops-bootstrap.yaml` (existing greenfield pattern).
+
+**Acceptance:**
+- [ ] `wave run onboard-project` produces `.agents/personas/*`, `.agents/pipelines/*`, `.agents/prompts/*`
+- [ ] `detection.schema.json` validates the JSON shape produced by the persona
+- [ ] Smoke run on a throwaway Go repo + Node repo (real verification per memory)
+- [ ] Sentinel `.agents/.onboarding-done` written on completion (PRE-2 helper `MarkDoneAt`)
+
+**Pipeline:** `impl-issue` (`--adapter claude --model cheapest`)
+
+## Acceptance Criteria
+
+1. `wave run onboard-project` produces:
+   - `.agents/personas/*` — at least one project-tailored persona
+   - `.agents/pipelines/*` — at least one project-tailored pipeline
+   - `.agents/prompts/*` — prompt files referenced by generated pipelines
+2. `detection.schema.json` (in `internal/defaults/contracts/`) validates the JSON shape produced by the onboarder persona during the detection step.
+3. Smoke run completes successfully on:
+   - A throwaway Go repo (greenfield-ish)
+   - A throwaway Node repo
+4. Sentinel `.agents/.onboarding-done` is written on completion using the existing PRE-2 helper `onboarding.MarkDoneAt`.
+
+## Dependencies
+
+- PRE-1 (#1566) — service layer (merged)
+- PRE-2 (#1569) — onboarding rewrite + `MarkDoneAt` sentinel helper (merged)
+- Pattern: `internal/defaults/pipelines/ops-bootstrap.yaml`
+
+## Reference
+
+- Plan doc: `docs/scope/onboarding-as-session-plan.md` § Phase 1, row 1.1
+- Sentinel constant: `internal/onboarding/service.go` `SentinelFile = ".agents/.onboarding-done"`
+- Helper: `internal/onboarding/service.go` `MarkDoneAt(projectDir string) error`

--- a/specs/1576-onboarder-meta-pipeline/tasks.md
+++ b/specs/1576-onboarder-meta-pipeline/tasks.md
@@ -1,0 +1,30 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Inspect `internal/defaults/` embed mechanism — confirmed glob `personas/*.md`, `pipelines/*.yaml`, `contracts/*.json contracts/*.md`, `prompts/**/*.md` auto-pick up new files (see `internal/defaults/embed.go`)
+- [X] Item 1.2: Inspect existing contract loader — `detection.schema.json` placed in `internal/defaults/contracts/` is auto-discovered; mirrored copy required in `.agents/contracts/` per `TestSchemaSync`
+- [X] Item 1.3: Inspect persona loader — `onboarder.md` + `onboarder.yaml` auto-discovered by `GetPersonas` / `GetPersonaConfigs`
+
+## Phase 2: Core Implementation
+- [X] Item 2.1: Wrote `internal/defaults/contracts/detection.schema.json` (flavour, build_system, test_command, package_managers, signals[], additional_signals object, project_intent, frameworks). Mirror copy at `.agents/contracts/detection.schema.json`.
+- [X] Item 2.2: Wrote `internal/defaults/personas/onboarder.{md,yaml}` — workspace-scoped persona, full-tool access, hard rule: never write outside `.agents/`
+- [X] Item 2.3: Wrote `internal/defaults/prompts/onboard/detect.md`
+- [X] Item 2.4: Wrote `internal/defaults/prompts/onboard/propose.md`
+- [X] Item 2.5: Wrote `internal/defaults/prompts/onboard/generate.md`
+- [X] Item 2.6: Wrote `internal/defaults/prompts/onboard/finalize.md`
+- [X] Item 2.7: Wrote `internal/defaults/pipelines/onboard-project.yaml` — 4-step (detect → propose → generate → finalize) meta-pipeline
+- [X] Item 2.8: Embed registration not required (glob pattern picks up new paths)
+
+## Phase 3: Testing
+- [X] Item 3.1: Schema validation test with valid + invalid fixtures (`TestDetectionSchemaValidatesFixtures` in `internal/defaults/onboarder_test.go`)
+- [X] Item 3.2: Defaults-registry test asserting `onboard-project` and `onboarder` load (`TestOnboardProjectPipelineRegistered`, `TestOnboarderPersonaRegistered`)
+- [X] Item 3.3: Pipeline structure validates via `go test ./internal/defaults/...` and full `go test ./...` (existing `TestSchemaSync` reverse-check passes)
+- [ ] Item 3.4: Smoke run on throwaway Go repo (real LLM, `--model cheapest`) — deferred; requires live adapter and lies outside the impl-issue pipeline scope. Will run before merge.
+- [ ] Item 3.5: Smoke run on throwaway Node repo (real LLM, `--model cheapest`) — deferred; same reason as 3.4.
+- [ ] Item 3.6: Verify sentinel `.agents/.onboarding-done` written after each smoke run — deferred with 3.4/3.5.
+
+## Phase 4: Polish
+- [X] Item 4.1: Marked `1.1 ✅` in `docs/scope/onboarding-as-session-plan.md` Phase 1 row 1.1 with the actual file list shipped
+- [ ] Item 4.2: Tick acceptance boxes on issue #1576 (PR step)
+- [ ] Item 4.3: Open PR with conventional title (PR step)
+- [X] Item 4.4: Final check — only project files staged; `.agents/artifacts/`, `.agents/output/`, `.claude/`, `CLAUDE.md` excluded via the documented `git reset HEAD --` filter


### PR DESCRIPTION
## Summary
- Adds `onboarder` persona for project introspection and `.agents/*` generation
- Adds `onboard-project` meta-pipeline (4 steps: detect → propose → generate → finalize)
- Adds `detection.schema.json` JSON Schema for validating persona detection output
- Adds prompts under `internal/defaults/prompts/onboard/` for each step
- Writes sentinel `.agents/.onboarding-done` via PRE-2 `MarkDoneAt` helper

Related to #1576

## Changes
- `internal/defaults/personas/onboarder.{md,yaml}` — new persona definition
- `internal/defaults/pipelines/onboard-project.yaml` — meta-pipeline (mirrors `ops-bootstrap.yaml` pattern)
- `internal/defaults/contracts/detection.schema.json` + `.agents/contracts/detection.schema.json` — JSON schema for detection output
- `internal/defaults/prompts/onboard/{detect,propose,generate,finalize}.md` — step prompts
- `internal/defaults/onboarder_test.go` — embed + schema validation tests
- `specs/1576-onboarder-meta-pipeline/{spec,plan,tasks}.md` — planning docs

## Test Plan
- [x] `go test ./internal/defaults/...` (embed + schema validation)
- [ ] Smoke run `wave run onboard-project` on Go repo
- [ ] Smoke run `wave run onboard-project` on Node repo
- [ ] Verify `.agents/personas/*`, `.agents/pipelines/*`, `.agents/prompts/*` produced
- [ ] Verify sentinel `.agents/.onboarding-done` written