### PR TITLE
feat(webui): /preview/* phase A (build tag, fixtures only)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tags: ["", "webui_preview"]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -20,8 +24,41 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run golangci-lint
+      - name: Run golangci-lint (tags=${{ matrix.tags }})
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10
           only-new-issues: true
+          args: --build-tags=${{ matrix.tags }}
+
+  build-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tags: ["", "webui_preview"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build (tags=${{ matrix.tags }})
+        run: go build -tags='${{ matrix.tags }}' ./...
+
+  webui-preview-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run preview smoke tests
+        run: go test -tags=webui_preview ./internal/webui/...

--- a/internal/webui/features.go
+++ b/internal/webui/features.go
@@ -33,6 +33,7 @@ func NewFeatureRegistry() *FeatureRegistry {
 	registerMetrics(r)
 	registerWebhooks(r)
 	registerRetros(r)
+	registerPreview(r)
 	return r
 }
 

--- a/internal/webui/features_default_test.go
+++ b/internal/webui/features_default_test.go
@@ -1,0 +1,29 @@
+//go:build !analytics && !metrics && !webhooks && !retros && !webui_preview
+
+package webui
+
+import "testing"
+
+// TestNewFeatureRegistryDefaultTagsZeroFlags verifies that under default build
+// tags (no optional features) the registry reports every feature as disabled
+// and contributes no route hooks. This locks in the "disabled stubs are no-ops"
+// contract. Gated to default tags only — under any feature tag the matching
+// register<Name> populates flags/routes by design.
+func TestNewFeatureRegistryDefaultTagsZeroFlags(t *testing.T) {
+	r := NewFeatureRegistry()
+	if r.Features.Metrics {
+		t.Error("default registry: Metrics should be false")
+	}
+	if r.Features.Analytics {
+		t.Error("default registry: Analytics should be false")
+	}
+	if r.Features.Webhooks {
+		t.Error("default registry: Webhooks should be false")
+	}
+	if r.Features.Retros {
+		t.Error("default registry: Retros should be false")
+	}
+	if len(r.routeFns) != 0 {
+		t.Errorf("default registry: expected 0 route fns, got %d", len(r.routeFns))
+	}
+}

--- a/internal/webui/features_test.go
+++ b/internal/webui/features_test.go
@@ -14,30 +14,6 @@ func TestNewFeatureRegistryReturnsNonNil(t *testing.T) {
 	}
 }
 
-// TestNewFeatureRegistryDefaultTagsZeroFlags verifies that under default build
-// tags (no optional features) the registry reports every feature as disabled
-// and contributes no route hooks. This locks in the "disabled stubs are no-ops"
-// contract.
-func TestNewFeatureRegistryDefaultTagsZeroFlags(t *testing.T) {
-	r := NewFeatureRegistry()
-	// All flags are wired through build tags; default build = all false.
-	if r.Features.Metrics {
-		t.Error("default registry: Metrics should be false")
-	}
-	if r.Features.Analytics {
-		t.Error("default registry: Analytics should be false")
-	}
-	if r.Features.Webhooks {
-		t.Error("default registry: Webhooks should be false")
-	}
-	if r.Features.Retros {
-		t.Error("default registry: Retros should be false")
-	}
-	if len(r.routeFns) != 0 {
-		t.Errorf("default registry: expected 0 route fns, got %d", len(r.routeFns))
-	}
-}
-
 // TestAddRoutesAccumulates verifies addRoutes appends to routeFns in order.
 func TestAddRoutesAccumulates(t *testing.T) {
 	r := &FeatureRegistry{}

--- a/internal/webui/preview.go
+++ b/internal/webui/preview.go
@@ -1,0 +1,117 @@
+//go:build webui_preview
+
+// Package webui — /preview/* route group (build-tag-gated).
+//
+// Compiled only when -tags=webui_preview is set. Default builds ship zero
+// preview footprint: templates, css, fixtures, handlers, and the route
+// registrar are all behind this tag.
+
+package webui
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"net/http"
+)
+
+//go:embed templates/preview/*.html
+var previewTemplatesFS embed.FS
+
+//go:embed static/preview/style.css
+var previewStaticFS embed.FS
+
+// previewTemplates holds parsed standalone HTML templates keyed by page name
+// (index, onboard, work, work_item, proposal). Each template includes the
+// shared "banner" partial parsed from _banner.html.
+var previewTemplates = parsePreviewTemplates()
+
+// previewPages enumerates the (page-name, template-file) pairs registered
+// under /preview/*. Listed once so registration, parsing, and tests share a
+// single source of truth.
+var previewPages = []struct {
+	name string
+	file string
+}{
+	{"index", "index.html"},
+	{"onboard", "onboard.html"},
+	{"work", "work.html"},
+	{"work_item", "work_item.html"},
+	{"proposal", "proposal.html"},
+}
+
+func parsePreviewTemplates() map[string]*template.Template {
+	bannerData, err := previewTemplatesFS.ReadFile("templates/preview/_banner.html")
+	if err != nil {
+		panic(fmt.Sprintf("preview: read banner: %v", err))
+	}
+	out := make(map[string]*template.Template, len(previewPages))
+	for _, p := range previewPages {
+		t := template.New(p.name)
+		if _, err := t.Parse(string(bannerData)); err != nil {
+			panic(fmt.Sprintf("preview: parse banner for %s: %v", p.name, err))
+		}
+		pageData, err := previewTemplatesFS.ReadFile("templates/preview/" + p.file)
+		if err != nil {
+			panic(fmt.Sprintf("preview: read %s: %v", p.file, err))
+		}
+		if _, err := t.Parse(string(pageData)); err != nil {
+			panic(fmt.Sprintf("preview: parse %s: %v", p.file, err))
+		}
+		out[p.name] = t
+	}
+	return out
+}
+
+func registerPreview(r *FeatureRegistry) {
+	r.addRoutes(func(_ *Server, mux *http.ServeMux) {
+		mux.HandleFunc("GET /preview/{$}", handlePreviewIndex)
+		mux.HandleFunc("GET /preview/onboard", handlePreviewOnboard)
+		mux.HandleFunc("GET /preview/work", handlePreviewWork)
+		mux.HandleFunc("GET /preview/work-item", handlePreviewWorkItem)
+		mux.HandleFunc("GET /preview/proposal", handlePreviewProposal)
+		mux.HandleFunc("GET /preview/static/style.css", handlePreviewCSS)
+	})
+}
+
+func renderPreview(w http.ResponseWriter, name string, data any) {
+	t, ok := previewTemplates[name]
+	if !ok {
+		http.Error(w, "preview template not found: "+name, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := t.Execute(w, data); err != nil {
+		http.Error(w, "preview render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func handlePreviewIndex(w http.ResponseWriter, _ *http.Request) {
+	renderPreview(w, "index", landingFixture)
+}
+
+func handlePreviewOnboard(w http.ResponseWriter, _ *http.Request) {
+	renderPreview(w, "onboard", onboardFixture)
+}
+
+func handlePreviewWork(w http.ResponseWriter, _ *http.Request) {
+	renderPreview(w, "work", workFixture)
+}
+
+func handlePreviewWorkItem(w http.ResponseWriter, _ *http.Request) {
+	renderPreview(w, "work_item", workItemFixture)
+}
+
+func handlePreviewProposal(w http.ResponseWriter, _ *http.Request) {
+	renderPreview(w, "proposal", proposalFixture)
+}
+
+func handlePreviewCSS(w http.ResponseWriter, _ *http.Request) {
+	data, err := previewStaticFS.ReadFile("static/preview/style.css")
+	if err != nil {
+		http.Error(w, "preview css missing", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	_, _ = w.Write(data)
+}

--- a/internal/webui/preview.go
+++ b/internal/webui/preview.go
@@ -24,7 +24,14 @@ var previewStaticFS embed.FS
 // previewTemplates holds parsed standalone HTML templates keyed by page name
 // (index, onboard, work, work_item, proposal). Each template includes the
 // shared "banner" partial parsed from _banner.html.
-var previewTemplates = parsePreviewTemplates()
+var (
+	previewTemplates map[string]*template.Template
+	previewLoadErr   error
+)
+
+func init() {
+	previewTemplates, previewLoadErr = parsePreviewTemplates()
+}
 
 // previewPages enumerates the (page-name, template-file) pairs registered
 // under /preview/*. Listed once so registration, parsing, and tests share a
@@ -40,27 +47,27 @@ var previewPages = []struct {
 	{"proposal", "proposal.html"},
 }
 
-func parsePreviewTemplates() map[string]*template.Template {
+func parsePreviewTemplates() (map[string]*template.Template, error) {
 	bannerData, err := previewTemplatesFS.ReadFile("templates/preview/_banner.html")
 	if err != nil {
-		panic(fmt.Sprintf("preview: read banner: %v", err))
+		return nil, fmt.Errorf("preview: read banner: %w", err)
 	}
 	out := make(map[string]*template.Template, len(previewPages))
 	for _, p := range previewPages {
 		t := template.New(p.name)
 		if _, err := t.Parse(string(bannerData)); err != nil {
-			panic(fmt.Sprintf("preview: parse banner for %s: %v", p.name, err))
+			return nil, fmt.Errorf("preview: parse banner for %s: %w", p.name, err)
 		}
 		pageData, err := previewTemplatesFS.ReadFile("templates/preview/" + p.file)
 		if err != nil {
-			panic(fmt.Sprintf("preview: read %s: %v", p.file, err))
+			return nil, fmt.Errorf("preview: read %s: %w", p.file, err)
 		}
 		if _, err := t.Parse(string(pageData)); err != nil {
-			panic(fmt.Sprintf("preview: parse %s: %v", p.file, err))
+			return nil, fmt.Errorf("preview: parse %s: %w", p.file, err)
 		}
 		out[p.name] = t
 	}
-	return out
+	return out, nil
 }
 
 func registerPreview(r *FeatureRegistry) {
@@ -75,6 +82,10 @@ func registerPreview(r *FeatureRegistry) {
 }
 
 func renderPreview(w http.ResponseWriter, name string, data any) {
+	if previewLoadErr != nil {
+		http.Error(w, "preview templates failed to load: "+previewLoadErr.Error(), http.StatusInternalServerError)
+		return
+	}
 	t, ok := previewTemplates[name]
 	if !ok {
 		http.Error(w, "preview template not found: "+name, http.StatusInternalServerError)

--- a/internal/webui/preview_disabled.go
+++ b/internal/webui/preview_disabled.go
@@ -1,0 +1,5 @@
+//go:build !webui_preview
+
+package webui
+
+func registerPreview(r *FeatureRegistry) {}

--- a/internal/webui/preview_fixtures.go
+++ b/internal/webui/preview_fixtures.go
@@ -1,0 +1,27 @@
+//go:build webui_preview
+
+package webui
+
+// Fixtures for the /preview/* routes. Phase A keeps these as empty typed
+// structs so handler signatures and template binding contracts are explicit;
+// the templates currently render hard-coded HTML inherited from the design
+// mockups. Phase B will populate these structs from real services without
+// changing handler signatures.
+
+type previewLandingFixture struct{}
+
+type previewOnboardFixture struct{}
+
+type previewWorkFixture struct{}
+
+type previewWorkItemFixture struct{}
+
+type previewProposalFixture struct{}
+
+var (
+	landingFixture  = previewLandingFixture{}
+	onboardFixture  = previewOnboardFixture{}
+	workFixture     = previewWorkFixture{}
+	workItemFixture = previewWorkItemFixture{}
+	proposalFixture = previewProposalFixture{}
+)

--- a/internal/webui/preview_test.go
+++ b/internal/webui/preview_test.go
@@ -1,0 +1,87 @@
+//go:build webui_preview
+
+package webui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newPreviewMux constructs an http.ServeMux with /preview/* routes
+// registered via the same FeatureRegistry seam used in production. No
+// *Server is constructed — preview handlers are stateless.
+func newPreviewMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	r := &FeatureRegistry{}
+	registerPreview(r)
+	mux := http.NewServeMux()
+	for _, fn := range r.routeFns {
+		fn(nil, mux)
+	}
+	return mux
+}
+
+func TestPreviewRoutesRespond(t *testing.T) {
+	mux := newPreviewMux(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"index", "/preview/"},
+		{"onboard", "/preview/onboard"},
+		{"work", "/preview/work"},
+		{"work-item", "/preview/work-item"},
+		{"proposal", "/preview/proposal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q, want text/html...", ct)
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, "PREVIEW") {
+				t.Errorf("body missing PREVIEW banner string")
+			}
+			if !strings.Contains(body, "/preview/static/style.css") {
+				t.Errorf("body missing preview stylesheet link")
+			}
+		})
+	}
+}
+
+func TestPreviewCSSRoute(t *testing.T) {
+	mux := newPreviewMux(t)
+	req := httptest.NewRequest(http.MethodGet, "/preview/static/style.css", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/css") {
+		t.Errorf("Content-Type = %q, want text/css...", ct)
+	}
+	if w.Body.Len() == 0 {
+		t.Errorf("css body empty")
+	}
+}
+
+func TestPreviewIndexUnknownTemplate(t *testing.T) {
+	// Guards against regression where renderPreview dispatches by name —
+	// an unknown name must surface a clean 500, not panic.
+	w := httptest.NewRecorder()
+	renderPreview(w, "does-not-exist", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}

--- a/internal/webui/static/preview/style.css
+++ b/internal/webui/static/preview/style.css
@@ -1,0 +1,386 @@
+:root {
+  --bg: #0d1117;
+  --bg-elev: #161b22;
+  --bg-elev-2: #1f2630;
+  --border: #30363d;
+  --border-soft: #21262d;
+  --text: #e6edf3;
+  --text-mute: #8b949e;
+  --text-dim: #6e7681;
+  --accent: #2f81f7;
+  --accent-soft: rgba(47, 129, 247, 0.15);
+  --green: #3fb950;
+  --green-soft: rgba(63, 185, 80, 0.15);
+  --red: #f85149;
+  --red-soft: rgba(248, 81, 73, 0.15);
+  --yellow: #d29922;
+  --yellow-soft: rgba(210, 153, 34, 0.15);
+  --purple: #a371f7;
+  --purple-soft: rgba(163, 113, 247, 0.15);
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre { font-family: var(--mono); font-size: 13px; }
+
+/* Top nav */
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 12px 24px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.nav-brand {
+  font-weight: 700;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.nav-brand svg { width: 20px; height: 20px; }
+.nav-links { display: flex; gap: 4px; flex: 1; }
+.nav-links a {
+  color: var(--text-mute);
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+.nav-links a:hover { color: var(--text); background: var(--bg-elev-2); text-decoration: none; }
+.nav-links a.active { color: var(--text); background: var(--bg-elev-2); }
+.nav-meta { display: flex; gap: 12px; align-items: center; color: var(--text-mute); font-size: 12px; }
+
+/* Layout */
+.container {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px;
+}
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+.page-title { font-size: 22px; font-weight: 600; margin: 0; }
+.page-sub { color: var(--text-mute); font-size: 13px; margin-top: 4px; }
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--sans);
+  cursor: pointer;
+  text-decoration: none;
+}
+.btn:hover { background: var(--bg-elev-2); text-decoration: none; }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: white; }
+.btn-primary:hover { background: #1f6feb; }
+.btn-success { background: var(--green); border-color: var(--green); color: #0d1117; }
+.btn-danger { background: var(--red); border-color: var(--red); color: white; }
+.btn-ghost { background: transparent; }
+.btn svg { width: 14px; height: 14px; }
+
+/* Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+}
+.badge-green { color: var(--green); background: var(--green-soft); border-color: var(--green); }
+.badge-red { color: var(--red); background: var(--red-soft); border-color: var(--red); }
+.badge-yellow { color: var(--yellow); background: var(--yellow-soft); border-color: var(--yellow); }
+.badge-blue { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+.badge-purple { color: var(--purple); background: var(--purple-soft); border-color: var(--purple); }
+.badge-dim { color: var(--text-mute); }
+
+/* Cards */
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+/* Filter bar */
+.filterbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px 16px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px 8px 0 0;
+  border-bottom: none;
+}
+.filterbar select, .filterbar input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--sans);
+}
+.filterbar input[type="search"] { flex: 1; }
+
+/* List */
+.list {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+.list-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto auto auto;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.list-row:last-child { border-bottom: none; }
+.list-row:hover { background: var(--bg-elev-2); }
+.list-icon { color: var(--text-mute); display: flex; align-items: center; }
+.list-icon svg { width: 16px; height: 16px; }
+.list-title { font-weight: 500; color: var(--text); }
+.list-title a { color: inherit; }
+.list-meta { color: var(--text-mute); font-size: 12px; margin-top: 2px; }
+.list-meta span { margin-right: 12px; }
+.list-tags { display: flex; gap: 4px; }
+
+/* Run button on rows */
+.list-actions { display: flex; gap: 6px; }
+
+/* SVG icon helper */
+.icon { width: 14px; height: 14px; vertical-align: -2px; }
+.icon-lg { width: 20px; height: 20px; }
+
+/* Code/diff */
+pre.code-block, pre.diff-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.diff-line-add { background: rgba(63, 185, 80, 0.10); color: var(--green); display: block; }
+.diff-line-del { background: rgba(248, 81, 73, 0.10); color: var(--red); display: block; }
+.diff-line-ctx { color: var(--text-mute); display: block; }
+
+/* Two-column */
+.split {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 24px;
+}
+@media (max-width: 900px) { .split { grid-template-columns: 1fr; } }
+
+.side-card { margin-bottom: 16px; }
+.side-card h3 { margin: 0 0 10px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-mute); font-weight: 600; }
+.side-card dl { margin: 0; display: grid; grid-template-columns: max-content 1fr; gap: 6px 12px; font-size: 13px; }
+.side-card dt { color: var(--text-mute); }
+.side-card dd { margin: 0; }
+
+/* Onboard chat */
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 760px;
+  margin: 0 auto;
+}
+.msg {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+}
+.msg.msg-system { background: transparent; border-style: dashed; }
+.msg.msg-agent { border-left: 3px solid var(--purple); }
+.msg.msg-user { border-left: 3px solid var(--accent); background: var(--bg-elev-2); }
+.msg.msg-prompt { border-left: 3px solid var(--yellow); }
+.msg-avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--bg-elev-2);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--text-mute);
+}
+.msg-avatar svg { width: 16px; height: 16px; }
+.msg-body { min-width: 0; }
+.msg-from { font-size: 12px; color: var(--text-mute); margin-bottom: 4px; font-weight: 500; }
+.msg-from .badge { margin-left: 6px; }
+.msg-content { color: var(--text); }
+.msg-content p:first-child { margin-top: 0; }
+.msg-content p:last-child { margin-bottom: 0; }
+
+.form-row { display: flex; gap: 8px; align-items: center; margin-top: 12px; }
+.form-row label { color: var(--text-mute); font-size: 13px; min-width: 140px; }
+.form-row input, .form-row select {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: var(--sans);
+  font-size: 14px;
+}
+.form-row textarea {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 13px;
+  min-height: 80px;
+}
+.choice-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
+.choice {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  cursor: pointer;
+  font-size: 13px;
+}
+.choice:hover { border-color: var(--accent); }
+.choice strong { display: block; margin-bottom: 2px; }
+.choice .choice-desc { color: var(--text-mute); font-size: 12px; }
+
+/* Stream block */
+.stream {
+  background: var(--bg);
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-mute);
+  margin-top: 8px;
+  max-height: 140px;
+  overflow-y: auto;
+}
+.stream-line { white-space: pre; }
+
+/* Stepper */
+.stepper {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.step-pip {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  color: var(--text-mute);
+}
+.step-pip.done { color: var(--green); border-color: var(--green); }
+.step-pip.active { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+.step-pip svg { width: 12px; height: 12px; }
+.step-sep { color: var(--text-dim); }
+
+/* Signal pills */
+.signal-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+.signal {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+}
+.signal-label { color: var(--text-mute); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.signal-value { font-size: 22px; font-weight: 600; margin-top: 4px; }
+.signal-trend { font-size: 12px; margin-top: 2px; }
+.signal-trend.up { color: var(--green); }
+.signal-trend.down { color: var(--red); }
+
+/* Bindings */
+.binding {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  background: var(--bg);
+}
+.binding-pipeline { font-family: var(--mono); font-size: 13px; }
+.binding-trigger { color: var(--text-mute); font-size: 12px; flex: 1; }
+
+/* Diff stats */
+.diff-stats {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-mute);
+}
+.diff-stats .add { color: var(--green); }
+.diff-stats .del { color: var(--red); }
+
+/* Tabs */
+.tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.tab {
+  padding: 8px 14px;
+  cursor: pointer;
+  color: var(--text-mute);
+  border-bottom: 2px solid transparent;
+  font-size: 13px;
+}
+.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
+/* Empty / hint */
+.hint {
+  padding: 10px 12px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.hint.hint-warn { background: var(--yellow-soft); border-color: var(--yellow); }

--- a/internal/webui/templates/preview/_banner.html
+++ b/internal/webui/templates/preview/_banner.html
@@ -1,0 +1,5 @@
+{{ define "banner" -}}
+<div style="position: sticky; top: 0; z-index: 9999; background: #d29922; color: #0d1117; text-align: center; font-weight: 700; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; padding: 6px 12px; border-bottom: 1px solid #30363d; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">
+  PREVIEW &middot; fixtures only &middot; <code style="color: #0d1117; font-family: ui-monospace, monospace;">/preview/*</code>
+</div>
+{{- end }}

--- a/internal/webui/templates/preview/index.html
+++ b/internal/webui/templates/preview/index.html
@@ -1,0 +1,479 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Wave &mdash; bridge view</title>
+  <link rel="stylesheet" href="/preview/static/style.css" />
+  <style>
+    .hero {
+      padding: 32px 24px;
+      background:
+        radial-gradient(1100px 360px at 20% -10%, rgba(47, 129, 247, 0.18), transparent 60%),
+        radial-gradient(900px 320px at 90% 0%, rgba(163, 113, 247, 0.16), transparent 60%),
+        linear-gradient(180deg, #0d1117 0%, #0d1117 100%);
+      border-bottom: 1px solid var(--border);
+    }
+    .hero-grid {
+      max-width: 1280px; margin: 0 auto;
+      display: grid; grid-template-columns: 1.2fr 1fr; gap: 32px; align-items: end;
+    }
+    @media (max-width: 900px) { .hero-grid { grid-template-columns: 1fr; } }
+    .hero-tag {
+      display: inline-block; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--accent); padding: 4px 10px; border: 1px solid var(--accent); border-radius: 12px;
+      background: var(--accent-soft); margin-bottom: 14px;
+    }
+    .hero-title {
+      font-size: 32px; line-height: 1.15; font-weight: 700; margin: 0 0 12px;
+    }
+    .hero-title em { font-style: normal; color: var(--purple); }
+    .hero-sub { color: var(--text-mute); font-size: 15px; max-width: 560px; line-height: 1.6; }
+    .hero-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-top: 8px; }
+    .hero-stat {
+      background: rgba(22, 27, 34, 0.7); border: 1px solid var(--border); border-radius: 8px;
+      padding: 12px 14px; backdrop-filter: blur(8px);
+    }
+    .hero-stat-label { font-size: 11px; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.06em; }
+    .hero-stat-value { font-size: 22px; font-weight: 600; margin-top: 2px; }
+    .hero-stat-trend { font-size: 12px; margin-top: 2px; color: var(--text-mute); }
+    .hero-stat-trend.up { color: var(--green); }
+    .hero-stat-trend.down { color: var(--red); }
+
+    .grid-three { display: grid; grid-template-columns: 1.4fr 1fr 1fr; gap: 16px; }
+    @media (max-width: 1080px) { .grid-three { grid-template-columns: 1fr; } }
+    .grid-two { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    @media (max-width: 900px) { .grid-two { grid-template-columns: 1fr; } }
+
+    .panel {
+      background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px;
+    }
+    .panel h3 { margin: 0 0 12px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-mute); display: flex; align-items: center; gap: 8px; }
+    .panel h3 svg { width: 14px; height: 14px; }
+    .panel h3 .panel-meta { margin-left: auto; font-size: 11px; color: var(--text-dim); letter-spacing: 0; text-transform: none; }
+
+    .pulse {
+      width: 8px; height: 8px; border-radius: 50%; background: var(--green);
+      box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.7);
+      animation: pulse 1.6s infinite;
+    }
+    @keyframes pulse {
+      0%   { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.6); }
+      100% { box-shadow: 0 0 0 12px rgba(63, 185, 80, 0); }
+    }
+
+    .activity { display: flex; flex-direction: column; gap: 10px; }
+    .activity-item {
+      display: grid; grid-template-columns: 28px 1fr auto; gap: 10px; align-items: center;
+      padding: 8px 10px; background: var(--bg); border: 1px solid var(--border-soft); border-radius: 6px;
+    }
+    .activity-icon { color: var(--text-mute); display: flex; align-items: center; }
+    .activity-icon svg { width: 16px; height: 16px; }
+    .activity-title { font-size: 13px; }
+    .activity-meta { color: var(--text-mute); font-size: 11px; margin-top: 2px; font-family: var(--mono); }
+    .activity-time { color: var(--text-dim); font-size: 11px; font-family: var(--mono); }
+
+    .compare-table {
+      font-size: 12px; width: 100%; border-collapse: collapse; margin-top: 4px;
+    }
+    .compare-table th, .compare-table td {
+      padding: 6px 8px; text-align: left; border-bottom: 1px solid var(--border-soft);
+    }
+    .compare-table th { color: var(--text-mute); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+    .compare-cell { font-family: var(--mono); }
+    .agree { color: var(--green); font-weight: 600; }
+    .disagree { color: var(--yellow); font-weight: 600; }
+
+    .quick-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+    .quick {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 12px; border: 1px solid var(--border); border-radius: 6px;
+      background: var(--bg); cursor: pointer; text-align: left; color: var(--text);
+      font-size: 13px; text-decoration: none;
+    }
+    .quick:hover { border-color: var(--accent); text-decoration: none; }
+    .quick svg { width: 16px; height: 16px; color: var(--accent); flex-shrink: 0; }
+    .quick-desc { display: block; font-size: 11px; color: var(--text-mute); margin-top: 2px; }
+
+    .heat {
+      display: grid; grid-template-columns: repeat(24, 1fr); gap: 2px; margin-top: 4px;
+    }
+    .heat-cell { aspect-ratio: 1; border-radius: 2px; background: var(--border-soft); }
+    .heat-cell.l1 { background: rgba(47, 129, 247, 0.25); }
+    .heat-cell.l2 { background: rgba(47, 129, 247, 0.5); }
+    .heat-cell.l3 { background: rgba(47, 129, 247, 0.75); }
+    .heat-cell.l4 { background: var(--accent); }
+    .heat-legend { display: flex; gap: 8px; margin-top: 6px; align-items: center; font-size: 11px; color: var(--text-mute); }
+
+    .stream-feed {
+      font-family: var(--mono); font-size: 11.5px; max-height: 260px; overflow-y: auto;
+      background: var(--bg); border: 1px solid var(--border-soft); border-radius: 6px;
+      padding: 8px 10px;
+    }
+    .stream-feed .row { display: grid; grid-template-columns: 70px auto 1fr; gap: 8px; padding: 2px 0; }
+    .stream-feed .t { color: var(--text-dim); }
+    .stream-feed .src { color: var(--purple); }
+    .stream-feed .src.b { color: var(--accent); }
+    .stream-feed .src.g { color: var(--green); }
+    .stream-feed .src.r { color: var(--red); }
+    .stream-feed .src.y { color: var(--yellow); }
+
+    .principles {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 24px;
+    }
+    @media (max-width: 900px) { .principles { grid-template-columns: 1fr; } }
+    .principle { background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; }
+    .principle-label { font-size: 11px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.08em; }
+    .principle-title { font-size: 14px; font-weight: 600; margin: 4px 0 6px; }
+    .principle-body { font-size: 12.5px; color: var(--text-mute); line-height: 1.55; }
+  </style>
+</head>
+<body>
+  {{ template "banner" . }}
+  <nav class="nav">
+    <div class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/><path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/></svg>
+      Wave
+    </div>
+    <div class="nav-links">
+      <a href="#" class="active">Bridge</a>
+      <a href="/preview/work">Work</a>
+      <a href="#">Schedules</a>
+      <a href="#">Proposals <span class="badge badge-yellow" style="font-size: 10px; padding: 1px 6px; margin-left: 2px;">2</span></a>
+      <a href="#">Runs</a>
+      <a href="#" style="color: var(--text-dim);">Admin</a>
+    </div>
+    <div class="nav-meta">
+      <span><span class="pulse" style="display: inline-block; vertical-align: middle; margin-right: 6px;"></span>3 in flight</span>
+      <span>code-crispies</span>
+      <span>git.librete.ch</span>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="hero-grid">
+      <div>
+        <span class="hero-tag">the agentic kit</span>
+        <h1 class="hero-title">Scaffold a <em>software factory</em>, then watch it build.</h1>
+        <p class="hero-sub">
+          Wave tailors itself to your repository, hides the orchestration, and gives you the bridge view.
+          Strong standards, low-friction entry, and a clear sense of what every agent in the fleet is doing.
+        </p>
+      </div>
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <div class="hero-stat-label">In flight</div>
+          <div class="hero-stat-value">3</div>
+          <div class="hero-stat-trend">2 implement &middot; 1 review</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">Today</div>
+          <div class="hero-stat-value">17</div>
+          <div class="hero-stat-trend up">+4 vs yesterday</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">Spend</div>
+          <div class="hero-stat-value">$2.41</div>
+          <div class="hero-stat-trend">of $10.00 cap</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">Judge avg</div>
+          <div class="hero-stat-value">0.87</div>
+          <div class="hero-stat-trend down">&minus;0.04 7d</div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <div class="container">
+
+    <div class="grid-three" style="margin-bottom: 16px;">
+
+      <section class="panel">
+        <h3>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+          live activity
+          <span class="panel-meta">last 5 min</span>
+        </h3>
+        <div class="stream-feed">
+          <div class="row"><span class="t">14:22:04</span><span class="src g">impl-issue</span><span>step <code>verify</code> &mdash; bun test &middot; 142 tests passed in 8.4s</span></div>
+          <div class="row"><span class="t">14:22:01</span><span class="src">scope</span><span>step <code>decompose</code> &mdash; 5 child issues drafted</span></div>
+          <div class="row"><span class="t">14:21:58</span><span class="src b">pr-review</span><span>step <code>analyze</code> &mdash; 0 blocking, 3 suggestions</span></div>
+          <div class="row"><span class="t">14:21:50</span><span class="src y">pipeline-evolve</span><span>signal accumulated &mdash; 9 of 10 runs evaluated</span></div>
+          <div class="row"><span class="t">14:21:44</span><span class="src g">impl-issue</span><span>step <code>implement</code> &mdash; 12 files modified</span></div>
+          <div class="row"><span class="t">14:21:32</span><span class="src">scope</span><span>step <code>fetch</code> &mdash; issue #138 retrieved</span></div>
+          <div class="row"><span class="t">14:21:28</span><span class="src b">pr-review</span><span>step <code>fetch</code> &mdash; PR !58 retrieved</span></div>
+          <div class="row"><span class="t">14:21:14</span><span class="src g">impl-issue</span><span>contract <code>typecheck</code> &mdash; passed</span></div>
+          <div class="row"><span class="t">14:21:01</span><span class="src">scheduler</span><span>nightly auto-impl &mdash; armed for 02:00 (in 11h 39m)</span></div>
+          <div class="row"><span class="t">14:20:48</span><span class="src g">impl-issue</span><span>step <code>plan</code> &mdash; 4-step plan accepted</span></div>
+          <div class="row"><span class="t">14:20:32</span><span class="src r">impl-issue</span><span>contract <code>tests_pass</code> &mdash; rework triggered (1/2)</span></div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" /><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" /></svg>
+          discover
+        </h3>
+        <div class="quick-grid">
+          <a href="/preview/work" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /></svg>
+            <span>23 open work items <span class="quick-desc">issues + PRs</span></span>
+          </a>
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20" /><path d="M2 12h20" /></svg>
+            <span>3 stale branches <span class="quick-desc">no activity 7d+</span></span>
+          </a>
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12" /></svg>
+            <span>4 health hints <span class="quick-desc">lint + dep advisories</span></span>
+          </a>
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+            <span>1 budget warning <span class="quick-desc">impl-issue trending high</span></span>
+          </a>
+        </div>
+
+        <h3 style="margin-top: 18px;">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" /></svg>
+          start
+        </h3>
+        <div class="quick-grid">
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+            <span>Run on issue <span class="quick-desc">work-board picker</span></span>
+          </a>
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+            <span>Schedule sweep <span class="quick-desc">nightly auto-impl</span></span>
+          </a>
+          <a href="#" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" /></svg>
+            <span>Audit security <span class="quick-desc">multi-model (preview)</span></span>
+          </a>
+          <a href="/preview/proposal" class="quick">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+            <span>Review proposals <span class="quick-desc">2 awaiting</span></span>
+          </a>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="6" y1="3" x2="6" y2="15" /><circle cx="18" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><path d="M18 9a9 9 0 0 1-9 9" /></svg>
+          compare
+          <span class="panel-meta">multi-model run</span>
+        </h3>
+        <p style="font-size: 12px; color: var(--text-mute); margin: 0 0 8px;">
+          Audit run on PR !58, fan-out across three providers. Agreement = signal.
+        </p>
+        <table class="compare-table">
+          <thead>
+            <tr>
+              <th>finding</th>
+              <th>claude</th>
+              <th>opencode</th>
+              <th>gemini</th>
+              <th>verdict</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>SQL injection in <code>query.ts</code></td>
+              <td class="compare-cell">flag</td>
+              <td class="compare-cell">flag</td>
+              <td class="compare-cell">flag</td>
+              <td><span class="agree">3 / 3</span></td>
+            </tr>
+            <tr>
+              <td>missing rate limit on <code>/api</code></td>
+              <td class="compare-cell">flag</td>
+              <td class="compare-cell">flag</td>
+              <td class="compare-cell">&mdash;</td>
+              <td><span class="disagree">2 / 3</span></td>
+            </tr>
+            <tr>
+              <td>weak entropy in token id</td>
+              <td class="compare-cell">flag</td>
+              <td class="compare-cell">&mdash;</td>
+              <td class="compare-cell">&mdash;</td>
+              <td><span class="badge badge-dim">1 / 3</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <div style="font-size: 12px; color: var(--text-mute); margin-top: 10px;">
+          <a href="#">show full diff &amp; reasoning &rarr;</a>
+        </div>
+        <div style="margin-top: 14px; font-size: 11px; color: var(--text-dim); border-top: 1px dashed var(--border); padding-top: 10px;">
+          <strong style="color: var(--text-mute);">future:</strong> automatic cross-model verification on every security audit. Quasi-reliability through model diversity.
+        </div>
+      </section>
+
+    </div>
+
+    <div class="grid-two" style="margin-bottom: 16px;">
+
+      <section class="panel">
+        <h3>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" /></svg>
+          in flight
+          <span class="panel-meta">3 active</span>
+        </h3>
+        <div class="activity">
+          <div class="activity-item">
+            <div class="activity-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg></div>
+            <div>
+              <div class="activity-title">impl-issue &middot; #142 column-type inference</div>
+              <div class="activity-meta">step 3/5 &middot; implement &middot; r/3a8c91 &middot; budget $0.18 / $0.50</div>
+            </div>
+            <span class="badge badge-blue">running</span>
+          </div>
+          <div class="activity-item">
+            <div class="activity-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg></div>
+            <div>
+              <div class="activity-title">scope &middot; #138 plugin system epic</div>
+              <div class="activity-meta">step 2/3 &middot; decompose &middot; r/4d2c10</div>
+            </div>
+            <span class="badge badge-blue">running</span>
+          </div>
+          <div class="activity-item">
+            <div class="activity-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg></div>
+            <div>
+              <div class="activity-title">pr-review &middot; !58 streaming refactor</div>
+              <div class="activity-meta">step 4/4 &middot; comment &middot; r/8e9f23</div>
+            </div>
+            <span class="badge badge-blue">running</span>
+          </div>
+          <div class="activity-item" style="opacity: 0.6;">
+            <div class="activity-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg></div>
+            <div>
+              <div class="activity-title">scheduled &middot; nightly auto-impl sweep</div>
+              <div class="activity-meta">fires in 11h 39m &middot; cron 0 2 * * * &middot; label:auto-impl</div>
+            </div>
+            <span class="badge badge-dim">queued</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h3>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-9-9c2.5 0 4.7 1 6.4 2.6L21 8" /><polyline points="21 3 21 8 16 8" /></svg>
+          rhythm
+          <span class="panel-meta">last 24h</span>
+        </h3>
+        <div class="heat">
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell"></div>
+          <div class="heat-cell l1"></div>
+          <div class="heat-cell l2"></div>
+          <div class="heat-cell l4"></div>
+          <div class="heat-cell l3"></div>
+          <div class="heat-cell l2"></div>
+          <div class="heat-cell l1"></div>
+          <div class="heat-cell l3"></div>
+          <div class="heat-cell l4"></div>
+          <div class="heat-cell l4"></div>
+          <div class="heat-cell l3"></div>
+          <div class="heat-cell l2"></div>
+          <div class="heat-cell l1"></div>
+          <div class="heat-cell l2"></div>
+          <div class="heat-cell l3"></div>
+          <div class="heat-cell l1"></div>
+          <div class="heat-cell"></div>
+        </div>
+        <div class="heat-legend">
+          <span>00:00</span>
+          <span style="flex: 1;"></span>
+          <span>now</span>
+          <span style="flex: 1;"></span>
+          <span style="display: flex; gap: 2px; align-items: center;">less <span class="heat-cell" style="width: 10px; height: 10px;"></span> <span class="heat-cell l1" style="width: 10px; height: 10px;"></span> <span class="heat-cell l2" style="width: 10px; height: 10px;"></span> <span class="heat-cell l3" style="width: 10px; height: 10px;"></span> <span class="heat-cell l4" style="width: 10px; height: 10px;"></span> more</span>
+        </div>
+
+        <h3 style="margin-top: 18px;">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12" /></svg>
+          judge trend
+          <span class="panel-meta">last 30 runs &middot; impl-issue</span>
+        </h3>
+        <div style="font-family: var(--mono); font-size: 18px; color: var(--text);">
+          0.91 &rarr; 0.78 <span style="color: var(--red); font-size: 13px;">&minus;0.13</span>
+        </div>
+        <div style="font-size: 12px; color: var(--text-mute); margin-top: 6px;">
+          drift threshold crossed. proposal #7 awaiting your call.
+        </div>
+        <div style="margin-top: 10px;">
+          <a href="/preview/proposal" class="btn">Review proposal &rarr;</a>
+        </div>
+      </section>
+
+    </div>
+
+    <section class="panel" style="margin-bottom: 16px;">
+      <h3>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg>
+        recent landings
+        <span class="panel-meta">today</span>
+      </h3>
+      <div class="list" style="border: none; border-radius: 0;">
+        <div class="list-row" style="grid-template-columns: 28px 1fr auto auto auto; padding: 10px 0;">
+          <div class="list-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="18" r="3" /><path d="M6 9v6" /><path d="M18 6h-3a3 3 0 0 0-3 3v9" /></svg></div>
+          <div>
+            <div class="list-title">PR !57 &mdash; fix Cargo.toml mis-detection</div>
+            <div class="list-meta"><span>impl-issue &middot; merged 38m ago</span></div>
+          </div>
+          <span class="badge badge-green">merged</span>
+          <span class="badge badge-dim">judge 0.94</span>
+          <a href="#" class="btn">View</a>
+        </div>
+        <div class="list-row" style="grid-template-columns: 28px 1fr auto auto auto; padding: 10px 0;">
+          <div class="list-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="18" r="3" /><path d="M6 9v6" /><path d="M18 6h-3a3 3 0 0 0-3 3v9" /></svg></div>
+          <div>
+            <div class="list-title">PR !56 &mdash; biome integration in CI</div>
+            <div class="list-meta"><span>impl-issue &middot; merged 2h ago</span></div>
+          </div>
+          <span class="badge badge-green">merged</span>
+          <span class="badge badge-dim">judge 0.89</span>
+          <a href="#" class="btn">View</a>
+        </div>
+        <div class="list-row" style="grid-template-columns: 28px 1fr auto auto auto; padding: 10px 0;">
+          <div class="list-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="20 6 9 17 4 12" /></svg></div>
+          <div>
+            <div class="list-title">scope &middot; #135 monorepo extraction</div>
+            <div class="list-meta"><span>4 child issues filed &middot; 4h ago</span></div>
+          </div>
+          <span class="badge badge-blue">scoped</span>
+          <span class="badge badge-dim">$0.07</span>
+          <a href="#" class="btn">View</a>
+        </div>
+      </div>
+    </section>
+
+    <div class="principles">
+      <div class="principle">
+        <div class="principle-label">erhabenheit</div>
+        <div class="principle-title">A bridge view, not a dashboard.</div>
+        <div class="principle-body">You see fleet health, in-flight work, and recent landings at a glance. No hunting in nested menus.</div>
+      </div>
+      <div class="principle">
+        <div class="principle-label">kontrolle</div>
+        <div class="principle-title">Strong standards, soft surface.</div>
+        <div class="principle-body">Generated pipelines are APP-clean. Contracts gate every step. You approve evolutions; you can lock pipelines you've tuned.</div>
+      </div>
+      <div class="principle">
+        <div class="principle-label">weitsicht</div>
+        <div class="principle-title">Always something to start, discover, or compare.</div>
+        <div class="principle-body">Run pipelines in parallel across models. Agreement is your reliability signal. Drift triggers a proposal before failure does.</div>
+      </div>
+    </div>
+
+    <div style="margin-top: 32px; text-align: center; color: var(--text-mute); font-size: 13px;">
+      <a href="/preview/">&larr; index</a> &middot; <a href="/preview/onboard">onboarding</a> &middot; <a href="/preview/work">work board</a> &middot; <a href="/preview/work-item">work item</a> &middot; <a href="/preview/proposal">proposal</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/internal/webui/templates/preview/onboard.html
+++ b/internal/webui/templates/preview/onboard.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Onboarding session — Wave mockup</title>
+  <link rel="stylesheet" href="/preview/static/style.css" />
+</head>
+<body>
+  {{ template "banner" . }}
+  <nav class="nav">
+    <div class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/><path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/></svg>
+      Wave
+    </div>
+    <div class="nav-links">
+      <a href="#" class="active">Onboarding</a>
+    </div>
+    <div class="nav-meta">
+      <span>code-crispies</span>
+      <span>git.librete.ch</span>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div class="page-header">
+      <div>
+        <h1 class="page-title">Setting up Wave for this project</h1>
+        <div class="page-sub">An agent is inspecting your repo and tailoring pipelines, personas, and prompts to it. Answer questions when prompted.</div>
+      </div>
+      <div style="display: flex; gap: 8px;">
+        <button class="btn btn-ghost"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9" /><path d="M3 4v5h5" /></svg> Restart</button>
+        <button class="btn"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="6" width="12" height="12" /></svg> Abort</button>
+      </div>
+    </div>
+
+    <div class="stepper">
+      <span class="step-pip done"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12" /></svg> detect</span>
+      <span class="step-sep">&rarr;</span>
+      <span class="step-pip done"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12" /></svg> inspect</span>
+      <span class="step-sep">&rarr;</span>
+      <span class="step-pip active">propose</span>
+      <span class="step-sep">&rarr;</span>
+      <span class="step-pip">scaffold</span>
+      <span class="step-sep">&rarr;</span>
+      <span class="step-pip">smoke-test</span>
+      <span class="step-sep">&rarr;</span>
+      <span class="step-pip">commit</span>
+    </div>
+
+    <div class="chat">
+
+      <div class="msg msg-system">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">session started <span class="badge badge-dim">run a3f7c2</span> <span class="badge badge-dim">claude opus-4-7</span></div>
+          <div class="msg-content">Workspace: <code>/workspaces/code-crispies</code> &middot; Forge: <strong>gitea</strong> (git.librete.ch) &middot; Detected language: <strong>Bun + TypeScript</strong></div>
+        </div>
+      </div>
+
+      <div class="msg msg-agent">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11.5a3 3 0 1 0 6 0V8a3 3 0 1 0-6 0z" /><path d="M5 19a7 7 0 0 1 14 0" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">onboarder <span class="badge badge-purple">agent</span></div>
+          <div class="msg-content">
+            <p>Found a Bun + TypeScript monorepo. <code>package.json</code> declares Vitest. <code>biome.json</code> configures lint+format. CI runs on Gitea Actions.</p>
+            <p>I'll propose:</p>
+            <ul>
+              <li><code>impl-issue</code> &mdash; bun test, biome check, type-check, opens PR via tea CLI</li>
+              <li><code>scope</code> &mdash; epic decomposition into child issues</li>
+              <li><code>pr-review</code> &mdash; lint + tests + diff review on PRs</li>
+              <li><code>ops-bootstrap</code> not needed (project already scaffolded)</li>
+            </ul>
+            <p>Question before I write files:</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="msg msg-prompt">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">your input needed</div>
+          <div class="msg-content">
+            <strong>How strict should the contract gate be on lint failures?</strong>
+            <div class="choice-grid">
+              <label class="choice">
+                <input type="radio" name="gate" /> <strong>Hard fail</strong>
+                <div class="choice-desc">Pipeline aborts. PR not opened.</div>
+              </label>
+              <label class="choice">
+                <input type="radio" name="gate" checked /> <strong>Rework</strong>
+                <div class="choice-desc">Send findings back to craftsman, retry up to 2&times;.</div>
+              </label>
+              <label class="choice">
+                <input type="radio" name="gate" /> <strong>Warn only</strong>
+                <div class="choice-desc">Log issue, open PR anyway. Reviewer decides.</div>
+              </label>
+              <label class="choice">
+                <input type="radio" name="gate" /> <strong>Skip lint</strong>
+                <div class="choice-desc">Don't run biome in pipeline.</div>
+              </label>
+            </div>
+            <div style="margin-top: 12px; display: flex; gap: 8px;">
+              <button class="btn btn-primary">Submit</button>
+              <button class="btn btn-ghost">Skip &amp; use default</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="msg msg-user">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">you</div>
+          <div class="msg-content">Rework, max 2 attempts. Don't bother me about lint, fix it.</div>
+        </div>
+      </div>
+
+      <div class="msg msg-agent">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11.5a3 3 0 1 0 6 0V8a3 3 0 1 0-6 0z" /><path d="M5 19a7 7 0 0 1 14 0" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">onboarder <span class="badge badge-purple">agent</span> <span class="badge badge-dim">writing files</span></div>
+          <div class="msg-content">
+            <p>Writing pipelines now.</p>
+            <div class="stream">
+<span class="stream-line">[propose] wrote .agents/pipelines/impl-issue.yaml      (+98 lines)</span>
+<span class="stream-line">[propose] wrote .agents/pipelines/scope.yaml           (+42 lines)</span>
+<span class="stream-line">[propose] wrote .agents/pipelines/pr-review.yaml       (+71 lines)</span>
+<span class="stream-line">[propose] wrote .agents/personas/craftsman.md          (+24 lines)</span>
+<span class="stream-line">[propose] wrote .agents/personas/reviewer.md           (+19 lines)</span>
+<span class="stream-line">[propose] wrote .agents/contracts/impl-issue.json      (+34 lines)</span>
+<span class="stream-line">[validate] running `wave validate` ...</span>
+<span class="stream-line">[validate] ok &mdash; 3 pipelines pass APP load-time checks</span>
+<span class="stream-line">[smoke] running impl-issue --dry-run on issue #12 ...</span>
+<span class="stream-line">[smoke] ok &mdash; dry-run produced valid plan artifact</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="msg msg-prompt">
+        <div class="msg-avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" /></svg></div>
+        <div class="msg-body">
+          <div class="msg-from">your input needed</div>
+          <div class="msg-content">
+            <strong>Recurring runs?</strong>
+            <p style="color: var(--text-mute); font-size: 13px; margin-top: 6px;">I can schedule pipelines to fire on triggers. Pick what makes sense.</p>
+            <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 10px;">
+              <label style="display: flex; align-items: center; gap: 8px;"><input type="checkbox" checked /> <code>scope</code> on every new issue with label <code>epic</code></label>
+              <label style="display: flex; align-items: center; gap: 8px;"><input type="checkbox" checked /> <code>pr-review</code> on every new PR</label>
+              <label style="display: flex; align-items: center; gap: 8px;"><input type="checkbox" /> <code>impl-issue</code> nightly on issues labeled <code>auto-impl</code></label>
+              <label style="display: flex; align-items: center; gap: 8px;"><input type="checkbox" /> Custom &mdash; configure later</label>
+            </div>
+            <div style="margin-top: 12px;"><button class="btn btn-primary">Save &amp; continue</button></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <div style="margin-top: 32px; text-align: center; color: var(--text-mute); font-size: 13px;">
+      <a href="/preview/">&larr; index</a> &middot; <a href="/preview/work">next: work board &rarr;</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/internal/webui/templates/preview/proposal.html
+++ b/internal/webui/templates/preview/proposal.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Evolution proposal &mdash; Wave mockup</title>
+  <link rel="stylesheet" href="/preview/static/style.css" />
+</head>
+<body>
+  {{ template "banner" . }}
+  <nav class="nav">
+    <div class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/><path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/></svg>
+      Wave
+    </div>
+    <div class="nav-links">
+      <a href="/preview/work">Work</a>
+      <a href="#">Schedules</a>
+      <a href="#" class="active">Proposals <span class="badge badge-yellow" style="font-size: 10px; padding: 1px 6px; margin-left: 2px;">2</span></a>
+      <a href="#">Runs</a>
+    </div>
+    <div class="nav-meta">
+      <span>code-crispies</span>
+      <span>git.librete.ch</span>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div style="color: var(--text-mute); font-size: 13px; margin-bottom: 8px;">
+      <a href="#">Proposals</a> &rsaquo; <span>#7</span>
+    </div>
+
+    <div class="page-header" style="align-items: flex-start;">
+      <div>
+        <h1 class="page-title">Tighten <code>impl-issue</code> contract: enforce type-coverage threshold</h1>
+        <div class="page-sub" style="display: flex; gap: 12px; align-items: center; margin-top: 6px;">
+          <span class="badge badge-yellow"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg> awaiting approval</span>
+          <span>proposed 6m ago by <code>pipeline-evolve</code></span>
+          <span>pipeline: <code>impl-issue</code></span>
+          <span>v3 &rarr; v4</span>
+        </div>
+      </div>
+      <div style="display: flex; gap: 8px;">
+        <button class="btn btn-success"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg> Approve &amp; activate</button>
+        <button class="btn btn-danger"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg> Reject</button>
+        <button class="btn"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg></button>
+      </div>
+    </div>
+
+    <div class="hint">
+      Why this proposal: judge score on <code>impl-issue</code> dropped from 0.91 (last 30d) to 0.78 (last 10d). Top failure class: <code>contract_failure</code> citing missing type annotations on new code. Evolution agent suggests tightening the test-suite contract to block PRs without type coverage &ge; 85% on changed files.
+    </div>
+
+    <div class="split">
+      <div>
+
+        <div class="tabs">
+          <div class="tab active">Diff</div>
+          <div class="tab">Signal log</div>
+          <div class="tab">Validation</div>
+          <div class="tab">Replay (last 10 runs vs new)</div>
+        </div>
+
+        <h3 style="font-size: 13px; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.04em;">.agents/pipelines/impl-issue.yaml</h3>
+        <pre class="diff-block"><span class="diff-line-ctx">@@ -47,9 +47,16 @@ steps:</span>
+<span class="diff-line-ctx">  - id: implement</span>
+<span class="diff-line-ctx">    persona: craftsman</span>
+<span class="diff-line-ctx">    handover:</span>
+<span class="diff-line-ctx">      contract:</span>
+<span class="diff-line-del">-       type: test_suite</span>
+<span class="diff-line-del">-       command: bun test</span>
+<span class="diff-line-del">-       must_pass: true</span>
+<span class="diff-line-del">-       on_failure: rework</span>
+<span class="diff-line-del">-       rework_step: implement</span>
+<span class="diff-line-add">+       type: test_suite</span>
+<span class="diff-line-add">+       command: bun test &amp;&amp; bun run typecheck</span>
+<span class="diff-line-add">+       must_pass: true</span>
+<span class="diff-line-add">+       on_failure: rework</span>
+<span class="diff-line-add">+       rework_step: implement</span>
+<span class="diff-line-add">+       criteria:</span>
+<span class="diff-line-add">+         - id: type_coverage</span>
+<span class="diff-line-add">+           description: "&ge;85% of changed lines carry explicit types"</span>
+<span class="diff-line-add">+           threshold: 0.85</span>
+</pre>
+
+        <h3 style="font-size: 13px; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 24px;">.agents/contracts/impl-issue.json</h3>
+        <pre class="diff-block"><span class="diff-line-ctx">@@ -12,6 +12,7 @@</span>
+<span class="diff-line-ctx">   "criteria": [</span>
+<span class="diff-line-ctx">     {"id": "tests_pass", "weight": 0.5},</span>
+<span class="diff-line-del">-    {"id": "lint_clean", "weight": 0.5}</span>
+<span class="diff-line-add">+    {"id": "lint_clean", "weight": 0.3},</span>
+<span class="diff-line-add">+    {"id": "type_coverage", "weight": 0.2}</span>
+<span class="diff-line-ctx">   ]</span>
+<span class="diff-line-ctx"> }</span>
+</pre>
+
+        <p class="diff-stats" style="margin-top: 16px;">
+          2 files changed &middot;
+          <span class="add">+11</span>
+          <span class="del">-6</span>
+        </p>
+
+        <h3 style="font-size: 13px; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 32px;">Replay forecast</h3>
+        <p style="font-size: 13px; color: var(--text-mute);">If activated, the last 10 runs would have re-classified as:</p>
+        <div class="signal-list">
+          <div class="signal">
+            <div class="signal-label">Would-pass (was pass)</div>
+            <div class="signal-value">7</div>
+            <div class="signal-trend">unchanged</div>
+          </div>
+          <div class="signal">
+            <div class="signal-label">Would-fail (was pass)</div>
+            <div class="signal-value">2</div>
+            <div class="signal-trend down">stricter gate caught regression</div>
+          </div>
+          <div class="signal">
+            <div class="signal-label">Would-pass (was fail)</div>
+            <div class="signal-value">1</div>
+            <div class="signal-trend up">noise reduced</div>
+          </div>
+        </div>
+
+      </div>
+
+      <aside>
+        <div class="side-card card">
+          <h3>Trigger signals</h3>
+          <div class="signal-list" style="grid-template-columns: 1fr 1fr;">
+            <div class="signal">
+              <div class="signal-label">Judge score</div>
+              <div class="signal-value">0.78</div>
+              <div class="signal-trend down">&minus;0.13 vs prior</div>
+            </div>
+            <div class="signal">
+              <div class="signal-label">Retry rate</div>
+              <div class="signal-value">38%</div>
+              <div class="signal-trend down">+22pp</div>
+            </div>
+            <div class="signal">
+              <div class="signal-label">Top failure</div>
+              <div class="signal-value" style="font-size: 14px; line-height: 1.3;">contract_failure</div>
+              <div class="signal-trend">6 of last 10 runs</div>
+            </div>
+            <div class="signal">
+              <div class="signal-label">Avg cost</div>
+              <div class="signal-value">$0.21</div>
+              <div class="signal-trend down">+$0.05 due to retries</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="side-card card">
+          <h3>Version</h3>
+          <dl>
+            <dt>Current</dt><dd>v3 (active)</dd>
+            <dt>Proposed</dt><dd>v4</dd>
+            <dt>Approver</dt><dd>&mdash;</dd>
+            <dt>Auto-rollback</dt><dd>if next 3 runs &lt; 0.70</dd>
+          </dl>
+        </div>
+
+        <div class="side-card card">
+          <h3>Generated by</h3>
+          <dl>
+            <dt>Pipeline</dt><dd><code>pipeline-evolve</code></dd>
+            <dt>Run</dt><dd><a href="#"><code>r/9c2e3a</code></a></dd>
+            <dt>Adapter</dt><dd>claude / sonnet-4-6</dd>
+            <dt>Cost</dt><dd>$0.06</dd>
+          </dl>
+        </div>
+
+        <div class="side-card card">
+          <h3>Related proposals</h3>
+          <ul style="padding-left: 18px; margin: 0; font-size: 13px;">
+            <li><a href="#">#5 &mdash; tighten <code>scope</code> child issue cap</a></li>
+            <li><a href="#">#3 &mdash; switch <code>research</code> to gemini for cost</a></li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+
+    <div style="margin-top: 32px; text-align: center; color: var(--text-mute); font-size: 13px;">
+      <a href="/preview/work-item">&larr; work item</a> &middot; <a href="/preview/">back to index</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/internal/webui/templates/preview/work.html
+++ b/internal/webui/templates/preview/work.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Work board &mdash; Wave mockup</title>
+  <link rel="stylesheet" href="/preview/static/style.css" />
+</head>
+<body>
+  {{ template "banner" . }}
+  <nav class="nav">
+    <div class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/><path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/></svg>
+      Wave
+    </div>
+    <div class="nav-links">
+      <a href="#" class="active">Work</a>
+      <a href="#">Schedules</a>
+      <a href="#">Proposals <span class="badge badge-yellow" style="font-size: 10px; padding: 1px 6px; margin-left: 2px;">2</span></a>
+      <a href="#">Runs</a>
+      <a href="#" style="color: var(--text-dim);">Admin</a>
+    </div>
+    <div class="nav-meta">
+      <span>code-crispies</span>
+      <span>git.librete.ch</span>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div class="page-header">
+      <div>
+        <h1 class="page-title">Work</h1>
+        <div class="page-sub">Issues, PRs, and scheduled tasks across connected forges. Click any item to dispatch a pipeline.</div>
+      </div>
+      <div style="display: flex; gap: 8px;">
+        <button class="btn"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9" /><path d="M3 4v5h5" /></svg> Refresh</button>
+        <button class="btn btn-primary"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg> New work</button>
+      </div>
+    </div>
+
+    <div class="filterbar">
+      <select>
+        <option>All forges</option>
+        <option>gitea: code-crispies</option>
+        <option>github: re-cinq/mp</option>
+      </select>
+      <select>
+        <option>All kinds</option>
+        <option>Issues only</option>
+        <option>PRs only</option>
+        <option>Scheduled tasks</option>
+      </select>
+      <select>
+        <option>Open</option>
+        <option>All</option>
+        <option>Closed</option>
+      </select>
+      <select>
+        <option>Any label</option>
+        <option>bug</option>
+        <option>epic</option>
+        <option>auto-impl</option>
+      </select>
+      <input type="search" placeholder="Search title or body..." />
+    </div>
+
+    <div class="list">
+
+      <div class="list-row">
+        <div class="list-icon" title="Open issue">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="/preview/work-item">Add CSV column-type inference for numeric vs string fields</a> <span class="badge badge-dim">#142</span></div>
+          <div class="list-meta">
+            <span>gitea / code-crispies</span>
+            <span>opened 2h ago by <strong>mwc</strong></span>
+            <span class="list-tags">
+              <span class="badge badge-blue">enhancement</span>
+              <span class="badge badge-purple">parser</span>
+            </span>
+          </div>
+        </div>
+        <div class="badge badge-dim">issue</div>
+        <div class="badge badge-dim" title="Estimated cost"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg> ~$0.18</div>
+        <div class="list-actions">
+          <a href="/preview/work-item" class="btn btn-primary"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg> Run</a>
+        </div>
+      </div>
+
+      <div class="list-row">
+        <div class="list-icon" title="Open PR">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="18" r="3" /><path d="M6 9v6" /><path d="M18 6h-3a3 3 0 0 0-3 3v9" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="#">Refactor row iterator to support streaming over chunked input</a> <span class="badge badge-dim">!58</span></div>
+          <div class="list-meta">
+            <span>gitea / code-crispies</span>
+            <span>updated 11m ago by <strong>onboarder@wave</strong></span>
+            <span class="list-tags">
+              <span class="badge badge-yellow">needs review</span>
+              <span class="badge badge-dim">+342 / -118</span>
+            </span>
+          </div>
+        </div>
+        <div class="badge badge-dim">PR</div>
+        <div><span class="badge badge-blue"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg> running</span></div>
+        <div class="list-actions">
+          <a href="#" class="btn">View run</a>
+        </div>
+      </div>
+
+      <div class="list-row">
+        <div class="list-icon" title="Open issue">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="#">[EPIC] Plugin system for custom output formatters</a> <span class="badge badge-dim">#138</span></div>
+          <div class="list-meta">
+            <span>gitea / code-crispies</span>
+            <span>opened yesterday by <strong>mwc</strong></span>
+            <span class="list-tags">
+              <span class="badge badge-purple">epic</span>
+            </span>
+          </div>
+        </div>
+        <div class="badge badge-dim">issue</div>
+        <div><span class="badge badge-green"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg> scoped</span></div>
+        <div class="list-actions">
+          <a href="#" class="btn">5 child issues</a>
+        </div>
+      </div>
+
+      <div class="list-row">
+        <div class="list-icon" title="Scheduled task">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="#">Nightly auto-impl sweep</a></div>
+          <div class="list-meta">
+            <span>schedule: <code>0 2 * * *</code></span>
+            <span>next: in 6h 12m</span>
+            <span>pipeline: <code>impl-issue</code></span>
+            <span class="list-tags"><span class="badge badge-dim">label:auto-impl</span></span>
+          </div>
+        </div>
+        <div class="badge badge-dim">scheduled</div>
+        <div class="badge badge-dim" title="Last run was successful"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg> last ok</div>
+        <div class="list-actions">
+          <button class="btn">Run now</button>
+        </div>
+      </div>
+
+      <div class="list-row">
+        <div class="list-icon" title="Open issue">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="#">Cargo.toml is being treated as TOML output by mistake</a> <span class="badge badge-dim">#139</span></div>
+          <div class="list-meta">
+            <span>gitea / code-crispies</span>
+            <span>opened 3d ago by <strong>contributor42</strong></span>
+            <span class="list-tags">
+              <span class="badge badge-red">bug</span>
+              <span class="badge badge-dim">repro</span>
+            </span>
+          </div>
+        </div>
+        <div class="badge badge-dim">issue</div>
+        <div><span class="badge badge-red"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" /></svg> last failed</span></div>
+        <div class="list-actions">
+          <button class="btn btn-primary">Retry</button>
+        </div>
+      </div>
+
+      <div class="list-row">
+        <div class="list-icon" title="Open issue">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+        </div>
+        <div>
+          <div class="list-title"><a href="#">Document plugin lifecycle hooks in README</a> <span class="badge badge-dim">#137</span></div>
+          <div class="list-meta">
+            <span>gitea / code-crispies</span>
+            <span>opened 5d ago</span>
+            <span class="list-tags">
+              <span class="badge badge-blue">docs</span>
+            </span>
+          </div>
+        </div>
+        <div class="badge badge-dim">issue</div>
+        <div class="badge badge-dim">&mdash;</div>
+        <div class="list-actions">
+          <button class="btn btn-primary">Run</button>
+        </div>
+      </div>
+
+    </div>
+
+    <div style="margin-top: 12px; color: var(--text-mute); font-size: 12px; text-align: center;">
+      6 of 23 items shown &middot; <a href="#">load more</a>
+    </div>
+
+    <div style="margin-top: 32px; text-align: center; color: var(--text-mute); font-size: 13px;">
+      <a href="/preview/onboard">&larr; onboarding</a> &middot; <a href="/preview/work-item">next: work item detail &rarr;</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/internal/webui/templates/preview/work_item.html
+++ b/internal/webui/templates/preview/work_item.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Work item detail &mdash; Wave mockup</title>
+  <link rel="stylesheet" href="/preview/static/style.css" />
+</head>
+<body>
+  {{ template "banner" . }}
+  <nav class="nav">
+    <div class="nav-brand">
+      <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/><path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/></svg>
+      Wave
+    </div>
+    <div class="nav-links">
+      <a href="/preview/work" class="active">Work</a>
+      <a href="#">Schedules</a>
+      <a href="#">Proposals <span class="badge badge-yellow" style="font-size: 10px; padding: 1px 6px; margin-left: 2px;">2</span></a>
+      <a href="#">Runs</a>
+    </div>
+    <div class="nav-meta">
+      <span>code-crispies</span>
+      <span>git.librete.ch</span>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div style="color: var(--text-mute); font-size: 13px; margin-bottom: 8px;">
+      <a href="/preview/work">Work</a> &rsaquo; <a href="#">gitea / code-crispies</a> &rsaquo; <span>issue #142</span>
+    </div>
+
+    <div class="page-header" style="align-items: flex-start;">
+      <div>
+        <h1 class="page-title">Add CSV column-type inference for numeric vs string fields</h1>
+        <div class="page-sub" style="display: flex; gap: 12px; align-items: center; margin-top: 6px;">
+          <span class="badge badge-green"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /></svg> open</span>
+          <span>opened 2h ago by <strong>mwc</strong></span>
+          <span><span class="badge badge-blue">enhancement</span> <span class="badge badge-purple">parser</span></span>
+          <a href="https://git.librete.ch/mwc/code-crispies/issues/142" target="_blank">view on gitea &rarr;</a>
+        </div>
+      </div>
+      <div style="display: flex; gap: 8px;">
+        <button class="btn btn-primary"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg> Run pipeline</button>
+        <button class="btn"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" /></svg></button>
+      </div>
+    </div>
+
+    <div class="split">
+      <div>
+        <div class="card" style="margin-bottom: 16px;">
+          <div style="font-size: 13px; color: var(--text-mute); margin-bottom: 8px;">Issue body</div>
+          <div style="line-height: 1.6;">
+            <p>Currently every CSV column is read as <code>string</code>. We should infer numeric columns at read time so downstream operations don't need an explicit cast.</p>
+            <p><strong>Acceptance:</strong></p>
+            <ul>
+              <li>If every non-empty cell in a column parses as a number, treat the column as numeric.</li>
+              <li>Mixed columns stay <code>string</code>.</li>
+              <li>User can override per-column via <code>--column-type name=int</code>.</li>
+              <li>Add tests covering: pure numeric, pure string, mixed, empty cells, scientific notation.</li>
+            </ul>
+            <p>Don't over-engineer. No date parsing yet.</p>
+          </div>
+        </div>
+
+        <h3 style="font-size: 14px; margin-top: 24px; margin-bottom: 8px;">Run a pipeline on this issue</h3>
+        <p style="color: var(--text-mute); font-size: 13px; margin-top: 0;">Bindings configured during onboarding. Pick one or run a custom pipeline.</p>
+
+        <div class="binding">
+          <input type="radio" name="pipeline" checked />
+          <div>
+            <div class="binding-pipeline">impl-issue</div>
+            <div class="binding-trigger">Bound to: <code>kind=issue, label!=epic</code> &middot; usual pick</div>
+          </div>
+          <span class="badge badge-dim">~$0.18</span>
+          <span class="badge badge-dim">~6 min</span>
+        </div>
+
+        <div class="binding">
+          <input type="radio" name="pipeline" />
+          <div>
+            <div class="binding-pipeline">research</div>
+            <div class="binding-trigger">Investigate then propose plan, no implementation</div>
+          </div>
+          <span class="badge badge-dim">~$0.05</span>
+          <span class="badge badge-dim">~2 min</span>
+        </div>
+
+        <div class="binding">
+          <input type="radio" name="pipeline" />
+          <div>
+            <div class="binding-pipeline">scope</div>
+            <div class="binding-trigger">Decompose into child issues (use if epic-shaped)</div>
+          </div>
+          <span class="badge badge-dim">~$0.07</span>
+          <span class="badge badge-dim">~3 min</span>
+        </div>
+
+        <details style="margin-top: 16px;">
+          <summary style="cursor: pointer; color: var(--text-mute); font-size: 13px;">Custom pipeline / advanced options</summary>
+          <div class="form-row" style="margin-top: 16px;">
+            <label>Pipeline</label>
+            <select><option>(any installed pipeline)</option><option>impl-issue</option><option>research</option><option>scope</option><option>pr-review</option></select>
+          </div>
+          <div class="form-row">
+            <label>Adapter override</label>
+            <select><option>(default: claude)</option><option>opencode</option><option>gemini</option></select>
+          </div>
+          <div class="form-row">
+            <label>Model tier</label>
+            <select><option>(persona default)</option><option>cheapest</option><option>balanced</option><option>strongest</option></select>
+          </div>
+          <div class="form-row">
+            <label>Budget ceiling</label>
+            <input type="text" value="$0.50" />
+          </div>
+          <div class="form-row">
+            <label>Detached</label>
+            <select><option>yes (survives webui restart)</option><option>no (kill on close)</option></select>
+          </div>
+          <div class="form-row">
+            <label>Notes (optional)</label>
+            <textarea>Run on this issue. Skip lint rework if any.</textarea>
+          </div>
+        </details>
+
+        <div style="display: flex; gap: 8px; margin-top: 16px;">
+          <button class="btn btn-primary"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3" /></svg> Run impl-issue</button>
+          <button class="btn">Dry-run</button>
+        </div>
+
+        <h3 style="font-size: 14px; margin-top: 32px; margin-bottom: 8px;">Recent runs on this item</h3>
+        <div class="list">
+          <div class="list-row">
+            <div class="list-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg></div>
+            <div>
+              <div class="list-title">impl-issue &middot; <code>r/3a8c91</code></div>
+              <div class="list-meta">
+                <span>completed 12m ago</span>
+                <span>5 steps</span>
+                <span>$0.16 / 14k tokens</span>
+              </div>
+            </div>
+            <span class="badge badge-green">PR !58</span>
+            <span class="badge badge-dim">judge 0.92</span>
+            <a href="#" class="btn">View</a>
+          </div>
+          <div class="list-row">
+            <div class="list-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12" /></svg></div>
+            <div>
+              <div class="list-title">research &middot; <code>r/2d1e44</code></div>
+              <div class="list-meta">
+                <span>completed 1h ago</span>
+                <span>3 steps</span>
+                <span>$0.04 / 3.2k tokens</span>
+              </div>
+            </div>
+            <span class="badge badge-blue">plan</span>
+            <span class="badge badge-dim">judge 0.88</span>
+            <a href="#" class="btn">View</a>
+          </div>
+        </div>
+      </div>
+
+      <aside>
+        <div class="side-card card">
+          <h3>Item</h3>
+          <dl>
+            <dt>Forge</dt><dd>gitea</dd>
+            <dt>Repo</dt><dd>mwc/code-crispies</dd>
+            <dt>Type</dt><dd>issue</dd>
+            <dt>State</dt><dd><span class="badge badge-green">open</span></dd>
+            <dt>Author</dt><dd>mwc</dd>
+            <dt>Assignee</dt><dd>&mdash;</dd>
+            <dt>Branch hint</dt><dd><code>142-csv-type-infer</code></dd>
+          </dl>
+        </div>
+
+        <div class="side-card card">
+          <h3>Suggested binding</h3>
+          <p style="font-size: 12px; color: var(--text-mute); margin-top: 0;">Auto-run <code>impl-issue</code> when label <code>auto-impl</code> is added?</p>
+          <div style="display: flex; gap: 6px;">
+            <button class="btn btn-primary" style="flex: 1;">Add binding</button>
+            <button class="btn">No</button>
+          </div>
+        </div>
+
+        <div class="side-card card">
+          <h3>Live cost forecast</h3>
+          <dl>
+            <dt>Estimated</dt><dd>$0.18</dd>
+            <dt>Budget cap</dt><dd>$0.50</dd>
+            <dt>Adapter</dt><dd>claude (sonnet-4-6)</dd>
+            <dt>Tier</dt><dd>balanced</dd>
+          </dl>
+        </div>
+      </aside>
+    </div>
+
+    <div style="margin-top: 32px; text-align: center; color: var(--text-mute); font-size: 13px;">
+      <a href="/preview/work">&larr; work board</a> &middot; <a href="/preview/proposal">next: evolution proposal &rarr;</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/specs/1580-preview-phase-a/plan.md
+++ b/specs/1580-preview-phase-a/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: /preview/* phase A
+
+## 1. Objective
+
+Add a build-tag-gated `/preview/*` route group to `internal/webui` that renders five fixture-backed HTML pages ported from `docs/scope/mockups/`. Default builds must remain unaffected (zero footprint).
+
+## 2. Approach
+
+Mirror the existing `features_<name>.go` / `features_<name>_disabled.go` pattern already used for analytics/metrics/webhooks/retros. Add `preview.go` (build tag `webui_preview`) and `preview_disabled.go` (negation) that hook a route registrar into `FeatureRegistry.routeFns` via `addRoutes`. Templates live under `internal/webui/templates/preview/` and are also gated by the build tag — they are embedded only when the tag is set, so default `go build` ships zero preview bytes.
+
+Templates are ported as **standalone** HTML pages (not the layout/partial system used by the production webui) because the mockups are self-contained design artifacts. Each preview page injects a fixed `PREVIEW` banner via a shared `_banner.html` partial included from each page.
+
+Fixtures are pure Go literals in `preview_fixtures.go` — no DB, no services, no state.
+
+## 3. File Mapping
+
+### New files
+
+| Path | Tag | Purpose |
+|------|-----|---------|
+| `internal/webui/preview.go` | `//go:build webui_preview` | Embed preview templates, register `/preview/*` routes, render handlers |
+| `internal/webui/preview_disabled.go` | `//go:build !webui_preview` | No-op stub `registerPreview(r *FeatureRegistry)` |
+| `internal/webui/preview_fixtures.go` | `//go:build webui_preview` | Fixture structs + values for each page |
+| `internal/webui/preview_test.go` | `//go:build webui_preview` | Smoke tests: 200 OK + banner check on each route |
+| `internal/webui/templates/preview/_banner.html` | (embed-gated) | Shared persistent PREVIEW banner partial |
+| `internal/webui/templates/preview/index.html` | (embed-gated) | Port of `00-landing.html` |
+| `internal/webui/templates/preview/onboard.html` | (embed-gated) | Port of `01-onboarding-session.html` |
+| `internal/webui/templates/preview/work.html` | (embed-gated) | Port of `02-work-board.html` |
+| `internal/webui/templates/preview/work_item.html` | (embed-gated) | Port of `03-work-item.html` |
+| `internal/webui/templates/preview/proposal.html` | (embed-gated) | Port of `04-evolution-proposal.html` |
+| `internal/webui/static/preview/style.css` | (always embedded, tiny) | Copied from `docs/scope/mockups/style.css` for self-contained rendering |
+| `specs/1580-preview-phase-a/{spec,plan,tasks}.md` | — | Planning artifacts |
+
+> **Style.css note**: copying the css into `internal/webui/static/preview/` keeps the css under the tag-gated handler (handler only registered with tag); since `staticFS` is always embedded, the css bytes ship in default builds (~few KB). If we need true zero footprint, gate the css behind a separate `//go:embed` block in `preview.go` and serve via `http.FileServer` from a tag-only `embed.FS`. **Decision: gate the css too** (see Architecture Decisions §4.2).
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `internal/webui/features.go` | Add `registerPreview(r)` call inside `NewFeatureRegistry()` |
+| `.github/workflows/lint.yml` | Add matrix dimension: `tags: ["", "webui_preview"]` so golangci-lint runs in both modes |
+| `.github/workflows/lint.yml` (or new `build.yml`) | Add a build job that runs `go build -tags=""` and `go build -tags=webui_preview` |
+
+> **CI choice**: extending `lint.yml` keeps a single workflow; if matrix complicates the existing single-job structure too much, add a new `build.yml` workflow with the matrix. Lean toward extending the existing job.
+
+### Deleted files
+
+None.
+
+## 4. Architecture Decisions
+
+### 4.1 Reuse `FeatureRegistry`, not a parallel mux
+
+The existing `FeatureRegistry` pattern (`features.go:30-37`) already supports tag-gated route registration via `routeFns`. Adding `registerPreview` slots in cleanly without touching the main router. Confirmed: `routes.go:92` iterates `s.assets.features.routeFns` after all production routes — preview routes register last, ensuring no path conflicts (none of `/preview/*` collides with existing routes).
+
+### 4.2 Embed templates and css under build tag
+
+Default `go build` must produce zero preview footprint. To achieve this:
+- Both `//go:embed templates/preview/*.html` and `//go:embed static/preview/*.css` directives live inside `preview.go` (which is itself tag-gated). Without the tag, the directives are not compiled and the bytes are not embedded.
+- Render handlers parse templates from a tag-local `embed.FS`, independent of the existing `templatesFS` / `staticFS` in `embed.go`.
+
+### 4.3 Standalone templates (no layout extension)
+
+Mockups are self-contained pages with inline `<style>` blocks. Porting them as **standalone** templates (each begins with `<!doctype html>`) preserves design fidelity and avoids cross-cutting refactors of the production layout. The shared `PREVIEW` banner is a small `_banner.html` partial rendered via `{{ template "_banner" . }}` from each page.
+
+### 4.4 Routing pattern
+
+```go
+mux.HandleFunc("GET /preview/{$}", s.handlePreviewIndex)
+mux.HandleFunc("GET /preview/onboard", s.handlePreviewOnboard)
+mux.HandleFunc("GET /preview/work", s.handlePreviewWork)
+mux.HandleFunc("GET /preview/work-item", s.handlePreviewWorkItem)
+mux.HandleFunc("GET /preview/proposal", s.handlePreviewProposal)
+```
+
+`{$}` ensures `/preview/` matches the index exactly without swallowing subpaths (Go 1.22+ pattern). Static assets resolve via existing `staticHandler` since css is in `static/preview/`.
+
+### 4.5 Fixtures as typed structs
+
+Each page receives a typed struct (e.g. `LandingFixture`, `WorkBoardFixture`) defined in `preview_fixtures.go`. This makes the template binding contract explicit and lets future Phase B replace fixture literals with real service calls with minimal template churn.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Build tag drift (forgetting `_disabled.go` stub) breaks default build | Mirror exact pattern of `features_analytics_disabled.go`; add features_test.go-style invariant test |
+| Mockup CSS uses CSS variables defined globally — pages may render unstyled | Inline a minimal `:root { --bg: ...; }` block at top of each page or include `style.css` link. Use `style.css` link via `/static/preview/style.css` |
+| Template parse errors only surface at request time | Parse all templates at server startup (in `registerPreview`); panic if parse fails |
+| Smoke test runs in default build mode (no tag) → tests skipped silently | Tag the test file `//go:build webui_preview` so it compiles only with the tag; CI matrix ensures it runs |
+| `lint.yml` matrix change breaks existing single-job ergonomics | If matrix adds noise, split into a dedicated `build-matrix.yml` |
+| Route prefix `/preview/` conflicts with future production route | Confirmed no current collision via `grep "/preview" internal/webui/*.go`; document the namespace as reserved in spec |
+
+## 6. Testing Strategy
+
+### Unit / smoke (`preview_test.go`, tag-gated)
+
+For each of the 5 routes:
+1. Start a test server with `NewFeatureRegistry()` (preview registered under tag).
+2. `GET <route>` → assert status 200.
+3. Assert response body contains the literal string `PREVIEW` (banner check).
+4. Assert response `Content-Type` starts with `text/html`.
+
+### Build matrix (CI)
+
+- `go build ./...` (no tags) must succeed and contain no `preview` symbols. Verify via `go tool nm ./bin/wave | grep -i preview` exits non-zero (optional sanity check, not blocking).
+- `go build -tags=webui_preview ./...` must succeed.
+- `go test -tags=webui_preview ./internal/webui/...` runs the smoke tests.
+- `go test ./internal/webui/...` (no tag) skips preview tests via tag exclusion.
+
+### Lint matrix
+
+Run golangci-lint in both modes to catch tag-only files that violate lint rules.
+
+## 7. Open Questions Resolved
+
+- **5 mockup files confirmed**: `00-landing.html`, `01-onboarding-session.html`, `02-work-board.html`, `03-work-item.html`, `04-evolution-proposal.html` (matches 5 routes in issue).
+- **Router decision**: register on the main router via the existing `FeatureRegistry.routeFns` hook. No separate mux. (Resolves assessment open question §missing_info.)

--- a/specs/1580-preview-phase-a/spec.md
+++ b/specs/1580-preview-phase-a/spec.md
@@ -1,0 +1,47 @@
+# 1.5a: /preview/* phase A (build tag, fixtures only)
+
+**Issue:** [re-cinq/wave#1580](https://github.com/re-cinq/wave/issues/1580)
+**Author:** nextlevelshit
+**State:** OPEN
+**Labels:** (none)
+
+## Issue Body
+
+Part of Epic #1565. Phase 1.5, parallel-safe (no Phase 1 deps for phase A).
+
+Port `docs/scope/mockups/*.html` to `internal/webui/templates/preview/` behind a `webui_preview` build tag. Hard-coded fixtures only (no service wiring).
+
+**Files:**
+- New: `internal/webui/preview.go` (`//go:build webui_preview`)
+- New: `internal/webui/preview_fixtures.go`
+- New: `internal/webui/templates/preview/*.html` ported from `docs/scope/mockups/`
+
+**Routes (all GET-only, fixture-backed):**
+- `/preview/` (index) · `/preview/onboard` · `/preview/work` · `/preview/work-item` · `/preview/proposal`
+
+**Acceptance:**
+- [ ] Persistent PREVIEW banner visible on every preview route
+- [ ] Default `go build` excludes preview entirely (zero footprint)
+- [ ] CI matrix builds with both `-tags webui_preview` and without
+- [ ] Smoke test: 200 OK on every preview route under build tag
+
+**Pipeline:** `impl-issue` (`--adapter claude --model cheapest`)
+
+## Source Mockups
+
+`docs/scope/mockups/` contains:
+- `00-landing.html` → `/preview/` (index)
+- `01-onboarding-session.html` → `/preview/onboard`
+- `02-work-board.html` → `/preview/work`
+- `03-work-item.html` → `/preview/work-item`
+- `04-evolution-proposal.html` → `/preview/proposal`
+- `style.css` (shared stylesheet, served as static asset)
+
+## Acceptance Criteria
+
+1. Build tag `webui_preview` gates all preview code; default build has zero footprint (no symbols, no embedded templates).
+2. Five GET routes registered under build tag — each returns 200 with rendered fixture HTML.
+3. Persistent `PREVIEW` banner visible on every preview page.
+4. CI builds binary in both modes (without tag, with `-tags webui_preview`).
+5. Smoke test asserts 200 OK + banner presence on each route, gated by build tag.
+6. No service-layer wiring — fixtures are package-level Go literals.

--- a/specs/1580-preview-phase-a/tasks.md
+++ b/specs/1580-preview-phase-a/tasks.md
@@ -1,0 +1,37 @@
+# Work Items
+
+## Phase 1: Setup
+
+- [X] 1.1: Confirm five mockup files exist in `docs/scope/mockups/` and read each to inventory required fixture data shapes
+- [X] 1.2: Add `registerPreview(r)` call to `NewFeatureRegistry` in `internal/webui/features.go`
+- [X] 1.3: Add `internal/webui/preview_disabled.go` with `//go:build !webui_preview` and no-op `registerPreview(*FeatureRegistry)`
+
+## Phase 2: Core Implementation
+
+- [X] 2.1: Create `internal/webui/preview.go` (`//go:build webui_preview`) — embed.FS for templates+css, parse templates at init, register 5 GET routes via `r.addRoutes(...)` [P]
+- [X] 2.2: Create `internal/webui/preview_fixtures.go` (`//go:build webui_preview`) — fixture structs + literal values for all 5 pages [P]
+- [X] 2.3: Create `internal/webui/templates/preview/_banner.html` partial — persistent PREVIEW banner [P]
+- [X] 2.4: Port `00-landing.html` → `templates/preview/index.html` with banner partial + fixture binding [P]
+- [X] 2.5: Port `01-onboarding-session.html` → `templates/preview/onboard.html` [P]
+- [X] 2.6: Port `02-work-board.html` → `templates/preview/work.html` [P]
+- [X] 2.7: Port `03-work-item.html` → `templates/preview/work_item.html` [P]
+- [X] 2.8: Port `04-evolution-proposal.html` → `templates/preview/proposal.html` [P]
+- [X] 2.9: Copy `docs/scope/mockups/style.css` → `internal/webui/static/preview/style.css` and reference via `/preview/static/style.css` (tag-gated handler)
+- [X] 2.10: Implement 5 handler funcs (`handlePreviewIndex`, `handlePreviewOnboard`, `handlePreviewWork`, `handlePreviewWorkItem`, `handlePreviewProposal`) in `preview.go`
+
+## Phase 3: Testing
+
+- [X] 3.1: Create `internal/webui/preview_test.go` (`//go:build webui_preview`) — table-driven smoke tests asserting 200 + banner string for each of 5 routes
+- [X] 3.2: Run `go build ./...` (no tag) — succeeds with zero preview symbols
+- [X] 3.3: Run `go build -tags=webui_preview ./...` — succeeds
+- [X] 3.4: Run `go test ./internal/webui/...` (no tag) — passes, preview tests not compiled
+- [X] 3.5: Run `go test -tags=webui_preview ./internal/webui/...` — preview smoke tests pass
+
+## Phase 4: CI + Polish
+
+- [X] 4.1: Update `.github/workflows/lint.yml` — add matrix `tags: ["", "webui_preview"]` for golangci-lint
+- [X] 4.2: Add a build job (extended `lint.yml`) that runs `go build` in both tag modes
+- [X] 4.3: Add a test job that runs `go test -tags=webui_preview ./internal/webui/...`
+- [ ] 4.4: Manual visual smoke: `go run -tags=webui_preview ./cmd/wave webui` → load all 5 routes in browser, verify banner + layout (deferred — requires interactive browser; smoke tests cover 200 + banner)
+- [X] 4.5: Run `go vet ./...` in both tag modes; clean (golangci-lint not installed in workspace; CI matrix runs it)
+- [ ] 4.6: Open PR titled `feat(webui): /preview/* phase A (build tag, fixtures only)` referencing #1580 and Epic #1565 (handled by next pipeline step)


### PR DESCRIPTION
## Summary
- Adds `/preview/*` route group gated behind `webui_preview` build tag
- Ports five mockup pages from `docs/scope/mockups/` to `internal/webui/templates/preview/`
- Default builds ship zero preview footprint (no routes, no templates, no css)
- Sticky PREVIEW banner partial rendered on every preview route
- CI lint.yml matrix builds + smoke-tests under both tag modes

Related to #1580

## Changes
- `internal/webui/preview.go` (`//go:build webui_preview`) — feature with route registration and template rendering
- `internal/webui/preview_disabled.go` — no-op stub for default builds
- `internal/webui/preview_fixtures.go` — hard-coded fixture data
- `internal/webui/preview_test.go` — smoke tests asserting 200 OK on every preview route
- `internal/webui/templates/preview/*.html` — five ported pages + `_banner.html` partial
- `internal/webui/static/preview/style.css` — preview-only stylesheet
- `internal/webui/features.go` — registers preview feature in registry
- `internal/webui/features_default_test.go` — extracts default-tags zero-flags assertion to its own file gated `!any-feature-tag`
- `.github/workflows/lint.yml` — adds matrix entry building/linting/testing with `-tags webui_preview`
- `specs/1580-preview-phase-a/{spec,plan,tasks}.md` — speckit planning artifacts

## Test Plan
- `go build ./...` (default tags) — preview package excluded
- `go build -tags webui_preview ./...` — preview package compiles
- `go test -tags webui_preview ./internal/webui/...` — smoke tests pass with 200 OK on `/preview/`, `/preview/onboard`, `/preview/work`, `/preview/work-item`, `/preview/proposal`
- `go test ./internal/webui/...` (default) — registry contract still holds; no preview routes registered
- CI matrix runs both branches