### PR TITLE
chore(timeouts): loosen aggressive defaults causing canceled steps

### DIFF
--- a/internal/defaults/embedfs/pipelines/audit-architecture.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-architecture.yaml
@@ -118,5 +118,5 @@ steps:
         source: .agents/output/architecture-report.md
         model: cheapest
         token_budget: 0
-        timeout: 90s
+        timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/audit-issue.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-issue.yaml
@@ -532,7 +532,7 @@ steps:
           source: .agents/output/audit-doc.json
           model: balanced
           token_budget: 0
-          timeout: 120s
+          timeout: 300s
           on_failure: warn
 
   # ─── Phase 8: file follow-up issues (iterate.serial) ─────────────────────

--- a/internal/defaults/embedfs/pipelines/audit-security.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-security.yaml
@@ -382,5 +382,5 @@ steps:
         source: .agents/output/security-report.md
         model: cheapest
         token_budget: 0
-        timeout: 90s
+        timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/audit-tests.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-tests.yaml
@@ -118,5 +118,5 @@ steps:
         source: .agents/output/tests-report.md
         model: cheapest
         token_budget: 0
-        timeout: 90s
+        timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/embedfs/pipelines/impl-issue-core.yaml
@@ -114,7 +114,7 @@ steps:
           source: .agents/output/impl-plan.json
           model: balanced
           token_budget: 0
-          timeout: 120s
+          timeout: 300s
           on_failure: warn
 
   - id: implement

--- a/internal/defaults/embedfs/pipelines/impl-issue.yaml
+++ b/internal/defaults/embedfs/pipelines/impl-issue.yaml
@@ -107,7 +107,7 @@ steps:
           source: .agents/output/impl-plan.json
           model: balanced
           token_budget: 0
-          timeout: 120s
+          timeout: 300s
           on_failure: warn
 
   - id: implement
@@ -238,7 +238,7 @@ steps:
           criteria_path: .agents/contracts/impl-review-criteria.md
           model: cheapest
           token_budget: 0
-          timeout: 90s
+          timeout: 300s
           context:
             - source: git_diff
           on_failure: warn

--- a/internal/defaults/embedfs/pipelines/ops-pr-respond.yaml
+++ b/internal/defaults/embedfs/pipelines/ops-pr-respond.yaml
@@ -462,7 +462,7 @@ steps:
           source: .agents/output/triaged-findings.json
           model: cheapest
           token_budget: 0
-          timeout: 90s
+          timeout: 300s
           criteria:
             - "Every actionable item has a non-empty remediation that names a concrete edit."
             - "Severity classifications are calibrated — critical/high reserved for correctness or security risks."
@@ -735,7 +735,7 @@ steps:
           source: .agents/output/comment-result.json
           model: cheapest
           token_budget: 0
-          timeout: 60s
+          timeout: 300s
           criteria:
             - "The posted comment maps every actionable finding id to either a commit SHA or a clear skipped/failed status."
             - "Verdict line at the top matches verify-verdict.json."

--- a/internal/defaults/embedfs/pipelines/ops-pr-review.yaml
+++ b/internal/defaults/embedfs/pipelines/ops-pr-review.yaml
@@ -377,7 +377,7 @@ steps:
         source: .agents/output/quality-review.md
         model: cheapest
         token_budget: 0
-        timeout: 90s
+        timeout: 300s
         on_failure: continue
 
   - id: slop-review

--- a/internal/pipeline/gate_test.go
+++ b/internal/pipeline/gate_test.go
@@ -553,8 +553,8 @@ func TestParsePollGateTiming_Defaults(t *testing.T) {
 	if interval != 30*time.Second {
 		t.Errorf("expected 30s interval, got %v", interval)
 	}
-	if timeout != 30*time.Minute {
-		t.Errorf("expected 30m timeout, got %v", timeout)
+	if timeout != 60*time.Minute {
+		t.Errorf("expected 60m timeout, got %v", timeout)
 	}
 }
 

--- a/internal/timeouts/timeouts.go
+++ b/internal/timeouts/timeouts.go
@@ -10,21 +10,27 @@ package timeouts
 import "time"
 
 const (
-	StepDefault      = 5 * time.Minute
-	RelayCompaction  = 5 * time.Minute
-	MetaDefault      = 30 * time.Minute
-	SkillInstall     = 2 * time.Minute
-	SkillCLI         = 2 * time.Minute
-	SkillHTTP        = 2 * time.Minute
-	SkillHTTPHeader  = 30 * time.Second
-	SkillPublish     = 30 * time.Second
+	// Step + relay timeouts loosened 2026-04-30 — impl-issue runs that exercise
+	// `go test ./...` on the Wave codebase routinely take 6-10 minutes; the old
+	// 5-minute step default forced a "canceled" failure class even when the
+	// step was making progress. ForgeAPI* loosened so transient GitHub
+	// hiccups don't poison long-running pipelines. Override per-step in
+	// pipeline yaml or per-runtime in wave.yaml when a tighter bound matters.
+	StepDefault      = 30 * time.Minute
+	RelayCompaction  = 15 * time.Minute
+	MetaDefault      = 60 * time.Minute
+	SkillInstall     = 5 * time.Minute
+	SkillCLI         = 5 * time.Minute
+	SkillHTTP        = 5 * time.Minute
+	SkillHTTPHeader  = 60 * time.Second
+	SkillPublish     = 60 * time.Second
 	ProcessGrace     = 3 * time.Second
 	StdoutDrain      = 1 * time.Second
 	GateApproval     = 24 * time.Hour
 	GatePollInterval = 30 * time.Second
-	GatePollTimeout  = 30 * time.Minute
-	GitCommand       = 30 * time.Second
-	ForgeAPI         = 15 * time.Second
-	ForgeAPIList     = 30 * time.Second
+	GatePollTimeout  = 60 * time.Minute
+	GitCommand       = 90 * time.Second
+	ForgeAPI         = 60 * time.Second
+	ForgeAPIList     = 90 * time.Second
 	RetryMaxDelay    = 60 * time.Second
 )


### PR DESCRIPTION
## Summary

During Phase 1 dispatch (#1577 + #1578) the impl-issue pipeline produced \`canceled\` failure-class step terminations even when the step was making clear progress — caused by a 5-minute \`StepDefault\` that's tighter than \`go test ./...\` typically takes on this codebase.

## Changes

**Constants in \`internal/timeouts/timeouts.go\`:**

| Constant | Old | New |
|---|---|---|
| StepDefault | 5m | 30m |
| RelayCompaction | 5m | 15m |
| MetaDefault | 30m | 60m |
| SkillInstall/CLI/HTTP | 2m | 5m |
| SkillHTTPHeader | 30s | 60s |
| SkillPublish | 30s | 60s |
| GatePollTimeout | 30m | 60m |
| GitCommand | 30s | 90s |
| ForgeAPI | 15s | 60s |
| ForgeAPIList | 30s | 90s |

**Pipeline yaml agent_review contract timeouts** — all 60/90/120s → 300s across:
- audit-architecture.yaml, audit-issue.yaml, audit-security.yaml, audit-tests.yaml
- impl-issue.yaml, impl-issue-core.yaml
- ops-pr-respond.yaml, ops-pr-review.yaml

## Why

Agent reviews on multi-file diffs need real read time. 90s was the dominant \"contract validation failed\" cause in Phase 1 runs. Step defaults that fight the rest of the system mask real failures behind \`canceled\` noise.

All values still overridable per-step in pipeline yaml or per-runtime in wave.yaml; this only loosens the fallback floor.

## Test plan

- [x] \`go test ./internal/timeouts/...\` green
- [x] \`go build ./...\` clean
- [ ] Future impl-issue dispatches no longer canceled at the 5-min mark

## Related

- Epic #1565 — Phase 1 surfaced the issue