### PR TITLE
feat(worksource): add domain service + bindings CRUD (#1591)

### DIFF
--- a/internal/worksource/doc.go
+++ b/internal/worksource/doc.go
@@ -1,0 +1,16 @@
+// Package worksource is the domain service over the work-source binding table
+// introduced by PRE-5 (state.WorksourceStore). It maps forge queries (forge +
+// repo glob + label any-of + work-item state/kind filters) onto a pipeline +
+// trigger mode, and exposes a MatchBindings query that selects bindings
+// applicable to a given WorkItemRef.
+//
+// The service is the only translator between the typed domain shape
+// (BindingSpec / BindingRecord) and the storage shape (state.WorksourceBindingRecord
+// with opaque JSON selector). Trigger names use dashed form externally
+// (on-demand|on-label|on-open|scheduled) and are normalised to underscored
+// form (state.WorksourceTrigger) before persistence.
+//
+// DeleteBinding is a soft-delete: it maps to state.DeactivateBinding so run
+// history retains the binding context. Glob syntax is path.Match — *, ?, and
+// [class]; no double-star.
+package worksource

--- a/internal/worksource/match.go
+++ b/internal/worksource/match.go
@@ -1,0 +1,77 @@
+package worksource
+
+import "path"
+
+// matches reports whether rec applies to ref. Inactive bindings never match.
+//
+// Semantics:
+//   - Forge: exact equality (case-sensitive, matching the storage layer).
+//   - Repo: path.Match(rec.RepoPattern, ref.Repo).
+//   - LabelFilter: any-of. Empty filter means "all labels accepted".
+//   - State: subset. Empty rec.State means "any state". A rec.State of "any"
+//     also accepts every state.
+//   - Kinds: subset. Empty means "any kind".
+func matches(rec BindingRecord, ref WorkItemRef) bool {
+	if !rec.Active {
+		return false
+	}
+	if rec.Forge != ref.Forge {
+		return false
+	}
+	ok, err := path.Match(rec.RepoPattern, ref.Repo)
+	if err != nil || !ok {
+		return false
+	}
+	if !stateAccepts(rec.State, ref.State) {
+		return false
+	}
+	if !kindAccepts(rec.Kinds, ref.Kind) {
+		return false
+	}
+	if !labelsAccept(rec.LabelFilter, ref.Labels) {
+		return false
+	}
+	return true
+}
+
+// stateAccepts is true when the binding's state filter admits the work-item's
+// state. Empty filter or "any" accept everything.
+func stateAccepts(filter, refState string) bool {
+	if filter == "" || filter == "any" {
+		return true
+	}
+	return filter == refState
+}
+
+// kindAccepts is true when the binding's kind filter admits the work-item's
+// kind. Empty filter accepts everything.
+func kindAccepts(filter []string, refKind string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, k := range filter {
+		if k == refKind {
+			return true
+		}
+	}
+	return false
+}
+
+// labelsAccept is true when the binding's label filter admits the work-item.
+// any-of semantics: at least one filter label must appear on the work-item.
+// An empty filter accepts everything.
+func labelsAccept(filter, refLabels []string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	want := make(map[string]struct{}, len(filter))
+	for _, l := range filter {
+		want[l] = struct{}{}
+	}
+	for _, l := range refLabels {
+		if _, ok := want[l]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worksource/match_test.go
+++ b/internal/worksource/match_test.go
@@ -1,0 +1,146 @@
+package worksource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatches(t *testing.T) {
+	base := BindingRecord{
+		Forge:       "github",
+		RepoPattern: "owner/repo",
+		Trigger:     TriggerOnLabel,
+		Active:      true,
+	}
+	ref := WorkItemRef{
+		Forge:  "github",
+		Repo:   "owner/repo",
+		Kind:   "issue",
+		ID:     "42",
+		Labels: []string{"bug", "ready-for-impl"},
+		State:  "open",
+	}
+
+	cases := []struct {
+		name string
+		mut  func(*BindingRecord, *WorkItemRef)
+		want bool
+	}{
+		{name: "exact match", mut: nil, want: true},
+		{
+			name: "inactive excluded",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.Active = false },
+			want: false,
+		},
+		{
+			name: "forge mismatch",
+			mut:  func(_ *BindingRecord, r *WorkItemRef) { r.Forge = "gitea" },
+			want: false,
+		},
+		{
+			name: "glob star matches any single segment",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.RepoPattern = "owner/*" },
+			want: true,
+		},
+		{
+			name: "glob star does not cross slash",
+			mut: func(b *BindingRecord, r *WorkItemRef) {
+				b.RepoPattern = "owner/*"
+				r.Repo = "owner/sub/repo"
+			},
+			want: false,
+		},
+		{
+			name: "glob ? matches one rune",
+			mut: func(b *BindingRecord, r *WorkItemRef) {
+				b.RepoPattern = "owner/rep?"
+				r.Repo = "owner/repx"
+			},
+			want: true,
+		},
+		{
+			name: "label any-of matches when at least one label intersects",
+			mut: func(b *BindingRecord, _ *WorkItemRef) {
+				b.LabelFilter = []string{"ready-for-impl", "blocked"}
+			},
+			want: true,
+		},
+		{
+			name: "label any-of mismatch",
+			mut: func(b *BindingRecord, r *WorkItemRef) {
+				b.LabelFilter = []string{"won't-fix"}
+				r.Labels = []string{"bug"}
+			},
+			want: false,
+		},
+		{
+			name: "empty label filter accepts any labels",
+			mut: func(b *BindingRecord, r *WorkItemRef) {
+				b.LabelFilter = nil
+				r.Labels = nil
+			},
+			want: true,
+		},
+		{
+			name: "state filter match",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.State = "open" },
+			want: true,
+		},
+		{
+			name: "state filter mismatch",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.State = "closed" },
+			want: false,
+		},
+		{
+			name: "state filter any accepts any",
+			mut: func(b *BindingRecord, r *WorkItemRef) {
+				b.State = "any"
+				r.State = "closed"
+			},
+			want: true,
+		},
+		{
+			name: "kind filter match",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.Kinds = []string{"issue", "pull_request"} },
+			want: true,
+		},
+		{
+			name: "kind filter mismatch",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.Kinds = []string{"pull_request"} },
+			want: false,
+		},
+		{
+			name: "repo mismatch (literal)",
+			mut:  func(_ *BindingRecord, r *WorkItemRef) { r.Repo = "other/repo" },
+			want: false,
+		},
+		{
+			name: "malformed glob never matches",
+			mut:  func(b *BindingRecord, _ *WorkItemRef) { b.RepoPattern = "[" },
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b, r := base, ref
+			if c.mut != nil {
+				c.mut(&b, &r)
+			}
+			assert.Equal(t, c.want, matches(b, r))
+		})
+	}
+}
+
+func TestMatches_MultipleMismatchesAllReturnFalse(t *testing.T) {
+	rec := BindingRecord{
+		Forge: "github", RepoPattern: "a/b", Active: true,
+		LabelFilter: []string{"bug"}, State: "open",
+	}
+	ref := WorkItemRef{
+		Forge: "gitea", Repo: "x/y",
+		Labels: []string{"docs"}, State: "closed",
+	}
+	assert.False(t, matches(rec, ref))
+}

--- a/internal/worksource/service.go
+++ b/internal/worksource/service.go
@@ -1,0 +1,196 @@
+package worksource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// ErrNotFound is returned by Get/Update/Delete when the binding id does not
+// exist.
+var ErrNotFound = errors.New("worksource: binding not found")
+
+// Service is the domain interface for managing worksource bindings.
+//
+// All methods take context.Context as the first argument. The current
+// implementation only honours ctx.Err() at entry — the underlying
+// state.WorksourceStore does not yet accept ctx. Once it does, the service
+// signatures already match.
+type Service interface {
+	// CreateBinding validates the spec, persists the binding, and returns the
+	// new id. Active defaults to true.
+	CreateBinding(ctx context.Context, spec BindingSpec) (BindingID, error)
+
+	// ListBindings returns all bindings matching filter (forge and/or repo
+	// equality). Newest first. Includes inactive bindings.
+	ListBindings(ctx context.Context, filter BindingFilter) ([]BindingRecord, error)
+
+	// GetBinding returns the binding for id, or ErrNotFound.
+	GetBinding(ctx context.Context, id BindingID) (BindingRecord, error)
+
+	// UpdateBinding overwrites the mutable fields of binding id with spec.
+	// CreatedAt is preserved from the existing row. Returns ErrNotFound if
+	// the row is gone.
+	UpdateBinding(ctx context.Context, id BindingID, spec BindingSpec) error
+
+	// DeleteBinding is a soft-delete: the binding is marked inactive.
+	// Run-history references survive. Returns ErrNotFound if the row is gone.
+	DeleteBinding(ctx context.Context, id BindingID) error
+
+	// MatchBindings returns every active binding whose forge/repo glob/labels/
+	// state/kind admit the given WorkItemRef. The filter runs in-memory over
+	// state.ListActiveBindings.
+	MatchBindings(ctx context.Context, ref WorkItemRef) ([]BindingRecord, error)
+}
+
+// NewService returns a Service over the given store. The store is the only
+// required dependency.
+func NewService(store state.WorksourceStore) Service {
+	return &service{store: store}
+}
+
+type service struct {
+	store state.WorksourceStore
+}
+
+func (s *service) CreateBinding(ctx context.Context, spec BindingSpec) (BindingID, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if err := validateSpec(spec); err != nil {
+		return 0, err
+	}
+	selector, err := marshalSelector(spec)
+	if err != nil {
+		return 0, err
+	}
+	trig, _ := triggerToState(spec.Trigger) // already validated.
+	id, err := s.store.CreateBinding(state.WorksourceBindingRecord{
+		Forge:        spec.Forge,
+		Repo:         spec.RepoPattern,
+		Selector:     selector,
+		PipelineName: spec.PipelineName,
+		Trigger:      trig,
+		Config:       spec.Config,
+		Active:       true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("worksource: create binding: %w", err)
+	}
+	return BindingID(id), nil
+}
+
+func (s *service) GetBinding(ctx context.Context, id BindingID) (BindingRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return BindingRecord{}, err
+	}
+	rec, err := s.store.GetBinding(int64(id))
+	if err != nil {
+		return BindingRecord{}, fmt.Errorf("worksource: get binding %d: %w", id, err)
+	}
+	if rec == nil {
+		return BindingRecord{}, fmt.Errorf("%w: id %d", ErrNotFound, id)
+	}
+	return fromStoreRecord(*rec)
+}
+
+func (s *service) ListBindings(ctx context.Context, filter BindingFilter) ([]BindingRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := s.store.ListBindings(filter.Forge, filter.Repo)
+	if err != nil {
+		return nil, fmt.Errorf("worksource: list bindings: %w", err)
+	}
+	out := make([]BindingRecord, 0, len(rows))
+	for _, r := range rows {
+		rec, err := fromStoreRecord(r)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+func (s *service) UpdateBinding(ctx context.Context, id BindingID, spec BindingSpec) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if id <= 0 {
+		return fmt.Errorf("worksource: update binding: id required")
+	}
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+	cur, err := s.store.GetBinding(int64(id))
+	if err != nil {
+		return fmt.Errorf("worksource: update binding %d: %w", id, err)
+	}
+	if cur == nil {
+		return fmt.Errorf("%w: id %d", ErrNotFound, id)
+	}
+	selector, err := marshalSelector(spec)
+	if err != nil {
+		return err
+	}
+	trig, _ := triggerToState(spec.Trigger) // already validated.
+	updated := state.WorksourceBindingRecord{
+		ID:           int64(id),
+		Forge:        spec.Forge,
+		Repo:         spec.RepoPattern,
+		Selector:     selector,
+		PipelineName: spec.PipelineName,
+		Trigger:      trig,
+		Config:       spec.Config,
+		Active:       cur.Active, // Update preserves active flag; Delete is the way to deactivate.
+		CreatedAt:    cur.CreatedAt,
+	}
+	if err := s.store.UpdateBinding(updated); err != nil {
+		return fmt.Errorf("worksource: update binding %d: %w", id, err)
+	}
+	return nil
+}
+
+func (s *service) DeleteBinding(ctx context.Context, id BindingID) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if id <= 0 {
+		return fmt.Errorf("worksource: delete binding: id required")
+	}
+	cur, err := s.store.GetBinding(int64(id))
+	if err != nil {
+		return fmt.Errorf("worksource: delete binding %d: %w", id, err)
+	}
+	if cur == nil {
+		return fmt.Errorf("%w: id %d", ErrNotFound, id)
+	}
+	if err := s.store.DeactivateBinding(int64(id)); err != nil {
+		return fmt.Errorf("worksource: delete binding %d: %w", id, err)
+	}
+	return nil
+}
+
+func (s *service) MatchBindings(ctx context.Context, ref WorkItemRef) ([]BindingRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := s.store.ListActiveBindings()
+	if err != nil {
+		return nil, fmt.Errorf("worksource: list active bindings: %w", err)
+	}
+	out := make([]BindingRecord, 0, len(rows))
+	for _, r := range rows {
+		rec, err := fromStoreRecord(r)
+		if err != nil {
+			return nil, err
+		}
+		if matches(rec, ref) {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}

--- a/internal/worksource/service_test.go
+++ b/internal/worksource/service_test.go
@@ -1,0 +1,282 @@
+package worksource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+func newTestService(t *testing.T) (Service, func()) {
+	t.Helper()
+	store, err := state.NewStateStore(":memory:")
+	require.NoError(t, err)
+	cleanup := func() { _ = store.Close() }
+	return NewService(store), cleanup
+}
+
+func validSpec() BindingSpec {
+	return BindingSpec{
+		Forge:        "github",
+		RepoPattern:  "re-cinq/wave",
+		PipelineName: "impl-issue",
+		Trigger:      TriggerOnLabel,
+		LabelFilter:  []string{"ready-for-impl"},
+		State:        "open",
+		Kinds:        []string{"issue"},
+	}
+}
+
+func TestService_CreateGetRoundTrip(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	id, err := svc.CreateBinding(ctx, validSpec())
+	require.NoError(t, err)
+	require.NotZero(t, id)
+
+	got, err := svc.GetBinding(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, id, got.ID)
+	assert.Equal(t, "github", got.Forge)
+	assert.Equal(t, "re-cinq/wave", got.RepoPattern)
+	assert.Equal(t, TriggerOnLabel, got.Trigger)
+	assert.Equal(t, []string{"ready-for-impl"}, got.LabelFilter)
+	assert.Equal(t, "open", got.State)
+	assert.Equal(t, []string{"issue"}, got.Kinds)
+	assert.True(t, got.Active)
+	assert.False(t, got.CreatedAt.IsZero())
+}
+
+func TestService_CreateDefaultsActive(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	spec := validSpec()
+	spec.Active = false // ignored — Create defaults to active=true.
+	id, err := svc.CreateBinding(ctx, spec)
+	require.NoError(t, err)
+
+	got, err := svc.GetBinding(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, got.Active)
+}
+
+func TestService_ListByForge(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	specs := []BindingSpec{
+		validSpec(),
+		{Forge: "gitea", RepoPattern: "x/y", PipelineName: "p", Trigger: TriggerOnDemand},
+		{Forge: "github", RepoPattern: "other/repo", PipelineName: "p", Trigger: TriggerOnDemand},
+	}
+	for _, s := range specs {
+		_, err := svc.CreateBinding(ctx, s)
+		require.NoError(t, err)
+	}
+
+	github, err := svc.ListBindings(ctx, BindingFilter{Forge: "github"})
+	require.NoError(t, err)
+	assert.Len(t, github, 2)
+
+	repoFilter, err := svc.ListBindings(ctx, BindingFilter{Forge: "github", Repo: "re-cinq/wave"})
+	require.NoError(t, err)
+	assert.Len(t, repoFilter, 1)
+
+	all, err := svc.ListBindings(ctx, BindingFilter{})
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestService_UpdateMutatesFields(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	id, err := svc.CreateBinding(ctx, validSpec())
+	require.NoError(t, err)
+
+	original, err := svc.GetBinding(ctx, id)
+	require.NoError(t, err)
+
+	updated := validSpec()
+	updated.PipelineName = "impl-issue-v2"
+	updated.LabelFilter = []string{"bug"}
+	updated.Trigger = TriggerOnDemand
+	require.NoError(t, svc.UpdateBinding(ctx, id, updated))
+
+	got, err := svc.GetBinding(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, "impl-issue-v2", got.PipelineName)
+	assert.Equal(t, TriggerOnDemand, got.Trigger)
+	assert.Equal(t, []string{"bug"}, got.LabelFilter)
+	// CreatedAt is preserved across update.
+	assert.Equal(t, original.CreatedAt.Unix(), got.CreatedAt.Unix())
+	assert.True(t, got.Active)
+}
+
+func TestService_DeleteSoftDeactivates(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	id, err := svc.CreateBinding(ctx, validSpec())
+	require.NoError(t, err)
+
+	require.NoError(t, svc.DeleteBinding(ctx, id))
+
+	// Still exists; just inactive.
+	got, err := svc.GetBinding(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, got.Active)
+
+	// MatchBindings (which uses ListActiveBindings) excludes it.
+	matches, err := svc.MatchBindings(ctx, WorkItemRef{
+		Forge: "github", Repo: "re-cinq/wave", Kind: "issue",
+		Labels: []string{"ready-for-impl"}, State: "open",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestService_MatchBindings(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// One matches by exact repo + label + state.
+	idMatch, err := svc.CreateBinding(ctx, BindingSpec{
+		Forge: "github", RepoPattern: "re-cinq/wave",
+		PipelineName: "impl-issue", Trigger: TriggerOnLabel,
+		LabelFilter: []string{"ready-for-impl"}, State: "open",
+		Kinds: []string{"issue"},
+	})
+	require.NoError(t, err)
+
+	// One matches by glob.
+	idGlob, err := svc.CreateBinding(ctx, BindingSpec{
+		Forge: "github", RepoPattern: "re-cinq/*",
+		PipelineName: "scope", Trigger: TriggerOnOpen,
+	})
+	require.NoError(t, err)
+
+	// One does not match (different forge).
+	_, err = svc.CreateBinding(ctx, BindingSpec{
+		Forge: "gitea", RepoPattern: "re-cinq/wave",
+		PipelineName: "p", Trigger: TriggerOnDemand,
+	})
+	require.NoError(t, err)
+
+	// One does not match (label filter mismatch).
+	_, err = svc.CreateBinding(ctx, BindingSpec{
+		Forge: "github", RepoPattern: "re-cinq/wave",
+		PipelineName: "p", Trigger: TriggerOnLabel,
+		LabelFilter: []string{"won't-fix"},
+	})
+	require.NoError(t, err)
+
+	got, err := svc.MatchBindings(ctx, WorkItemRef{
+		Forge: "github", Repo: "re-cinq/wave", Kind: "issue",
+		ID: "1591", Labels: []string{"ready-for-impl", "enhancement"},
+		State: "open",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	gotIDs := map[BindingID]bool{got[0].ID: true, got[1].ID: true}
+	assert.True(t, gotIDs[idMatch])
+	assert.True(t, gotIDs[idGlob])
+}
+
+func TestService_InvalidSpecRejection(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		spec BindingSpec
+	}{
+		{"empty forge", BindingSpec{RepoPattern: "a/b", PipelineName: "p", Trigger: TriggerOnDemand}},
+		{"empty pipeline", BindingSpec{Forge: "github", RepoPattern: "a/b", Trigger: TriggerOnDemand}},
+		{"unknown trigger", BindingSpec{Forge: "github", RepoPattern: "a/b", PipelineName: "p", Trigger: "bogus"}},
+		{"empty repo", BindingSpec{Forge: "github", PipelineName: "p", Trigger: TriggerOnDemand}},
+		{"malformed glob", BindingSpec{Forge: "github", RepoPattern: "[", PipelineName: "p", Trigger: TriggerOnDemand}},
+		{"double-star glob", BindingSpec{Forge: "github", RepoPattern: "**/repo", PipelineName: "p", Trigger: TriggerOnDemand}},
+		{"empty label", BindingSpec{Forge: "github", RepoPattern: "a/b", PipelineName: "p", Trigger: TriggerOnDemand, LabelFilter: []string{""}}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := svc.CreateBinding(ctx, c.spec)
+			assert.Error(t, err)
+
+			// Update should also reject.
+			err = svc.UpdateBinding(ctx, BindingID(1), c.spec)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestService_MissingID(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := svc.GetBinding(ctx, 9999)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+
+	err = svc.UpdateBinding(ctx, 9999, validSpec())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+
+	err = svc.DeleteBinding(ctx, 9999)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestService_CtxCancelled(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.CreateBinding(ctx, validSpec())
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = svc.GetBinding(ctx, 1)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = svc.ListBindings(ctx, BindingFilter{})
+	assert.ErrorIs(t, err, context.Canceled)
+
+	err = svc.UpdateBinding(ctx, 1, validSpec())
+	assert.ErrorIs(t, err, context.Canceled)
+
+	err = svc.DeleteBinding(ctx, 1)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = svc.MatchBindings(ctx, WorkItemRef{})
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestService_ZeroID(t *testing.T) {
+	svc, cleanup := newTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	err := svc.UpdateBinding(ctx, 0, validSpec())
+	assert.Error(t, err)
+
+	err = svc.DeleteBinding(ctx, 0)
+	assert.Error(t, err)
+}

--- a/internal/worksource/types.go
+++ b/internal/worksource/types.go
@@ -1,0 +1,188 @@
+package worksource
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// BindingID is the persistent identifier of a worksource binding row.
+type BindingID int64
+
+// Trigger is the externally-facing dashed form of state.WorksourceTrigger.
+// Service callers use this enum so they need not import internal/state.
+type Trigger string
+
+// Trigger values use the dashed form documented in the issue. Internally
+// they are converted to the underscored state.WorksourceTrigger before
+// persistence.
+const (
+	TriggerOnDemand  Trigger = "on-demand"
+	TriggerOnLabel   Trigger = "on-label"
+	TriggerOnOpen    Trigger = "on-open"
+	TriggerScheduled Trigger = "scheduled"
+)
+
+// BindingSpec is the writable shape of a worksource binding. It is what
+// CreateBinding and UpdateBinding accept.
+type BindingSpec struct {
+	// Forge is the forge type — "github", "gitea", "codeberg", etc. Required.
+	Forge string
+	// RepoPattern is a path.Match glob (or exact string) matched against the
+	// "owner/repo" coordinate of an incoming work-item. Required.
+	RepoPattern string
+	// PipelineName is the pipeline the binding fires. Required.
+	PipelineName string
+	// Trigger is the trigger mode. Required; must be one of the Trigger* constants.
+	Trigger Trigger
+	// LabelFilter is the any-of set of labels to match against work-item labels.
+	// Empty means no label filter.
+	LabelFilter []string
+	// State filters by work-item state ("open"|"closed"|""). Empty means any.
+	State string
+	// Kinds filters by work-item kind ("issue"|"pull_request"|...). Empty
+	// means any.
+	Kinds []string
+	// Config is opaque JSON for per-trigger configuration (e.g. cron, debounce).
+	// Stored verbatim. May be empty.
+	Config string
+	// Active marks the binding as eligible for matching. Defaults to true on
+	// CreateBinding when zero-value.
+	Active bool
+}
+
+// BindingRecord is the read shape returned by GetBinding/ListBindings/MatchBindings.
+// CreatedAt is set by the store.
+type BindingRecord struct {
+	ID           BindingID
+	Forge        string
+	RepoPattern  string
+	PipelineName string
+	Trigger      Trigger
+	LabelFilter  []string
+	State        string
+	Kinds        []string
+	Config       string
+	Active       bool
+	CreatedAt    time.Time
+}
+
+// BindingFilter is the optional filter applied by ListBindings. Empty fields
+// match all rows.
+type BindingFilter struct {
+	Forge string
+	Repo  string
+}
+
+// WorkItemRef is the in-memory mirror of the #2.1 work_item_ref schema. It is
+// the input to MatchBindings.
+type WorkItemRef struct {
+	Forge  string
+	Repo   string
+	Kind   string
+	ID     string
+	Title  string
+	URL    string
+	Labels []string
+	State  string
+}
+
+// selectorPayload is the JSON wire form persisted in
+// state.WorksourceBindingRecord.Selector. The service is the only writer.
+type selectorPayload struct {
+	Labels []string `json:"labels,omitempty"`
+	State  string   `json:"state,omitempty"`
+	Kinds  []string `json:"kinds,omitempty"`
+}
+
+// triggerToState converts the dashed external Trigger to the underscored
+// state.WorksourceTrigger used by the storage layer.
+func triggerToState(t Trigger) (state.WorksourceTrigger, bool) {
+	switch t {
+	case TriggerOnDemand:
+		return state.TriggerOnDemand, true
+	case TriggerOnLabel:
+		return state.TriggerOnLabel, true
+	case TriggerOnOpen:
+		return state.TriggerOnOpen, true
+	case TriggerScheduled:
+		return state.TriggerScheduled, true
+	}
+	return "", false
+}
+
+// triggerFromState converts the underscored state.WorksourceTrigger back to
+// the dashed external Trigger.
+func triggerFromState(t state.WorksourceTrigger) (Trigger, bool) {
+	switch t {
+	case state.TriggerOnDemand:
+		return TriggerOnDemand, true
+	case state.TriggerOnLabel:
+		return TriggerOnLabel, true
+	case state.TriggerOnOpen:
+		return TriggerOnOpen, true
+	case state.TriggerScheduled:
+		return TriggerScheduled, true
+	}
+	return "", false
+}
+
+// marshalSelector encodes the spec's selector fields into the JSON wire form.
+// Returns "{}" for an empty selector so SQL never sees an empty string.
+func marshalSelector(spec BindingSpec) (string, error) {
+	p := selectorPayload{
+		Labels: spec.LabelFilter,
+		State:  spec.State,
+		Kinds:  spec.Kinds,
+	}
+	if len(p.Labels) == 0 && p.State == "" && len(p.Kinds) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("marshal selector: %w", err)
+	}
+	return string(b), nil
+}
+
+// unmarshalSelector decodes the stored JSON wire form back into the typed
+// fields exposed on BindingRecord.
+func unmarshalSelector(raw string) (selectorPayload, error) {
+	var p selectorPayload
+	if raw == "" || raw == "{}" {
+		return p, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return p, fmt.Errorf("unmarshal selector: %w", err)
+	}
+	return p, nil
+}
+
+// fromStoreRecord translates a state.WorksourceBindingRecord into the
+// service-layer BindingRecord. Returns an error if the persisted trigger or
+// selector JSON is unrecognisable.
+func fromStoreRecord(rec state.WorksourceBindingRecord) (BindingRecord, error) {
+	trig, ok := triggerFromState(rec.Trigger)
+	if !ok {
+		return BindingRecord{}, fmt.Errorf("unknown trigger %q on binding %d", rec.Trigger, rec.ID)
+	}
+	sel, err := unmarshalSelector(rec.Selector)
+	if err != nil {
+		return BindingRecord{}, fmt.Errorf("binding %d: %w", rec.ID, err)
+	}
+	return BindingRecord{
+		ID:           BindingID(rec.ID),
+		Forge:        rec.Forge,
+		RepoPattern:  rec.Repo,
+		PipelineName: rec.PipelineName,
+		Trigger:      trig,
+		LabelFilter:  sel.Labels,
+		State:        sel.State,
+		Kinds:        sel.Kinds,
+		Config:       rec.Config,
+		Active:       rec.Active,
+		CreatedAt:    rec.CreatedAt,
+	}, nil
+}

--- a/internal/worksource/types_test.go
+++ b/internal/worksource/types_test.go
@@ -1,0 +1,122 @@
+package worksource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+func TestTriggerRoundTrip(t *testing.T) {
+	cases := []struct {
+		dashed     Trigger
+		underscore state.WorksourceTrigger
+	}{
+		{TriggerOnDemand, state.TriggerOnDemand},
+		{TriggerOnLabel, state.TriggerOnLabel},
+		{TriggerOnOpen, state.TriggerOnOpen},
+		{TriggerScheduled, state.TriggerScheduled},
+	}
+	for _, c := range cases {
+		t.Run(string(c.dashed), func(t *testing.T) {
+			got, ok := triggerToState(c.dashed)
+			require.True(t, ok)
+			assert.Equal(t, c.underscore, got)
+
+			back, ok := triggerFromState(c.underscore)
+			require.True(t, ok)
+			assert.Equal(t, c.dashed, back)
+		})
+	}
+}
+
+func TestTriggerToState_Unknown(t *testing.T) {
+	_, ok := triggerToState("garbage")
+	assert.False(t, ok)
+}
+
+func TestTriggerFromState_Unknown(t *testing.T) {
+	_, ok := triggerFromState(state.WorksourceTrigger("garbage"))
+	assert.False(t, ok)
+}
+
+func TestMarshalSelector_Empty(t *testing.T) {
+	got, err := marshalSelector(BindingSpec{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", got)
+}
+
+func TestMarshalSelector_Pinned(t *testing.T) {
+	got, err := marshalSelector(BindingSpec{
+		LabelFilter: []string{"bug", "ready-for-impl"},
+		State:       "open",
+		Kinds:       []string{"issue"},
+	})
+	require.NoError(t, err)
+	// Field order is fixed by Go struct field order — pin the wire form.
+	assert.Equal(t, `{"labels":["bug","ready-for-impl"],"state":"open","kinds":["issue"]}`, got)
+}
+
+func TestMarshalSelector_PartialFields(t *testing.T) {
+	got, err := marshalSelector(BindingSpec{State: "closed"})
+	require.NoError(t, err)
+	assert.Equal(t, `{"state":"closed"}`, got)
+}
+
+func TestUnmarshalSelector_RoundTrip(t *testing.T) {
+	in := `{"labels":["bug"],"state":"open","kinds":["issue"]}`
+	p, err := unmarshalSelector(in)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bug"}, p.Labels)
+	assert.Equal(t, "open", p.State)
+	assert.Equal(t, []string{"issue"}, p.Kinds)
+}
+
+func TestUnmarshalSelector_EmptyForms(t *testing.T) {
+	for _, raw := range []string{"", "{}"} {
+		p, err := unmarshalSelector(raw)
+		require.NoError(t, err)
+		assert.Empty(t, p.Labels)
+		assert.Empty(t, p.State)
+		assert.Empty(t, p.Kinds)
+	}
+}
+
+func TestUnmarshalSelector_Bad(t *testing.T) {
+	_, err := unmarshalSelector("not json")
+	assert.Error(t, err)
+}
+
+func TestFromStoreRecord_Round(t *testing.T) {
+	rec, err := fromStoreRecord(state.WorksourceBindingRecord{
+		ID:           42,
+		Forge:        "github",
+		Repo:         "owner/repo",
+		Selector:     `{"labels":["bug"],"state":"open"}`,
+		PipelineName: "impl-issue",
+		Trigger:      state.TriggerOnLabel,
+		Active:       true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, BindingID(42), rec.ID)
+	assert.Equal(t, TriggerOnLabel, rec.Trigger)
+	assert.Equal(t, []string{"bug"}, rec.LabelFilter)
+	assert.Equal(t, "open", rec.State)
+}
+
+func TestFromStoreRecord_BadTrigger(t *testing.T) {
+	_, err := fromStoreRecord(state.WorksourceBindingRecord{
+		ID: 1, Forge: "github", Repo: "x/y", Trigger: state.WorksourceTrigger("???"),
+	})
+	assert.Error(t, err)
+}
+
+func TestFromStoreRecord_BadSelector(t *testing.T) {
+	_, err := fromStoreRecord(state.WorksourceBindingRecord{
+		ID: 1, Forge: "github", Repo: "x/y", Trigger: state.TriggerOnDemand,
+		Selector: "not json",
+	})
+	assert.Error(t, err)
+}

--- a/internal/worksource/validate.go
+++ b/internal/worksource/validate.go
@@ -1,0 +1,46 @@
+package worksource
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+// validateSpec rejects malformed BindingSpec values at the service boundary.
+//
+// Rules:
+//   - Forge, RepoPattern, PipelineName must be non-empty.
+//   - Trigger must be one of the documented constants.
+//   - RepoPattern must be a valid path.Match glob; double-star (**) is
+//     rejected because path.Match does not support it and silent acceptance
+//     would surprise callers.
+//   - LabelFilter entries must be non-empty.
+func validateSpec(spec BindingSpec) error {
+	if strings.TrimSpace(spec.Forge) == "" {
+		return errors.New("worksource: forge required")
+	}
+	if strings.TrimSpace(spec.PipelineName) == "" {
+		return errors.New("worksource: pipeline_name required")
+	}
+	if strings.TrimSpace(spec.RepoPattern) == "" {
+		return errors.New("worksource: repo_pattern required")
+	}
+	if _, ok := triggerToState(spec.Trigger); !ok {
+		return fmt.Errorf("worksource: unknown trigger %q (want on-demand|on-label|on-open|scheduled)", spec.Trigger)
+	}
+	if strings.Contains(spec.RepoPattern, "**") {
+		return fmt.Errorf("worksource: repo_pattern %q uses ** which path.Match does not support", spec.RepoPattern)
+	}
+	// path.Match validates pattern syntax against an arbitrary input. A
+	// malformed pattern returns ErrBadPattern regardless of the input.
+	if _, err := path.Match(spec.RepoPattern, "probe"); err != nil {
+		return fmt.Errorf("worksource: malformed repo_pattern %q: %w", spec.RepoPattern, err)
+	}
+	for i, lbl := range spec.LabelFilter {
+		if strings.TrimSpace(lbl) == "" {
+			return fmt.Errorf("worksource: label_filter[%d] is empty", i)
+		}
+	}
+	return nil
+}

--- a/specs/1591-worksource-service/plan.md
+++ b/specs/1591-worksource-service/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan — #1591 WorkSourceService + bindings CRUD
+
+## 1. Objective
+
+Add a domain service in `internal/worksource/` that wraps the existing `state.WorksourceStore` (PRE-5) with validated CRUD plus a `MatchBindings` query that selects bindings applicable to a given `WorkItemRef` (forge + repo + labels + state). No HTTP/webui yet — pure service + tests.
+
+## 2. Approach
+
+Thin domain layer on top of `internal/state`:
+
+- Define value types (`BindingSpec`, `BindingRecord`, `BindingID`, `BindingFilter`, `WorkItemRef`) in `internal/worksource/types.go`.
+- Define the `Service` interface and a `service` struct backed by `state.WorksourceStore` in `internal/worksource/service.go`.
+- Translate between domain `BindingSpec` (typed: repo glob, label filter slice, trigger enum) and the storage shape (`WorksourceBindingRecord` with opaque JSON `selector`/`config`). Selector JSON shape: `{ "labels": [], "state": "open|closed|any", "kinds": [] }`.
+- `MatchBindings` filters via `ListActiveBindings()` then in-Go: forge equality, `path.Match` glob on `repo`, label intersection, kind/state subset. Index already exists for forge+repo (active=1).
+- Reject invalid specs at write time: empty forge, empty pipeline name, invalid trigger value, malformed glob (`path.Match("", "test")` returns error on bad pattern), non-positive ID on update/get/delete.
+- Map "delete" to `DeactivateBinding` (state layer never hard-deletes; preserves run history per existing comment).
+
+### Trigger naming
+
+Issue uses dashed form (`on-demand`); state layer uses underscored form (`on_demand`). Service accepts the dashed external form, normalises to underscored before persisting, and renders dashed on the way out. One conversion table in `types.go`.
+
+## 3. File Mapping
+
+| Action | Path | Purpose |
+|---|---|---|
+| CREATE | `internal/worksource/doc.go` | Package doc — domain service for forge↔pipeline bindings |
+| CREATE | `internal/worksource/types.go` | `BindingSpec`, `BindingRecord`, `BindingID`, `BindingFilter`, `WorkItemRef`, `Trigger` enum + dashed↔underscored converters, selector marshal/unmarshal |
+| CREATE | `internal/worksource/service.go` | `Service` interface + `NewService(state.WorksourceStore) Service` + struct impl of all six methods |
+| CREATE | `internal/worksource/validate.go` | `validateSpec(BindingSpec) error` — central rejection rules (forge, pipeline, trigger, repo glob, label values) |
+| CREATE | `internal/worksource/match.go` | `matches(rec BindingRecord, ref WorkItemRef) bool` — the in-memory predicate used by `MatchBindings` |
+| CREATE | `internal/worksource/service_test.go` | CRUD round-trip + invalid-spec rejection cases (uses `state` test helper to stand up SQLite) |
+| CREATE | `internal/worksource/match_test.go` | match-by-label, match-by-glob, match-state, no-match cases (table driven) |
+| MODIFY | (none in state package) | PRE-5 already complete |
+
+No `internal/service/worksource.go` — issue scopes only `internal/worksource/`. The thicker service-layer wrapper (`internal/service/`) does not exist yet and is out of scope for #2.2; #2.4 ("Run on this issue" button) will introduce it if needed.
+
+## 4. Architecture Decisions
+
+1. **Domain types separate from storage record.** `BindingRecord` exposes typed `LabelFilter []string`, `RepoPattern string`, `Trigger Trigger`; storage `WorksourceBindingRecord` keeps opaque JSON `Selector`/`Config`. Service is the only translator. Keeps state layer schema-stable as the dispatch matrix grows (per the comment in `state/worksource.go:23`).
+2. **Soft-delete via `DeactivateBinding`.** `DeleteBinding` does not hard-delete; it flips `active=0`. Matches PRE-5 design and preserves run-history references. Documented on the interface method.
+3. **`MatchBindings` is in-memory filter, not SQL.** Glob and label intersection do not map cleanly onto SQLite. `ListActiveBindings()` is bounded by binding count (small N — one row per project/forge/pipeline tuple), so an in-memory filter is fine and avoids encoding glob semantics in SQL. Revisit if N exceeds ~10⁴.
+4. **`WorkItemRef` lives in this package, not in `internal/contract/schemas/shared/`.** #2.1 ships the JSON Schema. The Go struct is a plain value object here, mirroring the schema shape so that when #2.1 lands, the validator can be wired in via a one-line registry call. `WorkItemRef` fields: `Forge`, `Repo`, `Kind`, `ID`, `Title`, `URL`, `Labels []string`, `State string`.
+5. **Trigger enum mirrored, not re-exported.** Define `worksource.Trigger` separately from `state.WorksourceTrigger` so service callers don't import `state`. Conversion in `types.go`.
+6. **No context plumbing into the state store yet.** `state.WorksourceStore` methods don't take `context.Context`. Service interface accepts ctx (matches issue signature), checks `ctx.Err()` at entry, then calls store. State layer can add ctx in a follow-up without breaking the service contract.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|---|---|
+| #2.1 `work_item_ref` schema not yet merged | Define Go struct locally with the schema shape from `onboarding-as-session-plan.md` §5. When schema lands, swap to schema-bound validation; field names already aligned. |
+| Glob semantics surprise (`path.Match` is not full glob — no `**`) | Doc-string the supported syntax (`*`, `?`, `[abc]`); reject double-star at validate time with clear error. Real-world repo patterns don't need `**`. |
+| Trigger string mismatch (dashed vs underscored) breaks round-trip | Conversion in one place (`types.go`); table-test both directions. |
+| Selector JSON shape drift between writers | Single private `selectorPayload` struct with `json` tags; only marshalled by the service. Tests pin the wire form. |
+| Test isolation across packages (state migrations need temp SQLite) | Reuse the existing test helper in `internal/state` (e.g. `newTestStore(t)` pattern); `t.TempDir()` for the DB file. |
+
+## 6. Testing Strategy
+
+Unit tests live in `internal/worksource/`. Each test spins up a fresh SQLite-backed `state.StateStore` via the existing test helper, then a `worksource.Service` over it.
+
+| File | Cases |
+|---|---|
+| `service_test.go` | Create→Get round-trip, Create→List filter (forge, repo), Update mutates fields, Delete deactivates (List active excludes), invalid spec rejection (empty forge / empty pipeline / bad trigger / bad glob / empty repo pattern), Get/Update/Delete on missing ID returns error. |
+| `match_test.go` | Table-driven: exact repo match, glob `*` match, glob `owner/*` match, label-filter (any-of semantics) match, state filter match, kind filter match, no match (forge mismatch / repo mismatch / label mismatch / state mismatch / inactive bindings excluded). |
+
+Run gate: `go test ./internal/worksource/... -race`. Project contract: `go test ./...` (per `wave.yaml` `contract_test_command`).
+
+No integration tests against real forges in this phase — that's #2.3/#2.4.
+
+## 7. Out of Scope
+
+- HTTP handlers / webui (#2.3)
+- Dispatch wiring to `ExecutorService.Run` (#2.4)
+- Schedule / cron evaluation (PRE-6 / phase 3)
+- `work_item_ref` schema file (#2.1) — consumed as a Go struct here

--- a/specs/1591-worksource-service/spec.md
+++ b/specs/1591-worksource-service/spec.md
@@ -1,0 +1,42 @@
+# Phase 2.2: WorkSourceService + bindings CRUD
+
+**Issue:** [re-cinq/wave#1591](https://github.com/re-cinq/wave/issues/1591)
+**Epic:** #1565 Phase 2 (work-source dispatch)
+**Labels:** enhancement, ready-for-impl
+**State:** OPEN
+**Author:** nextlevelshit
+
+## Goal
+
+Implement `WorkSourceService` in `internal/worksource/` that manages bindings between work-sources (forges, schedules) and the pipelines they should trigger. CRUD over the `worksource_binding` table from PRE-5.
+
+## Acceptance Criteria
+
+- [ ] `internal/worksource/service.go` with interface:
+  - `CreateBinding(ctx, BindingSpec) (BindingID, error)`
+  - `ListBindings(ctx, filter) ([]BindingRecord, error)`
+  - `GetBinding(ctx, BindingID) (BindingRecord, error)`
+  - `UpdateBinding(ctx, BindingID, BindingSpec) error`
+  - `DeleteBinding(ctx, BindingID) error`
+  - `MatchBindings(ctx, work_item_ref) ([]BindingRecord, error)` — returns bindings that match a given work-item
+- [ ] BindingSpec validates: forge type, repo pattern (glob or exact), label filter, pipeline name, trigger mode (`on-demand|on-label|on-open|scheduled`)
+- [ ] Tests: CRUD round-trip + match-by-label + match-by-glob + invalid-spec rejection
+- [ ] No webui yet (that is #2.3)
+
+## Dependencies
+
+- **PRE-5** — `worksource_binding` table (MERGED in `internal/state/migration_definitions.go` v32, `internal/state/worksource.go`)
+- **#2.1** — `work_item_ref` shared schema. Per `docs/scope/onboarding-as-session-plan.md` §6 Phase 2, this lives at `internal/contract/schemas/shared/work_item_ref.json` and generalises `issue_ref` / `pr_ref`. **NOT YET LANDED** at the time of this plan; see plan §Risks.
+
+## Open Questions / Missing Info
+
+1. **Exact `BindingSpec` / `BindingRecord` shape** — the issue lists fields by name only. Plan §Architecture infers a concrete shape compatible with the existing `WorksourceBindingRecord` (state layer) and the trigger enum already in code.
+2. **`work_item_ref` consumer contract** — schema not yet checked in. Plan adopts the shape published in onboarding-as-session-plan §5 (`forge`, `repo`, `kind`, `id`, `title`, `url`, plus optional `labels`, `state`) and gates real schema-bound validation on #2.1.
+
+## References
+
+- Original: https://github.com/re-cinq/wave/issues/1591
+- ADR-010 (pipeline IO protocol)
+- ADR-016 (work-source-centric webui IA)
+- `docs/scope/onboarding-as-session-plan.md` §4.2, §6 Phase 2
+- Existing infra: `internal/state/worksource.go`, `internal/state/migration_definitions.go` (v32)

--- a/specs/1591-worksource-service/tasks.md
+++ b/specs/1591-worksource-service/tasks.md
@@ -1,0 +1,34 @@
+# Work Items — #1591 WorkSourceService
+
+## Phase 1: Setup
+
+- [X] 1.1: Create `internal/worksource/` directory + `doc.go` package comment
+- [X] 1.2: Add `internal/worksource/types.go` skeleton — `BindingID`, `Trigger` enum (with dashed↔underscored converters), `BindingSpec`, `BindingRecord`, `BindingFilter`, `WorkItemRef`, `selectorPayload` (private)
+
+## Phase 2: Core Implementation
+
+- [X] 2.1: `internal/worksource/validate.go` — `validateSpec`: empty forge / empty pipeline / unknown trigger / empty repo pattern / `path.Match` syntax check / no-`**` rule [P]
+- [X] 2.2: `internal/worksource/match.go` — `matches(BindingRecord, WorkItemRef) bool`: forge equal, `path.Match` repo, label any-of, state subset, kind subset [P]
+- [X] 2.3: `internal/worksource/service.go` — `Service` interface (six methods, ctx-first) + `service` struct + `NewService(state.WorksourceStore) Service`
+- [X] 2.4: Wire `CreateBinding` — `validateSpec` → marshal selector JSON → `store.CreateBinding` → return `BindingID`
+- [X] 2.5: Wire `GetBinding`/`ListBindings` — call store, translate `WorksourceBindingRecord`→`BindingRecord` (selector JSON unmarshal, trigger denormalise)
+- [X] 2.6: Wire `UpdateBinding` — re-validate spec, preserve `CreatedAt`, call `store.UpdateBinding`
+- [X] 2.7: Wire `DeleteBinding` → `store.DeactivateBinding` (soft-delete; document on interface)
+- [X] 2.8: Wire `MatchBindings` — `store.ListActiveBindings` → in-memory `matches` filter
+
+## Phase 3: Testing
+
+- [X] 3.1: `internal/worksource/service_test.go` — CRUD round-trip with real SQLite state store [P]
+- [X] 3.2: `internal/worksource/service_test.go` — invalid-spec rejection table (empty forge, empty pipeline, bad trigger, bad glob, empty repo) [P]
+- [X] 3.3: `internal/worksource/service_test.go` — Get/Update/Delete missing-ID error paths [P]
+- [X] 3.4: `internal/worksource/match_test.go` — exact repo, glob, label any-of, state, kind, inactive-excluded, multi-mismatch [P]
+- [X] 3.5: `internal/worksource/types_test.go` — trigger dashed↔underscored round-trip; selector JSON wire form pinned [P]
+- [X] 3.6: Run `go test ./internal/worksource/... -race` — green
+- [X] 3.7: Run `go test ./...` (project contract) — green
+
+## Phase 4: Polish
+
+- [X] 4.1: Doc-string every exported symbol; note glob syntax limits and soft-delete semantics
+- [ ] 4.2: Run `golangci-lint run ./internal/worksource/...` — clean (lint binary not present in this sandbox; `go vet ./internal/worksource/...` clean)
+- [X] 4.3: Cross-check acceptance criteria checklist on the issue, mark each
+- [X] 4.4: PR description references epic #1565, lists files, calls out #2.1 schema follow-up


### PR DESCRIPTION
## Summary

- Add `internal/worksource` package implementing `WorkSourceService` over the existing PRE-5 `state.WorksourceStore`
- Six ctx-first methods: Create/List/Get/Update/Delete/Match plus typed `BindingSpec` validation (forge, repo glob, label filter, pipeline name, trigger enum)
- In-memory `MatchBindings` filter against a `WorkItemRef` (Go mirror of #2.1 schema)
- `DeleteBinding` maps to soft-delete (`DeactivateBinding`) so run history keeps binding context
- Trigger names use dashed form externally, normalised to underscored `state.WorksourceTrigger` before persistence; glob syntax follows `path.Match` (double-star rejected at validate)

Related to #1591

## Changes

- `internal/worksource/service.go` — Service interface + implementation, CRUD over WorksourceStore
- `internal/worksource/types.go` — `BindingSpec`, `BindingRecord`, `WorkItemRef`, trigger enum
- `internal/worksource/validate.go` — Spec validation (forge/repo/glob/label/pipeline/trigger)
- `internal/worksource/match.go` — `MatchBindings` filter logic
- `internal/worksource/{service,match,types}_test.go` — CRUD round-trip, list filters, update-preserves-created-at, soft-delete exclusion, invalid-spec table, ctx-cancelled, match table (exact/glob/label any-of/state/kind/multi-mismatch/inactive)
- `internal/worksource/doc.go` — package doc
- `specs/1591-worksource-service/{spec,plan,tasks}.md` — planning artifacts

## Test Plan

- [x] `go test ./internal/worksource/...` passes (CRUD round-trip + match table + invalid-spec rejection + ctx-cancelled)
- [x] Selector JSON wire form pinned by golden test
- [x] No webui (#2.3) or executor wiring (#2.4) in this PR — explicit out-of-scope
- [x] `WorkItemRef` ready for one-line registry wire-up once #2.1 schema lands