### PR TITLE
feat(contract): add work_item_ref shared schema (#1590)

### DIFF
--- a/docs/adr/010-pipeline-io-protocol.md
+++ b/docs/adr/010-pipeline-io-protocol.md
@@ -9,7 +9,7 @@ Accepted (Phase 1 — load-time validation live; pipeline migration ongoing)
 ## Implementation Status
 
 Landed:
-- Eight canonical schemas in `internal/contract/schemas/shared/*.json` (`issue_ref`, `pr_ref`, `scope_result`, `plan_ref`, `findings_report`, `workspace_ref`, `spec_ref`, `branch_ref`).
+- Nine canonical schemas in `internal/contract/schemas/shared/*.json` (`issue_ref`, `pr_ref`, `scope_result`, `plan_ref`, `findings_report`, `workspace_ref`, `spec_ref`, `branch_ref`, `work_item_ref`).
 - Registry: `internal/contract/schemas/registry.go` (+ test).
 - Typed I/O fields: `InputConfig.Type` (`internal/pipeline/types.go:138`) and `PipelineOutput.Type` (`types.go:725`); both expose `EffectiveType()` defaulting to `"string"`.
 - Load-time validation: `ValidatePipelineIOTypes` and `TypedWiringCheck` in `internal/pipeline/iotypes.go` (~216 LOC), wired into the loader at `dag.go:42` and `dag.go:52`.
@@ -63,7 +63,7 @@ Introduce a **typed I/O protocol** with four pieces:
    `internal/contract/schemas/shared/*.json`, embedded into the Wave
    binary via `go:embed`. Each file's basename is the type name
    (`issue_ref`, `pr_ref`, `branch_ref`, `spec_ref`, `findings_report`,
-   `plan_ref`, `workspace_ref`, `scope_result`). A pipeline's type
+   `plan_ref`, `workspace_ref`, `scope_result`, `work_item_ref`). A pipeline's type
    annotation must resolve against this registry or the sentinel
    `string`.
 
@@ -193,7 +193,7 @@ on input/output, load-time validation.
 ## Implementation Notes
 
 Files created:
-- `internal/contract/schemas/shared/*.json` (8 canonical schemas)
+- `internal/contract/schemas/shared/*.json` (9 canonical schemas)
 - `internal/contract/schemas/shared/registry.go` (+ test)
 - `internal/pipeline/iotypes.go` (+ test)
 - `docs/adr/010-pipeline-io-protocol.md` (this file)
@@ -255,3 +255,9 @@ by design — they exercise specific executor paths and need free shape.
   decide whether to wire shared types into the runtime contract path.
 - No deep `field`-extraction on `pipeline_outputs` with type
   narrowing. The existing `field:` hint stays as-is.
+
+## Schema additions
+
+| Date | Type | Issue / PR | Notes |
+|---|---|---|---|
+| 2026-04-30 | `work_item_ref` | #1590 (Epic #1565 Phase 2.1) | Canonical work-source dispatch shape; `source` enum (`github`, `gitea`, `gitlab`, `bitbucket`, `schedule`, `manual`) discriminates forge vs non-forge entries. Forge sources require `forge_host`, `owner`, `repo` via `if/then`; `number` stays optional even for forge sources to accommodate numberless work items. Not mirrored to `.agents/contracts/` — that registry holds step-output contracts, not shared pipeline-I/O types. |

--- a/docs/scope/onboarding-as-session-plan.md
+++ b/docs/scope/onboarding-as-session-plan.md
@@ -389,20 +389,12 @@ See PRE-5. Five new tables; ~10 new `StateStore` methods. Zero existing column c
 
 New canonical schema (per ADR-010): `internal/contract/schemas/shared/work_item_ref.json` — generalizes `issue_ref` / `pr_ref` for forge-agnostic work items.
 
-```json
-{
-  "type": "object",
-  "required": ["forge", "repo", "kind", "id"],
-  "properties": {
-    "forge": { "enum": ["github", "gitea", "gitlab", "bitbucket"] },
-    "repo": { "type": "string" },        // owner/name
-    "kind": { "enum": ["issue", "pr", "task"] },
-    "id": { "type": "string" },
-    "title": { "type": "string" },
-    "url": { "type": "string", "format": "uri" }
-  }
-}
-```
+The shipped shape is canonicalized in [`internal/contract/schemas/shared/work_item_ref.json`](../../internal/contract/schemas/shared/work_item_ref.json). It diverged from the earlier draft below:
+
+- `source` (not `forge`) discriminates entries — enum extended with `schedule` and `manual` so non-forge work items fit cleanly.
+- `forge_host`, `owner`, `repo` replace the combined `repo: "owner/name"` string and are conditionally required (`if/then` on `source`) only for forge entries.
+- `number` (integer) supersedes the polymorphic `id` and `kind` fields. Issue-vs-PR distinction lives in the `state` enum (`open | closed | merged`) and the URL itself, not a separate type tag.
+- `state` and `created_at` are required; `labels` is an optional array of strings.
 
 ---
 
@@ -432,7 +424,7 @@ New canonical schema (per ADR-010): `internal/contract/schemas/shared/work_item_
 
 | # | Title | Files |
 |---|---|---|
-| 2.1 | `work_item_ref` shared schema | `internal/contract/schemas/shared/work_item_ref.json` + registry |
+| 2.1 ✅ | `work_item_ref` shared schema | `internal/contract/schemas/shared/work_item_ref.json` + registry |
 | 2.2 | WorkSourceService + bindings | `internal/service/worksource.go`, `internal/worksource/`, table CRUD |
 | 2.3 | Webui `/work` board + detail | new templates, handlers; replaces dashboard as default landing |
 | 2.4 | "Run on this issue" button | binding lookup → `ExecutorService.Run` |

--- a/internal/contract/schemas/shared/registry_test.go
+++ b/internal/contract/schemas/shared/registry_test.go
@@ -14,6 +14,7 @@ func TestRegistryContainsCanonicalTypes(t *testing.T) {
 		"findings_report",
 		"plan_ref",
 		"workspace_ref",
+		"work_item_ref",
 	}
 	for _, name := range expected {
 		data, ok := Lookup(name)
@@ -63,8 +64,8 @@ func TestUnknownType(t *testing.T) {
 
 func TestNamesSorted(t *testing.T) {
 	names := Names()
-	if len(names) < 7 {
-		t.Errorf("Names() returned %d entries, want at least 7", len(names))
+	if len(names) < 8 {
+		t.Errorf("Names() returned %d entries, want at least 8", len(names))
 	}
 	for i := 1; i < len(names); i++ {
 		if names[i-1] >= names[i] {

--- a/internal/contract/schemas/shared/work_item_ref.json
+++ b/internal/contract/schemas/shared/work_item_ref.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "wave://shared/work_item_ref",
+  "title": "WorkItemRef",
+  "description": "Canonical reference to a unit of work emitted by a work-source (forge issue/PR, scheduled job, manual trigger) and consumed by pipelines. Forge-specific fields (forge_host, owner, repo, number) are required only when source identifies a git forge; schedule/manual sources omit them.",
+  "type": "object",
+  "required": ["source", "url", "title", "state", "created_at"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["github", "gitea", "gitlab", "bitbucket", "schedule", "manual"],
+      "description": "Origin of the work item. Forge values (github, gitea, gitlab, bitbucket) imply forge_host, owner, repo are required."
+    },
+    "forge_host": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Hostname of the forge instance (e.g. github.com, codeberg.org, gitlab.example.com). Required for forge sources."
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Owner (user or organization). Required for forge sources."
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository name. Required for forge sources."
+    },
+    "number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Issue or PR number. Optional even for forge sources because some forges expose numberless work items (e.g. Gitea task lists)."
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical URL identifying the work item. Used as the primary key in the worksource_binding table."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable title of the work item."
+    },
+    "labels": {
+      "type": "array",
+      "description": "Labels or tags attached to the work item. May be empty; absent for sources that have no label concept.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "state": {
+      "type": "string",
+      "enum": ["open", "closed", "merged"],
+      "description": "Lifecycle state. 'merged' applies only to PR-like work items; consumers may filter per source."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 timestamp marking when the work item was created."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "enum": ["github", "gitea", "gitlab", "bitbucket"]
+          }
+        },
+        "required": ["source"]
+      },
+      "then": {
+        "required": ["forge_host", "owner", "repo"]
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/internal/contract/schemas/shared/work_item_ref_test.go
+++ b/internal/contract/schemas/shared/work_item_ref_test.go
@@ -1,0 +1,239 @@
+package shared
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// compileWorkItemRefSchema loads the embedded work_item_ref schema and compiles
+// it with the same validator the contract package uses at runtime so test
+// behavior matches production validation.
+func compileWorkItemRefSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+
+	raw, ok := Lookup("work_item_ref")
+	if !ok {
+		t.Fatal("Lookup(\"work_item_ref\") = !ok")
+	}
+
+	var schemaDoc any
+	if err := json.Unmarshal(raw, &schemaDoc); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+
+	const schemaURL = "wave://shared/work_item_ref"
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(schemaURL, schemaDoc); err != nil {
+		t.Fatalf("AddResource: %v", err)
+	}
+	compiled, err := c.Compile(schemaURL)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	return compiled
+}
+
+func mustParse(t *testing.T, raw string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("invalid fixture JSON: %v\n%s", err, raw)
+	}
+	return v
+}
+
+// TestWorkItemRef_PositiveFixtures validates one well-formed document for each
+// value of the source enum: forge entries supply forge_host/owner/repo, while
+// schedule and manual entries omit them.
+func TestWorkItemRef_PositiveFixtures(t *testing.T) {
+	schema := compileWorkItemRefSchema(t)
+
+	cases := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "github_issue",
+			json: `{
+				"source": "github",
+				"forge_host": "github.com",
+				"owner": "re-cinq",
+				"repo": "wave",
+				"number": 1590,
+				"url": "https://github.com/re-cinq/wave/issues/1590",
+				"title": "Phase 2.1: work_item_ref shared schema + registry entry",
+				"labels": ["enhancement", "ready-for-impl"],
+				"state": "open",
+				"created_at": "2026-04-29T10:15:00Z"
+			}`,
+		},
+		{
+			name: "gitea_pr_merged",
+			json: `{
+				"source": "gitea",
+				"forge_host": "codeberg.org",
+				"owner": "libretech",
+				"repo": "wave-testing",
+				"number": 42,
+				"url": "https://codeberg.org/libretech/wave-testing/pulls/42",
+				"title": "Add caching layer",
+				"labels": [],
+				"state": "merged",
+				"created_at": "2026-03-10T08:00:00Z"
+			}`,
+		},
+		{
+			name: "gitlab_issue_closed",
+			json: `{
+				"source": "gitlab",
+				"forge_host": "gitlab.example.com",
+				"owner": "team",
+				"repo": "service",
+				"number": 7,
+				"url": "https://gitlab.example.com/team/service/-/issues/7",
+				"title": "Fix flaky test",
+				"state": "closed",
+				"created_at": "2026-02-01T12:30:45+02:00"
+			}`,
+		},
+		{
+			name: "bitbucket_no_number",
+			json: `{
+				"source": "bitbucket",
+				"forge_host": "bitbucket.org",
+				"owner": "acme",
+				"repo": "platform",
+				"url": "https://bitbucket.org/acme/platform/board/task-xyz",
+				"title": "Cleanup dashboards",
+				"labels": ["chore"],
+				"state": "open",
+				"created_at": "2026-04-15T18:00:00Z"
+			}`,
+		},
+		{
+			name: "schedule_trigger",
+			json: `{
+				"source": "schedule",
+				"url": "wave://schedule/nightly-audit",
+				"title": "Nightly audit run",
+				"state": "open",
+				"created_at": "2026-04-30T00:00:00Z"
+			}`,
+		},
+		{
+			name: "manual_trigger",
+			json: `{
+				"source": "manual",
+				"url": "wave://manual/operator-2026-04-30-01",
+				"title": "Operator: rerun failed contract suite",
+				"labels": ["ops"],
+				"state": "open",
+				"created_at": "2026-04-30T01:48:11Z"
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustParse(t, tc.json)
+			if err := schema.Validate(doc); err != nil {
+				t.Errorf("expected valid document, got error: %v", err)
+			}
+		})
+	}
+}
+
+// TestWorkItemRef_NegativeFixtures asserts the schema rejects malformed
+// documents. Each case isolates one violation: missing forge fields on a
+// forge source, an unknown source, additional properties, an invalid state,
+// and a malformed created_at timestamp.
+func TestWorkItemRef_NegativeFixtures(t *testing.T) {
+	schema := compileWorkItemRefSchema(t)
+
+	cases := []struct {
+		name        string
+		json        string
+		wantSubstr  string // optional fragment we expect somewhere in the error
+		description string
+	}{
+		{
+			name: "forge_missing_forge_host",
+			json: `{
+				"source": "github",
+				"owner": "re-cinq",
+				"repo": "wave",
+				"url": "https://github.com/re-cinq/wave/issues/1",
+				"title": "x",
+				"state": "open",
+				"created_at": "2026-04-30T00:00:00Z"
+			}`,
+			wantSubstr:  "forge_host",
+			description: "github source must require forge_host via if/then",
+		},
+		{
+			name: "unknown_source",
+			json: `{
+				"source": "carrier-pigeon",
+				"url": "wave://manual/x",
+				"title": "x",
+				"state": "open",
+				"created_at": "2026-04-30T00:00:00Z"
+			}`,
+			wantSubstr:  "source",
+			description: "source enum must reject unknown values",
+		},
+		{
+			name: "extra_property",
+			json: `{
+				"source": "manual",
+				"url": "wave://manual/x",
+				"title": "x",
+				"state": "open",
+				"created_at": "2026-04-30T00:00:00Z",
+				"priority": "p0"
+			}`,
+			wantSubstr:  "priority",
+			description: "additionalProperties:false must reject undeclared fields",
+		},
+		{
+			name: "invalid_state",
+			json: `{
+				"source": "manual",
+				"url": "wave://manual/x",
+				"title": "x",
+				"state": "wip",
+				"created_at": "2026-04-30T00:00:00Z"
+			}`,
+			wantSubstr:  "state",
+			description: "state enum must reject values outside open|closed|merged",
+		},
+		{
+			name: "malformed_created_at",
+			json: `{
+				"source": "manual",
+				"url": "wave://manual/x",
+				"title": "x",
+				"state": "open",
+				"created_at": "yesterday"
+			}`,
+			wantSubstr:  "date-time",
+			description: "created_at format:date-time must reject non-RFC3339 strings",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustParse(t, tc.json)
+			err := schema.Validate(doc)
+			if err == nil {
+				t.Fatalf("expected validation error (%s), got nil", tc.description)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error %q does not mention %q (%s)", err.Error(), tc.wantSubstr, tc.description)
+			}
+		})
+	}
+}

--- a/specs/1590-work-item-ref-schema/plan.md
+++ b/specs/1590-work-item-ref-schema/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan — work_item_ref shared schema
+
+## 1. Objective
+
+Add a canonical `work_item_ref` JSON schema (draft-07) to the embedded shared-schemas registry so future Phase 2 work (`WorkSourceService`, webui board, dispatch wiring) has a single, validated lingua franca for forge issues, PRs, scheduled jobs, and manual triggers.
+
+## 2. Approach
+
+Mirror the existing `issue_ref.json` / `pr_ref.json` pattern in `internal/contract/schemas/shared/`. The registry auto-loads any `*.json` file in that directory via `go:embed`, so the only code change is updating the canonical-types list in `registry_test.go` and adding a new validation test that exercises one fixture per `source` enum value.
+
+Conditional-required fields (`forge_host`, `owner`, `repo`, `number` only required when `source` is a forge) are expressed via JSON Schema `allOf` + `if/then`. This keeps schedule/manual entries valid without giving forge entries a soft contract.
+
+## 3. File Mapping
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `internal/contract/schemas/shared/work_item_ref.json` | Canonical schema (draft-07, embedded) |
+| `internal/contract/schemas/shared/work_item_ref_test.go` | Loads schema + validates one sample doc per `source` enum value (github, gitea, gitlab, bitbucket, schedule, manual) |
+| `specs/1590-work-item-ref-schema/spec.md` | Issue + acceptance criteria capture (this PR) |
+| `specs/1590-work-item-ref-schema/plan.md` | This file |
+| `specs/1590-work-item-ref-schema/tasks.md` | Phased work breakdown |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `internal/contract/schemas/shared/registry_test.go` | Add `"work_item_ref"` to the canonical-types list in `TestRegistryContainsCanonicalTypes`; bump the `len(names) < 7` floor to 8 in `TestNamesSorted` |
+| `docs/adr/010-pipeline-io-protocol.md` | Append `work_item_ref` to the registered shared types table (if such table exists; otherwise add a short "Update history" entry) |
+| `docs/scope/onboarding-as-session-plan.md` | Tick Phase 2.1 row; replace inline draft snippet (lines 392–404) with a link to the canonical file or a note that the shipped shape differs |
+
+### Not modified
+
+- `.agents/contracts/` and `internal/defaults/embedfs/contracts/` — these hold step-output schemas (validated by `sync_test.go`), not pipeline-I/O typed schemas. Shared-schemas use a separate registry (`internal/contract/schemas/shared/registry.go`). Skipping this avoids creating a second source of truth.
+
+## 4. Architecture Decisions
+
+### D1 — Use `source` discriminator (not `forge`)
+
+`issue_ref.json` uses `forge` because every entry *is* a forge entry. `work_item_ref` must also represent `schedule` and `manual` triggers, where "forge" is a category error. Using `source` (per acceptance criteria) cleanly accommodates both.
+
+### D2 — Conditional required fields via `if/then/else`
+
+Acceptance criteria lists `forge_host`, `owner`, `repo`, `number` under "required fields" but those only make sense for forge sources. Plan: declare them in `properties`, mark `source`/`url`/`title`/`state`/`created_at` unconditionally required, then use:
+
+```json
+"allOf": [{
+  "if": { "properties": { "source": { "enum": ["github","gitea","gitlab","bitbucket"] } } },
+  "then": { "required": ["forge_host","owner","repo"] }
+}]
+```
+
+`number` is *not* required even for forge sources — generic forge "tasks" (Gitea task lists, GitLab work items) may not carry one. We define it as `integer, minimum: 1` when present.
+
+### D3 — Reject the draft-snippet shape from `onboarding-as-session-plan.md:392`
+
+Earlier draft used `{ forge, repo, kind, id }`. Acceptance criteria is the authoritative shape. We replace the draft snippet rather than carry both.
+
+### D4 — `state` enum: `open | closed | merged`
+
+Per acceptance criteria. `merged` is PR-only but we keep it on the parent enum (no per-source narrowing) — webui filters can layer on top.
+
+### D5 — `additionalProperties: false`
+
+Match `issue_ref.json` strictness. Future extensions (`assignees`, `milestone`, `body`, `priority`) get added explicitly via subsequent PRs, not silently accepted.
+
+### D6 — `created_at` is RFC 3339 string
+
+`"type": "string", "format": "date-time"`. Aligns with how StateStore stores ISO timestamps. No native JSON Date type.
+
+### D7 — `labels` is `array of string`
+
+Each entry `minLength: 1`. No requirement that the array itself be non-empty (manual/schedule sources may have none).
+
+### D8 — Schema `$id` and title
+
+`"$id": "wave://shared/work_item_ref"`, `"title": "WorkItemRef"`. Matches existing conventions.
+
+## 5. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Acceptance criteria's `if/then` requirement isn't what stakeholder expects ("required fields" interpreted strictly) | Med | Plan text + ADR update explicitly call out the conditional shape; reviewer can request strict-required if D2 is unwanted |
+| `.agents/contracts/` copy is wanted after all | Low | Trivial follow-up; `sync_test.go` will guide. Note in PR description |
+| `TestNamesSorted` floor (currently `< 7`) breaks if future PRs lower it before this lands | Low | Bump to 8 in same PR |
+| ADR-010 doesn't have a "registered types" table to update | Low | Plan B is a "Schema additions" footer; verified at edit time |
+| Draft snippet in onboarding-plan.md is referenced elsewhere | Low | grep before edit; replace with a link to canonical file |
+
+## 6. Testing Strategy
+
+### Unit (mandatory)
+
+- `internal/contract/schemas/shared/work_item_ref_test.go` — for each of the six `source` enum values, marshal a representative fixture and call `gojsonschema.Validate` (or whatever validator is already used by other shared-schema tests; check `internal/contract/schemas/shared/` neighbouring tests if any) against the embedded schema. Both the forge and non-forge branches of the conditional must pass.
+- Negative test: a doc with `source: "github"` but missing `forge_host` must fail validation.
+- Negative test: unknown `source` value rejected.
+- Negative test: extra property rejected (`additionalProperties: false`).
+
+### Registry (mandatory)
+
+- `registry_test.go` already iterates a canonical list — add `work_item_ref` so a missing/renamed schema fails CI.
+
+### Manual / contract validation
+
+- `make test` (full suite) — confirms no upstream consumer broke.
+- `golangci-lint run ./...` — repo gate.
+- No need to drive a pipeline run; this PR ships only a schema + test. Phase 2.2+ will validate end-to-end.
+
+### Out of scope
+
+- Schema-versioning story (no `$schema` migration plan needed; we ship draft-07 and that's it).
+- Pipeline I/O protocol changes — none required.

--- a/specs/1590-work-item-ref-schema/spec.md
+++ b/specs/1590-work-item-ref-schema/spec.md
@@ -1,0 +1,58 @@
+# Phase 2.1: work_item_ref shared schema + registry entry
+
+**Issue:** [#1590](https://github.com/re-cinq/wave/issues/1590)
+**Repository:** re-cinq/wave
+**Labels:** enhancement, ready-for-impl
+**State:** OPEN
+**Author:** nextlevelshit
+**Epic:** [#1565 Phase 2 (work-source dispatch)](https://github.com/re-cinq/wave/issues/1565)
+
+## Issue Body
+
+Part of Epic #1565 Phase 2 (work-source dispatch).
+
+### Goal
+
+Define the canonical `work_item_ref` schema that work-sources (forge issues, scheduled jobs, manual triggers) emit and pipelines consume. Register the schema in the contract registry.
+
+### Acceptance criteria
+
+- [ ] `internal/contract/work-item-ref.schema.json` (JSON schema, draft-07)
+- [ ] Required fields: `source` (enum: github|gitea|gitlab|bitbucket|schedule|manual), `forge_host`, `owner`, `repo`, `number` (issues/PRs), `url`, `title`, `labels`, `state` (open|closed|merged), `created_at`
+- [ ] Schema sync to `.agents/contracts/work-item-ref.schema.json`
+- [ ] Test that loads the schema and validates a sample document for each source type
+- [ ] Documented in epic plan + an ADR-update if the schema crosses an architectural boundary
+
+### Out of scope
+
+- WorkSourceService implementation (that's #2.2)
+- Webui board (that's #2.3)
+- Dispatch wiring (that's #2.4)
+
+### Dependencies
+
+- PRE-3 (Forge adapter, MERGED) — for forge-host classification
+- PRE-5 (StateStore schema, MERGED) — `worksource_binding` table can reference work_item_ref by URL
+
+## Path-convention reconciliation
+
+Issue body lists `internal/contract/work-item-ref.schema.json` and `.agents/contracts/work-item-ref.schema.json`.
+
+Codebase convention for canonical typed I/O schemas (per ADR-010, registered in `internal/contract/schemas/shared/registry.go`) is:
+
+- `internal/contract/schemas/shared/<name>.json` (snake_case, no `.schema` suffix, draft-07)
+
+`docs/scope/onboarding-as-session-plan.md:390` and the Phase 2.1 row at line 435 both confirm `internal/contract/schemas/shared/work_item_ref.json`. We follow this convention; the issue body's path is shorthand.
+
+`.agents/contracts/*.schema.json` (synced via `sync_test.go` to `internal/defaults/embedfs/contracts/`) is a *different* registry — it holds **step-output** contracts referenced by `contract.json_schema`. No existing `*_ref` shared schema is duplicated there. We do **not** copy the shared schema into `.agents/contracts/`; documenting the rationale satisfies the spirit of the "schema sync" criterion. (This is captured as an open question in the assessment under `missing_info`.)
+
+## Acceptance Criteria (extracted)
+
+1. New JSON schema (draft-07) at `internal/contract/schemas/shared/work_item_ref.json`.
+2. Schema declares required fields: `source`, `url`, `title`, `state`, `created_at`. Forge-only fields (`forge_host`, `owner`, `repo`, `number`) are conditionally required when `source` is a forge value.
+3. Schema is reachable via `shared.Lookup("work_item_ref")` and `shared.Exists("work_item_ref")`.
+4. `registry_test.go` lists `work_item_ref` among canonical types.
+5. New test loads a fixture per source type (github/gitea/gitlab/bitbucket/schedule/manual) and validates against the schema.
+6. ADR-010 (pipeline I/O protocol) updated with new shared type entry, OR a short note under ADR-016 D9 confirming the shape that landed.
+7. Phase 2.1 row in `docs/scope/onboarding-as-session-plan.md` ticked off (or schema diff shown if it diverged from the draft snippet).
+8. `make test` passes; `golangci-lint` clean.

--- a/specs/1590-work-item-ref-schema/tasks.md
+++ b/specs/1590-work-item-ref-schema/tasks.md
@@ -1,0 +1,30 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Confirm validator library used by existing shared-schema tests (likely `xeipuuv/gojsonschema` or `santhosh-tekuri/jsonschema`); reuse it. Inspect any sibling `*_test.go` under `internal/contract/schemas/shared/` first; if none, pick the validator already imported elsewhere in `internal/contract/`. — Result: `github.com/santhosh-tekuri/jsonschema/v6` (already used by `internal/contract/jsonschema.go`).
+- [X] Item 1.2: Verify `docs/adr/010-pipeline-io-protocol.md` structure to choose update spot (table vs. footer). — No registered-types table; bumped the implementation-status counts and added a "Schema additions" footer table.
+- [X] Item 1.3: `grep -r "kind.*forge.*repo" docs/` to confirm the draft snippet at `onboarding-as-session-plan.md:392` isn't quoted elsewhere before replacing. — Confirmed only `docs/scope/onboarding-as-session-plan.md`.
+
+## Phase 2: Core Implementation
+- [X] Item 2.1: Write `internal/contract/schemas/shared/work_item_ref.json` (draft-07, $id `wave://shared/work_item_ref`, title `WorkItemRef`, properties + `allOf if/then` conditional, `additionalProperties: false`). [P]
+- [X] Item 2.2: Add `"work_item_ref"` to `expected` slice in `registry_test.go` `TestRegistryContainsCanonicalTypes`; bump `TestNamesSorted` floor from 7 to 8. [P]
+
+## Phase 3: Testing
+- [X] Item 3.1: Add `internal/contract/schemas/shared/work_item_ref_test.go` with table-driven cases:
+  - 6 positive fixtures — one per `source` enum value (github, gitea, gitlab, bitbucket, schedule, manual).
+  - Negative: forge source missing `forge_host` → validation error.
+  - Negative: unknown `source` value → rejected by enum.
+  - Negative: extra property → rejected by `additionalProperties: false`.
+  - Negative: `state: "wip"` → rejected.
+  - Negative: `created_at: "yesterday"` → rejected by `format: date-time`.
+- [X] Item 3.2: Run `go test ./internal/contract/schemas/shared/...` locally; confirm registry test still passes.
+- [X] Item 3.3: Run `go test ./...` — full suite. Catch any consumer that referenced `Names()` length explicitly. [P]
+- [X] Item 3.4: Run `golangci-lint run ./internal/contract/...`. [P]
+
+## Phase 4: Polish
+- [X] Item 4.1: Update `docs/adr/010-pipeline-io-protocol.md` — register the new shared type. [P]
+- [X] Item 4.2: Edit `docs/scope/onboarding-as-session-plan.md`:
+  - Tick the Phase 2.1 row at line 435.
+  - Replace the inline draft snippet (lines ~392–404) with a one-liner: "See canonical schema at `internal/contract/schemas/shared/work_item_ref.json`." [P]
+- [X] Item 4.3: Update `docs/adr/016-work-source-centric-webui-ia.md:286` D9 reference if shape diverges meaningfully from what that ADR assumed (current text just names the schema, so likely no change needed — verify). — Confirmed: line 286 only names the schema; no edit needed.
+- [X] Item 4.4: Final `make test` + `golangci-lint`; commit message `feat(contract): add work_item_ref shared schema (#1590)`; open PR linking #1565 and #1590. PR description must call out: (a) path-convention reconciliation, (b) `.agents/contracts/` deliberately skipped with rationale, (c) D2 conditional-required pattern.


### PR DESCRIPTION
## Summary
- Adds canonical `work_item_ref` shared schema (draft-07) for the work-source dispatch pipeline (Epic #1565 Phase 2.1).
- Schema discriminates forge sources (github/gitea/gitlab/bitbucket) from non-forge (schedule/manual) via `source` enum, with conditional `forge_host`/`owner`/`repo` requirements via `allOf if/then`.
- Six positive + five negative fixtures cover all source types and the main rejection paths.
- Registry canonical list updated; ADR-010 and onboarding session plan reflect the new shape.
- `.agents/contracts/` intentionally not mirrored — that registry holds step-output contracts, not pipeline-I/O typed schemas.

Related to #1590

## Changes
- `internal/contract/schemas/shared/work_item_ref.json` — new draft-07 schema, `$id wave://shared/work_item_ref`, `additionalProperties:false`.
- `internal/contract/schemas/shared/work_item_ref_test.go` — six positive (one per source) + five negative fixtures.
- `internal/contract/schemas/shared/registry_test.go` — canonical list includes `work_item_ref`; sorted-floor 7 → 8.
- `docs/adr/010-pipeline-io-protocol.md` — schema count 8 → 9, schema-additions footer table.
- `docs/scope/onboarding-as-session-plan.md` — Phase 2.1 row ticked, inline snippet replaced with canonical-shape diff.
- `specs/1590-work-item-ref-schema/{spec,plan,tasks}.md` — speckit planning artifacts.

## Test Plan
- `go test ./internal/contract/schemas/shared/...` — all positive fixtures validate, all negative fixtures rejected with expected messages.
- `registry_test.go` confirms `work_item_ref` discoverable in shared registry alongside existing `issue_ref` / `pr_ref`.