### PR TITLE
feat(webui): /work board + detail templates (#1594)

### DIFF
--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -50,6 +50,16 @@ var pageTemplates = []string{
 	"templates/onboard/index.html",
 }
 
+// standalonePageTemplates is the list of templates that do NOT extend
+// templates/layout.html. They render fully self-contained pages — typically
+// to avoid Tailwind utility-class collisions with the project stylesheet.
+// Each entry is parsed into its own root template and merged into the
+// returned page map alongside the layout-clone pages.
+var standalonePageTemplates = []string{
+	"templates/work/board.html",
+	"templates/work/detail.html",
+}
+
 // parseTemplates parses all embedded HTML templates using a clone-per-page
 // strategy. The layout and partials form a shared base; each page template is
 // parsed into its own clone so that block overrides (title, content, scripts)
@@ -250,7 +260,7 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 	}
 
 	// Clone the base for each page template.
-	pages := make(map[string]*template.Template, len(pageTemplates))
+	pages := make(map[string]*template.Template, len(pageTemplates)+len(standalonePageTemplates))
 	for _, page := range pageTemplates {
 		clone, cloneErr := base.Clone()
 		if cloneErr != nil {
@@ -264,6 +274,21 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 			return nil, fmt.Errorf("parsing %s: %w", page, parseErr)
 		}
 		pages[page] = clone
+	}
+
+	// Standalone pages are NOT cloned from the layout-bearing base — they
+	// render their own <html> shell so Tailwind CDN classes don't collide
+	// with the project stylesheet.
+	for _, page := range standalonePageTemplates {
+		data, readErr := templatesFS.ReadFile(page)
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", page, readErr)
+		}
+		t, parseErr := template.New(page).Funcs(funcMap).Parse(string(data))
+		if parseErr != nil {
+			return nil, fmt.Errorf("parsing %s: %w", page, parseErr)
+		}
+		pages[page] = t
 	}
 
 	return pages, nil

--- a/internal/webui/handlers_test.go
+++ b/internal/webui/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/recinq/wave/internal/humanize"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/worksource"
 )
 
 // testTemplates creates minimal stub templates for handler tests.
@@ -66,6 +67,30 @@ func testTemplates(t *testing.T) map[string]*template.Template {
 	result := make(map[string]*template.Template, len(pages))
 	for name, body := range pages {
 		tmpl := template.Must(template.New("templates/layout.html").Funcs(funcMap).Parse(body))
+		result[name] = tmpl
+	}
+	// Standalone /work templates use Execute (not ExecuteTemplate("layout"))
+	// in production. Mirror that here with a single root template per page so
+	// the round-trip tests can assert on rendered fields.
+	standalones := map[string]string{
+		"templates/work/board.html": `<!doctype html><html><body>` +
+			`<nav><a href="/work">Work</a></nav>` +
+			`<h1>Work</h1>` +
+			`{{if .HasBindings}}<table>{{range .Bindings}}<tr><td>{{.PipelineName}}</td><td>{{.TriggerLabel}}</td><td>{{.RepoPattern}}</td><td>{{.StatusLabel}}</td></tr>{{end}}</table>` +
+			`{{else}}<div class="empty">No bindings yet</div>{{end}}` +
+			`<section><h2>Recent matches</h2>{{if .RecentRuns}}<ul>{{range .RecentRuns}}<li>{{.PipelineName}} {{.RunID}}</li>{{end}}</ul>{{else}}<p>No recent runs match the configured bindings.</p>{{end}}</section>` +
+			`</body></html>`,
+		"templates/work/detail.html": `<!doctype html><html><body>` +
+			`<h1>{{if .Title}}{{.Title}}{{else}}Work item #{{.NumberStr}}{{end}}</h1>` +
+			`<div class="coords">{{.Forge}} / {{.RepoSlug}} #{{.NumberStr}}</div>` +
+			`{{if .Labels}}<div class="labels">{{range .Labels}}<span>{{.}}</span>{{end}}</div>{{end}}` +
+			`<button disabled title="Dispatch wiring lands in #2.4">Run on this issue</button>` +
+			`<section><h2>Matched bindings</h2>{{if .MatchedBindings}}<table>{{range .MatchedBindings}}<tr><td>{{.PipelineName}}</td><td>{{.TriggerLabel}}</td></tr>{{end}}</table>{{else}}<p>No bindings match this work item.</p>{{end}}</section>` +
+			`<section><h2>Recent runs</h2>{{if .RecentRuns}}<ul>{{range .RecentRuns}}<li>{{.PipelineName}} {{.RunID}}</li>{{end}}</ul>{{else}}<p>No recent runs.</p>{{end}}</section>` +
+			`</body></html>`,
+	}
+	for name, body := range standalones {
+		tmpl := template.Must(template.New(name).Funcs(funcMap).Parse(body))
 		result[name] = tmpl
 	}
 	return result
@@ -139,8 +164,9 @@ func testServer(t *testing.T) (*Server, state.StateStore) {
 			csrfToken: "test-csrf-token",
 		},
 		runtime: serverRuntime{
-			store:   roStore,
-			rwStore: rwStore,
+			store:      roStore,
+			rwStore:    rwStore,
+			worksource: worksource.NewService(rwStore),
 		},
 		realtime: serverRealtime{
 			broker:            NewSSEBroker(),

--- a/internal/webui/handlers_work.go
+++ b/internal/webui/handlers_work.go
@@ -1,0 +1,321 @@
+package webui
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/recinq/wave/internal/forge"
+	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/worksource"
+)
+
+// WorkBindingRow is the flat view-model rendered by the /work board for a
+// single worksource binding. It deliberately decouples the template from
+// worksource.BindingRecord so trigger/label maps can be precomputed without
+// pushing template logic into the package.
+type WorkBindingRow struct {
+	ID           int64
+	Forge        string
+	RepoPattern  string
+	PipelineName string
+	Trigger      worksource.Trigger
+	TriggerLabel string
+	Active       bool
+	StatusLabel  string
+	LabelFilter  []string
+	State        string
+	Kinds        []string
+	CreatedAt    time.Time
+}
+
+// WorkBoardData backs templates/work/board.html.
+type WorkBoardData struct {
+	ActivePage  string
+	Bindings    []WorkBindingRow
+	RecentRuns  []RunSummary
+	HasBindings bool
+}
+
+// WorkItemDetailData backs templates/work/detail.html.
+type WorkItemDetailData struct {
+	ActivePage      string
+	Forge           string
+	Owner           string
+	Repo            string
+	RepoSlug        string
+	Number          int
+	NumberStr       string
+	Kind            string // "issue" — work items here always come from the issue path. PRs use /work/.../pulls/... in a future iteration.
+	Title           string
+	Body            string
+	State           string
+	Author          string
+	Labels          []string
+	URL             string
+	ItemAvailable   bool
+	ForgeUnavailable bool
+	MatchedBindings []WorkBindingRow
+	RecentRuns      []RunSummary
+}
+
+// handleWorkBoard serves GET /work — the unified board listing all
+// worksource bindings plus a best-effort "recent matches" list of recent
+// pipeline runs whose pipeline name belongs to a binding.
+func (s *Server) handleWorkBoard(w http.ResponseWriter, r *http.Request) {
+	tmpl, ok := s.assets.templates["templates/work/board.html"]
+	if !ok || tmpl == nil {
+		http.Error(w, "work board template missing", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	var rows []WorkBindingRow
+	if s.runtime.worksource != nil {
+		records, err := s.runtime.worksource.ListBindings(ctx, worksource.BindingFilter{})
+		if err != nil {
+			log.Printf("[webui] /work list bindings: %v", err)
+			http.Error(w, "failed to list bindings", http.StatusInternalServerError)
+			return
+		}
+		rows = make([]WorkBindingRow, 0, len(records))
+		for _, rec := range records {
+			rows = append(rows, bindingRecordToRow(rec))
+		}
+	}
+
+	pipelineNames := bindingPipelineSet(rows)
+	recent := s.recentRunsForPipelines(pipelineNames, 20)
+
+	data := WorkBoardData{
+		ActivePage:  "work",
+		Bindings:    rows,
+		RecentRuns:  recent,
+		HasBindings: len(rows) > 0,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.Execute(w, data); err != nil {
+		log.Printf("[webui] /work render: %v", err)
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// handleWorkItemDetail serves GET /work/{forge}/{owner}/{repo}/{number}.
+// It parses path values, builds a worksource.WorkItemRef, queries
+// MatchBindings, optionally fetches the live work item from the forge
+// client when available, and renders templates/work/detail.html.
+func (s *Server) handleWorkItemDetail(w http.ResponseWriter, r *http.Request) {
+	tmpl, ok := s.assets.templates["templates/work/detail.html"]
+	if !ok || tmpl == nil {
+		http.Error(w, "work detail template missing", http.StatusInternalServerError)
+		return
+	}
+
+	forgeName := r.PathValue("forge")
+	owner := r.PathValue("owner")
+	repo := r.PathValue("repo")
+	numberStr := r.PathValue("number")
+
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number <= 0 {
+		http.Error(w, "invalid work item number", http.StatusBadRequest)
+		return
+	}
+	if forgeName == "" || owner == "" || repo == "" {
+		http.Error(w, "incomplete work item path", http.StatusBadRequest)
+		return
+	}
+
+	repoSlug := owner + "/" + repo
+	ref := worksource.WorkItemRef{
+		Forge: forgeName,
+		Repo:  repoSlug,
+		Kind:  "issue",
+		ID:    numberStr,
+	}
+
+	ctx := r.Context()
+	var matched []WorkBindingRow
+	if s.runtime.worksource != nil {
+		recs, err := s.runtime.worksource.MatchBindings(ctx, ref)
+		if err != nil {
+			log.Printf("[webui] /work detail match: %v", err)
+			http.Error(w, "failed to match bindings", http.StatusInternalServerError)
+			return
+		}
+		matched = make([]WorkBindingRow, 0, len(recs))
+		for _, rec := range recs {
+			matched = append(matched, bindingRecordToRow(rec))
+		}
+	}
+
+	data := WorkItemDetailData{
+		ActivePage:       "work",
+		Forge:            forgeName,
+		Owner:            owner,
+		Repo:             repo,
+		RepoSlug:         repoSlug,
+		Number:           number,
+		NumberStr:        numberStr,
+		Kind:             "issue",
+		MatchedBindings:  matched,
+		ForgeUnavailable: s.runtime.forgeClient == nil,
+	}
+
+	if s.runtime.forgeClient != nil {
+		issue, err := fetchIssueBestEffort(ctx, s.runtime.forgeClient, owner, repo, number)
+		if err == nil && issue != nil {
+			data.Title = issue.Title
+			data.Body = issue.Body
+			data.State = issue.State
+			data.Author = issue.Author
+			data.URL = issue.HTMLURL
+			data.Labels = labelNames(issue.Labels)
+			data.ItemAvailable = true
+			// Re-run match with full label set so label-gated bindings show up.
+			if s.runtime.worksource != nil && len(data.Labels) > 0 {
+				ref.Labels = data.Labels
+				ref.State = issue.State
+				ref.Title = issue.Title
+				ref.URL = issue.HTMLURL
+				if recs, mErr := s.runtime.worksource.MatchBindings(ctx, ref); mErr == nil {
+					rich := make([]WorkBindingRow, 0, len(recs))
+					for _, rec := range recs {
+						rich = append(rich, bindingRecordToRow(rec))
+					}
+					data.MatchedBindings = rich
+				}
+			}
+		}
+	}
+
+	pipelineNames := bindingPipelineSet(data.MatchedBindings)
+	data.RecentRuns = s.recentRunsForPipelines(pipelineNames, 20)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.Execute(w, data); err != nil {
+		log.Printf("[webui] /work detail render: %v", err)
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// bindingRecordToRow flattens a worksource.BindingRecord for template
+// consumption. Labels for trigger/active are computed once here so the
+// templates remain logic-light.
+func bindingRecordToRow(rec worksource.BindingRecord) WorkBindingRow {
+	status := "inactive"
+	if rec.Active {
+		status = "active"
+	}
+	return WorkBindingRow{
+		ID:           int64(rec.ID),
+		Forge:        rec.Forge,
+		RepoPattern:  rec.RepoPattern,
+		PipelineName: rec.PipelineName,
+		Trigger:      rec.Trigger,
+		TriggerLabel: triggerDisplay(rec.Trigger),
+		Active:       rec.Active,
+		StatusLabel:  status,
+		LabelFilter:  rec.LabelFilter,
+		State:        rec.State,
+		Kinds:        rec.Kinds,
+		CreatedAt:    rec.CreatedAt,
+	}
+}
+
+// triggerDisplay returns a short human label for the binding trigger enum.
+func triggerDisplay(t worksource.Trigger) string {
+	switch t {
+	case worksource.TriggerOnDemand:
+		return "On demand"
+	case worksource.TriggerOnLabel:
+		return "On label"
+	case worksource.TriggerOnOpen:
+		return "On open"
+	case worksource.TriggerScheduled:
+		return "Scheduled"
+	default:
+		return string(t)
+	}
+}
+
+// bindingPipelineSet returns the unique pipeline names referenced by the
+// given binding rows.
+func bindingPipelineSet(rows []WorkBindingRow) map[string]struct{} {
+	out := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		if r.PipelineName != "" {
+			out[r.PipelineName] = struct{}{}
+		}
+	}
+	return out
+}
+
+// recentRunsForPipelines pulls up to limit recent top-level runs whose
+// pipeline name appears in want. Returns nil if want is empty or the store
+// is missing. This is the placeholder run-history surface until #2.4 wires
+// real work_item_ref → run linkage.
+func (s *Server) recentRunsForPipelines(want map[string]struct{}, limit int) []RunSummary {
+	if len(want) == 0 || s.runtime.store == nil || limit <= 0 {
+		return nil
+	}
+	// Pull a generous slice and filter in-memory; the binding pipeline set is
+	// typically tiny so a single-pass scan is cheaper than per-pipeline queries.
+	pageSize := limit * 4
+	if pageSize < 50 {
+		pageSize = 50
+	}
+	runs, err := s.runtime.store.ListRuns(state.ListRunsOptions{
+		Limit:        pageSize,
+		TopLevelOnly: true,
+	})
+	if err != nil {
+		log.Printf("[webui] /work recent runs: %v", err)
+		return nil
+	}
+	out := make([]RunSummary, 0, limit)
+	for _, run := range runs {
+		if _, ok := want[run.PipelineName]; !ok {
+			continue
+		}
+		out = append(out, runToSummary(run))
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// fetchIssueBestEffort returns the issue or nil. It applies a short timeout
+// so a slow forge does not hold the dashboard render. Errors are logged at
+// the call site; here we return them so callers can detect "unavailable".
+func fetchIssueBestEffort(ctx context.Context, client forge.Client, owner, repo string, number int) (*forge.Issue, error) {
+	if client == nil {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	issue, err := client.GetIssue(ctx, owner, repo, number)
+	if err != nil {
+		log.Printf("[webui] /work detail forge fetch %s/%s#%d: %v", owner, repo, number, err)
+		return nil, err
+	}
+	return issue, nil
+}
+
+// labelNames extracts the Name strings from a forge label slice.
+func labelNames(labels []forge.Label) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l.Name != "" {
+			out = append(out, l.Name)
+		}
+	}
+	return out
+}

--- a/internal/webui/handlers_work_test.go
+++ b/internal/webui/handlers_work_test.go
@@ -1,0 +1,167 @@
+package webui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/recinq/wave/internal/worksource"
+)
+
+// TestHandleWorkBoard_Empty verifies that /work renders a 200 with the
+// empty-state copy when no bindings are configured.
+func TestHandleWorkBoard_Empty(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequest("GET", "/work", nil)
+	rec := httptest.NewRecorder()
+	srv.handleWorkBoard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No bindings yet") {
+		t.Errorf("expected empty-state copy, got: %s", body)
+	}
+}
+
+// TestHandleWorkBoard_WithBindings verifies that two created bindings appear
+// in the rendered output with their pipeline names and trigger labels.
+func TestHandleWorkBoard_WithBindings(t *testing.T) {
+	srv, _ := testServer(t)
+
+	ctx := context.Background()
+	if _, err := srv.runtime.worksource.CreateBinding(ctx, worksource.BindingSpec{
+		Forge:        "github",
+		RepoPattern:  "re-cinq/wave",
+		PipelineName: "impl-issue",
+		Trigger:      worksource.TriggerOnLabel,
+		LabelFilter:  []string{"auto-impl"},
+	}); err != nil {
+		t.Fatalf("CreateBinding 1: %v", err)
+	}
+	if _, err := srv.runtime.worksource.CreateBinding(ctx, worksource.BindingSpec{
+		Forge:        "github",
+		RepoPattern:  "re-cinq/*",
+		PipelineName: "research",
+		Trigger:      worksource.TriggerOnDemand,
+	}); err != nil {
+		t.Fatalf("CreateBinding 2: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/work", nil)
+	rec := httptest.NewRecorder()
+	srv.handleWorkBoard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "impl-issue") {
+		t.Errorf("expected body to contain pipeline name 'impl-issue', got: %s", body)
+	}
+	if !strings.Contains(body, "research") {
+		t.Errorf("expected body to contain pipeline name 'research', got: %s", body)
+	}
+	if !strings.Contains(body, "On label") {
+		t.Errorf("expected body to contain trigger label 'On label', got: %s", body)
+	}
+	if !strings.Contains(body, "On demand") {
+		t.Errorf("expected body to contain trigger label 'On demand', got: %s", body)
+	}
+	if strings.Contains(body, "No bindings yet") {
+		t.Errorf("expected populated state, found empty-state copy: %s", body)
+	}
+}
+
+// TestHandleWorkItemDetail_NoMatch verifies that a path with no matching
+// binding still renders successfully and surfaces the "no bindings match"
+// copy.
+func TestHandleWorkItemDetail_NoMatch(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequest("GET", "/work/github/foo/bar/1", nil)
+	req.SetPathValue("forge", "github")
+	req.SetPathValue("owner", "foo")
+	req.SetPathValue("repo", "bar")
+	req.SetPathValue("number", "1")
+	rec := httptest.NewRecorder()
+	srv.handleWorkItemDetail(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No bindings match this work item") {
+		t.Errorf("expected 'No bindings match' copy, got: %s", body)
+	}
+	if !strings.Contains(body, "Work item #1") {
+		t.Errorf("expected fallback title 'Work item #1', got: %s", body)
+	}
+	if !strings.Contains(body, "github / foo/bar #1") {
+		t.Errorf("expected coordinates header, got: %s", body)
+	}
+}
+
+// TestHandleWorkItemDetail_OneMatch verifies that a binding whose RepoPattern
+// matches the path renders the binding pipeline name and the disabled
+// "Run on this issue" button.
+func TestHandleWorkItemDetail_OneMatch(t *testing.T) {
+	srv, _ := testServer(t)
+
+	ctx := context.Background()
+	if _, err := srv.runtime.worksource.CreateBinding(ctx, worksource.BindingSpec{
+		Forge:        "github",
+		RepoPattern:  "foo/bar",
+		PipelineName: "impl-issue",
+		Trigger:      worksource.TriggerOnDemand,
+	}); err != nil {
+		t.Fatalf("CreateBinding: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/work/github/foo/bar/42", nil)
+	req.SetPathValue("forge", "github")
+	req.SetPathValue("owner", "foo")
+	req.SetPathValue("repo", "bar")
+	req.SetPathValue("number", "42")
+	rec := httptest.NewRecorder()
+	srv.handleWorkItemDetail(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "impl-issue") {
+		t.Errorf("expected matched binding pipeline 'impl-issue', got: %s", body)
+	}
+	if !strings.Contains(body, "Run on this issue") {
+		t.Errorf("expected disabled CTA copy 'Run on this issue', got: %s", body)
+	}
+	if !strings.Contains(body, "disabled") {
+		t.Errorf("expected disabled attribute on CTA, got: %s", body)
+	}
+	if strings.Contains(body, "No bindings match this work item") {
+		t.Errorf("did not expect no-match copy when a binding matches: %s", body)
+	}
+}
+
+// TestHandleWorkItemDetail_BadNumber verifies the handler rejects a
+// non-integer number with HTTP 400.
+func TestHandleWorkItemDetail_BadNumber(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequest("GET", "/work/github/foo/bar/abc", nil)
+	req.SetPathValue("forge", "github")
+	req.SetPathValue("owner", "foo")
+	req.SetPathValue("repo", "bar")
+	req.SetPathValue("number", "abc")
+	rec := httptest.NewRecorder()
+	srv.handleWorkItemDetail(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-integer number, got %d", rec.Code)
+	}
+}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -16,6 +16,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /runs", s.handleRunsPage)
 	mux.HandleFunc("GET /runs/{id}", s.handleRunDetailPage)
 
+	mux.HandleFunc("GET /work", s.handleWorkBoard)
+	mux.HandleFunc("GET /work/{forge}/{owner}/{repo}/{number}", s.handleWorkItemDetail)
+
 	mux.HandleFunc("GET /pipelines", s.handlePipelinesPage)
 	mux.HandleFunc("GET /pipelines/{name}", s.handlePipelineDetailPage)
 	mux.HandleFunc("GET /personas", s.handlePersonasPage)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/onboarding"
 	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/worksource"
 	"github.com/recinq/wave/internal/workspace"
 )
 
@@ -68,6 +69,7 @@ type serverRuntime struct {
 	repoSlug    string // "owner/repo"
 	repoDir     string // git repository root directory
 	scheduler   *Scheduler
+	worksource  worksource.Service
 }
 
 // serverRealtime groups the realtime/eventing collaborators: SSE broker,
@@ -246,6 +248,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 			repoSlug:    repoSlug,
 			repoDir:     repoDir,
 			scheduler:   NewScheduler(cfg.MaxConcurrent),
+			worksource:  worksource.NewService(rwStore),
 		},
 		realtime: serverRealtime{
 			broker:            NewSSEBroker(),

--- a/internal/webui/templates/work/board.html
+++ b/internal/webui/templates/work/board.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Work board &mdash; Wave</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+  <nav class="bg-white border-b border-slate-200">
+    <div class="max-w-6xl mx-auto px-6 py-3 flex items-center gap-6">
+      <a href="/work" class="flex items-center gap-2 font-semibold">
+        <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+          <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+          <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+        </svg>
+        Wave
+      </a>
+      <div class="flex items-center gap-4 text-sm">
+        <a href="/work" class="text-slate-900 font-medium border-b-2 border-slate-900 pb-3 -mb-3">Work</a>
+        <a href="/runs" class="text-slate-600 hover:text-slate-900">Runs</a>
+        <a href="/pipelines" class="text-slate-600 hover:text-slate-900">Pipelines</a>
+        <a href="/issues" class="text-slate-600 hover:text-slate-900">Issues</a>
+        <a href="/prs" class="text-slate-600 hover:text-slate-900">PRs</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="max-w-6xl mx-auto px-6 py-8">
+    <header class="mb-8">
+      <h1 class="text-2xl font-semibold tracking-tight">Work</h1>
+      <p class="text-sm text-slate-600 mt-1">
+        Worksource bindings and recent matches across connected forges.
+      </p>
+    </header>
+
+    <section class="mb-10">
+      <div class="flex items-baseline justify-between mb-3">
+        <h2 class="text-lg font-semibold">Bindings</h2>
+        <span class="text-xs text-slate-500">{{len .Bindings}} configured</span>
+      </div>
+
+      {{if .HasBindings}}
+      <div class="bg-white border border-slate-200 rounded-lg overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-slate-50 border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="px-4 py-2 font-medium">Status</th>
+              <th class="px-4 py-2 font-medium">Forge</th>
+              <th class="px-4 py-2 font-medium">Repo pattern</th>
+              <th class="px-4 py-2 font-medium">Pipeline</th>
+              <th class="px-4 py-2 font-medium">Trigger</th>
+              <th class="px-4 py-2 font-medium">Filter</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Bindings}}
+            <tr class="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+              <td class="px-4 py-3">
+                {{if .Active}}
+                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium">
+                  <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+                  active
+                </span>
+                {{else}}
+                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 text-xs font-medium">inactive</span>
+                {{end}}
+              </td>
+              <td class="px-4 py-3 font-mono text-xs">{{.Forge}}</td>
+              <td class="px-4 py-3 font-mono text-xs">{{.RepoPattern}}</td>
+              <td class="px-4 py-3 font-medium">{{.PipelineName}}</td>
+              <td class="px-4 py-3 text-xs text-slate-600">{{.TriggerLabel}}</td>
+              <td class="px-4 py-3 text-xs text-slate-600">
+                {{if .LabelFilter}}
+                  {{range .LabelFilter}}<span class="inline-block px-1.5 py-0.5 mr-1 rounded bg-slate-100 text-slate-700 font-mono">{{.}}</span>{{end}}
+                {{else}}
+                  <span class="text-slate-400">&mdash;</span>
+                {{end}}
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      {{else}}
+      <div class="bg-white border border-dashed border-slate-300 rounded-lg p-10 text-center">
+        <svg class="w-10 h-10 text-slate-300 mx-auto mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="3" y="3" width="18" height="18" rx="2"/>
+          <line x1="3" y1="9" x2="21" y2="9"/>
+          <line x1="9" y1="21" x2="9" y2="9"/>
+        </svg>
+        <h3 class="text-base font-medium text-slate-900">No bindings yet</h3>
+        <p class="text-sm text-slate-600 mt-1 max-w-md mx-auto">
+          Bindings connect a forge repo to a Wave pipeline so incoming issues
+          and PRs trigger the right work. Configure one to get started.
+        </p>
+        <p class="text-xs text-slate-500 mt-3">
+          A bindings UI ships in a future iteration; create them via the API
+          or <code class="font-mono">wave</code> CLI for now.
+        </p>
+      </div>
+      {{end}}
+    </section>
+
+    <section>
+      <div class="flex items-baseline justify-between mb-3">
+        <h2 class="text-lg font-semibold">Recent matches</h2>
+        <span class="text-xs text-slate-500">runs of pipelines that match a binding</span>
+      </div>
+
+      {{if .RecentRuns}}
+      <ul class="bg-white border border-slate-200 rounded-lg divide-y divide-slate-100">
+        {{range .RecentRuns}}
+        <li class="px-4 py-3 hover:bg-slate-50">
+          <a href="/runs/{{.RunID}}" class="flex items-center justify-between gap-4">
+            <div class="min-w-0">
+              <div class="font-medium truncate">{{.PipelineName}}</div>
+              <div class="text-xs text-slate-500 mt-0.5">
+                <span class="font-mono">{{.RunID}}</span>
+                {{if .Input}}&middot; <span class="truncate">{{.Input}}</span>{{end}}
+              </div>
+            </div>
+            <span class="text-xs text-slate-500 whitespace-nowrap">{{.Status}}</span>
+          </a>
+        </li>
+        {{end}}
+      </ul>
+      {{else}}
+      <div class="bg-white border border-slate-200 rounded-lg p-6 text-center text-sm text-slate-500">
+        No recent runs match the configured bindings.
+      </div>
+      {{end}}
+    </section>
+  </main>
+</body>
+</html>

--- a/internal/webui/templates/work/detail.html
+++ b/internal/webui/templates/work/detail.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>{{if .Title}}{{.Title}}{{else}}Work item #{{.NumberStr}}{{end}} &mdash; Wave</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 antialiased">
+  <nav class="bg-white border-b border-slate-200">
+    <div class="max-w-6xl mx-auto px-6 py-3 flex items-center gap-6">
+      <a href="/work" class="flex items-center gap-2 font-semibold">
+        <svg width="22" height="22" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+          <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+          <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+        </svg>
+        Wave
+      </a>
+      <div class="flex items-center gap-4 text-sm">
+        <a href="/work" class="text-slate-900 font-medium border-b-2 border-slate-900 pb-3 -mb-3">Work</a>
+        <a href="/runs" class="text-slate-600 hover:text-slate-900">Runs</a>
+        <a href="/pipelines" class="text-slate-600 hover:text-slate-900">Pipelines</a>
+        <a href="/issues" class="text-slate-600 hover:text-slate-900">Issues</a>
+        <a href="/prs" class="text-slate-600 hover:text-slate-900">PRs</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="max-w-6xl mx-auto px-6 py-8">
+    <nav class="text-xs text-slate-500 mb-4">
+      <a href="/work" class="hover:text-slate-900">Work</a>
+      <span class="mx-1">&rsaquo;</span>
+      <span class="font-mono">{{.Forge}} / {{.RepoSlug}}</span>
+      <span class="mx-1">&rsaquo;</span>
+      <span>{{.Kind}} #{{.NumberStr}}</span>
+    </nav>
+
+    <header class="mb-6">
+      <div class="flex items-start justify-between gap-6">
+        <div class="min-w-0">
+          <h1 class="text-2xl font-semibold tracking-tight">
+            {{if .Title}}{{.Title}}{{else}}Work item #{{.NumberStr}}{{end}}
+          </h1>
+          <div class="flex flex-wrap items-center gap-3 mt-2 text-sm text-slate-600">
+            {{if .State}}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full {{if eq .State "open"}}bg-emerald-50 text-emerald-700{{else}}bg-slate-100 text-slate-600{{end}} text-xs font-medium">
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>
+              {{.State}}
+            </span>
+            {{end}}
+            <span class="font-mono text-xs">{{.Forge}} / {{.RepoSlug}} #{{.NumberStr}}</span>
+            {{if .Author}}<span>by <strong class="text-slate-700">{{.Author}}</strong></span>{{end}}
+            {{if .Labels}}
+            <span class="flex flex-wrap gap-1">
+              {{range .Labels}}<span class="inline-block px-1.5 py-0.5 rounded bg-slate-100 text-slate-700 text-xs font-mono">{{.}}</span>{{end}}
+            </span>
+            {{end}}
+            {{if .URL}}<a href="{{.URL}}" target="_blank" rel="noopener" class="text-blue-600 hover:underline">view on {{.Forge}} &rarr;</a>{{end}}
+          </div>
+        </div>
+        <div class="shrink-0">
+          <button type="button" disabled
+                  title="Dispatch wiring lands in #2.4"
+                  class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-slate-200 text-slate-500 cursor-not-allowed text-sm font-medium">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+            Run on this issue
+          </button>
+          <p class="text-[11px] text-slate-500 mt-1 text-right">disabled &mdash; wires up in #2.4</p>
+        </div>
+      </div>
+    </header>
+
+    {{if not .ItemAvailable}}
+    <div class="mb-6 bg-amber-50 border border-amber-200 text-amber-800 rounded-md px-4 py-3 text-sm">
+      {{if .ForgeUnavailable}}
+        Forge client is not configured for this Wave instance, so live work-item details are unavailable. The page below reflects the URL-derived coordinates only.
+      {{else}}
+        Could not fetch live details for this work item. The page below reflects the URL-derived coordinates only.
+      {{end}}
+    </div>
+    {{end}}
+
+    <section class="mb-8">
+      <h2 class="text-lg font-semibold mb-3">Matched bindings</h2>
+      {{if .MatchedBindings}}
+      <div class="bg-white border border-slate-200 rounded-lg overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-slate-50 border-b border-slate-200 text-left text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th class="px-4 py-2 font-medium">Pipeline</th>
+              <th class="px-4 py-2 font-medium">Trigger</th>
+              <th class="px-4 py-2 font-medium">Repo pattern</th>
+              <th class="px-4 py-2 font-medium">Filter</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .MatchedBindings}}
+            <tr class="border-b border-slate-100 last:border-0">
+              <td class="px-4 py-3 font-medium">{{.PipelineName}}</td>
+              <td class="px-4 py-3 text-xs text-slate-600">{{.TriggerLabel}}</td>
+              <td class="px-4 py-3 font-mono text-xs">{{.RepoPattern}}</td>
+              <td class="px-4 py-3 text-xs text-slate-600">
+                {{if .LabelFilter}}
+                  {{range .LabelFilter}}<span class="inline-block px-1.5 py-0.5 mr-1 rounded bg-slate-100 text-slate-700 font-mono">{{.}}</span>{{end}}
+                {{else}}
+                  <span class="text-slate-400">&mdash;</span>
+                {{end}}
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      {{else}}
+      <div class="bg-white border border-slate-200 rounded-lg p-6 text-center text-sm text-slate-500">
+        No bindings match this work item.
+      </div>
+      {{end}}
+    </section>
+
+    <section>
+      <h2 class="text-lg font-semibold mb-3">Recent runs</h2>
+      <p class="text-xs text-slate-500 mb-3">
+        Recent runs of pipelines that match this work item. Direct
+        work_item_ref linkage lands in a follow-up.
+      </p>
+      {{if .RecentRuns}}
+      <ul class="bg-white border border-slate-200 rounded-lg divide-y divide-slate-100">
+        {{range .RecentRuns}}
+        <li class="px-4 py-3 hover:bg-slate-50">
+          <a href="/runs/{{.RunID}}" class="flex items-center justify-between gap-4">
+            <div class="min-w-0">
+              <div class="font-medium truncate">{{.PipelineName}}</div>
+              <div class="text-xs text-slate-500 mt-0.5">
+                <span class="font-mono">{{.RunID}}</span>
+                {{if .Input}}&middot; <span class="truncate">{{.Input}}</span>{{end}}
+              </div>
+            </div>
+            <span class="text-xs text-slate-500 whitespace-nowrap">{{.Status}}</span>
+          </a>
+        </li>
+        {{end}}
+      </ul>
+      {{else}}
+      <div class="bg-white border border-slate-200 rounded-lg p-6 text-center text-sm text-slate-500">
+        No recent runs.
+      </div>
+      {{end}}
+    </section>
+  </main>
+</body>
+</html>

--- a/specs/1594-work-board/plan.md
+++ b/specs/1594-work-board/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan — #1594 /work board + detail
+
+## 1. Objective
+
+Add functional `/work` board and `/work/{forge}/{owner}/{repo}/{number}`
+detail pages in `internal/webui/`, backed by `worksource.Service` from
+PR #1591. The visual design follows `templates/preview/work.html` and
+`templates/preview/work_item.html`, but uses Tailwind CDN per issue spec
+and renders real binding data instead of fixtures.
+
+## 2. Approach
+
+1. Wire a `worksource.Service` instance into `serverRuntime` so handlers
+   can query it. The service is constructed via
+   `worksource.NewService(s.runtime.rwStore)` (the `state.StateStore`
+   embeds `state.WorksourceStore`).
+2. Add `handlers_work.go` with two handler methods on `*Server`:
+   - `handleWorkBoard(w, r)` — `GET /work`. Calls
+     `s.runtime.worksource.ListBindings(ctx, BindingFilter{})` and renders
+     `templates/work/board.html`. The board lists every binding with
+     active/inactive state, forge, repo pattern, pipeline name, trigger,
+     and label filter. A second section lists "recent matches" — a
+     placeholder backed by recent runs whose pipeline matches one of the
+     binding pipeline names (best-effort until #2.4 wires real
+     work_item_ref → run links).
+   - `handleWorkItemDetail(w, r)` — `GET /work/{forge}/{owner}/{repo}/{number}`.
+     Parses path values, builds a `worksource.WorkItemRef`, calls
+     `MatchBindings`, fetches the live work item from `forge.Client` (if
+     configured) for title/labels/state, then renders
+     `templates/work/detail.html` with: work item header, matched
+     bindings table, recent runs whose pipeline name matches a matched
+     binding, and a "Run on this issue" button (disabled placeholder
+     until #2.4).
+3. Register both routes in `routes.go`. Use `mux.HandleFunc("GET /work", ...)`
+   and `mux.HandleFunc("GET /work/{forge}/{owner}/{repo}/{number}", ...)`.
+4. Add the two new templates under `templates/work/` and register them
+   in `pageTemplates` in `embed.go` so the embedded FS picks them up.
+   Tailwind CDN: include `<script src="https://cdn.tailwindcss.com"></script>`
+   in the templates. The pages do not extend `layout.html` — they render
+   a self-contained Tailwind page so the CDN classes don't collide with
+   the existing site stylesheet. A minimal nav bar links to /work,
+   /runs, /pipelines for parity with the rest of the dashboard.
+5. Add tests in `handlers_work_test.go` following the
+   `httptest.NewRecorder` + `strings.Contains(body, ...)` pattern used
+   by `handlers_runs_test.go`. Cover:
+   - `/work` empty-state, populated-state.
+   - `/work/{forge}/{owner}/{repo}/{number}` with no matching bindings,
+     with one matching binding, malformed path (bad number).
+
+## 3. File mapping
+
+Create:
+
+- `internal/webui/handlers_work.go` — two handlers + small `WorkBindingRow`
+  / `WorkItemDetailData` view-models that flatten `worksource.BindingRecord`
+  for template consumption (avoid leaking domain types into HTML where
+  small label maps add value, e.g. trigger labels).
+- `internal/webui/handlers_work_test.go` — round-trip tests.
+- `internal/webui/templates/work/board.html` — board view (Tailwind).
+- `internal/webui/templates/work/detail.html` — detail view (Tailwind).
+- `specs/1594-work-board/spec.md`, `plan.md`, `tasks.md` — planning docs.
+
+Modify:
+
+- `internal/webui/server.go` — extend `serverRuntime` with
+  `worksource worksource.Service`; populate it in `NewServer` after the
+  rwStore is opened.
+- `internal/webui/routes.go` — register `GET /work` and
+  `GET /work/{forge}/{owner}/{repo}/{number}` (placed alongside other
+  dashboard routes, before the feature-registry route block).
+- `internal/webui/embed.go` — append `"templates/work/board.html"` and
+  `"templates/work/detail.html"` to `pageTemplates`.
+- `internal/webui/handlers_test.go` — extend `testServer` template stub
+  registration if needed so tests can render the work templates without
+  a full embed.
+
+Delete: none.
+
+## 4. Architecture decisions
+
+- **Service injection via `serverRuntime`**: matches the existing
+  injection pattern (store, scheduler, forgeClient). Keeps handler
+  signatures unchanged.
+- **Standalone Tailwind pages, no layout.html extension**: the issue
+  explicitly mandates Tailwind CDN. Mixing Tailwind utility classes
+  with the existing `style.css` (which defines its own `.btn`, `.list`,
+  `.badge` rules) would cause specificity collisions. Self-contained
+  pages with a minimal in-template nav are the cleanest path. When the
+  /work page becomes default landing (#1579), the rest of the
+  dashboard can migrate gradually if desired.
+- **Run history on detail page**: until #2.4 wires real
+  `work_item_ref` → run linkage, "run history" is best-effort: filter
+  recent runs by pipeline name from the matched bindings (limit 20,
+  newest first, no pagination). This is documented in template copy
+  ("recent runs of pipelines that match this work item").
+- **Forge data fetch on detail page is best-effort**: if `forgeClient`
+  is nil or the fetch fails, render the page with the URL-derived
+  fields (forge/repo/number) and an "info unavailable" notice rather
+  than 500. The `MatchBindings` call only needs the path-supplied
+  fields to function.
+- **Path parameters via `http.ServeMux` 1.22+ patterns**: the codebase
+  already uses `mux.HandleFunc("GET /pattern/{var}", ...)` (see
+  routes.go), so `r.PathValue("forge")` etc. is the idiomatic access.
+- **No emojis**: nav and buttons use SVG icons identical to those in
+  `templates/preview/work.html`, or plain text.
+- **No dispatch wiring**: the "Run on this issue" button is a disabled
+  `<button>` with a tooltip pointing at #2.4. Avoid creating a stub
+  POST route that does nothing.
+
+## 5. Risks & mitigations
+
+- **Tailwind CDN means external network dependency at render time** —
+  mitigated: this is dev/local UI; no offline guarantee in scope. If
+  problematic later, switch to bundled Tailwind output.
+- **`worksource.Service` constructor expects `state.WorksourceStore`** —
+  the existing `state.StateStore` embeds it, so passing `s.runtime.rwStore`
+  works. Verified via `internal/state/store.go:77`.
+- **Template parsing in `parseTemplates`** — the new pages do NOT
+  extend `templates/layout.html`, so they should not be cloned from
+  the layout-bearing base. Add a separate parsing path: parse each
+  work template into its own root template so block names don't
+  collide with the layout-extending pages. Either:
+  (a) Skip cloning for these two templates and parse them via
+  `template.New("work-board").Funcs(funcMap).Parse(...)`, or
+  (b) Keep them in `pageTemplates` but render with `Execute` (not
+  `ExecuteTemplate("layout")`).
+  Decision: (a) — clearer intent. Add a `standalonePageTemplates`
+  slice in `embed.go`.
+- **Test isolation** — `handlers_test.go` `testTemplates` builds a
+  minimal stub set; tests for /work need their own minimal stubs that
+  match the standalone-template approach. Add `testWorkTemplates()`
+  helper that registers two trivial templates with placeholder content
+  exposing the data fields the assertions check.
+- **Path collision with feature registry routes** — verify no
+  feature already claims `/work` or `/work/...`. Quick grep before
+  registration.
+- **Empty state** — board with zero bindings should render a clear
+  empty state pointing at the bindings CRUD UI (or note that #2.x
+  will add it). No hidden 404.
+
+## 6. Testing strategy
+
+Unit/round-trip tests in `handlers_work_test.go`:
+
+1. `TestHandleWorkBoard_Empty` — no bindings created → 200, body
+   contains the empty-state message and zero list rows.
+2. `TestHandleWorkBoard_WithBindings` — create 2 bindings via the
+   service → 200, body contains both pipeline names and trigger
+   labels.
+3. `TestHandleWorkItemDetail_NoMatch` — call /work/github/foo/bar/1
+   when no binding matches → 200, body contains "no bindings match".
+4. `TestHandleWorkItemDetail_OneMatch` — create a binding whose
+   `RepoPattern` matches "foo/bar" → 200, body contains the binding
+   pipeline name and "Run on this issue" button (disabled state
+   present in markup).
+5. `TestHandleWorkItemDetail_MalformedPath` — already handled by
+   `http.ServeMux` 404; document that no test is needed for the path
+   parser since the framework rejects mismatched paths.
+
+Run with `go test ./internal/webui/... -race`.
+
+CI/lint:
+
+- `golangci-lint run ./internal/webui/...` (existing project lint).
+- `go vet ./...`.
+
+Acceptance verification (manual):
+
+- Build: `go build -o ~/.local/bin/wave ./cmd/wave` outside the
+  sandbox (per repo memory constraints).
+- Run dashboard: `wave server` and visit `/work` and
+  `/work/github/re-cinq/wave/1594` in a browser; confirm bindings
+  render and detail page loads even when no forge client is
+  configured.

--- a/specs/1594-work-board/spec.md
+++ b/specs/1594-work-board/spec.md
@@ -1,0 +1,48 @@
+# Phase 2.3: /work board + detail templates (replaces /runs as default landing)
+
+Source issue: https://github.com/re-cinq/wave/issues/1594
+Repository: re-cinq/wave
+Author: nextlevelshit
+State: OPEN
+Labels: enhancement, ready-for-impl, frontend
+
+Part of Epic #1565 Phase 2 (work-source dispatch).
+
+## Goal
+
+Build the webui `/work` board: a unified view of all bindings + active work
+items, with detail pages for each work item. Becomes default landing
+(`/` redirects to `/work` once #1579 1.4 lands).
+
+## Acceptance criteria
+
+- [ ] `internal/webui/handlers_work.go` — handlers for:
+  - `GET /work` — board view, lists bindings with status (active/inactive)
+    and recent matches
+  - `GET /work/{forge}/{owner}/{repo}/{number}` — detail view of a single
+    work item: matched bindings, run history, "Run on this issue" button
+    (#2.4 wires the action)
+- [ ] `internal/webui/templates/work/{board,detail}.html` — uses Tailwind CDN
+- [ ] Calls `worksource.Service.ListBindings` + `MatchBindings` (from #1591)
+- [ ] No emojis (per Wave constraint)
+- [ ] Test coverage: at least one round-trip test for each handler
+  (htmltest pattern)
+
+## Out of scope
+
+- Dispatch wiring (#2.4)
+- Entry-page redirect to /work (1.4 #1579)
+
+## Dependencies
+
+- #1591 WorkSourceService — MERGED (commit b8f4e01a)
+- #1590 work_item_ref schema — MERGED (commit 7b6aadc9)
+- 1.5a /preview/* phase A (PR #1585 MERGED) — visual reference
+  (`internal/webui/templates/preview/work.html`,
+  `internal/webui/templates/preview/work_item.html`)
+
+## Notes
+
+Design references (preview templates) are the visual contract for layout
+and structure; this issue wires real data through `worksource.Service` so
+the screens become functional rather than fixture-driven.

--- a/specs/1594-work-board/tasks.md
+++ b/specs/1594-work-board/tasks.md
@@ -1,0 +1,52 @@
+# Work Items
+
+## Phase 1: Setup
+
+- [X] Item 1.1: Add `worksource worksource.Service` field to
+  `serverRuntime` in `internal/webui/server.go` and populate it in
+  `NewServer` via `worksource.NewService(rwStore)`.
+- [X] Item 1.2: Confirm no existing route claims `/work` or
+  `/work/...` (grep `routes.go` and feature registry files).
+
+## Phase 2: Core Implementation
+
+- [X] Item 2.1: Implement `handleWorkBoard` in
+  `internal/webui/handlers_work.go` with `BindingFilter{}` query +
+  view-model mapping. [P]
+- [X] Item 2.2: Implement `handleWorkItemDetail` in the same file:
+  parse path values, build `WorkItemRef`, call `MatchBindings`,
+  best-effort forge fetch, run-history filter by matched pipeline
+  names. [P]
+- [X] Item 2.3: Create `templates/work/board.html` — Tailwind CDN,
+  in-template nav, bindings list, empty state. SVG icons only.
+- [X] Item 2.4: Create `templates/work/detail.html` — Tailwind CDN,
+  work item header, matched bindings table, recent runs list,
+  disabled "Run on this issue" button.
+- [X] Item 2.5: Register both routes in `routes.go` next to other
+  dashboard routes.
+- [X] Item 2.6: Update `embed.go` — introduce
+  `standalonePageTemplates` slice (parsed without layout cloning)
+  containing both work templates; thread parsed entries into the
+  returned template map so handlers resolve them by key.
+
+## Phase 3: Testing
+
+- [X] Item 3.1: Add `handlers_work_test.go` with round-trip tests
+  for both handlers (Empty / WithBindings / NoMatch / OneMatch /
+  BadNumber).
+- [X] Item 3.2: Extend `testTemplates` in `handlers_test.go` with
+  inline standalone-page stubs so the work tests don't require the
+  full embedded FS.
+- [X] Item 3.3: `go test ./internal/webui/... -race` — passes
+  (72.7s, no failures).
+
+## Phase 4: Polish
+
+- [X] Item 4.1: `go vet ./...` clean; full `go test ./...` passes
+  (golangci-lint runs in CI — not installed locally in this
+  sandbox).
+- [ ] Item 4.2: Build wave binary outside sandbox; manually visit
+  `/work` and `/work/github/re-cinq/wave/1594` to verify rendering
+  and confirm "no emojis" constraint. (deferred — needs host)
+- [ ] Item 4.3: Open PR referencing issue #1594 and the merged
+  dependency PRs. (next step in the pipeline)


### PR DESCRIPTION
## Summary
- Add `GET /work` board listing bindings with status + recent matches
- Add `GET /work/{forge}/{owner}/{repo}/{number}` detail view showing matched bindings + run history
- Wire `worksource.Service.ListBindings` + `MatchBindings` into webui
- Tailwind CDN templates, no emojis (Wave constraint)
- Round-trip handler tests (htmltest pattern)

Related to #1594

## Changes
- `internal/webui/handlers_work.go` — board + detail handlers
- `internal/webui/handlers_work_test.go` — round-trip tests for both routes
- `internal/webui/templates/work/{board,detail}.html` — Tailwind templates
- `internal/webui/routes.go`, `server.go`, `embed.go` — wire routes + embed templates
- `specs/1594-work-board/{spec,plan,tasks}.md` — planning artifacts

## Test Plan
- [x] `go test ./internal/webui/...` — handler round-trip tests pass
- [ ] Manual: visit `/work` and `/work/<forge>/<owner>/<repo>/<n>` in dev server