### PR TITLE
feat(webui): wire run-on-this-issue dispatch (#1595)

### DIFF
--- a/internal/webui/handlers_work_dispatch.go
+++ b/internal/webui/handlers_work_dispatch.go
@@ -1,0 +1,265 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/recinq/wave/internal/forge"
+	"github.com/recinq/wave/internal/timeouts"
+	"github.com/recinq/wave/internal/worksource"
+)
+
+// handleWorkDispatch handles POST /work/{forge}/{owner}/{repo}/{number}/dispatch.
+//
+// It resolves matching worksource bindings for the work item, picks a pipeline,
+// serializes a shared `work_item_ref` schema document as the run input, and
+// launches the pipeline through the existing s.launchPipelineExecution path.
+//
+// Response codes:
+//   - 302 Found → /runs/{runID} on a successful launch.
+//   - 400 Bad Request when the path number is malformed, when multiple bindings
+//     match and no `pipeline` form/query param disambiguates, or when the
+//     supplied `pipeline` value is not in the match set.
+//   - 409 Conflict when no active binding matches the work item.
+func (s *Server) handleWorkDispatch(w http.ResponseWriter, r *http.Request) {
+	if s.runtime.worksource == nil {
+		http.Error(w, "worksource service not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	forgeName := strings.ToLower(r.PathValue("forge"))
+	owner := r.PathValue("owner")
+	repo := r.PathValue("repo")
+	numberStr := r.PathValue("number")
+	if forgeName == "" || owner == "" || repo == "" || numberStr == "" {
+		http.Error(w, "missing path parameter", http.StatusBadRequest)
+		return
+	}
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number <= 0 {
+		http.Error(w, "invalid issue number", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeouts.ForgeAPI)
+	defer cancel()
+
+	ref := s.buildWorkItemRef(ctx, forgeName, owner, repo, number)
+
+	matches, err := s.runtime.worksource.MatchBindings(ctx, ref)
+	if err != nil {
+		http.Error(w, "match bindings: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form body", http.StatusBadRequest)
+		return
+	}
+	requested := strings.TrimSpace(r.FormValue("pipeline"))
+
+	pipelineName, status, msg := selectBindingPipeline(matches, requested)
+	if status != http.StatusOK {
+		http.Error(w, msg, status)
+		return
+	}
+
+	hostOverride := ""
+	if s.runtime.forgeClient != nil && string(s.runtime.forgeClient.ForgeType()) == forgeName {
+		hostOverride = s.runtime.forgeHost
+	}
+	input, err := serializeWorkItemRef(ref, hostOverride)
+	if err != nil {
+		http.Error(w, "serialize work_item_ref: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	runID, err := s.runtime.rwStore.CreateRun(pipelineName, input)
+	if err != nil {
+		http.Error(w, "create run: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.launchPipelineExecution(runID, pipelineName, input, RunOptions{})
+
+	http.Redirect(w, r, "/runs/"+runID, http.StatusFound)
+}
+
+// buildWorkItemRef constructs a worksource.WorkItemRef for the given path
+// coordinates. When a configured forge client matches the path forge, it
+// enriches the ref with title/state/labels/url from the live issue. Otherwise
+// the ref carries only the structural fields, which is enough for repo- and
+// forge-pattern matches but not for label filters.
+func (s *Server) buildWorkItemRef(ctx context.Context, forgeName, owner, repo string, number int) worksource.WorkItemRef {
+	ref := worksource.WorkItemRef{
+		Forge: forgeName,
+		Repo:  owner + "/" + repo,
+		Kind:  "issue",
+		ID:    strconv.Itoa(number),
+		State: "open",
+	}
+
+	if s.runtime.forgeClient == nil {
+		return ref
+	}
+	if string(s.runtime.forgeClient.ForgeType()) != forgeName {
+		return ref
+	}
+
+	issue, err := s.runtime.forgeClient.GetIssue(ctx, owner, repo, number)
+	if err != nil || issue == nil {
+		return ref
+	}
+
+	ref.Title = issue.Title
+	ref.URL = issue.HTMLURL
+	if issue.State != "" {
+		ref.State = issue.State
+	}
+	if len(issue.Labels) > 0 {
+		ref.Labels = make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			ref.Labels = append(ref.Labels, l.Name)
+		}
+	}
+	return ref
+}
+
+// selectBindingPipeline picks the pipeline name to launch from the match set
+// and an optionally-supplied disambiguation parameter. Returns the chosen
+// pipeline, an HTTP status (200 on success), and an error message for the
+// non-success path. Behaviour:
+//   - 0 matches → 409 Conflict.
+//   - 1 match  → that binding's pipeline.
+//   - >1 match, no requested → 400 listing the available pipelines.
+//   - >1 match, requested in set → that pipeline.
+//   - >1 match, requested not in set → 400 listing the available pipelines.
+func selectBindingPipeline(matches []worksource.BindingRecord, requested string) (string, int, string) {
+	switch len(matches) {
+	case 0:
+		return "", http.StatusConflict, "no worksource binding matches this work item"
+	case 1:
+		if requested != "" && requested != matches[0].PipelineName {
+			return "", http.StatusBadRequest, fmt.Sprintf("requested pipeline %q does not match binding pipeline %q", requested, matches[0].PipelineName)
+		}
+		return matches[0].PipelineName, http.StatusOK, ""
+	}
+
+	allowed := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		if _, ok := seen[m.PipelineName]; ok {
+			continue
+		}
+		seen[m.PipelineName] = struct{}{}
+		allowed = append(allowed, m.PipelineName)
+	}
+	sort.Strings(allowed)
+
+	if requested == "" {
+		return "", http.StatusBadRequest, fmt.Sprintf("multiple bindings match; specify pipeline (one of: %s)", strings.Join(allowed, ", "))
+	}
+	for _, p := range allowed {
+		if p == requested {
+			return requested, http.StatusOK, ""
+		}
+	}
+	return "", http.StatusBadRequest, fmt.Sprintf("requested pipeline %q is not in the match set (allowed: %s)", requested, strings.Join(allowed, ", "))
+}
+
+// workItemRefJSON is the wire shape that mirrors the shared work_item_ref
+// schema. The handler is the only writer; field tags must stay in sync with
+// internal/contract/schemas/shared/work_item_ref.json.
+type workItemRefJSON struct {
+	Source    string   `json:"source"`
+	ForgeHost string   `json:"forge_host,omitempty"`
+	Owner     string   `json:"owner,omitempty"`
+	Repo      string   `json:"repo,omitempty"`
+	Number    int      `json:"number,omitempty"`
+	URL       string   `json:"url"`
+	Title     string   `json:"title"`
+	Labels    []string `json:"labels,omitempty"`
+	State     string   `json:"state"`
+	CreatedAt string   `json:"created_at"`
+}
+
+// serializeWorkItemRef encodes the in-memory ref into the JSON wire form used
+// as a pipeline run input. Forge-specific fields are populated when the ref
+// looks like a forge work-item; otherwise the document falls back to the
+// "manual" source. hostOverride, when non-empty, replaces the canonical host
+// inferred from the forge type — used to capture self-hosted gitea/gitlab
+// instances whose hostnames the canonical map can't know.
+func serializeWorkItemRef(ref worksource.WorkItemRef, hostOverride string) (string, error) {
+	source, host := mapForgeToSource(ref.Forge)
+	if hostOverride != "" {
+		host = hostOverride
+	}
+
+	owner, repo := splitRepoSlug(ref.Repo)
+
+	var number int
+	if ref.ID != "" {
+		if n, err := strconv.Atoi(ref.ID); err == nil {
+			number = n
+		}
+	}
+
+	url := ref.URL
+	title := ref.Title
+	if title == "" {
+		title = fmt.Sprintf("%s/%s #%s", owner, repo, ref.ID)
+	}
+	if url == "" {
+		url = fmt.Sprintf("wave://dispatch/%s/%s/%s/%s/%s", source, host, owner, repo, ref.ID)
+	}
+
+	doc := workItemRefJSON{
+		Source:    source,
+		ForgeHost: host,
+		Owner:     owner,
+		Repo:      repo,
+		Number:    number,
+		URL:       url,
+		Title:     title,
+		Labels:    ref.Labels,
+		State:     ref.State,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if doc.State == "" {
+		doc.State = "open"
+	}
+
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// mapForgeToSource translates a forge type as stored on a worksource binding
+// (e.g. "github", "codeberg", "forgejo") into the (source, host) tuple
+// expected by the shared work_item_ref schema. Codeberg/Forgejo collapse to
+// "gitea" because they share Gitea's API surface.
+func mapForgeToSource(forgeName string) (source, host string) {
+	switch strings.ToLower(forgeName) {
+	case string(forge.ForgeGitHub):
+		return string(forge.ForgeGitHub), "github.com"
+	case string(forge.ForgeGitLab):
+		return string(forge.ForgeGitLab), "gitlab.com"
+	case string(forge.ForgeBitbucket):
+		return string(forge.ForgeBitbucket), "bitbucket.org"
+	case string(forge.ForgeGitea):
+		return string(forge.ForgeGitea), "gitea.com"
+	case string(forge.ForgeCodeberg):
+		return string(forge.ForgeGitea), "codeberg.org"
+	case string(forge.ForgeForgejo):
+		return string(forge.ForgeGitea), "codeberg.org"
+	}
+	return "manual", ""
+}

--- a/internal/webui/handlers_work_dispatch_test.go
+++ b/internal/webui/handlers_work_dispatch_test.go
@@ -38,7 +38,7 @@ func dispatchTestServer(t *testing.T) (*Server, state.StateStore) {
 
 // seedBinding inserts a worksource binding directly into the state store. It
 // returns the new binding id.
-func seedBinding(t *testing.T, store state.WorksourceStore, repoPattern, pipelineName string, labels []string) int64 {
+func seedBinding(t *testing.T, store state.WorksourceStore, pipelineName string, labels []string) int64 {
 	t.Helper()
 	selector := "{}"
 	if len(labels) > 0 {
@@ -47,7 +47,7 @@ func seedBinding(t *testing.T, store state.WorksourceStore, repoPattern, pipelin
 	}
 	id, err := store.CreateBinding(state.WorksourceBindingRecord{
 		Forge:        "github",
-		Repo:         repoPattern,
+		Repo:         "re-cinq/wave",
 		Selector:     selector,
 		PipelineName: pipelineName,
 		Trigger:      state.TriggerOnDemand,
@@ -59,9 +59,13 @@ func seedBinding(t *testing.T, store state.WorksourceStore, repoPattern, pipelin
 	return id
 }
 
-func newDispatchRequest(t *testing.T, owner, repo, number string, body url.Values) *http.Request {
+func newDispatchRequest(t *testing.T, number string, body url.Values) *http.Request {
 	t.Helper()
-	const forge = "github"
+	const (
+		forge = "github"
+		owner = "re-cinq"
+		repo  = "wave"
+	)
 	target := "/work/" + forge + "/" + owner + "/" + repo + "/" + number + "/dispatch"
 	r := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body.Encode()))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -97,7 +101,7 @@ func compileSharedWorkItemRef(t *testing.T) *jsonschema.Schema {
 func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
 	srv, _ := dispatchTestServer(t)
 
-	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -108,9 +112,9 @@ func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
 
 func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "impl-issue", nil)
 
-	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -156,10 +160,10 @@ func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "impl-issue", nil)
+	seedBinding(t, store, "research", nil)
 
-	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -173,11 +177,11 @@ func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "impl-issue", nil)
+	seedBinding(t, store, "research", nil)
 
 	body := url.Values{"pipeline": []string{"research"}}
-	req := newDispatchRequest(t, "re-cinq", "wave", "1595", body)
+	req := newDispatchRequest(t, "1595", body)
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -196,11 +200,11 @@ func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "impl-issue", nil)
+	seedBinding(t, store, "research", nil)
 
 	body := url.Values{"pipeline": []string{"definitely-not-real"}}
-	req := newDispatchRequest(t, "re-cinq", "wave", "1595", body)
+	req := newDispatchRequest(t, "1595", body)
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -212,7 +216,7 @@ func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
 func TestHandleWorkDispatch_MalformedNumber_400(t *testing.T) {
 	srv, _ := dispatchTestServer(t)
 
-	req := newDispatchRequest(t, "re-cinq", "wave", "abc", url.Values{})
+	req := newDispatchRequest(t, "abc", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 

--- a/internal/webui/handlers_work_dispatch_test.go
+++ b/internal/webui/handlers_work_dispatch_test.go
@@ -38,7 +38,7 @@ func dispatchTestServer(t *testing.T) (*Server, state.StateStore) {
 
 // seedBinding inserts a worksource binding directly into the state store. It
 // returns the new binding id.
-func seedBinding(t *testing.T, store state.WorksourceStore, forge, repoPattern, pipelineName string, labels []string) int64 {
+func seedBinding(t *testing.T, store state.WorksourceStore, repoPattern, pipelineName string, labels []string) int64 {
 	t.Helper()
 	selector := "{}"
 	if len(labels) > 0 {
@@ -46,7 +46,7 @@ func seedBinding(t *testing.T, store state.WorksourceStore, forge, repoPattern, 
 		selector = string(raw)
 	}
 	id, err := store.CreateBinding(state.WorksourceBindingRecord{
-		Forge:        forge,
+		Forge:        "github",
 		Repo:         repoPattern,
 		Selector:     selector,
 		PipelineName: pipelineName,
@@ -59,8 +59,9 @@ func seedBinding(t *testing.T, store state.WorksourceStore, forge, repoPattern, 
 	return id
 }
 
-func newDispatchRequest(t *testing.T, forge, owner, repo, number string, body url.Values) *http.Request {
+func newDispatchRequest(t *testing.T, owner, repo, number string, body url.Values) *http.Request {
 	t.Helper()
+	const forge = "github"
 	target := "/work/" + forge + "/" + owner + "/" + repo + "/" + number + "/dispatch"
 	r := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body.Encode()))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -96,7 +97,7 @@ func compileSharedWorkItemRef(t *testing.T) *jsonschema.Schema {
 func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
 	srv, _ := dispatchTestServer(t)
 
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -107,9 +108,9 @@ func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
 
 func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
 
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -155,10 +156,10 @@ func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "re-cinq/wave", "research", nil)
 
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	req := newDispatchRequest(t, "re-cinq", "wave", "1595", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -172,11 +173,11 @@ func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "re-cinq/wave", "research", nil)
 
 	body := url.Values{"pipeline": []string{"research"}}
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", body)
+	req := newDispatchRequest(t, "re-cinq", "wave", "1595", body)
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -195,11 +196,11 @@ func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
-	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+	seedBinding(t, store, "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "re-cinq/wave", "research", nil)
 
 	body := url.Values{"pipeline": []string{"definitely-not-real"}}
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", body)
+	req := newDispatchRequest(t, "re-cinq", "wave", "1595", body)
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 
@@ -211,7 +212,7 @@ func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
 func TestHandleWorkDispatch_MalformedNumber_400(t *testing.T) {
 	srv, _ := dispatchTestServer(t)
 
-	req := newDispatchRequest(t, "github", "re-cinq", "wave", "abc", url.Values{})
+	req := newDispatchRequest(t, "re-cinq", "wave", "abc", url.Values{})
 	rec := httptest.NewRecorder()
 	srv.handleWorkDispatch(rec, req)
 

--- a/internal/webui/handlers_work_dispatch_test.go
+++ b/internal/webui/handlers_work_dispatch_test.go
@@ -1,0 +1,237 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/recinq/wave/internal/contract/schemas/shared"
+	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/worksource"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// dispatchTestServer extends testServer with a worksource service backed by the
+// real state store. The handler under test reads s.runtime.worksource directly,
+// so tests must wire it up explicitly.
+func dispatchTestServer(t *testing.T) (*Server, state.StateStore) {
+	t.Helper()
+	srv, store := testServer(t)
+	srv.runtime.worksource = worksource.NewService(store)
+	// Pin cwd so the detached subprocess SpawnDetached doesn't litter the repo
+	// with a top-level .agents/logs directory across the test suite.
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	return srv, store
+}
+
+// seedBinding inserts a worksource binding directly into the state store. It
+// returns the new binding id.
+func seedBinding(t *testing.T, store state.WorksourceStore, forge, repoPattern, pipelineName string, labels []string) int64 {
+	t.Helper()
+	selector := "{}"
+	if len(labels) > 0 {
+		raw, _ := json.Marshal(map[string]any{"labels": labels})
+		selector = string(raw)
+	}
+	id, err := store.CreateBinding(state.WorksourceBindingRecord{
+		Forge:        forge,
+		Repo:         repoPattern,
+		Selector:     selector,
+		PipelineName: pipelineName,
+		Trigger:      state.TriggerOnDemand,
+		Active:       true,
+	})
+	if err != nil {
+		t.Fatalf("seedBinding: %v", err)
+	}
+	return id
+}
+
+func newDispatchRequest(t *testing.T, forge, owner, repo, number string, body url.Values) *http.Request {
+	t.Helper()
+	target := "/work/" + forge + "/" + owner + "/" + repo + "/" + number + "/dispatch"
+	r := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.SetPathValue("forge", forge)
+	r.SetPathValue("owner", owner)
+	r.SetPathValue("repo", repo)
+	r.SetPathValue("number", number)
+	return r
+}
+
+func compileSharedWorkItemRef(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	raw, ok := shared.Lookup("work_item_ref")
+	if !ok {
+		t.Fatal("work_item_ref schema not registered")
+	}
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("schema parse: %v", err)
+	}
+	const schemaURL = "wave://shared/work_item_ref"
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(schemaURL, doc); err != nil {
+		t.Fatalf("add resource: %v", err)
+	}
+	compiled, err := c.Compile(schemaURL)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return compiled
+}
+
+func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
+	srv, _ := dispatchTestServer(t)
+
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
+	srv, store := dispatchTestServer(t)
+	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
+
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/runs/") {
+		t.Fatalf("expected /runs/<id> redirect, got %q", loc)
+	}
+	runID := strings.TrimPrefix(loc, "/runs/")
+
+	run, err := store.GetRun(runID)
+	if err != nil {
+		t.Fatalf("GetRun(%s): %v", runID, err)
+	}
+	if run.PipelineName != "impl-issue" {
+		t.Errorf("expected pipeline impl-issue, got %q", run.PipelineName)
+	}
+
+	// Round-trip: input must validate against the shared work_item_ref schema
+	// and decode to the expected work-item coordinates.
+	schema := compileSharedWorkItemRef(t)
+	var doc any
+	if err := json.Unmarshal([]byte(run.Input), &doc); err != nil {
+		t.Fatalf("input is not JSON: %v\n%s", err, run.Input)
+	}
+	if err := schema.Validate(doc); err != nil {
+		t.Errorf("input fails work_item_ref schema: %v\n%s", err, run.Input)
+	}
+
+	var parsed workItemRefJSON
+	if err := json.Unmarshal([]byte(run.Input), &parsed); err != nil {
+		t.Fatalf("re-decode input: %v", err)
+	}
+	if parsed.Source != "github" {
+		t.Errorf("source = %q, want github", parsed.Source)
+	}
+	if parsed.Owner != "re-cinq" || parsed.Repo != "wave" || parsed.Number != 1595 {
+		t.Errorf("coords = %s/%s#%d, want re-cinq/wave#1595", parsed.Owner, parsed.Repo, parsed.Number)
+	}
+}
+
+func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
+	srv, store := dispatchTestServer(t)
+	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", url.Values{})
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "impl-issue") || !strings.Contains(rec.Body.String(), "research") {
+		t.Errorf("error body should list candidates, got %q", rec.Body.String())
+	}
+}
+
+func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
+	srv, store := dispatchTestServer(t)
+	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+
+	body := url.Values{"pipeline": []string{"research"}}
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", body)
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", rec.Code, rec.Body.String())
+	}
+	runID := strings.TrimPrefix(rec.Header().Get("Location"), "/runs/")
+	run, err := store.GetRun(runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.PipelineName != "research" {
+		t.Errorf("expected research, got %q", run.PipelineName)
+	}
+}
+
+func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
+	srv, store := dispatchTestServer(t)
+	seedBinding(t, store, "github", "re-cinq/wave", "impl-issue", nil)
+	seedBinding(t, store, "github", "re-cinq/wave", "research", nil)
+
+	body := url.Values{"pipeline": []string{"definitely-not-real"}}
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "1595", body)
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleWorkDispatch_MalformedNumber_400(t *testing.T) {
+	srv, _ := dispatchTestServer(t)
+
+	req := newDispatchRequest(t, "github", "re-cinq", "wave", "abc", url.Values{})
+	rec := httptest.NewRecorder()
+	srv.handleWorkDispatch(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSelectBindingPipeline_RequestedConflictsSingleMatch covers the corner
+// where a single binding matches but the caller's `pipeline` form value
+// disagrees — we 400 instead of silently overriding the binding decision.
+func TestSelectBindingPipeline_RequestedConflictsSingleMatch(t *testing.T) {
+	matches := []worksource.BindingRecord{
+		{PipelineName: "impl-issue", Active: true},
+	}
+	pipe, status, msg := selectBindingPipeline(matches, "research")
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", status, msg)
+	}
+	if pipe != "" {
+		t.Errorf("expected empty pipeline on error, got %q", pipe)
+	}
+}

--- a/internal/webui/handlers_work_dispatch_test.go
+++ b/internal/webui/handlers_work_dispatch_test.go
@@ -38,13 +38,9 @@ func dispatchTestServer(t *testing.T) (*Server, state.StateStore) {
 
 // seedBinding inserts a worksource binding directly into the state store. It
 // returns the new binding id.
-func seedBinding(t *testing.T, store state.WorksourceStore, pipelineName string, labels []string) int64 {
+func seedBinding(t *testing.T, store state.WorksourceStore, pipelineName string) int64 {
 	t.Helper()
-	selector := "{}"
-	if len(labels) > 0 {
-		raw, _ := json.Marshal(map[string]any{"labels": labels})
-		selector = string(raw)
-	}
+	const selector = "{}"
 	id, err := store.CreateBinding(state.WorksourceBindingRecord{
 		Forge:        "github",
 		Repo:         "re-cinq/wave",
@@ -112,7 +108,7 @@ func TestHandleWorkDispatch_NoMatch_409(t *testing.T) {
 
 func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "impl-issue", nil)
+	seedBinding(t, store, "impl-issue")
 
 	req := newDispatchRequest(t, "1595", url.Values{})
 	rec := httptest.NewRecorder()
@@ -160,8 +156,8 @@ func TestHandleWorkDispatch_SingleMatch_RedirectAndRunRow(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "impl-issue", nil)
-	seedBinding(t, store, "research", nil)
+	seedBinding(t, store, "impl-issue")
+	seedBinding(t, store, "research")
 
 	req := newDispatchRequest(t, "1595", url.Values{})
 	rec := httptest.NewRecorder()
@@ -177,8 +173,8 @@ func TestHandleWorkDispatch_MultiMatch_NoPipeline_400(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "impl-issue", nil)
-	seedBinding(t, store, "research", nil)
+	seedBinding(t, store, "impl-issue")
+	seedBinding(t, store, "research")
 
 	body := url.Values{"pipeline": []string{"research"}}
 	req := newDispatchRequest(t, "1595", body)
@@ -200,8 +196,8 @@ func TestHandleWorkDispatch_MultiMatch_ValidPipeline_Redirect(t *testing.T) {
 
 func TestHandleWorkDispatch_MultiMatch_BogusPipeline_400(t *testing.T) {
 	srv, store := dispatchTestServer(t)
-	seedBinding(t, store, "impl-issue", nil)
-	seedBinding(t, store, "research", nil)
+	seedBinding(t, store, "impl-issue")
+	seedBinding(t, store, "research")
 
 	body := url.Values{"pipeline": []string{"definitely-not-real"}}
 	req := newDispatchRequest(t, "1595", body)

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -74,6 +74,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/runs/{id}/events", s.handleSSE)
 	mux.HandleFunc("GET /api/issues", s.handleAPIIssues)
 	mux.HandleFunc("POST /api/issues/start", s.handleAPIStartFromIssue)
+	mux.HandleFunc("POST /work/{forge}/{owner}/{repo}/{number}/dispatch", s.handleWorkDispatch)
 	mux.HandleFunc("GET /api/prs", s.handleAPIPRs)
 	mux.HandleFunc("POST /api/prs/{number}/review", s.handlePRReview)
 	mux.HandleFunc("POST /api/prs/start", s.handleAPIStartFromPR)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/onboarding"
 	"github.com/recinq/wave/internal/state"
+	"github.com/recinq/wave/internal/worksource"
 	"github.com/recinq/wave/internal/workspace"
 )
 
@@ -66,8 +67,10 @@ type serverRuntime struct {
 	wsManager   workspace.WorkspaceManager
 	forgeClient forge.Client
 	repoSlug    string // "owner/repo"
+	forgeHost   string // hostname of the forge (e.g. "github.com")
 	repoDir     string // git repository root directory
 	scheduler   *Scheduler
+	worksource  worksource.Service
 }
 
 // serverRealtime groups the realtime/eventing collaborators: SSE broker,
@@ -244,8 +247,10 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 			wsManager:   wsManager,
 			forgeClient: forgeClient,
 			repoSlug:    repoSlug,
+			forgeHost:   forgeInfo.Host,
 			repoDir:     repoDir,
 			scheduler:   NewScheduler(cfg.MaxConcurrent),
+			worksource:  worksource.NewService(rwStore),
 		},
 		realtime: serverRealtime{
 			broker:            NewSSEBroker(),

--- a/specs/1595-dispatch-wiring/plan.md
+++ b/specs/1595-dispatch-wiring/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan — 1595 Dispatch Wiring
+
+## 1. Objective
+
+Add a `POST /work/{forge}/{owner}/{repo}/{number}/dispatch` endpoint that turns a work item into a real pipeline run by resolving matching `worksource` bindings, selecting a pipeline, serializing the `work_item_ref` as run input, and launching via the existing `runner.LaunchInProcess` plumbing.
+
+## 2. Approach
+
+1. Build a `worksource.WorkItemRef` from path params, querying the configured forge client for the live issue (title/labels/state).
+2. Call `worksource.Service.MatchBindings(ctx, ref)` to get candidate bindings.
+3. Pick the pipeline:
+   - 0 matches → 409 Conflict.
+   - 1 match → use that binding's `PipelineName`.
+   - >1 matches → require a `pipeline` form/query param; 400 if missing/not in match set.
+4. Marshal the `work_item_ref` (shared schema shape, #1590) as the run input string.
+5. Create the run via `runtime.rwStore.CreateRun(pipelineName, input)`.
+6. Launch via `s.launchPipelineExecution(runID, pipelineName, input, opts)` — same path as `/api/issues/start`, so `runner.BuildExecutorOptions` is preserved.
+7. Respond with `302 Found` to `/runs/{runID}`.
+
+## 3. File Mapping
+
+### Created
+
+- `internal/webui/handlers_work_dispatch.go` — new handler + helpers (`buildWorkItemRef`, `serializeWorkItemRef`, `selectBindingPipeline`).
+- `internal/webui/handlers_work_dispatch_test.go` — round-trip handler tests.
+- `specs/1595-dispatch-wiring/{spec,plan,tasks}.md` — planning artifacts.
+
+### Modified
+
+- `internal/webui/server.go` — add `worksource worksource.Service` to `serverRuntime`; construct in `NewServer` from `rwStore`.
+- `internal/webui/routes.go` — register `POST /work/{forge}/{owner}/{repo}/{number}/dispatch`.
+
+### Not Touched
+
+- `internal/worksource/*` — already merged (#1591).
+- `internal/runner/*` — reused as-is.
+- `internal/contract/schemas/shared/work_item_ref.json` — input artifact only.
+
+## 4. Architecture Decisions
+
+- **Path namespace**: `/work/...` (not `/api/work/...`) per the issue spec, because the success path returns a 302 — implying browser-form usage. JSON callers can still POST and follow the redirect.
+- **WorkItemRef construction**: the handler is the source of truth. It populates `Forge`, `Repo`, `Kind=issue`, `ID=number`, and enriches with `Title/Labels/State/URL` via `runtime.forgeClient.GetIssue` when available. If the forge client is unconfigured, fall back to the bare-bones ref (kind+id+repo) — matches will work for `repoPattern`/`forge` rules but label filters won't.
+- **Run input shape**: serialized JSON matching the shared `work_item_ref` schema (snake_case fields per `internal/contract/schemas/shared/work_item_ref.json`). The persona sees the same shape it would in the contract input.
+- **Service caching**: `worksource.Service` is constructed once in `NewServer` and stored on `serverRuntime`, mirroring the pattern used for `forgeClient`.
+- **Disambiguation source**: `pipeline` is read from the form body first, then query string — the `/work/...` endpoint is browser-friendly.
+
+## 5. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Forge client unconfigured → ref missing labels → label-filter bindings won't match | Document behavior in handler doc-comment; tests cover both with-forge and without-forge paths. |
+| Multiple bindings + caller picks one not in match set | Explicit 400 with allowed pipeline list in the error body. |
+| Path `/work/...` collides with future page route | Reserve only the `/dispatch` suffix; future GET pages can use the same prefix safely. |
+| Serialization drift from shared schema | Handler builds JSON using the documented field names; a test asserts the run input parses back to a matching `WorkItemRef`. |
+
+## 6. Testing Strategy
+
+- **Unit / handler tests** in `handlers_work_dispatch_test.go`:
+  - 0 bindings → 409.
+  - 1 binding → 302 redirect to `/runs/{id}`, run row exists with expected pipeline + JSON input.
+  - 2 bindings, no `pipeline` param → 400.
+  - 2 bindings, `pipeline=A` (in match set) → 302 with pipeline A.
+  - 2 bindings, `pipeline=Bogus` (not in match set) → 400.
+  - Path param parsing: missing parts → 404 (handled by mux), malformed `number` → 400.
+- **Round-trip assertion**: after dispatch, `rwStore.GetRun(runID)` returns a row whose `Input` is JSON that round-trips through the shared `work_item_ref` schema validator (using `internal/contract/schemas/shared/work_item_ref_test.go` style helpers).
+- Reuse `testServer(t)` pattern from `handlers_test.go`. Insert bindings directly into `rwStore` (already exposes `WorksourceStore` via interface composition).
+- No forge client needed for tests — pass labels/state via query params or use a fake forgeClient.
+
+## 7. Out of Scope
+
+- The work-board UI (#2.3) — the handler is callable but the button lives in another issue.
+- Detach mode — the issue mentions "(or detached)" parenthetically; default is in-process via `launchPipelineExecution`. A `detach=true` form field can be honored if trivial; otherwise deferred.
+- `on-open`/`scheduled`-trigger automatic dispatch — this issue covers only manual `/dispatch`.

--- a/specs/1595-dispatch-wiring/spec.md
+++ b/specs/1595-dispatch-wiring/spec.md
@@ -1,0 +1,52 @@
+# Phase 2.4: Run-on-this-issue dispatch wiring
+
+**Issue:** [re-cinq/wave#1595](https://github.com/re-cinq/wave/issues/1595)
+**Labels:** `enhancement`, `ready-for-impl`
+**State:** OPEN
+**Author:** nextlevelshit
+**Epic:** #1565 Phase 2 (work-source dispatch)
+
+## Body
+
+Part of Epic #1565 Phase 2 (work-source dispatch).
+
+### Goal
+
+Wire the "Run on this issue" button (from #2.3 work board detail) so it: looks up matching bindings via `worksource.Service.MatchBindings`, picks the appropriate pipeline, and invokes `runner.LaunchInProcess` (or detached) — closing the loop from work item → real run.
+
+### Acceptance criteria
+
+- [ ] `internal/webui/handlers_work_dispatch.go` (or extend handlers_work.go):
+  - `POST /work/{forge}/{owner}/{repo}/{number}/dispatch` — accepts pipeline name, validates against MatchBindings result, launches the run
+  - Returns redirect to the run detail page on success
+  - Returns 409 if no binding matches; 400 if multiple match and pipeline param missing
+- [ ] Goes through the existing service layer (no bypass of `runner.BuildExecutorOptions`)
+- [ ] Auto-injects work_item_ref as the run input (so the persona has the issue context)
+- [ ] Test coverage: round-trip test that fakes a binding + WorkItemRef and verifies a run is created in state store
+
+### Note on pipeline choice
+
+Originally tagged `impl-finding` in epic plan. Use `impl-issue` instead — `impl-finding` requires parent-pipeline-injected pr-context which doesn't fit fresh issue dispatch (lesson from PR #1588 dispatch).
+
+### Dependencies
+
+- #2.3 (work board) — UI surface
+- #1591 WorkSourceService.MatchBindings (MERGED)
+- PRE-1 service layer (MERGED) — uses runner.LaunchInProcess
+
+## Acceptance Criteria (extracted)
+
+1. New handler at `POST /work/{forge}/{owner}/{repo}/{number}/dispatch`.
+2. Accepts optional `pipeline` parameter (form or query) for disambiguation.
+3. 409 Conflict when zero bindings match the work item.
+4. 400 Bad Request when multiple bindings match and `pipeline` param is missing.
+5. Successful dispatch returns 302 redirect to `/runs/{runID}`.
+6. Run input is the JSON-serialized `work_item_ref` (shared schema #1590).
+7. Launch goes through `runner.LaunchInProcess` (via `s.launchPipelineExecution`) — no executor option bypass.
+8. Round-trip test creates a binding, fakes a `WorkItemRef`, hits the endpoint, asserts a run row exists in the state store with the expected pipeline + input.
+
+## Metadata
+
+- Branch: `1595-dispatch-wiring`
+- Complexity: medium
+- Skipped speckit steps: specify, clarify, checklist, analyze

--- a/specs/1595-dispatch-wiring/tasks.md
+++ b/specs/1595-dispatch-wiring/tasks.md
@@ -1,0 +1,34 @@
+# Work Items
+
+## Phase 1: Setup
+
+- [X] Item 1.1: Add `worksource worksource.Service` field to `serverRuntime` in `internal/webui/server.go`.
+- [X] Item 1.2: Construct the service from `rwStore` in `NewServer` and wire it into `runtime`.
+
+## Phase 2: Core Implementation
+
+- [X] Item 2.1: Create `internal/webui/handlers_work_dispatch.go` with `handleWorkDispatch(w, r)`. [P]
+- [X] Item 2.2: Implement helper `buildWorkItemRef(ctx, forge, owner, repo, number)` — uses `runtime.forgeClient` when available, falls back to bare ref otherwise. [P]
+- [X] Item 2.3: Implement helper `serializeWorkItemRef(ref) (string, error)` matching the shared `work_item_ref` JSON schema (#1590).
+- [X] Item 2.4: Implement `selectBindingPipeline(matches, requested string)` — returns chosen pipeline + HTTP status (200/400/409).
+- [X] Item 2.5: Wire `s.launchPipelineExecution(runID, pipelineName, input, RunOptions{})` and 302 redirect to `/runs/{runID}`.
+- [X] Item 2.6: Register `POST /work/{forge}/{owner}/{repo}/{number}/dispatch` in `internal/webui/routes.go`.
+
+## Phase 3: Testing
+
+- [X] Item 3.1: Add `handlers_work_dispatch_test.go` with `testServer(t)` setup + binding fixtures.
+- [X] Item 3.2: Test — zero matches → 409. [P]
+- [X] Item 3.3: Test — single match → 302, run row created with expected pipeline + serialized work_item_ref input. [P]
+- [X] Item 3.4: Test — multiple matches, no `pipeline` param → 400. [P]
+- [X] Item 3.5: Test — multiple matches with valid `pipeline` form value → 302 routes to chosen pipeline. [P]
+- [X] Item 3.6: Test — multiple matches with `pipeline` value not in match set → 400. [P]
+- [X] Item 3.7: Test — malformed `number` path param → 400. [P]
+- [X] Item 3.8: Round-trip assertion that the persisted run input parses back through the shared `work_item_ref` schema validator.
+
+## Phase 4: Polish
+
+- [X] Item 4.1: Run `go test ./internal/webui/... ./internal/worksource/...` and ensure no regressions.
+- [X] Item 4.2: Run `go test ./...` per repo policy.
+- [X] Item 4.3: Run `golangci-lint run ./...` and resolve findings. (golangci-lint not installed in workspace; `go vet` and `go test -race` clean.)
+- [X] Item 4.4: Verify `wave web` boot path still passes integration smoke (server starts, route registered). (Covered by webui suite — server constructor exercised via testServer + handler unit tests.)
+- [X] Item 4.5: Add brief doc-comments on the new handler and helpers; no separate doc page needed.


### PR DESCRIPTION
## Summary
- Add `POST /work/{forge}/{owner}/{repo}/{number}/dispatch` handler that closes the work-item → run loop
- Resolve matching `worksource.Service` bindings; 409 when none match, 400 when ambiguous (explicit `pipeline` form value disambiguates)
- Serialize `work_item_ref` shared schema as run input so the persona has issue context
- Launch via existing `launchPipelineExecution` path (no bypass of `runner.BuildExecutorOptions`)
- Wire `worksource.Service` onto `serverRuntime`; ship round-trip tests asserting state-store run creation and schema-conformant input

Related to #1595

## Changes
- `internal/webui/handlers_work_dispatch.go` — new dispatch handler with binding lookup, pipeline disambiguation, work_item_ref injection
- `internal/webui/handlers_work_dispatch_test.go` — round-trip tests covering happy path, 409 (no binding), 400 (ambiguous), explicit pipeline override
- `internal/webui/routes.go` — register dispatch route
- `internal/webui/server.go` — wire `worksource.Service` onto `serverRuntime`
- `specs/1595-dispatch-wiring/{spec,plan,tasks}.md` — planning artifacts

## Test Plan
- [x] `go test ./internal/webui/...` round-trip tests pass
- [x] State store records run with correct work_item_ref input
- [x] 409 returned when no binding matches
- [x] 400 returned when multiple bindings match without explicit pipeline param