### PR TITLE
feat(webui): smart-redirect / based on onboarding sentinel (#1599)

### DIFF
--- a/internal/webui/handlers_root.go
+++ b/internal/webui/handlers_root.go
@@ -1,0 +1,26 @@
+package webui
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/recinq/wave/internal/onboarding"
+)
+
+// handleRoot serves GET / by branching on the onboarding sentinel.
+// If .agents/.onboarding-done exists under the project root, redirect to
+// /work; otherwise redirect to /onboard so the operator can finish setup.
+// Stat errors fall through to /onboard — the safer default for a project
+// whose onboarding state cannot be confirmed.
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	projectDir := s.runtime.repoDir
+	if projectDir == "" {
+		projectDir = "."
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, onboarding.SentinelFile)); err == nil {
+		http.Redirect(w, r, "/work", http.StatusFound)
+		return
+	}
+	http.Redirect(w, r, "/onboard", http.StatusFound)
+}

--- a/internal/webui/handlers_root_test.go
+++ b/internal/webui/handlers_root_test.go
@@ -1,0 +1,89 @@
+package webui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/recinq/wave/internal/onboarding"
+)
+
+// TestHandleRoot drives Server.handleRoot directly via httptest, asserting
+// that GET / branches on the presence of .agents/.onboarding-done under the
+// configured repoDir.
+func TestHandleRoot(t *testing.T) {
+	tests := []struct {
+		name           string
+		writeSentinel  bool
+		wantLocation   string
+		repoDirOverlay func(t *testing.T, dir string) string
+	}{
+		{
+			name:          "sentinel present redirects to /work",
+			writeSentinel: true,
+			wantLocation:  "/work",
+		},
+		{
+			name:          "sentinel missing redirects to /onboard",
+			writeSentinel: false,
+			wantLocation:  "/onboard",
+		},
+		{
+			name:          "empty repoDir treated as cwd and missing sentinel",
+			writeSentinel: false,
+			wantLocation:  "/onboard",
+			repoDirOverlay: func(t *testing.T, _ string) string {
+				t.Helper()
+				cwd := t.TempDir()
+				oldwd, err := os.Getwd()
+				if err != nil {
+					t.Fatalf("getwd: %v", err)
+				}
+				if err := os.Chdir(cwd); err != nil {
+					t.Fatalf("chdir: %v", err)
+				}
+				t.Cleanup(func() { _ = os.Chdir(oldwd) })
+				return ""
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			if tc.writeSentinel {
+				if err := os.MkdirAll(filepath.Join(tmp, ".agents"), 0o755); err != nil {
+					t.Fatalf("mkdir .agents: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(tmp, onboarding.SentinelFile), []byte(""), 0o644); err != nil {
+					t.Fatalf("write sentinel: %v", err)
+				}
+			}
+
+			repoDir := tmp
+			if tc.repoDirOverlay != nil {
+				repoDir = tc.repoDirOverlay(t, tmp)
+			}
+
+			srv := &Server{
+				runtime: serverRuntime{repoDir: repoDir},
+			}
+
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			srv.handleRoot(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("expected 302, got %d", rec.Code)
+			}
+			if got := rec.Header().Get("Location"); got != tc.wantLocation {
+				t.Fatalf("Location: want %q, got %q", tc.wantLocation, got)
+			}
+			if rec.Header().Get("Location") == "/runs" {
+				t.Fatalf("legacy /runs redirect leaked through handleRoot")
+			}
+		})
+	}
+}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -10,9 +10,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /static/", staticHandler())
 
 	// Dashboard pages (HTML)
-	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/runs", http.StatusFound)
-	})
+	mux.HandleFunc("GET /{$}", s.handleRoot)
 	mux.HandleFunc("GET /runs", s.handleRunsPage)
 	mux.HandleFunc("GET /runs/{id}", s.handleRunDetailPage)
 

--- a/specs/1599-entry-page-branch/plan.md
+++ b/specs/1599-entry-page-branch/plan.md
@@ -1,0 +1,48 @@
+# Implementation Plan — #1599 Entry-page smart redirect
+
+## Objective
+
+Replace the static `GET /{$}` → `/runs` redirect in the webui with a sentinel-aware handler that routes `/` to `/onboard` (when `.agents/.onboarding-done` is missing) or `/work` (when present).
+
+## Approach
+
+- Extract the `GET /{$}` handler from `internal/webui/routes.go` into a new file `internal/webui/handlers_root.go` as `Server.handleRoot`.
+- `handleRoot` joins `s.runtime.repoDir` with `onboarding.SentinelFile` (`.agents/.onboarding-done`) and `os.Stat`s it. Missing → 302 `/onboard`; present → 302 `/work`.
+- Update `routes.go` to wire `mux.HandleFunc("GET /{$}", s.handleRoot)`.
+- Add `handlers_root_test.go` covering both branches via `t.TempDir()` fixtures plus a real `httptest.NewRecorder` round-trip on a `Server` whose `runtime.repoDir` points at the fixture.
+
+## File Mapping
+
+Created:
+- `internal/webui/handlers_root.go` — `handleRoot` method.
+- `internal/webui/handlers_root_test.go` — table test for sentinel present / missing / stat-error fallback.
+
+Modified:
+- `internal/webui/routes.go` — replace inline lambda with `s.handleRoot` reference.
+
+Deleted: none.
+
+## Architecture Decisions
+
+- **Sentinel detection lives in handler, not middleware.** Only `/` cares about the sentinel; a middleware would add per-request stat overhead to every route.
+- **Fallback on stat error → `/onboard`.** Permission errors or unreadable parent dirs should treat the project as not-yet-onboarded (safest default — operator can finish onboarding rather than land on an empty work board).
+- **Reuse `onboarding.SentinelFile` constant** from `internal/onboarding/service.go` rather than hardcoding the path again.
+- **`repoDir` is already on `serverRuntime`** (server.go:71, populated from `git rev-parse --show-toplevel`). No new plumbing needed.
+- **No build-tag gating.** This is a routing concern, not a feature-flagged surface.
+
+## Risks
+
+- **Sentinel created mid-session.** If onboarding completes while the user has `/` open, they'd need to refresh; acceptable — `/` is not a long-lived page.
+- **`repoDir` empty in test contexts.** Mitigation: handler treats empty `repoDir` as `"."` (matches existing `handlers_onboard.go:352` pattern).
+- **Symlinked `.agents` dirs.** `os.Stat` follows symlinks, which is what we want.
+
+## Testing Strategy
+
+Unit test in `handlers_root_test.go`:
+1. **Sentinel present** → expect `302 /work`. Setup: `t.TempDir()` + `os.MkdirAll(.agents)` + create the sentinel file. Build a minimal `Server{runtime: serverRuntime{repoDir: tmp}}` and invoke `handleRoot` directly.
+2. **Sentinel missing** → expect `302 /onboard`. Setup: bare `t.TempDir()`.
+3. **Verify no `/runs` references** appear in the redirect target for either path.
+
+Use `httptest.NewRecorder` + `httptest.NewRequest("GET", "/", nil)`. Assert `rec.Code == 302` and `rec.Header().Get("Location")`.
+
+No integration test needed — `routes.go` already wires the handler and the existing route-registration test (`features_default_test.go`) confirms the mux compiles.

--- a/specs/1599-entry-page-branch/spec.md
+++ b/specs/1599-entry-page-branch/spec.md
@@ -1,0 +1,28 @@
+# Phase 1.4: Entry-page branch / → /onboard or /work
+
+Issue: https://github.com/re-cinq/wave/issues/1599
+Repository: re-cinq/wave
+Labels: enhancement, ready-for-impl, frontend
+State: OPEN
+Author: nextlevelshit
+Branch: 1599-entry-page-branch
+
+Part of Epic #1565 Phase 1.
+
+## Goal
+
+Make `/` smart-redirect: if `.agents/.onboarding-done` sentinel missing → `/onboard` (kick off onboarding). Otherwise → `/work` (now that 2.3 + 2.4 are live).
+
+## Acceptance criteria
+
+- [ ] `internal/webui/handlers_root.go` (or extend routes.go):
+  - GET / → 302 to /onboard if sentinel missing
+  - GET / → 302 to /work otherwise
+- [ ] Test coverage: round-trip both paths via tmp fixtures
+- [ ] Removes any old default-landing logic (was /runs)
+- [ ] No emojis
+
+## Dependencies
+
+- 1.2 webui driver (PR #1587 MERGED)
+- 2.3 /work board (PR #1597 MERGED)

--- a/specs/1599-entry-page-branch/tasks.md
+++ b/specs/1599-entry-page-branch/tasks.md
@@ -1,0 +1,19 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] Item 1.1: Confirm `onboarding.SentinelFile` exported and import path correct
+- [X] Item 1.2: Confirm `s.runtime.repoDir` populated in `NewServer`
+
+## Phase 2: Core Implementation
+- [X] Item 2.1: Create `internal/webui/handlers_root.go` with `Server.handleRoot` (sentinel stat → 302 `/work` or `/onboard`)
+- [X] Item 2.2: Update `internal/webui/routes.go` `GET /{$}` to call `s.handleRoot` (replaces hardcoded `/runs` redirect)
+
+## Phase 3: Testing
+- [X] Item 3.1: Add `internal/webui/handlers_root_test.go` — sentinel present → `/work` [P]
+- [X] Item 3.2: Add `internal/webui/handlers_root_test.go` — sentinel missing → `/onboard` [P]
+- [X] Item 3.3: Run `go test ./internal/webui/... -race`
+
+## Phase 4: Polish
+- [X] Item 4.1: Run `golangci-lint run ./internal/webui/...`
+- [ ] Item 4.2: Manual smoke: `wave server` → curl `/` with and without sentinel
+- [X] Item 4.3: Verify no emojis introduced


### PR DESCRIPTION
## Summary
- GET / now 302-redirects to /onboard when `.agents/.onboarding-done` sentinel is missing, otherwise to /work
- Removes legacy default landing on /runs
- Adds round-trip test coverage for both redirect paths via tmp fixtures

Related to #1599

## Changes
- `internal/webui/handlers_root.go` — new root handler with sentinel-based branching
- `internal/webui/routes.go` — wire root handler, drop /runs default
- `internal/webui/handlers_root_test.go` — sentinel present/absent round-trip tests
- `specs/1599-entry-page-branch/` — spec, plan, tasks

## Test Plan
- `go test ./internal/webui/...` covers both redirect targets
- Manual: hit / with and without `.agents/.onboarding-done` present