### PR TITLE
chore(pipelines): raise judgment-step model from cheapest to balanced

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         # Common packages for all shells
         commonPackages = with pkgs; [
           go
+          golangci-lint  # CI lint parity (forbidigo, etc.); match v2.x in .github/workflows/lint.yml
           gh
           git
 	  tea

--- a/internal/defaults/embedfs/pipelines/audit-architecture.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-architecture.yaml
@@ -37,7 +37,7 @@ pipeline_outputs:
 steps:
   - id: scan
     persona: navigator
-    model: cheapest
+    model: balanced
     workspace:
       mount:
         - source: ./
@@ -116,7 +116,7 @@ steps:
         persona: navigator
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/architecture-report.md
-        model: cheapest
+        model: balanced
         token_budget: 0
         timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/audit-security.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-security.yaml
@@ -380,7 +380,7 @@ steps:
         persona: navigator
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/security-report.md
-        model: cheapest
+        model: balanced
         token_budget: 0
         timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/audit-tests.yaml
+++ b/internal/defaults/embedfs/pipelines/audit-tests.yaml
@@ -36,7 +36,7 @@ pipeline_outputs:
 steps:
   - id: scan
     persona: navigator
-    model: cheapest
+    model: balanced
     workspace:
       mount:
         - source: ./
@@ -116,7 +116,7 @@ steps:
         persona: navigator
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/tests-report.md
-        model: cheapest
+        model: balanced
         token_budget: 0
         timeout: 300s
         on_failure: warn

--- a/internal/defaults/embedfs/pipelines/impl-issue-core.yaml
+++ b/internal/defaults/embedfs/pipelines/impl-issue-core.yaml
@@ -49,7 +49,7 @@ input:
 steps:
   - id: fetch-assess
     persona: implementer
-    model: cheapest
+    model: balanced
     workspace:
       type: worktree
       branch: "{{ pipeline_id }}"

--- a/internal/defaults/embedfs/pipelines/impl-issue.yaml
+++ b/internal/defaults/embedfs/pipelines/impl-issue.yaml
@@ -49,7 +49,7 @@ pipeline_outputs:
 steps:
   - id: fetch-assess
     persona: implementer
-    model: cheapest
+    model: balanced
     workspace:
       type: worktree
       branch: "{{ pipeline_id }}"
@@ -236,7 +236,7 @@ steps:
         - type: agent_review
           persona: navigator
           criteria_path: .agents/contracts/impl-review-criteria.md
-          model: cheapest
+          model: balanced
           token_budget: 0
           timeout: 300s
           context:

--- a/internal/defaults/embedfs/pipelines/ops-bootstrap.yaml
+++ b/internal/defaults/embedfs/pipelines/ops-bootstrap.yaml
@@ -283,7 +283,7 @@ steps:
   - id: commit
     persona: craftsman
     thread: bootstrap
-    model: cheapest
+    model: balanced
     dependencies: [scaffold, assess]
     workspace:
       type: worktree

--- a/internal/defaults/embedfs/pipelines/ops-pr-review.yaml
+++ b/internal/defaults/embedfs/pipelines/ops-pr-review.yaml
@@ -54,7 +54,7 @@ steps:
   # ─── Phase 1: Diff analysis ───────────────────────────────────────────────
   - id: diff-analysis
     persona: navigator
-    model: cheapest
+    model: balanced
     workspace:
       mount:
         - source: ./
@@ -256,7 +256,7 @@ steps:
       contract:
         type: llm_judge
         source: .agents/output/security-review.md
-        model: cheapest
+        model: balanced
         criteria:
           - "Identifies injection vulnerabilities (SQL, command, XSS) if present in the diff"
           - "Checks for hardcoded credentials or secrets"
@@ -375,7 +375,7 @@ steps:
         persona: navigator
         criteria_path: .agents/contracts/quality-review-criteria.md
         source: .agents/output/quality-review.md
-        model: cheapest
+        model: balanced
         token_budget: 0
         timeout: 300s
         on_failure: continue

--- a/internal/defaults/embedfs/pipelines/plan-research.yaml
+++ b/internal/defaults/embedfs/pipelines/plan-research.yaml
@@ -128,7 +128,7 @@ steps:
   - id: analyze-topics
     persona: researcher
     thread: research
-    model: cheapest
+    model: balanced
     dependencies: [fetch-issue]
     memory:
       inject_artifacts:
@@ -224,7 +224,7 @@ steps:
   - id: research-topics
     persona: researcher
     thread: research
-    model: cheapest
+    model: balanced
     max_concurrent_agents: 5
     dependencies: [analyze-topics]
     memory:


### PR DESCRIPTION
## Summary

Real-world signal from Epic #1565 Phase 1 dispatch: cheapest tier (Haiku) produced shallow outputs on judgment-shaped work. Most visible cases:

- **#1582** — impl-issue persona deleted a passing test instead of scoping it by build tag
- **#1585** — preview implementation generated `panic()` calls in init paths, failing forbidigo

Both rooted in cheapest-tier model lacking the nuance to refactor / scope / reason. Pipeline yamls had `model: cheapest` baked into many judgment steps as a cost optimization that no longer holds when output quality breaks downstream.

## Change

Promoted to **balanced** on judgment steps; kept **cheapest** on summary/distill/format steps.

| Pipeline | Step (was cheapest) | New model | Why |
|---|---|---|---|
| impl-issue | fetch-assess | balanced | issue assessment is judgment |
| impl-issue | agent_review | balanced | review is judgment |
| impl-issue | create-pr (commenter) | cheapest (kept) | PR body formatting = summary |
| impl-issue-core | fetch-assess | balanced | same as impl-issue |
| audit-tests | scan | balanced | finding extraction = judgment |
| audit-tests | report (summarizer) | cheapest (kept) | distill scan into report |
| audit-tests | agent_review | balanced | review is judgment |
| audit-architecture | scan + agent_review | balanced | same |
| audit-security | agent_review | balanced | review is judgment |
| audit-security | report (summarizer) | cheapest (kept) | distill |
| ops-bootstrap | commit (craftsman) | balanced | scaffolding code = judgment |
| ops-pr-review | diff-analysis | balanced | analysis = judgment |
| ops-pr-review | security llm_judge | balanced | judgment |
| ops-pr-review | quality agent_review | balanced | judgment |
| plan-research | analyze-topics + research-topics | balanced | research = judgment |
| plan-research | fetch-issue + post-comment | cheapest (kept) | data fetch + format |

## Other change

Added `golangci-lint` to `flake.nix` devShell so the same forbidigo gate that broke CI on PR #1585 runs locally without manual install. CI ships v2.10; nixpkgs-unstable ships v2.8.0 — minor skew, acceptable.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/defaults/...` passes (embedded-fs parity tests)
- [x] `nix develop -c which golangci-lint` resolves
- [ ] Next dispatch (Phase 3 issues) uses these defaults — will validate via real run

## Related

- Closes nothing directly. Blocks recurrence of #1582-style and #1585-style regressions at the model-tier level.
- #1583, #1584 (sibling regression contracts) — defense-in-depth, complement this commit but ship independently.