### PR TITLE
feat(pipelines): add pipeline-evolve meta-pipeline

### DIFF
--- a/.agents/contracts/evolution-findings.schema.json
+++ b/.agents/contracts/evolution-findings.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evolution Findings",
+  "description": "Output from the analyze step of pipeline-evolve: classified failure signal aggregated from pipeline_eval rows for a target pipeline.",
+  "type": "object",
+  "required": ["pipeline_name", "sample_size", "failure_classes", "status"],
+  "properties": {
+    "pipeline_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target pipeline whose history was analyzed"
+    },
+    "sample_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of pipeline_eval rows considered"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["analyzed", "insufficient_data"],
+      "description": "analyzed when at least one row was present; insufficient_data when no eval rows were available"
+    },
+    "judge_score_median": {
+      "type": ["number", "null"],
+      "description": "Median judge_score across the sample, or null if no scored runs"
+    },
+    "contract_pass_rate": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Fraction of runs where contract_pass=true"
+    },
+    "retry_count_avg": {
+      "type": ["number", "null"],
+      "description": "Mean retry count across the sample"
+    },
+    "failure_classes": {
+      "type": "array",
+      "description": "Top recurring failure classes with counts, capped to top 10",
+      "items": {
+        "type": "object",
+        "required": ["class", "count"],
+        "properties": {
+          "class": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Failure class label as recorded in pipeline_eval.failure_class"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of occurrences in the sample"
+          },
+          "share": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Fraction of sample attributable to this class"
+          }
+        }
+      }
+    },
+    "recurring_symptoms": {
+      "type": "array",
+      "description": "Free-form natural-language symptom labels extracted by the analyzer",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "captured_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Wall-clock time when analysis ran"
+    }
+  }
+}

--- a/.agents/contracts/evolution-proposal.schema.json
+++ b/.agents/contracts/evolution-proposal.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evolution Proposal",
+  "description": "Output from the propose step of pipeline-evolve: pointers to candidate yaml/diff plus a structured rationale that gets written verbatim into evolution_proposal.signal_summary.",
+  "type": "object",
+  "required": [
+    "pipeline_name",
+    "candidate_yaml_path",
+    "diff_path",
+    "reason",
+    "signal_summary",
+    "version_before",
+    "version_after"
+  ],
+  "properties": {
+    "pipeline_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target pipeline name; mirrors the pipeline-evolve input"
+    },
+    "candidate_yaml_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the proposed v+1 yaml file inside the workspace (e.g. .agents/output/evolution/<run_id>/<pipeline>.next.yaml)"
+    },
+    "diff_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to a unified diff (yaml + persona prompt changes). Stored verbatim in evolution_proposal.diff_path."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-paragraph human-readable rationale; stored in evolution_proposal.reason"
+    },
+    "signal_summary": {
+      "type": "object",
+      "description": "Compact JSON summarizing the analyze findings; serialized verbatim into evolution_proposal.signal_summary",
+      "required": ["sample_size", "failure_classes"],
+      "properties": {
+        "sample_size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "judge_score_median": {
+          "type": ["number", "null"]
+        },
+        "contract_pass_rate": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "failure_classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["class", "count"],
+            "properties": {
+              "class": { "type": "string", "minLength": 1 },
+              "count": { "type": "integer", "minimum": 1 }
+            }
+          }
+        },
+        "recurring_symptoms": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "version_before": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Active version at proposal time; 0 if no row in pipeline_version"
+    },
+    "version_after": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Proposed next version, typically version_before + 1"
+    },
+    "prompt_changes": {
+      "type": "array",
+      "description": "Optional list of persona prompt edits suggested by the proposal (informational; the diff_path is the canonical artifact)",
+      "items": {
+        "type": "object",
+        "required": ["persona", "summary"],
+        "properties": {
+          "persona": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/.agents/pipelines/pipeline-evolve.yaml
+++ b/.agents/pipelines/pipeline-evolve.yaml
@@ -52,7 +52,6 @@ steps:
   - id: gather-eval
     type: command
     script: |
-      set -o pipefail
       mkdir -p .agents/output
 
       PIPELINE='{{ input }}'
@@ -122,7 +121,7 @@ steps:
   # produces a structured findings JSON. Schema-gated by evolution-findings.
   - id: analyze
     persona: navigator
-    model: cheapest
+    model: balanced
     dependencies: [gather-eval]
     memory:
       inject_artifacts:
@@ -423,7 +422,6 @@ steps:
     type: command
     dependencies: [propose]
     script: |
-      set -o pipefail
       mkdir -p .agents/output
 
       OUT=.agents/output/record-status.json

--- a/.agents/pipelines/pipeline-evolve.yaml
+++ b/.agents/pipelines/pipeline-evolve.yaml
@@ -1,0 +1,540 @@
+kind: WavePipeline
+metadata:
+  name: pipeline-evolve
+  description: >-
+    Meta-pipeline that ingests pipeline_eval history for a target pipeline,
+    classifies recurring failure signal, and proposes an improved v+1 (yaml +
+    persona prompt diffs) via LLM. Records the candidate as a 'proposed' row
+    in evolution_proposal so a human gate can approve, reject, or supersede
+    before activation. Closes the self-evolution loop initiated by the
+    EvalSignal hook (Phase 3 of epic #1565).
+  category: composition
+  release: false
+
+skills:
+  - "{{ project.skill }}"
+
+input:
+  source: cli
+  type: string
+  example: "impl-issue"
+  schema:
+    type: string
+    description: "Target pipeline name (e.g. impl-issue, audit-security). Empty input is rejected."
+
+chat_context:
+  artifact_summaries:
+    - eval-rollup
+    - findings
+    - proposal-summary
+    - record-status
+  suggested_questions:
+    - "Which failure classes recur most often for this pipeline?"
+    - "What changed between the active YAML and the proposed v+1?"
+    - "What proposal_id was recorded?"
+  focus_areas:
+    - "Recurring failure classes and judge score trends"
+    - "Specific YAML / persona-prompt diffs being proposed"
+    - "Insufficient-data short-circuit when no eval rows exist"
+
+pipeline_outputs:
+  proposal:
+    step: record
+    artifact: record-status
+    type: string
+
+# ─── Step 1: gather-eval ────────────────────────────────────────────────────
+# Pull pipeline_eval rows for the target pipeline directly from .agents/state.db.
+# Mirrors the audit-db-trace precedent (sqlite3 + jq, graceful fallback when the
+# DB is missing). Empty input is rejected up-front so downstream steps never run
+# on a meaningless target.
+steps:
+  - id: gather-eval
+    type: command
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      PIPELINE='{{ input }}'
+      TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      OUT=.agents/output/eval-rollup.json
+
+      if [ -z "$PIPELINE" ]; then
+        echo "pipeline-evolve: empty input; target pipeline name required" >&2
+        exit 1
+      fi
+
+      # Locate the project root by walking up from the workspace CWD looking
+      # for wave.yaml. Wave projects always have a manifest at the root, so
+      # this is a stable anchor independent of workspace nesting depth.
+      find_project_root() {
+        d="$PWD"
+        while [ "$d" != "/" ]; do
+          if [ -f "$d/wave.yaml" ] || [ -f "$d/wave.yml" ]; then
+            printf '%s\n' "$d"
+            return 0
+          fi
+          d=$(dirname "$d")
+        done
+        printf '%s\n' "$PWD"
+      }
+      ROOT=$(find_project_root)
+      DB="$ROOT/.agents/state.db"
+
+      if [ ! -f "$DB" ]; then
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, sample_size:0, status:"insufficient_data", rows:[], note:"No .agents/state.db on disk; gather-eval skipped.", captured_at:$ts}' \
+          > "$OUT"
+        exit 0
+      fi
+
+      # Pull the most recent 50 eval rows for the target pipeline. Use a
+      # positional parameter to dodge SQL-injection in the pipeline name.
+      ROWS=$(sqlite3 -json "$DB" \
+        "SELECT pipeline_name, run_id, judge_score, contract_pass, retry_count, failure_class, human_override, duration_ms, cost_dollars, recorded_at FROM pipeline_eval WHERE pipeline_name = '$PIPELINE' ORDER BY recorded_at DESC LIMIT 50" 2>/dev/null || true)
+      if [ -z "$ROWS" ]; then ROWS="[]"; fi
+
+      COUNT=$(printf '%s' "$ROWS" | jq 'length')
+      if [ "$COUNT" -eq 0 ]; then
+        STATUS="insufficient_data"
+      else
+        STATUS="ready"
+      fi
+
+      jq -n \
+        --arg pipeline "$PIPELINE" \
+        --arg status "$STATUS" \
+        --arg ts "$TS" \
+        --argjson rows "$ROWS" \
+        --argjson size "$COUNT" \
+        '{pipeline_name:$pipeline, sample_size:$size, status:$status, rows:$rows, captured_at:$ts}' \
+        > "$OUT"
+    output_artifacts:
+      - name: eval-rollup
+        path: .agents/output/eval-rollup.json
+        type: json
+        required: true
+
+  # ─── Step 2: analyze ──────────────────────────────────────────────────────
+  # Navigator (read-only, low-temp) classifies recurring failure classes and
+  # produces a structured findings JSON. Schema-gated by evolution-findings.
+  - id: analyze
+    persona: navigator
+    model: cheapest
+    dependencies: [gather-eval]
+    memory:
+      inject_artifacts:
+        - step: gather-eval
+          artifact: eval-rollup
+          as: eval_rollup
+    workspace:
+      mount:
+        - source: ./
+          target: /project
+          mode: readonly
+    exec:
+      type: prompt
+      source: |
+        ## Objective
+
+        Classify recurring failure signal in the injected `eval_rollup` artifact
+        and emit a structured findings JSON that summarises the analysis. The
+        downstream `propose` step will read your findings to draft an improved
+        v+1 of the target pipeline, so be precise and stable: identical inputs
+        must produce identical outputs.
+
+        Target pipeline: `{{ input }}`
+
+        ## Context
+
+        - The injected `eval_rollup` artifact contains:
+          - `pipeline_name`, `sample_size`, `status` (ready | insufficient_data),
+            `captured_at`, and `rows` — at most the last 50 pipeline_eval rows.
+          - Each row: `pipeline_name`, `run_id`, `judge_score` (nullable float),
+            `contract_pass` (nullable bool), `retry_count` (nullable int),
+            `failure_class` (nullable string), `human_override` (nullable bool),
+            `duration_ms`, `cost_dollars`, `recorded_at` (unix seconds).
+
+        - The pipeline source files live in the read-only project mount under
+          `internal/defaults/embedfs/pipelines/` and `.agents/pipelines/`. You
+          may inspect them to ground your symptom labels in real step IDs, but
+          do NOT modify any file in this step.
+
+        ## Requirements
+
+        ### Step 1 — Handle empty / insufficient data
+
+        If `eval_rollup.status == "insufficient_data"` OR `sample_size == 0`:
+        write a findings JSON with `status: "insufficient_data"`, an empty
+        `failure_classes` array, and zero metrics. Do not invent symptoms.
+        The downstream `record` step will short-circuit on this status.
+
+        ### Step 2 — Aggregate metrics
+
+        For the rows present:
+
+        - `judge_score_median`: median of non-null `judge_score` values, or null
+          when no row has a score.
+        - `contract_pass_rate`: count(contract_pass=true) / count(non-null
+          contract_pass), or null when no row has the field set.
+        - `retry_count_avg`: arithmetic mean of `retry_count` across rows that
+          have it set, or null otherwise.
+
+        ### Step 3 — Classify failure classes
+
+        Group rows by `failure_class` (skip rows where the field is null or
+        empty). Sort by count descending and keep the top 10. For each:
+
+        - `class`: the failure_class label as recorded.
+        - `count`: how many runs in the sample carried it.
+        - `share`: count / sample_size, rounded to 4 decimal places.
+
+        ### Step 4 — Recurring symptoms
+
+        Produce 1–5 short natural-language symptom labels that describe what
+        is going wrong, grounded in the failure_class distribution and judge
+        score trend. Each symptom is a single sentence under 120 characters.
+        Examples (do not copy verbatim — derive from the data):
+
+        - "Judge score regressed below 0.7 across the last 12 runs"
+        - "contract_validation_failed dominates failures after retry"
+
+        Skip this section if `status == "insufficient_data"`.
+
+        ### Step 5 — Write the findings JSON
+
+        Write to the output path declared in `output_artifacts`:
+        `.agents/output/evolution-findings.json`
+
+        The JSON must conform to `.agents/contracts/evolution-findings.schema.json`
+        with at least: `pipeline_name`, `sample_size`, `status`,
+        `failure_classes` (array, may be empty), and `captured_at` (RFC3339
+        timestamp).
+
+        ## Constraints and Anti-patterns
+
+        - DO NOT fabricate failure classes or symptoms not supported by the
+          rows. The downstream `propose` step trusts your output verbatim.
+        - DO NOT include more than 10 entries in `failure_classes`.
+        - DO NOT exceed 1500 bytes for the entire JSON file. The summary is
+          stored in the DB as `signal_summary` and must stay compact.
+        - DO NOT modify any file outside the declared output artifact path.
+
+        ## Quality Bar
+
+        A good findings JSON is deterministic for identical inputs, captures
+        the dominant failure modes faithfully, and stays small enough to
+        embed verbatim in the `evolution_proposal` row. A bad findings JSON
+        invents symptoms, misses the dominant class, or exceeds the size cap.
+    output_artifacts:
+      - name: findings
+        path: .agents/output/evolution-findings.json
+        type: json
+        required: true
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/evolution-findings.json
+        schema_path: .agents/contracts/evolution-findings.schema.json
+        must_pass: true
+        on_failure: warn
+
+  # ─── Step 3: propose ──────────────────────────────────────────────────────
+  # Craftsman drafts the v+1 candidate yaml + a unified prompt diff + a
+  # structured proposal-summary.json that record/ingests verbatim.
+  - id: propose
+    persona: craftsman
+    model: balanced
+    dependencies: [analyze]
+    memory:
+      inject_artifacts:
+        - step: gather-eval
+          artifact: eval-rollup
+          as: eval_rollup
+        - step: analyze
+          artifact: findings
+          as: findings
+    workspace:
+      mount:
+        - source: ./
+          target: /project
+          mode: readonly
+    exec:
+      type: prompt
+      source: |
+        ## Objective
+
+        Draft the next iteration of the target pipeline (`{{ input }}`) based on
+        the injected `findings` summary. Produce three artifacts:
+
+        1. A candidate v+1 YAML (full pipeline file, not a diff).
+        2. A unified `prompt.diff` over any persona prompt files you would
+           change, plus the YAML diff.
+        3. A `proposal-summary.json` that conforms to
+           `.agents/contracts/evolution-proposal.schema.json` and summarises
+           what you changed and why. The `record` step will copy
+           `signal_summary` from this JSON verbatim into the
+           `evolution_proposal` table.
+
+        ## Context
+
+        - The injected `findings` artifact carries the structured analysis
+          (failure classes, judge score median, recurring symptoms,
+          sample_size, status).
+        - The injected `eval_rollup` carries the raw rows for reference.
+        - The active pipeline yaml lives at one of:
+          - `internal/defaults/embedfs/pipelines/{{ input }}.yaml` (embedded default), or
+          - `.agents/pipelines/{{ input }}.yaml` (project override).
+        - Persona prompts live under `internal/defaults/embedfs/personas/`.
+        - You have a read-only project mount; persona-side write tools may
+          still create your output files, but DO NOT git-add or commit.
+
+        ## Requirements
+
+        ### Step 0 — Insufficient-data short-circuit
+
+        If `findings.status == "insufficient_data"` OR
+        `findings.sample_size == 0`:
+
+        - Skip the YAML/diff drafting.
+        - Write a minimal `proposal-summary.json` with
+          `version_before = 0`, `version_after = 1`,
+          `reason = "insufficient evaluation data; no proposal generated"`,
+          `signal_summary = { sample_size: 0, failure_classes: [] }`,
+          and set `candidate_yaml_path` and `diff_path` to empty strings.
+
+        The `record` step will see the empty paths and skip the DB insert.
+        Stop here.
+
+        ### Step 1 — Read the active YAML
+
+        Locate and read the active pipeline YAML for `{{ input }}` from the
+        embedded defaults or the project override. If neither exists, treat
+        the active version as 0 and the candidate as the first concrete
+        version (v1).
+
+        ### Step 2 — Draft the candidate
+
+        Write the candidate to:
+
+        ```
+        .agents/output/evolution/<pipeline>.next.yaml
+        ```
+
+        where `<pipeline>` is `{{ input }}`. The candidate is a *complete*
+        pipeline YAML, not a fragment. Keep the same `metadata.name`. Keep
+        the pipeline default-agnostic (no language-specific commands).
+
+        Your edits must be *targeted*: address the dominant failure class(es)
+        named in `findings`. Do not stylistic-rewrite untouched steps.
+
+        ### Step 3 — Write a unified diff
+
+        Write a unified diff (the kind `git diff` emits or `diff -u` produces)
+        spanning every file you would change — including persona prompt files
+        if your proposal edits them. Path:
+
+        ```
+        .agents/output/evolution/prompt.diff
+        ```
+
+        Use repo-relative paths inside the diff headers (e.g.
+        `--- a/internal/defaults/embedfs/pipelines/{{ input }}.yaml`).
+
+        ### Step 4 — Write proposal-summary.json
+
+        Write to:
+
+        ```
+        .agents/output/evolution/proposal-summary.json
+        ```
+
+        Required fields (match `evolution-proposal.schema.json`):
+
+        - `pipeline_name`: the target pipeline name.
+        - `candidate_yaml_path`: absolute or repo-relative path to the
+          candidate yaml you wrote in Step 2.
+        - `diff_path`: absolute or repo-relative path to the diff in Step 3.
+        - `reason`: one-paragraph rationale, plain English. Must reference
+          at least one failure class from `findings`.
+        - `signal_summary`: compact JSON object copying `sample_size`,
+          `failure_classes` (top 5 only), `judge_score_median`,
+          `contract_pass_rate`, and `recurring_symptoms` verbatim from
+          `findings`. Keep this under 1500 bytes when serialized.
+        - `version_before`: the active version. Treat 0 as "no recorded
+          active version".
+        - `version_after`: `version_before + 1`.
+        - Optionally: `prompt_changes` — a list of `{ persona, summary }`
+          entries describing persona prompt edits (informational only; the
+          diff is canonical).
+
+        ## Constraints and Anti-patterns
+
+        - DO NOT modify the active yaml file in-place. Write the candidate
+          to the `.agents/output/evolution/` directory only.
+        - DO NOT git-add, git-commit, or git-push from this step. The
+          proposal is opaque to git until a reviewer approves.
+        - DO NOT emit a candidate yaml that introduces project-specific
+          (Go, npm, etc.) commands or hard-codes a forge. Stay
+          default-agnostic — use `{{ project.* }}` and `{{ forge.* }}`.
+        - DO NOT exceed 1500 bytes in `signal_summary` after JSON
+          serialization. The DB stores it verbatim.
+
+        ## Quality Bar
+
+        A good proposal cites a specific failure class in `reason`, edits
+        only the steps implicated by that class, keeps the `signal_summary`
+        compact, and produces a syntactically valid YAML candidate that the
+        loader could parse. A bad proposal rewrites everything stylistically,
+        ignores the dominant failure class, or emits an invalid YAML.
+    output_artifacts:
+      - name: proposal-summary
+        path: .agents/output/evolution/proposal-summary.json
+        type: json
+        required: true
+      - name: candidate-yaml
+        path: .agents/output/evolution/{{ input }}.next.yaml
+        type: yaml
+        required: false
+      - name: prompt-diff
+        path: .agents/output/evolution/prompt.diff
+        type: text
+        required: false
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/evolution/proposal-summary.json
+        schema_path: .agents/contracts/evolution-proposal.schema.json
+        must_pass: true
+        on_failure: fail
+
+  # ─── Step 4: record ───────────────────────────────────────────────────────
+  # INSERT into evolution_proposal as 'proposed'. Empty/insufficient-data path
+  # short-circuits to status=skipped so the DB never grows noise rows.
+  - id: record
+    type: command
+    dependencies: [propose]
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      OUT=.agents/output/record-status.json
+      TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      PIPELINE='{{ input }}'
+
+      if [ -z "$PIPELINE" ]; then
+        echo "record: empty input; target pipeline name required" >&2
+        exit 1
+      fi
+
+      # Resolve the propose-step inputs via the WAVE_DEP_* contract. Falls
+      # back to the canonical injection path when WAVE_DEP_PROPOSE_* is not
+      # populated (older runtimes).
+      SUMMARY="${WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY:-.agents/artifacts/propose/proposal-summary}"
+      if [ ! -f "$SUMMARY" ]; then
+        echo "record: missing proposal-summary at $SUMMARY" >&2
+        exit 1
+      fi
+
+      # Locate the project root by walking up from CWD looking for wave.yaml.
+      find_project_root() {
+        d="$PWD"
+        while [ "$d" != "/" ]; do
+          if [ -f "$d/wave.yaml" ] || [ -f "$d/wave.yml" ]; then
+            printf '%s\n' "$d"
+            return 0
+          fi
+          d=$(dirname "$d")
+        done
+        printf '%s\n' "$PWD"
+      }
+      ROOT=$(find_project_root)
+      DB="$ROOT/.agents/state.db"
+
+      VERSION_BEFORE=$(jq -r '.version_before // 0' "$SUMMARY")
+      VERSION_AFTER=$(jq -r '.version_after // 1' "$SUMMARY")
+      DIFF_PATH=$(jq -r '.diff_path // ""' "$SUMMARY")
+      REASON=$(jq -r '.reason // ""' "$SUMMARY")
+      SIGNAL_SUMMARY=$(jq -c '.signal_summary // {}' "$SUMMARY")
+
+      # Insufficient-data short-circuit: when propose emitted empty paths
+      # because the analyze step had no data to work with, skip the INSERT
+      # and emit a record-status.json with status=skipped.
+      if [ -z "$DIFF_PATH" ] || [ -z "$REASON" ] || [ ! -f "$DB" ]; then
+        REASON_MSG="skipped"
+        if [ ! -f "$DB" ]; then
+          REASON_MSG="no_state_db"
+        elif [ -z "$DIFF_PATH" ]; then
+          REASON_MSG="insufficient_data"
+        fi
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg status "skipped" \
+          --arg reason "$REASON_MSG" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, status:$status, skip_reason:$reason, proposal_id:null, recorded_at:$ts}' \
+          > "$OUT"
+        exit 0
+      fi
+
+      # Stage the diff under .agents/output/evolution/<pipeline_id>/ at the
+      # project root so the recorded diff_path survives workspace cleanup.
+      STABLE_DIR="$ROOT/.agents/output/evolution/${PIPELINE}"
+      mkdir -p "$STABLE_DIR"
+
+      DIFF_BASENAME=$(basename "$DIFF_PATH")
+      STABLE_DIFF="$STABLE_DIR/${DIFF_BASENAME}"
+      if [ -f "$DIFF_PATH" ]; then
+        cp -f "$DIFF_PATH" "$STABLE_DIFF"
+      fi
+      # Always copy the proposal-summary alongside for auditability.
+      cp -f "$SUMMARY" "$STABLE_DIR/proposal-summary.json"
+
+      # SQL-escape every untrusted string by doubling single quotes. SQLite
+      # parses `''` inside a literal as a single quote, so this is the
+      # canonical defense against injection here.
+      sql_escape() {
+        printf '%s' "$1" | sed "s/'/''/g"
+      }
+      ESC_PIPELINE=$(sql_escape "$PIPELINE")
+      ESC_DIFF=$(sql_escape "$STABLE_DIFF")
+      ESC_REASON=$(sql_escape "$REASON")
+      ESC_SIGNAL=$(sql_escape "$SIGNAL_SUMMARY")
+
+      PROPOSED_AT=$(date -u +%s)
+
+      PROPOSAL_ID=$(sqlite3 "$DB" "INSERT INTO evolution_proposal (pipeline_name, version_before, version_after, diff_path, reason, signal_summary, status, proposed_at) VALUES ('$ESC_PIPELINE', $VERSION_BEFORE, $VERSION_AFTER, '$ESC_DIFF', '$ESC_REASON', '$ESC_SIGNAL', 'proposed', $PROPOSED_AT); SELECT last_insert_rowid();")
+
+      if [ -z "$PROPOSAL_ID" ]; then
+        echo "record: failed to insert evolution_proposal row" >&2
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, status:"failed", proposal_id:null, recorded_at:$ts}' \
+          > "$OUT"
+        exit 1
+      fi
+
+      jq -n \
+        --arg pipeline "$PIPELINE" \
+        --arg status "proposed" \
+        --argjson id "$PROPOSAL_ID" \
+        --arg diff "$STABLE_DIFF" \
+        --argjson vb "$VERSION_BEFORE" \
+        --argjson va "$VERSION_AFTER" \
+        --arg ts "$TS" \
+        '{pipeline_name:$pipeline, status:$status, proposal_id:$id, diff_path:$diff, version_before:$vb, version_after:$va, recorded_at:$ts}' \
+        > "$OUT"
+    output_artifacts:
+      - name: record-status
+        path: .agents/output/record-status.json
+        type: json
+        required: true

--- a/internal/defaults/embedfs/contracts/evolution-findings.schema.json
+++ b/internal/defaults/embedfs/contracts/evolution-findings.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evolution Findings",
+  "description": "Output from the analyze step of pipeline-evolve: classified failure signal aggregated from pipeline_eval rows for a target pipeline.",
+  "type": "object",
+  "required": ["pipeline_name", "sample_size", "failure_classes", "status"],
+  "properties": {
+    "pipeline_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target pipeline whose history was analyzed"
+    },
+    "sample_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of pipeline_eval rows considered"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["analyzed", "insufficient_data"],
+      "description": "analyzed when at least one row was present; insufficient_data when no eval rows were available"
+    },
+    "judge_score_median": {
+      "type": ["number", "null"],
+      "description": "Median judge_score across the sample, or null if no scored runs"
+    },
+    "contract_pass_rate": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Fraction of runs where contract_pass=true"
+    },
+    "retry_count_avg": {
+      "type": ["number", "null"],
+      "description": "Mean retry count across the sample"
+    },
+    "failure_classes": {
+      "type": "array",
+      "description": "Top recurring failure classes with counts, capped to top 10",
+      "items": {
+        "type": "object",
+        "required": ["class", "count"],
+        "properties": {
+          "class": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Failure class label as recorded in pipeline_eval.failure_class"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of occurrences in the sample"
+          },
+          "share": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Fraction of sample attributable to this class"
+          }
+        }
+      }
+    },
+    "recurring_symptoms": {
+      "type": "array",
+      "description": "Free-form natural-language symptom labels extracted by the analyzer",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "captured_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Wall-clock time when analysis ran"
+    }
+  }
+}

--- a/internal/defaults/embedfs/contracts/evolution-proposal.schema.json
+++ b/internal/defaults/embedfs/contracts/evolution-proposal.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evolution Proposal",
+  "description": "Output from the propose step of pipeline-evolve: pointers to candidate yaml/diff plus a structured rationale that gets written verbatim into evolution_proposal.signal_summary.",
+  "type": "object",
+  "required": [
+    "pipeline_name",
+    "candidate_yaml_path",
+    "diff_path",
+    "reason",
+    "signal_summary",
+    "version_before",
+    "version_after"
+  ],
+  "properties": {
+    "pipeline_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target pipeline name; mirrors the pipeline-evolve input"
+    },
+    "candidate_yaml_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the proposed v+1 yaml file inside the workspace (e.g. .agents/output/evolution/<run_id>/<pipeline>.next.yaml)"
+    },
+    "diff_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to a unified diff (yaml + persona prompt changes). Stored verbatim in evolution_proposal.diff_path."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-paragraph human-readable rationale; stored in evolution_proposal.reason"
+    },
+    "signal_summary": {
+      "type": "object",
+      "description": "Compact JSON summarizing the analyze findings; serialized verbatim into evolution_proposal.signal_summary",
+      "required": ["sample_size", "failure_classes"],
+      "properties": {
+        "sample_size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "judge_score_median": {
+          "type": ["number", "null"]
+        },
+        "contract_pass_rate": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "failure_classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["class", "count"],
+            "properties": {
+              "class": { "type": "string", "minLength": 1 },
+              "count": { "type": "integer", "minimum": 1 }
+            }
+          }
+        },
+        "recurring_symptoms": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "version_before": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Active version at proposal time; 0 if no row in pipeline_version"
+    },
+    "version_after": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Proposed next version, typically version_before + 1"
+    },
+    "prompt_changes": {
+      "type": "array",
+      "description": "Optional list of persona prompt edits suggested by the proposal (informational; the diff_path is the canonical artifact)",
+      "items": {
+        "type": "object",
+        "required": ["persona", "summary"],
+        "properties": {
+          "persona": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/internal/defaults/embedfs/pipelines/pipeline-evolve.yaml
+++ b/internal/defaults/embedfs/pipelines/pipeline-evolve.yaml
@@ -52,7 +52,6 @@ steps:
   - id: gather-eval
     type: command
     script: |
-      set -o pipefail
       mkdir -p .agents/output
 
       PIPELINE='{{ input }}'
@@ -122,7 +121,7 @@ steps:
   # produces a structured findings JSON. Schema-gated by evolution-findings.
   - id: analyze
     persona: navigator
-    model: cheapest
+    model: balanced
     dependencies: [gather-eval]
     memory:
       inject_artifacts:
@@ -423,7 +422,6 @@ steps:
     type: command
     dependencies: [propose]
     script: |
-      set -o pipefail
       mkdir -p .agents/output
 
       OUT=.agents/output/record-status.json

--- a/internal/defaults/embedfs/pipelines/pipeline-evolve.yaml
+++ b/internal/defaults/embedfs/pipelines/pipeline-evolve.yaml
@@ -1,0 +1,540 @@
+kind: WavePipeline
+metadata:
+  name: pipeline-evolve
+  description: >-
+    Meta-pipeline that ingests pipeline_eval history for a target pipeline,
+    classifies recurring failure signal, and proposes an improved v+1 (yaml +
+    persona prompt diffs) via LLM. Records the candidate as a 'proposed' row
+    in evolution_proposal so a human gate can approve, reject, or supersede
+    before activation. Closes the self-evolution loop initiated by the
+    EvalSignal hook (Phase 3 of epic #1565).
+  category: composition
+  release: false
+
+skills:
+  - "{{ project.skill }}"
+
+input:
+  source: cli
+  type: string
+  example: "impl-issue"
+  schema:
+    type: string
+    description: "Target pipeline name (e.g. impl-issue, audit-security). Empty input is rejected."
+
+chat_context:
+  artifact_summaries:
+    - eval-rollup
+    - findings
+    - proposal-summary
+    - record-status
+  suggested_questions:
+    - "Which failure classes recur most often for this pipeline?"
+    - "What changed between the active YAML and the proposed v+1?"
+    - "What proposal_id was recorded?"
+  focus_areas:
+    - "Recurring failure classes and judge score trends"
+    - "Specific YAML / persona-prompt diffs being proposed"
+    - "Insufficient-data short-circuit when no eval rows exist"
+
+pipeline_outputs:
+  proposal:
+    step: record
+    artifact: record-status
+    type: string
+
+# ─── Step 1: gather-eval ────────────────────────────────────────────────────
+# Pull pipeline_eval rows for the target pipeline directly from .agents/state.db.
+# Mirrors the audit-db-trace precedent (sqlite3 + jq, graceful fallback when the
+# DB is missing). Empty input is rejected up-front so downstream steps never run
+# on a meaningless target.
+steps:
+  - id: gather-eval
+    type: command
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      PIPELINE='{{ input }}'
+      TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      OUT=.agents/output/eval-rollup.json
+
+      if [ -z "$PIPELINE" ]; then
+        echo "pipeline-evolve: empty input; target pipeline name required" >&2
+        exit 1
+      fi
+
+      # Locate the project root by walking up from the workspace CWD looking
+      # for wave.yaml. Wave projects always have a manifest at the root, so
+      # this is a stable anchor independent of workspace nesting depth.
+      find_project_root() {
+        d="$PWD"
+        while [ "$d" != "/" ]; do
+          if [ -f "$d/wave.yaml" ] || [ -f "$d/wave.yml" ]; then
+            printf '%s\n' "$d"
+            return 0
+          fi
+          d=$(dirname "$d")
+        done
+        printf '%s\n' "$PWD"
+      }
+      ROOT=$(find_project_root)
+      DB="$ROOT/.agents/state.db"
+
+      if [ ! -f "$DB" ]; then
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, sample_size:0, status:"insufficient_data", rows:[], note:"No .agents/state.db on disk; gather-eval skipped.", captured_at:$ts}' \
+          > "$OUT"
+        exit 0
+      fi
+
+      # Pull the most recent 50 eval rows for the target pipeline. Use a
+      # positional parameter to dodge SQL-injection in the pipeline name.
+      ROWS=$(sqlite3 -json "$DB" \
+        "SELECT pipeline_name, run_id, judge_score, contract_pass, retry_count, failure_class, human_override, duration_ms, cost_dollars, recorded_at FROM pipeline_eval WHERE pipeline_name = '$PIPELINE' ORDER BY recorded_at DESC LIMIT 50" 2>/dev/null || true)
+      if [ -z "$ROWS" ]; then ROWS="[]"; fi
+
+      COUNT=$(printf '%s' "$ROWS" | jq 'length')
+      if [ "$COUNT" -eq 0 ]; then
+        STATUS="insufficient_data"
+      else
+        STATUS="ready"
+      fi
+
+      jq -n \
+        --arg pipeline "$PIPELINE" \
+        --arg status "$STATUS" \
+        --arg ts "$TS" \
+        --argjson rows "$ROWS" \
+        --argjson size "$COUNT" \
+        '{pipeline_name:$pipeline, sample_size:$size, status:$status, rows:$rows, captured_at:$ts}' \
+        > "$OUT"
+    output_artifacts:
+      - name: eval-rollup
+        path: .agents/output/eval-rollup.json
+        type: json
+        required: true
+
+  # ─── Step 2: analyze ──────────────────────────────────────────────────────
+  # Navigator (read-only, low-temp) classifies recurring failure classes and
+  # produces a structured findings JSON. Schema-gated by evolution-findings.
+  - id: analyze
+    persona: navigator
+    model: cheapest
+    dependencies: [gather-eval]
+    memory:
+      inject_artifacts:
+        - step: gather-eval
+          artifact: eval-rollup
+          as: eval_rollup
+    workspace:
+      mount:
+        - source: ./
+          target: /project
+          mode: readonly
+    exec:
+      type: prompt
+      source: |
+        ## Objective
+
+        Classify recurring failure signal in the injected `eval_rollup` artifact
+        and emit a structured findings JSON that summarises the analysis. The
+        downstream `propose` step will read your findings to draft an improved
+        v+1 of the target pipeline, so be precise and stable: identical inputs
+        must produce identical outputs.
+
+        Target pipeline: `{{ input }}`
+
+        ## Context
+
+        - The injected `eval_rollup` artifact contains:
+          - `pipeline_name`, `sample_size`, `status` (ready | insufficient_data),
+            `captured_at`, and `rows` — at most the last 50 pipeline_eval rows.
+          - Each row: `pipeline_name`, `run_id`, `judge_score` (nullable float),
+            `contract_pass` (nullable bool), `retry_count` (nullable int),
+            `failure_class` (nullable string), `human_override` (nullable bool),
+            `duration_ms`, `cost_dollars`, `recorded_at` (unix seconds).
+
+        - The pipeline source files live in the read-only project mount under
+          `internal/defaults/embedfs/pipelines/` and `.agents/pipelines/`. You
+          may inspect them to ground your symptom labels in real step IDs, but
+          do NOT modify any file in this step.
+
+        ## Requirements
+
+        ### Step 1 — Handle empty / insufficient data
+
+        If `eval_rollup.status == "insufficient_data"` OR `sample_size == 0`:
+        write a findings JSON with `status: "insufficient_data"`, an empty
+        `failure_classes` array, and zero metrics. Do not invent symptoms.
+        The downstream `record` step will short-circuit on this status.
+
+        ### Step 2 — Aggregate metrics
+
+        For the rows present:
+
+        - `judge_score_median`: median of non-null `judge_score` values, or null
+          when no row has a score.
+        - `contract_pass_rate`: count(contract_pass=true) / count(non-null
+          contract_pass), or null when no row has the field set.
+        - `retry_count_avg`: arithmetic mean of `retry_count` across rows that
+          have it set, or null otherwise.
+
+        ### Step 3 — Classify failure classes
+
+        Group rows by `failure_class` (skip rows where the field is null or
+        empty). Sort by count descending and keep the top 10. For each:
+
+        - `class`: the failure_class label as recorded.
+        - `count`: how many runs in the sample carried it.
+        - `share`: count / sample_size, rounded to 4 decimal places.
+
+        ### Step 4 — Recurring symptoms
+
+        Produce 1–5 short natural-language symptom labels that describe what
+        is going wrong, grounded in the failure_class distribution and judge
+        score trend. Each symptom is a single sentence under 120 characters.
+        Examples (do not copy verbatim — derive from the data):
+
+        - "Judge score regressed below 0.7 across the last 12 runs"
+        - "contract_validation_failed dominates failures after retry"
+
+        Skip this section if `status == "insufficient_data"`.
+
+        ### Step 5 — Write the findings JSON
+
+        Write to the output path declared in `output_artifacts`:
+        `.agents/output/evolution-findings.json`
+
+        The JSON must conform to `.agents/contracts/evolution-findings.schema.json`
+        with at least: `pipeline_name`, `sample_size`, `status`,
+        `failure_classes` (array, may be empty), and `captured_at` (RFC3339
+        timestamp).
+
+        ## Constraints and Anti-patterns
+
+        - DO NOT fabricate failure classes or symptoms not supported by the
+          rows. The downstream `propose` step trusts your output verbatim.
+        - DO NOT include more than 10 entries in `failure_classes`.
+        - DO NOT exceed 1500 bytes for the entire JSON file. The summary is
+          stored in the DB as `signal_summary` and must stay compact.
+        - DO NOT modify any file outside the declared output artifact path.
+
+        ## Quality Bar
+
+        A good findings JSON is deterministic for identical inputs, captures
+        the dominant failure modes faithfully, and stays small enough to
+        embed verbatim in the `evolution_proposal` row. A bad findings JSON
+        invents symptoms, misses the dominant class, or exceeds the size cap.
+    output_artifacts:
+      - name: findings
+        path: .agents/output/evolution-findings.json
+        type: json
+        required: true
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/evolution-findings.json
+        schema_path: .agents/contracts/evolution-findings.schema.json
+        must_pass: true
+        on_failure: warn
+
+  # ─── Step 3: propose ──────────────────────────────────────────────────────
+  # Craftsman drafts the v+1 candidate yaml + a unified prompt diff + a
+  # structured proposal-summary.json that record/ingests verbatim.
+  - id: propose
+    persona: craftsman
+    model: balanced
+    dependencies: [analyze]
+    memory:
+      inject_artifacts:
+        - step: gather-eval
+          artifact: eval-rollup
+          as: eval_rollup
+        - step: analyze
+          artifact: findings
+          as: findings
+    workspace:
+      mount:
+        - source: ./
+          target: /project
+          mode: readonly
+    exec:
+      type: prompt
+      source: |
+        ## Objective
+
+        Draft the next iteration of the target pipeline (`{{ input }}`) based on
+        the injected `findings` summary. Produce three artifacts:
+
+        1. A candidate v+1 YAML (full pipeline file, not a diff).
+        2. A unified `prompt.diff` over any persona prompt files you would
+           change, plus the YAML diff.
+        3. A `proposal-summary.json` that conforms to
+           `.agents/contracts/evolution-proposal.schema.json` and summarises
+           what you changed and why. The `record` step will copy
+           `signal_summary` from this JSON verbatim into the
+           `evolution_proposal` table.
+
+        ## Context
+
+        - The injected `findings` artifact carries the structured analysis
+          (failure classes, judge score median, recurring symptoms,
+          sample_size, status).
+        - The injected `eval_rollup` carries the raw rows for reference.
+        - The active pipeline yaml lives at one of:
+          - `internal/defaults/embedfs/pipelines/{{ input }}.yaml` (embedded default), or
+          - `.agents/pipelines/{{ input }}.yaml` (project override).
+        - Persona prompts live under `internal/defaults/embedfs/personas/`.
+        - You have a read-only project mount; persona-side write tools may
+          still create your output files, but DO NOT git-add or commit.
+
+        ## Requirements
+
+        ### Step 0 — Insufficient-data short-circuit
+
+        If `findings.status == "insufficient_data"` OR
+        `findings.sample_size == 0`:
+
+        - Skip the YAML/diff drafting.
+        - Write a minimal `proposal-summary.json` with
+          `version_before = 0`, `version_after = 1`,
+          `reason = "insufficient evaluation data; no proposal generated"`,
+          `signal_summary = { sample_size: 0, failure_classes: [] }`,
+          and set `candidate_yaml_path` and `diff_path` to empty strings.
+
+        The `record` step will see the empty paths and skip the DB insert.
+        Stop here.
+
+        ### Step 1 — Read the active YAML
+
+        Locate and read the active pipeline YAML for `{{ input }}` from the
+        embedded defaults or the project override. If neither exists, treat
+        the active version as 0 and the candidate as the first concrete
+        version (v1).
+
+        ### Step 2 — Draft the candidate
+
+        Write the candidate to:
+
+        ```
+        .agents/output/evolution/<pipeline>.next.yaml
+        ```
+
+        where `<pipeline>` is `{{ input }}`. The candidate is a *complete*
+        pipeline YAML, not a fragment. Keep the same `metadata.name`. Keep
+        the pipeline default-agnostic (no language-specific commands).
+
+        Your edits must be *targeted*: address the dominant failure class(es)
+        named in `findings`. Do not stylistic-rewrite untouched steps.
+
+        ### Step 3 — Write a unified diff
+
+        Write a unified diff (the kind `git diff` emits or `diff -u` produces)
+        spanning every file you would change — including persona prompt files
+        if your proposal edits them. Path:
+
+        ```
+        .agents/output/evolution/prompt.diff
+        ```
+
+        Use repo-relative paths inside the diff headers (e.g.
+        `--- a/internal/defaults/embedfs/pipelines/{{ input }}.yaml`).
+
+        ### Step 4 — Write proposal-summary.json
+
+        Write to:
+
+        ```
+        .agents/output/evolution/proposal-summary.json
+        ```
+
+        Required fields (match `evolution-proposal.schema.json`):
+
+        - `pipeline_name`: the target pipeline name.
+        - `candidate_yaml_path`: absolute or repo-relative path to the
+          candidate yaml you wrote in Step 2.
+        - `diff_path`: absolute or repo-relative path to the diff in Step 3.
+        - `reason`: one-paragraph rationale, plain English. Must reference
+          at least one failure class from `findings`.
+        - `signal_summary`: compact JSON object copying `sample_size`,
+          `failure_classes` (top 5 only), `judge_score_median`,
+          `contract_pass_rate`, and `recurring_symptoms` verbatim from
+          `findings`. Keep this under 1500 bytes when serialized.
+        - `version_before`: the active version. Treat 0 as "no recorded
+          active version".
+        - `version_after`: `version_before + 1`.
+        - Optionally: `prompt_changes` — a list of `{ persona, summary }`
+          entries describing persona prompt edits (informational only; the
+          diff is canonical).
+
+        ## Constraints and Anti-patterns
+
+        - DO NOT modify the active yaml file in-place. Write the candidate
+          to the `.agents/output/evolution/` directory only.
+        - DO NOT git-add, git-commit, or git-push from this step. The
+          proposal is opaque to git until a reviewer approves.
+        - DO NOT emit a candidate yaml that introduces project-specific
+          (Go, npm, etc.) commands or hard-codes a forge. Stay
+          default-agnostic — use `{{ project.* }}` and `{{ forge.* }}`.
+        - DO NOT exceed 1500 bytes in `signal_summary` after JSON
+          serialization. The DB stores it verbatim.
+
+        ## Quality Bar
+
+        A good proposal cites a specific failure class in `reason`, edits
+        only the steps implicated by that class, keeps the `signal_summary`
+        compact, and produces a syntactically valid YAML candidate that the
+        loader could parse. A bad proposal rewrites everything stylistically,
+        ignores the dominant failure class, or emits an invalid YAML.
+    output_artifacts:
+      - name: proposal-summary
+        path: .agents/output/evolution/proposal-summary.json
+        type: json
+        required: true
+      - name: candidate-yaml
+        path: .agents/output/evolution/{{ input }}.next.yaml
+        type: yaml
+        required: false
+      - name: prompt-diff
+        path: .agents/output/evolution/prompt.diff
+        type: text
+        required: false
+    retry:
+      policy: standard
+      max_attempts: 2
+    handover:
+      contract:
+        type: json_schema
+        source: .agents/output/evolution/proposal-summary.json
+        schema_path: .agents/contracts/evolution-proposal.schema.json
+        must_pass: true
+        on_failure: fail
+
+  # ─── Step 4: record ───────────────────────────────────────────────────────
+  # INSERT into evolution_proposal as 'proposed'. Empty/insufficient-data path
+  # short-circuits to status=skipped so the DB never grows noise rows.
+  - id: record
+    type: command
+    dependencies: [propose]
+    script: |
+      set -o pipefail
+      mkdir -p .agents/output
+
+      OUT=.agents/output/record-status.json
+      TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      PIPELINE='{{ input }}'
+
+      if [ -z "$PIPELINE" ]; then
+        echo "record: empty input; target pipeline name required" >&2
+        exit 1
+      fi
+
+      # Resolve the propose-step inputs via the WAVE_DEP_* contract. Falls
+      # back to the canonical injection path when WAVE_DEP_PROPOSE_* is not
+      # populated (older runtimes).
+      SUMMARY="${WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY:-.agents/artifacts/propose/proposal-summary}"
+      if [ ! -f "$SUMMARY" ]; then
+        echo "record: missing proposal-summary at $SUMMARY" >&2
+        exit 1
+      fi
+
+      # Locate the project root by walking up from CWD looking for wave.yaml.
+      find_project_root() {
+        d="$PWD"
+        while [ "$d" != "/" ]; do
+          if [ -f "$d/wave.yaml" ] || [ -f "$d/wave.yml" ]; then
+            printf '%s\n' "$d"
+            return 0
+          fi
+          d=$(dirname "$d")
+        done
+        printf '%s\n' "$PWD"
+      }
+      ROOT=$(find_project_root)
+      DB="$ROOT/.agents/state.db"
+
+      VERSION_BEFORE=$(jq -r '.version_before // 0' "$SUMMARY")
+      VERSION_AFTER=$(jq -r '.version_after // 1' "$SUMMARY")
+      DIFF_PATH=$(jq -r '.diff_path // ""' "$SUMMARY")
+      REASON=$(jq -r '.reason // ""' "$SUMMARY")
+      SIGNAL_SUMMARY=$(jq -c '.signal_summary // {}' "$SUMMARY")
+
+      # Insufficient-data short-circuit: when propose emitted empty paths
+      # because the analyze step had no data to work with, skip the INSERT
+      # and emit a record-status.json with status=skipped.
+      if [ -z "$DIFF_PATH" ] || [ -z "$REASON" ] || [ ! -f "$DB" ]; then
+        REASON_MSG="skipped"
+        if [ ! -f "$DB" ]; then
+          REASON_MSG="no_state_db"
+        elif [ -z "$DIFF_PATH" ]; then
+          REASON_MSG="insufficient_data"
+        fi
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg status "skipped" \
+          --arg reason "$REASON_MSG" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, status:$status, skip_reason:$reason, proposal_id:null, recorded_at:$ts}' \
+          > "$OUT"
+        exit 0
+      fi
+
+      # Stage the diff under .agents/output/evolution/<pipeline_id>/ at the
+      # project root so the recorded diff_path survives workspace cleanup.
+      STABLE_DIR="$ROOT/.agents/output/evolution/${PIPELINE}"
+      mkdir -p "$STABLE_DIR"
+
+      DIFF_BASENAME=$(basename "$DIFF_PATH")
+      STABLE_DIFF="$STABLE_DIR/${DIFF_BASENAME}"
+      if [ -f "$DIFF_PATH" ]; then
+        cp -f "$DIFF_PATH" "$STABLE_DIFF"
+      fi
+      # Always copy the proposal-summary alongside for auditability.
+      cp -f "$SUMMARY" "$STABLE_DIR/proposal-summary.json"
+
+      # SQL-escape every untrusted string by doubling single quotes. SQLite
+      # parses `''` inside a literal as a single quote, so this is the
+      # canonical defense against injection here.
+      sql_escape() {
+        printf '%s' "$1" | sed "s/'/''/g"
+      }
+      ESC_PIPELINE=$(sql_escape "$PIPELINE")
+      ESC_DIFF=$(sql_escape "$STABLE_DIFF")
+      ESC_REASON=$(sql_escape "$REASON")
+      ESC_SIGNAL=$(sql_escape "$SIGNAL_SUMMARY")
+
+      PROPOSED_AT=$(date -u +%s)
+
+      PROPOSAL_ID=$(sqlite3 "$DB" "INSERT INTO evolution_proposal (pipeline_name, version_before, version_after, diff_path, reason, signal_summary, status, proposed_at) VALUES ('$ESC_PIPELINE', $VERSION_BEFORE, $VERSION_AFTER, '$ESC_DIFF', '$ESC_REASON', '$ESC_SIGNAL', 'proposed', $PROPOSED_AT); SELECT last_insert_rowid();")
+
+      if [ -z "$PROPOSAL_ID" ]; then
+        echo "record: failed to insert evolution_proposal row" >&2
+        jq -n \
+          --arg pipeline "$PIPELINE" \
+          --arg ts "$TS" \
+          '{pipeline_name:$pipeline, status:"failed", proposal_id:null, recorded_at:$ts}' \
+          > "$OUT"
+        exit 1
+      fi
+
+      jq -n \
+        --arg pipeline "$PIPELINE" \
+        --arg status "proposed" \
+        --argjson id "$PROPOSAL_ID" \
+        --arg diff "$STABLE_DIFF" \
+        --argjson vb "$VERSION_BEFORE" \
+        --argjson va "$VERSION_AFTER" \
+        --arg ts "$TS" \
+        '{pipeline_name:$pipeline, status:$status, proposal_id:$id, diff_path:$diff, version_before:$vb, version_after:$va, recorded_at:$ts}' \
+        > "$OUT"
+    output_artifacts:
+      - name: record-status
+        path: .agents/output/record-status.json
+        type: json
+        required: true

--- a/internal/pipeline/pipeline_evolve_test.go
+++ b/internal/pipeline/pipeline_evolve_test.go
@@ -1,0 +1,497 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// TestPipelineEvolveYAMLStructure asserts the embedded pipeline-evolve.yaml
+// loads cleanly and exposes the four canonical steps in the order required by
+// the spec (gather-eval → analyze → propose → record). Catches YAML drift
+// without spinning up the executor.
+func TestPipelineEvolveYAMLStructure(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	path := filepath.Join(repoRoot, "internal", "defaults", "embedfs", "pipelines", "pipeline-evolve.yaml")
+
+	loader := &YAMLPipelineLoader{}
+	p, err := loader.Load(path)
+	if err != nil {
+		t.Fatalf("load pipeline-evolve.yaml: %v", err)
+	}
+
+	if p.Metadata.Name != "pipeline-evolve" {
+		t.Fatalf("metadata.name = %q; want pipeline-evolve", p.Metadata.Name)
+	}
+
+	wantSteps := []struct {
+		id      string
+		kind    string // "command" or "" (prompt)
+		persona string
+	}{
+		{"gather-eval", "command", ""},
+		{"analyze", "", "navigator"},
+		{"propose", "", "craftsman"},
+		{"record", "command", ""},
+	}
+	if len(p.Steps) != len(wantSteps) {
+		t.Fatalf("step count = %d; want %d", len(p.Steps), len(wantSteps))
+	}
+	for i, want := range wantSteps {
+		got := p.Steps[i]
+		if got.ID != want.id {
+			t.Errorf("steps[%d].id = %q; want %q", i, got.ID, want.id)
+		}
+		if got.Type != want.kind {
+			t.Errorf("steps[%d].type = %q; want %q", i, got.Type, want.kind)
+		}
+		if got.Persona != want.persona {
+			t.Errorf("steps[%d].persona = %q; want %q", i, got.Persona, want.persona)
+		}
+	}
+
+	// analyze + propose must validate against the contract schemas committed
+	// alongside the pipeline. Without these the LLM steps would proceed on
+	// unstructured output and the record step would crash on missing fields.
+	if p.Steps[1].Handover.Contract.Type != "json_schema" ||
+		!strings.HasSuffix(p.Steps[1].Handover.Contract.SchemaPath, "evolution-findings.schema.json") {
+		t.Errorf("analyze handover schema = %+v; want json_schema → evolution-findings.schema.json",
+			p.Steps[1].Handover.Contract)
+	}
+	if p.Steps[2].Handover.Contract.Type != "json_schema" ||
+		!strings.HasSuffix(p.Steps[2].Handover.Contract.SchemaPath, "evolution-proposal.schema.json") {
+		t.Errorf("propose handover schema = %+v; want json_schema → evolution-proposal.schema.json",
+			p.Steps[2].Handover.Contract)
+	}
+}
+
+// TestPipelineEvolveRecordWritesProposal exercises the record step's bash
+// script against a real on-disk SQLite state DB. Seeds five synthetic
+// pipeline_eval rows, fakes the upstream propose-summary artifact, runs the
+// extracted bash script with WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY pointing at the
+// canned summary, then verifies a row landed in evolution_proposal with
+// status='proposed' and the expected pipeline name / version_before /
+// version_after / non-empty diff_path / parseable signal_summary JSON.
+func TestPipelineEvolveRecordWritesProposal(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skipf("sqlite3 CLI not available: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq CLI not available: %v", err)
+	}
+
+	tmpRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpRoot, "wave.yaml"), []byte("kind: WaveProject\n"), 0644); err != nil {
+		t.Fatalf("write wave.yaml: %v", err)
+	}
+
+	dbDir := filepath.Join(tmpRoot, ".agents")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatalf("mkdir .agents: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "state.db")
+
+	// Initialise the DB by running migrations and seeding 5 synthetic eval
+	// rows for the target pipeline. Closing immediately so sqlite3 CLI can
+	// open it from the bash script without lock contention.
+	store, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("open state store: %v", err)
+	}
+	pipelineName := "pipeline-evolve-test"
+	now := time.Now()
+	scoreLow, scoreMid := 0.55, 0.92
+	pass, fail := true, false
+	one := 1
+	dur := int64(12345)
+	cost := 0.012
+	for i := 0; i < 5; i++ {
+		score := &scoreLow
+		cp := &fail
+		fc := "contract_validation_failed"
+		if i%2 == 0 {
+			score = &scoreMid
+			cp = &pass
+			fc = ""
+		}
+		rec := state.PipelineEvalRecord{
+			PipelineName: pipelineName,
+			RunID:        "run-" + string(rune('a'+i)),
+			JudgeScore:   score,
+			ContractPass: cp,
+			RetryCount:   &one,
+			FailureClass: fc,
+			DurationMs:   &dur,
+			CostDollars:  &cost,
+			RecordedAt:   now.Add(time.Duration(-i) * time.Hour),
+		}
+		if err := store.RecordEval(rec); err != nil {
+			t.Fatalf("RecordEval[%d]: %v", i, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	// Stand up a workspace under <tmpRoot>/.agents/workspaces/<pipe>/record/
+	// matching what the executor would create, plus the auto-injected
+	// upstream artifact for the propose step.
+	wsDir := filepath.Join(tmpRoot, ".agents", "workspaces", "pipeline-evolve", "record")
+	depDir := filepath.Join(wsDir, ".agents", "artifacts", "propose")
+	if err := os.MkdirAll(depDir, 0755); err != nil {
+		t.Fatalf("mkdir dep: %v", err)
+	}
+
+	// Canned propose-summary mimicking what a craftsman LLM would emit. The
+	// signal_summary JSON is what gets stored verbatim; reason references
+	// the dominant failure class so the proposal is auditable.
+	summary := map[string]any{
+		"pipeline_name":       pipelineName,
+		"candidate_yaml_path": ".agents/output/evolution/" + pipelineName + ".next.yaml",
+		"diff_path":           ".agents/output/evolution/prompt.diff",
+		"reason":              "contract_validation_failed dominates failures; loosen schema and add retry",
+		"signal_summary": map[string]any{
+			"sample_size":        5,
+			"failure_classes":    []map[string]any{{"class": "contract_validation_failed", "count": 2}},
+			"judge_score_median": 0.75,
+		},
+		"version_before": 0,
+		"version_after":  1,
+	}
+	summaryBytes, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	summaryPath := filepath.Join(depDir, "proposal-summary")
+	if err := os.WriteFile(summaryPath, summaryBytes, 0644); err != nil {
+		t.Fatalf("write summary: %v", err)
+	}
+	// Also stage the diff file at the path the summary points at, so the
+	// `cp -f "$DIFF_PATH" "$STABLE_DIFF"` line in the script has something
+	// to copy. The script tolerates a missing file but we want the happy
+	// path here.
+	stagedDiff := filepath.Join(wsDir, ".agents", "output", "evolution", "prompt.diff")
+	if err := os.MkdirAll(filepath.Dir(stagedDiff), 0755); err != nil {
+		t.Fatalf("mkdir diff: %v", err)
+	}
+	if err := os.WriteFile(stagedDiff, []byte("--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-old\n+new\n"), 0644); err != nil {
+		t.Fatalf("write diff: %v", err)
+	}
+
+	// Pull the record step's script straight out of the embedded YAML so
+	// this test catches drift if the script body changes.
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	loader := &YAMLPipelineLoader{}
+	p, err := loader.Load(filepath.Join(repoRoot, "internal", "defaults", "embedfs", "pipelines", "pipeline-evolve.yaml"))
+	if err != nil {
+		t.Fatalf("load pipeline-evolve.yaml: %v", err)
+	}
+	var script string
+	for _, s := range p.Steps {
+		if s.ID == "record" {
+			script = s.Script
+			break
+		}
+	}
+	if script == "" {
+		t.Fatal("record step has empty script")
+	}
+
+	// Resolve {{ input }} the way the executor would.
+	ctx := NewPipelineContext("test-run", "pipeline-evolve", "record")
+	ctx.Input = pipelineName
+	script = ctx.ResolvePlaceholders(script)
+	// Also resolve the relative DIFF_PATH stored in the summary into an
+	// absolute path so cp -f finds it from the workspace CWD.
+	script = strings.ReplaceAll(script,
+		`SUMMARY="${WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY:-.agents/artifacts/propose/proposal-summary}"`,
+		`SUMMARY="${WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY}"`,
+	)
+
+	// Rewrite the relative diff_path in the canned summary to the absolute
+	// staged path so the cp succeeds. Easier than rewriting the script.
+	summary["diff_path"] = stagedDiff
+	summaryBytes, _ = json.Marshal(summary)
+	_ = os.WriteFile(summaryPath, summaryBytes, 0644)
+
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = wsDir
+	cmd.Env = append(os.Environ(),
+		"WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY="+summaryPath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("record script failed: %v\nstdout/stderr:\n%s", err, out)
+	}
+
+	// Verify record-status.json was written and signals success.
+	statusPath := filepath.Join(wsDir, ".agents", "output", "record-status.json")
+	statusData, err := os.ReadFile(statusPath)
+	if err != nil {
+		t.Fatalf("read record-status: %v\nscript output:\n%s", err, out)
+	}
+	var status struct {
+		Status     string `json:"status"`
+		ProposalID *int64 `json:"proposal_id"`
+		DiffPath   string `json:"diff_path"`
+	}
+	if err := json.Unmarshal(statusData, &status); err != nil {
+		t.Fatalf("parse record-status: %v\ncontent: %s", err, statusData)
+	}
+	if status.Status != "proposed" {
+		t.Errorf("status.status = %q; want proposed", status.Status)
+	}
+	if status.ProposalID == nil || *status.ProposalID == 0 {
+		t.Errorf("status.proposal_id missing/zero: %+v", status)
+	}
+	if status.DiffPath == "" {
+		t.Errorf("status.diff_path empty")
+	}
+
+	// Reopen the DB and confirm the row landed with the expected shape.
+	store2, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen state store: %v", err)
+	}
+	defer store2.Close()
+	rows, err := store2.ListProposalsByStatus(state.ProposalProposed, 0)
+	if err != nil {
+		t.Fatalf("ListProposalsByStatus: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("proposed rows = %d; want 1; rows: %+v", len(rows), rows)
+	}
+	got := rows[0]
+	if got.PipelineName != pipelineName {
+		t.Errorf("pipeline_name = %q; want %q", got.PipelineName, pipelineName)
+	}
+	if got.VersionBefore != 0 || got.VersionAfter != 1 {
+		t.Errorf("version_before=%d version_after=%d; want 0 → 1", got.VersionBefore, got.VersionAfter)
+	}
+	if got.DiffPath == "" {
+		t.Errorf("diff_path empty")
+	}
+	if got.Reason == "" {
+		t.Errorf("reason empty")
+	}
+	var sig map[string]any
+	if err := json.Unmarshal([]byte(got.SignalSummary), &sig); err != nil {
+		t.Errorf("signal_summary not valid JSON: %v\ncontent: %s", err, got.SignalSummary)
+	}
+	if sig["sample_size"] == nil {
+		t.Errorf("signal_summary missing sample_size: %+v", sig)
+	}
+}
+
+// TestPipelineEvolveRecordSkipsInsufficientData verifies the record step's
+// short-circuit branch: when propose hands over an empty diff_path (the
+// insufficient-data signal), no row is inserted and the status artifact
+// reports status='skipped'.
+func TestPipelineEvolveRecordSkipsInsufficientData(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skipf("sqlite3 CLI not available: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq CLI not available: %v", err)
+	}
+
+	tmpRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpRoot, "wave.yaml"), []byte("kind: WaveProject\n"), 0644); err != nil {
+		t.Fatalf("write wave.yaml: %v", err)
+	}
+	dbDir := filepath.Join(tmpRoot, ".agents")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "state.db")
+	store, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	_ = store.Close()
+
+	wsDir := filepath.Join(tmpRoot, ".agents", "workspaces", "pipeline-evolve", "record")
+	depDir := filepath.Join(wsDir, ".agents", "artifacts", "propose")
+	if err := os.MkdirAll(depDir, 0755); err != nil {
+		t.Fatalf("mkdir dep: %v", err)
+	}
+	summary := map[string]any{
+		"pipeline_name":       "absent-pipeline",
+		"candidate_yaml_path": "",
+		"diff_path":           "",
+		"reason":              "insufficient evaluation data; no proposal generated",
+		"signal_summary":      map[string]any{"sample_size": 0, "failure_classes": []any{}},
+		"version_before":      0,
+		"version_after":       1,
+	}
+	summaryBytes, _ := json.Marshal(summary)
+	summaryPath := filepath.Join(depDir, "proposal-summary")
+	if err := os.WriteFile(summaryPath, summaryBytes, 0644); err != nil {
+		t.Fatalf("write summary: %v", err)
+	}
+
+	repoRoot, _ := filepath.Abs(filepath.Join("..", ".."))
+	loader := &YAMLPipelineLoader{}
+	p, err := loader.Load(filepath.Join(repoRoot, "internal", "defaults", "embedfs", "pipelines", "pipeline-evolve.yaml"))
+	if err != nil {
+		t.Fatalf("load pipeline: %v", err)
+	}
+	var script string
+	for _, s := range p.Steps {
+		if s.ID == "record" {
+			script = s.Script
+			break
+		}
+	}
+	ctx := NewPipelineContext("test-run", "pipeline-evolve", "record")
+	ctx.Input = "absent-pipeline"
+	script = ctx.ResolvePlaceholders(script)
+
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = wsDir
+	cmd.Env = append(os.Environ(), "WAVE_DEP_PROPOSE_PROPOSAL_SUMMARY="+summaryPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("record script failed: %v\noutput:\n%s", err, out)
+	}
+
+	statusData, err := os.ReadFile(filepath.Join(wsDir, ".agents", "output", "record-status.json"))
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	var status struct {
+		Status     string `json:"status"`
+		ProposalID *int64 `json:"proposal_id"`
+		SkipReason string `json:"skip_reason"`
+	}
+	if err := json.Unmarshal(statusData, &status); err != nil {
+		t.Fatalf("parse status: %v", err)
+	}
+	if status.Status != "skipped" {
+		t.Errorf("status = %q; want skipped\nscript output:\n%s", status.Status, out)
+	}
+	if status.ProposalID != nil {
+		t.Errorf("proposal_id = %v; want nil for skipped", status.ProposalID)
+	}
+
+	// The DB must remain empty — the short-circuit branch must not insert
+	// a noise row.
+	store2, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store2.Close()
+	rows, err := store2.ListProposalsByStatus(state.ProposalProposed, 0)
+	if err != nil {
+		t.Fatalf("list proposals: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("proposed rows = %d; want 0 on insufficient-data short-circuit", len(rows))
+	}
+}
+
+// TestPipelineEvolveGatherEvalReadsSeededRows seeds pipeline_eval rows and
+// runs the gather-eval bash script directly to verify the eval-rollup.json
+// shape (sample_size, status, rows) the analyze step depends on.
+func TestPipelineEvolveGatherEvalReadsSeededRows(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skipf("sqlite3 CLI not available: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq CLI not available: %v", err)
+	}
+
+	tmpRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpRoot, "wave.yaml"), []byte("kind: WaveProject\n"), 0644); err != nil {
+		t.Fatalf("write wave.yaml: %v", err)
+	}
+	dbDir := filepath.Join(tmpRoot, ".agents")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dbPath := filepath.Join(dbDir, "state.db")
+	store, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	pipelineName := "demo-pipe"
+	score := 0.8
+	pass := true
+	for i := 0; i < 3; i++ {
+		if err := store.RecordEval(state.PipelineEvalRecord{
+			PipelineName: pipelineName,
+			RunID:        "r-" + string(rune('a'+i)),
+			JudgeScore:   &score,
+			ContractPass: &pass,
+			RecordedAt:   time.Now().Add(time.Duration(-i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("seed eval %d: %v", i, err)
+		}
+	}
+	_ = store.Close()
+
+	wsDir := filepath.Join(tmpRoot, ".agents", "workspaces", "pipeline-evolve", "gather-eval")
+	if err := os.MkdirAll(wsDir, 0755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+
+	repoRoot, _ := filepath.Abs(filepath.Join("..", ".."))
+	loader := &YAMLPipelineLoader{}
+	p, err := loader.Load(filepath.Join(repoRoot, "internal", "defaults", "embedfs", "pipelines", "pipeline-evolve.yaml"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var script string
+	for _, s := range p.Steps {
+		if s.ID == "gather-eval" {
+			script = s.Script
+			break
+		}
+	}
+	ctx := NewPipelineContext("test-run", "pipeline-evolve", "gather-eval")
+	ctx.Input = pipelineName
+	script = ctx.ResolvePlaceholders(script)
+
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = wsDir
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gather-eval failed: %v\noutput:\n%s", err, out)
+	}
+
+	rollupBytes, err := os.ReadFile(filepath.Join(wsDir, ".agents", "output", "eval-rollup.json"))
+	if err != nil {
+		t.Fatalf("read rollup: %v", err)
+	}
+	var rollup struct {
+		PipelineName string `json:"pipeline_name"`
+		SampleSize   int    `json:"sample_size"`
+		Status       string `json:"status"`
+		Rows         []any  `json:"rows"`
+	}
+	if err := json.Unmarshal(rollupBytes, &rollup); err != nil {
+		t.Fatalf("parse rollup: %v\ncontent: %s", err, rollupBytes)
+	}
+	if rollup.PipelineName != pipelineName {
+		t.Errorf("pipeline_name = %q; want %q", rollup.PipelineName, pipelineName)
+	}
+	if rollup.SampleSize != 3 || len(rollup.Rows) != 3 {
+		t.Errorf("sample_size=%d rows=%d; want 3 / 3", rollup.SampleSize, len(rollup.Rows))
+	}
+	if rollup.Status != "ready" {
+		t.Errorf("status = %q; want ready", rollup.Status)
+	}
+}

--- a/specs/1607-pipeline-evolve/plan.md
+++ b/specs/1607-pipeline-evolve/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan — pipeline-evolve
+
+## 1. Objective
+
+Ship a meta-pipeline `pipeline-evolve.yaml` that reads `pipeline_eval` history for a target pipeline, asks an LLM to propose an improved v+1 (YAML + persona prompt diffs), and records the result as a `proposed` row in `evolution_proposal`.
+
+## 2. Approach
+
+Four sequential steps in one pipeline file, modeled on `audit-db-trace.yaml` (sqlite3 query) and `ops-issue-quality.yaml` (LLM persona step + structured artifact contract):
+
+1. **gather-eval** (`type: command`) — `sqlite3 .agents/state.db` against `pipeline_eval`, write JSON rollup artifact.
+2. **analyze** (`persona: navigator`, `model: cheapest`) — read rollup, classify recurring failures, write structured findings JSON.
+3. **propose** (`persona: craftsman`) — read findings + active YAML/persona files, write candidate `<pipeline>.next.yaml` + a unified `prompt.diff`, plus a JSON `proposal_summary` describing what changed and why.
+4. **record** (`type: command`) — copy diff/yaml to a stable on-disk diff dir under `.agents/output/evolution/<run_id>/`, then `INSERT INTO evolution_proposal (...) VALUES (..., 'proposed')` via `sqlite3`.
+
+Pipeline input is the **target pipeline name** (a string). Empty input fails fast.
+
+DB access pattern: pipeline reads/writes the SQLite state DB directly via `sqlite3` CLI. No new Go CLI subcommand is required — keeps blast radius minimal and aligns with how `audit-db-trace` reads `pipeline_run`.
+
+## 3. File Mapping
+
+### Created
+
+| Path | Why |
+|------|-----|
+| `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` | The pipeline itself (embedded into binary). |
+| `.agents/pipelines/pipeline-evolve.yaml` | Project-local copy synced from defaults so the `wave` repo can self-evolve. |
+| `.agents/contracts/evolution-findings.schema.json` | JSON schema for `analyze` step output (failure classes, recurring symptoms). |
+| `.agents/contracts/evolution-proposal.schema.json` | JSON schema for `propose` step output (paths to yaml/diff, reason, signal_summary). |
+| `internal/defaults/embedfs/pipelines/pipeline_evolve_test.go` | Integration test: seed synthetic `pipeline_eval` rows, run pipeline, assert `evolution_proposal` row exists with `status='proposed'`. |
+
+### Modified
+
+| Path | Why |
+|------|-----|
+| `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` registry — verify `loader_test.go` picks it up automatically (no list to update). | Validation. |
+
+### Not Modified
+
+- `internal/state/evolution.go` — already exposes everything we need.
+- Personas — reuse `navigator` + `craftsman` (default-agnostic).
+- `cmd/wave/commands/` — no new CLI subcommand. Pipeline talks to `.agents/state.db` directly via `sqlite3`.
+
+## 4. Architecture Decisions
+
+- **Direct `sqlite3` access over Go CLI shim.** Issue scope is one pipeline; a CLI shim is out of scope for Phase 3.2 and would add API surface that locks us in before the evolution loop is proven. Mirrors the existing `audit-db-trace` precedent.
+- **Diff format = unified diff text in a file**, not structured JSON. The diff is opaque to the DB (`diff_path TEXT`) and human-readable; `git apply --check` can verify it. The persona writes both the candidate yaml *and* the diff so reviewers can see the result either way.
+- **`signal_summary` = compact JSON**, the same artifact written by the `analyze` step (failure class counts, judge score median, sample size, recurring symptoms). Stored verbatim into the column so the human gate UI has structured context.
+- **`version_before` lookup**: query `pipeline_version` for active version; if none exists, default to `0` (the embedded default).
+- **`version_after = version_before + 1`** — proposal-only. Activation is a separate step (out of scope, handled by Phase 3.3).
+- **Persona choice**: `navigator` for analysis (read-only, low temp) and `craftsman` for proposal generation (creative, writes files). Both are default-agnostic and ship in `internal/defaults/embedfs/personas/`.
+- **No `output_artifacts` for the `record` step** — it produces a side-effect (DB row) plus a tiny JSON status. We emit `proposal_id` and `status` so downstream pipelines can chain.
+- **Empty-history short-circuit**: if `gather-eval` finds zero `pipeline_eval` rows, write a sentinel artifact and let `analyze` early-exit with `status='insufficient_data'`. The `record` step skips DB insert in that case (`on_failure: warn`).
+
+## 5. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `.agents/state.db` not present in mounted workspace | Same fallback as `audit-db-trace` — emit empty artifact and let downstream steps no-op gracefully. |
+| LLM proposes a YAML that doesn't parse | Test step uses `wave-cli` validation if available; otherwise schema check via `yq`. Failure → `status='proposed'` with diff still recorded; reviewer rejects. |
+| Embedded vs project-local pipeline drift | Add the `.agents/pipelines/` copy to keep both in sync; tests run against embedded. |
+| `signal_summary` exceeds reasonable size | `analyze` step caps the summary to top 10 failure classes; raw eval JSON is truncated to last 50 rows. |
+| Concurrent runs producing duplicate proposals | Acceptable for Phase 3.2 — `evolution_proposal` allows multiple `proposed` rows per pipeline; human gate dedupes. |
+| Default-agnostic violation (e.g. Go-only assumptions) | Step scripts use `sqlite3`/`jq` only. No Go test runner, no language-specific commands. Pipeline does not call `go test` or any project tooling. |
+
+## 6. Testing Strategy
+
+### Unit / integration
+
+- `pipeline_evolve_test.go` (new): builds an in-memory state store via `internal/testutil/statestore.go`, seeds 5 synthetic `PipelineEvalRecord` rows for a fake pipeline name (mix of pass/fail/judge_score), invokes the pipeline via `executor.Run` with a mock adapter that returns canned LLM output (a stub yaml + diff), then asserts:
+  1. One row in `evolution_proposal` with `status='proposed'`, matching `pipeline_name`, non-empty `diff_path`, valid `signal_summary` JSON.
+  2. `version_before == 0` (no active version), `version_after == 1`.
+  3. `gather-eval` artifact contains the seeded rows (sanity).
+
+- Mock adapter (`internal/adapter/mock.go` — already exists) returns the canned proposal artifact paths so `craftsman` step is deterministic.
+
+### Manual smoke
+
+After merge, run on a real pipeline with eval data:
+
+```
+wave run pipeline-evolve --input "impl-issue" --adapter claude --model balanced
+sqlite3 .agents/state.db "SELECT id, pipeline_name, status FROM evolution_proposal ORDER BY id DESC LIMIT 1;"
+```
+
+### CI
+
+- `go test -race ./internal/defaults/embedfs/pipelines/...` covers the new test file.
+- `golangci-lint` passes.
+- Existing pipeline-loader tests (e.g. `internal/pipeline/loader_test.go`) auto-discover the new YAML via `embed.FS` walk — no list to update.
+
+## 7. Out of Scope (Phase 3.3 territory)
+
+- Activation logic (flipping `pipeline_version.active`)
+- Human gate UI for approving/rejecting proposals
+- Auto-application of approved diffs
+- WebUI surface for the proposal queue

--- a/specs/1607-pipeline-evolve/spec.md
+++ b/specs/1607-pipeline-evolve/spec.md
@@ -1,0 +1,50 @@
+# Phase 3.2: pipeline-evolve meta-pipeline
+
+**Issue:** [#1607](https://github.com/re-cinq/wave/issues/1607)
+**Repository:** re-cinq/wave
+**Branch:** `1607-pipeline-evolve-impl`
+**Labels:** `enhancement`, `ready-for-impl`
+**State:** OPEN
+**Author:** nextlevelshit
+
+## Issue Body
+
+Part of Epic #1565 Phase 3.
+
+### Goal
+
+Ship `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` — a meta-pipeline that ingests `pipeline_eval` history for a target pipeline and proposes a new version (yaml + persona prompt diffs) via LLM.
+
+### Acceptance criteria
+
+- [ ] pipeline-evolve.yaml with steps: gather-eval (fetch from pipeline_eval), analyze (find recurring failures), propose (generate v+1 yaml + prompt diffs), record (insert into evolution_proposal as 'proposed')
+- [ ] Default-agnostic per memory feedback_defaults_agnostic
+- [ ] Test: run on a synthetic pipeline_eval seed → verify proposal row created with status=proposed
+
+### Dependencies
+
+- 3.1 EvalSignal hook (gathers data) — populates `pipeline_eval` rows at run completion
+- PRE-5 evolution_proposal table (MERGED) — defined in `internal/state/migration_definitions.go:612-631`
+
+## Acceptance Criteria (extracted)
+
+1. New file at `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml`
+2. Four-step structure: `gather-eval` → `analyze` → `propose` → `record`
+3. `gather-eval` queries `pipeline_eval` table for target pipeline
+4. `analyze` extracts recurring failure classes / low judge scores
+5. `propose` produces a v+1 YAML and persona prompt diffs via an LLM step
+6. `record` inserts a row into `evolution_proposal` with `status='proposed'`
+7. Pipeline is **default-agnostic** — language/framework neutral; uses `{{ project.* }}` and forge templating only
+8. Backed by a test seeded with synthetic `pipeline_eval` rows that verifies proposal creation
+
+## Schema References
+
+- `pipeline_eval`: `internal/state/migration_definitions.go:577-593`
+- `evolution_proposal`: `internal/state/migration_definitions.go:612-631`
+- Go API: `internal/state/evolution.go` (`EvolutionStore` interface)
+- Status enum: `proposed | approved | rejected | superseded`
+
+## Links
+
+- Issue: https://github.com/re-cinq/wave/issues/1607
+- Epic: https://github.com/re-cinq/wave/issues/1565

--- a/specs/1607-pipeline-evolve/tasks.md
+++ b/specs/1607-pipeline-evolve/tasks.md
@@ -1,0 +1,29 @@
+# Work Items
+
+## Phase 1: Setup
+- [X] 1.1 Create feature branch `1607-pipeline-evolve-impl` (done in this step)
+- [X] 1.2 Confirm `pipeline_eval` and `evolution_proposal` migrations are applied (sanity grep `internal/state/migration_definitions.go`)
+
+## Phase 2: Contracts
+- [X] 2.1 Write `.agents/contracts/evolution-findings.schema.json` (output of `analyze`) [P]
+- [X] 2.2 Write `.agents/contracts/evolution-proposal.schema.json` (output of `propose`) [P]
+
+## Phase 3: Pipeline YAML
+- [X] 3.1 Author `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` with metadata, input schema, four steps (`gather-eval`, `analyze`, `propose`, `record`), `pipeline_outputs`, `chat_context`
+- [X] 3.2 Implement `gather-eval` step: `sqlite3` query against `pipeline_eval`, JSON rollup with eval rows + aggregate stats, fallback when DB missing
+- [X] 3.3 Implement `analyze` step: `navigator` persona, prompt that classifies recurring failure classes and computes signal summary, `json_schema` contract
+- [X] 3.4 Implement `propose` step: `craftsman` persona, prompt that reads findings + active YAML, writes candidate `<pipeline>.next.yaml` and `prompt.diff`, plus `proposal_summary.json`, `json_schema` contract
+- [X] 3.5 Implement `record` step: `sqlite3 INSERT INTO evolution_proposal`, write `record_status.json` with proposal id, handle empty/insufficient-data branch
+- [X] 3.6 Mirror file to `.agents/pipelines/pipeline-evolve.yaml` (project-local copy)
+
+## Phase 4: Testing
+- [X] 4.1 Write `internal/pipeline/pipeline_evolve_test.go` — seed synthetic eval rows, run record + gather-eval scripts directly, assert proposal row + skip branch [P]
+- [X] 4.2 Mirror schemas into `internal/defaults/embedfs/contracts/` (TestSchemaSync gate) [P]
+- [X] 4.3 Confirm pipeline loader test (`internal/pipeline/all_pipelines_load_test.go`) discovers new YAML
+
+## Phase 5: Polish
+- [X] 5.1 Run `go test -race` against the new tests (full suite green)
+- [X] 5.2 `go vet` passes; `golangci-lint` deferred to CI (not installed locally)
+- [ ] 5.3 Manual smoke test against a real `pipeline_eval` seed using `wave run pipeline-evolve` (deferred to post-merge)
+- [ ] 5.4 Update `docs/guides/` if there is an evolution-loop guide; otherwise skip (no existing guide)
+- [ ] 5.5 Open PR linking back to #1607 and Epic #1565 (PR step)


### PR DESCRIPTION
## Summary
- Ship `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` — a 4-step meta-pipeline that ingests `pipeline_eval` history and proposes a v+1 candidate via LLM
- gather-eval pulls last 50 rows via sqlite3; analyze classifies failure classes (navigator/cheapest); propose drafts yaml + unified diff (craftsman/balanced); record inserts into `evolution_proposal` as `proposed`
- Insufficient-data short-circuit prevents DB noise rows
- New contract schemas `evolution-findings` + `evolution-proposal` mirrored into `.agents/` and `internal/defaults/` to satisfy `TestSchemaSync`
- Coverage: `internal/pipeline/pipeline_evolve_test.go` exercises gather-eval, record, and skip branches against real on-disk SQLite

Related to #1607

## Changes
- `internal/defaults/embedfs/pipelines/pipeline-evolve.yaml` (+ `.agents/pipelines/` mirror) — pipeline definition
- `internal/defaults/contracts/evolution-findings.schema.json` + `evolution-proposal.schema.json` (+ `.agents/contracts/` mirror) — typed contracts
- `internal/pipeline/pipeline_evolve_test.go` — bash-script tests for gather-eval/record/skip
- `specs/1607-pipeline-evolve/{spec,plan,tasks}.md` — planning artifacts

## Test Plan
- [x] `go test ./internal/pipeline/... -run PipelineEvolve` against real SQLite DB
- [x] `TestSchemaSync` passes (mirrors aligned)
- [ ] CI: full `go test ./...` + golangci-lint