### PR TITLE
feat(webui,cli): proposals approval UI for evolution gate

### DIFF
--- a/cmd/wave/commands/proposals.go
+++ b/cmd/wave/commands/proposals.go
@@ -1,0 +1,319 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/recinq/wave/internal/proposals"
+	"github.com/recinq/wave/internal/state"
+	"github.com/spf13/cobra"
+)
+
+const proposalsDBPath = ".agents/state.db"
+
+// NewProposalsCmd creates the `wave proposals` parent command.
+func NewProposalsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposals",
+		Short: "Manage evolution proposals",
+		Long: `List, inspect, approve, or reject evolution proposals.
+
+Proposals come from the pipeline-evolve meta-pipeline. Approving creates a
+new pipeline_version row with active=true, atomically deactivating priors.
+The next 'wave run <pipeline>' picks up the new yaml.`,
+	}
+
+	cmd.AddCommand(newProposalsListCmd())
+	cmd.AddCommand(newProposalsShowCmd())
+	cmd.AddCommand(newProposalsApproveCmd())
+	cmd.AddCommand(newProposalsRejectCmd())
+
+	return cmd
+}
+
+func newProposalsListCmd() *cobra.Command {
+	var statusFlag, format string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List proposals (default: status=proposed)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			format = ResolveFormat(cmd, format)
+			return runProposalsList(statusFlag, format)
+		},
+	}
+	cmd.Flags().StringVar(&statusFlag, "status", "proposed", "Filter by status: proposed, approved, rejected, superseded")
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: text, json")
+	return cmd
+}
+
+func newProposalsShowCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show a single proposal with reason + signal summary",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format = ResolveFormat(cmd, format)
+			return runProposalsShow(args[0], format)
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "text", "Output format: text, json")
+	return cmd
+}
+
+func newProposalsApproveCmd() *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "approve <id>",
+		Short: "Approve a proposal and activate the new pipeline version",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runProposalsApprove(args[0], reason)
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "Optional approval note (recorded in decided_by)")
+	return cmd
+}
+
+func newProposalsRejectCmd() *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "reject <id>",
+		Short: "Reject a proposal",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runProposalsReject(args[0], reason)
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "Rejection reason (recorded in decided_by)")
+	return cmd
+}
+
+func openProposalStore() (state.StateStore, error) {
+	if _, err := os.Stat(proposalsDBPath); os.IsNotExist(err) {
+		return nil, NewCLIError(CodeStateDBError,
+			fmt.Sprintf("state database not found: %s", proposalsDBPath),
+			"Run 'wave run' once to create the database, or check your working directory")
+	}
+	store, err := state.NewStateStore(proposalsDBPath)
+	if err != nil {
+		return nil, NewCLIError(CodeStateDBError,
+			fmt.Sprintf("failed to open state database: %s", err),
+			"Check .agents/state.db file permissions").WithCause(err)
+	}
+	return store, nil
+}
+
+func parseProposalsID(raw string) (int64, error) {
+	id, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, NewCLIError(CodeInvalidArgs,
+			fmt.Sprintf("invalid proposal id: %q", raw),
+			"Pass a positive integer id (see 'wave proposals list')")
+	}
+	return id, nil
+}
+
+func runProposalsList(statusFlag, format string) error {
+	store, err := openProposalStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	st := state.EvolutionProposalStatus(strings.TrimSpace(statusFlag))
+	if st == "" {
+		st = state.ProposalProposed
+	}
+	recs, err := store.ListProposalsByStatus(st, 0)
+	if err != nil {
+		return NewCLIError(CodeInternalError,
+			fmt.Sprintf("list proposals: %s", err), "").WithCause(err)
+	}
+
+	if format == "json" {
+		out := make([]map[string]any, 0, len(recs))
+		for _, r := range recs {
+			out = append(out, proposalToMap(r))
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	if len(recs) == 0 {
+		fmt.Printf("No proposals with status %s\n", st)
+		return nil
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tPIPELINE\tVERSIONS\tSTATUS\tPROPOSED\tREASON")
+	for _, r := range recs {
+		fmt.Fprintf(tw, "%d\t%s\tv%d->v%d\t%s\t%s\t%s\n",
+			r.ID, r.PipelineName, r.VersionBefore, r.VersionAfter,
+			r.Status, r.ProposedAt.Format("2006-01-02 15:04"), truncateProposalsField(r.Reason, 60))
+	}
+	return tw.Flush()
+}
+
+func runProposalsShow(idStr, format string) error {
+	id, err := parseProposalsID(idStr)
+	if err != nil {
+		return err
+	}
+	store, err := openProposalStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	rec, err := store.GetProposal(id)
+	if err != nil {
+		return NewCLIError(CodeInternalError, err.Error(), "").WithCause(err)
+	}
+	if rec == nil {
+		return NewCLIError(CodeRunNotFound,
+			fmt.Sprintf("proposal %d not found", id),
+			"Run 'wave proposals list' to see available proposals")
+	}
+
+	if format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(proposalToMap(*rec))
+	}
+
+	fmt.Printf("Proposal #%d\n", rec.ID)
+	fmt.Printf("  Pipeline:   %s\n", rec.PipelineName)
+	fmt.Printf("  Versions:   v%d -> v%d\n", rec.VersionBefore, rec.VersionAfter)
+	fmt.Printf("  Status:     %s\n", rec.Status)
+	fmt.Printf("  Proposed:   %s\n", rec.ProposedAt.Format("2006-01-02 15:04:05"))
+	if rec.DecidedAt != nil {
+		fmt.Printf("  Decided:    %s by %s\n", rec.DecidedAt.Format("2006-01-02 15:04:05"), rec.DecidedBy)
+	}
+	fmt.Printf("  Diff:       %s\n", rec.DiffPath)
+	fmt.Printf("\nReason:\n  %s\n", rec.Reason)
+	if rec.SignalSummary != "" {
+		fmt.Printf("\nSignal summary:\n  %s\n", rec.SignalSummary)
+	}
+	return nil
+}
+
+func runProposalsApprove(idStr, reason string) error {
+	id, err := parseProposalsID(idStr)
+	if err != nil {
+		return err
+	}
+	store, err := openProposalStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	rec, err := store.GetProposal(id)
+	if err != nil {
+		return NewCLIError(CodeInternalError, err.Error(), "").WithCause(err)
+	}
+	if rec == nil {
+		return NewCLIError(CodeRunNotFound,
+			fmt.Sprintf("proposal %d not found", id), "")
+	}
+	decidedBy := buildDecidedBy(reason)
+
+	res, err := proposals.Approve(store, rec, decidedBy)
+	if err != nil {
+		return mapApproveError(err)
+	}
+	fmt.Printf("Approved proposal #%d. Activated %s v%d (%s)\n",
+		rec.ID, rec.PipelineName, res.NewVersion, res.YAMLPath)
+	return nil
+}
+
+func runProposalsReject(idStr, reason string) error {
+	id, err := parseProposalsID(idStr)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(reason) == "" {
+		return NewCLIError(CodeInvalidArgs,
+			"--reason is required to reject a proposal",
+			"Provide a short rationale: wave proposals reject <id> --reason \"…\"")
+	}
+	store, err := openProposalStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	decidedBy := buildDecidedBy(reason)
+	if err := store.DecideProposal(id, state.ProposalRejected, decidedBy); err != nil {
+		return NewCLIError(CodeValidationFailed,
+			fmt.Sprintf("reject failed: %s", err),
+			"The proposal may already be decided or removed").WithCause(err)
+	}
+	fmt.Printf("Rejected proposal #%d (reason: %s)\n", id, reason)
+	return nil
+}
+
+// buildDecidedBy concatenates user identity with the optional reason so the
+// audit row preserves both. The schema only has decided_by; the reason is
+// folded into the same column to avoid a schema migration for a single field.
+func buildDecidedBy(reason string) string {
+	user := strings.TrimSpace(os.Getenv("USER"))
+	if user == "" {
+		user = "cli"
+	}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		return user + ": " + reason
+	}
+	return user
+}
+
+func mapApproveError(err error) error {
+	switch {
+	case errors.Is(err, proposals.ErrAlreadyDecided):
+		return NewCLIError(CodeValidationFailed, err.Error(),
+			"Proposal already decided; check 'wave proposals show <id>'").WithCause(err)
+	case errors.Is(err, proposals.ErrVersionConflict):
+		// Exit code 2 surfaces via the CLIError code mapping in main.
+		return NewCLIError(CodeValidationFailed, err.Error(),
+			"Another approval likely landed first; re-list and retry").WithCause(err)
+	case errors.Is(err, proposals.ErrAfterYAMLMissing):
+		return NewCLIError(CodeValidationFailed, err.Error(),
+			"pipeline-evolve must emit <DiffPath>.after.yaml alongside the diff").WithCause(err)
+	default:
+		return NewCLIError(CodeInternalError, err.Error(), "").WithCause(err)
+	}
+}
+
+func proposalToMap(r state.EvolutionProposalRecord) map[string]any {
+	out := map[string]any{
+		"id":             r.ID,
+		"pipeline_name":  r.PipelineName,
+		"version_before": r.VersionBefore,
+		"version_after":  r.VersionAfter,
+		"diff_path":      r.DiffPath,
+		"reason":         r.Reason,
+		"signal_summary": r.SignalSummary,
+		"status":         string(r.Status),
+		"proposed_at":    r.ProposedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if r.DecidedAt != nil {
+		out["decided_at"] = r.DecidedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if r.DecidedBy != "" {
+		out["decided_by"] = r.DecidedBy
+	}
+	return out
+}
+
+func truncateProposalsField(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/cmd/wave/commands/proposals_test.go
+++ b/cmd/wave/commands/proposals_test.go
@@ -1,0 +1,267 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/recinq/wave/internal/proposals"
+	"github.com/recinq/wave/internal/state"
+)
+
+// proposalsTestHelper holds the chdir-based scaffolding used by all CLI
+// proposals tests. The CLI commands always read .agents/state.db relative
+// to the current working directory, so each test must chdir to its tempdir.
+type proposalsTestHelper struct {
+	t       *testing.T
+	tmpDir  string
+	origDir string
+	dbPath  string
+}
+
+func newProposalsTestHelper(t *testing.T) *proposalsTestHelper {
+	t.Helper()
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".agents"), 0o755); err != nil {
+		t.Fatalf("mkdir .agents: %v", err)
+	}
+	dbPath := filepath.Join(tmpDir, ".agents", "state.db")
+	// Pre-create the DB so subsequent CLI invocations open the same migrated handle.
+	store, err := state.NewStateStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+	store.Close()
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	return &proposalsTestHelper{t: t, tmpDir: tmpDir, origDir: orig, dbPath: dbPath}
+}
+
+func (h *proposalsTestHelper) openStore() state.StateStore {
+	h.t.Helper()
+	store, err := state.NewStateStore(h.dbPath)
+	if err != nil {
+		h.t.Fatalf("open store: %v", err)
+	}
+	return store
+}
+
+// seedProposalCLI inserts a proposal and writes the matching post-diff yaml.
+func (h *proposalsTestHelper) seedProposalCLI(pipelineName, yamlBody string) (int64, string) {
+	h.t.Helper()
+	diffPath := filepath.Join(h.tmpDir, "p"+pipelineName+".diff")
+	if err := os.WriteFile(diffPath, []byte("--- a\n+++ b\n"), 0o600); err != nil {
+		h.t.Fatalf("write diff: %v", err)
+	}
+	yamlPath := diffPath + ".after.yaml"
+	if err := os.WriteFile(yamlPath, []byte(yamlBody), 0o600); err != nil {
+		h.t.Fatalf("write yaml: %v", err)
+	}
+	store := h.openStore()
+	defer store.Close()
+	id, err := store.CreateProposal(state.EvolutionProposalRecord{
+		PipelineName:  pipelineName,
+		VersionBefore: 1,
+		VersionAfter:  2,
+		DiffPath:      diffPath,
+		Reason:        "tighten contract",
+		SignalSummary: `{"judge_score":0.78}`,
+	})
+	if err != nil {
+		h.t.Fatalf("CreateProposal: %v", err)
+	}
+	return id, yamlPath
+}
+
+func (h *proposalsTestHelper) seedV1Active(pipelineName string) {
+	h.t.Helper()
+	store := h.openStore()
+	defer store.Close()
+	if err := store.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: pipelineName, Version: 1, SHA256: "sha-old",
+		YAMLPath: "old.yaml", Active: true,
+	}); err != nil {
+		h.t.Fatalf("CreatePipelineVersion(v1): %v", err)
+	}
+}
+
+func TestRunProposalsList_TextEmpty(t *testing.T) {
+	_ = newProposalsTestHelper(t)
+	if err := runProposalsList("proposed", "text"); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+}
+
+func TestRunProposalsApprove_FlipsActive(t *testing.T) {
+	h := newProposalsTestHelper(t)
+	h.seedV1Active("impl-issue")
+	id, yamlPath := h.seedProposalCLI("impl-issue", "version: 2\nsteps: []\n")
+
+	if err := runProposalsApprove(strconv.FormatInt(id, 10), "ok"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	store := h.openStore()
+	defer store.Close()
+	active, err := store.GetActiveVersion("impl-issue")
+	if err != nil {
+		t.Fatalf("GetActiveVersion: %v", err)
+	}
+	if active == nil || active.Version != 2 {
+		t.Fatalf("expected active v2, got %+v", active)
+	}
+	if active.YAMLPath != yamlPath {
+		t.Errorf("expected yaml_path=%s, got %s", yamlPath, active.YAMLPath)
+	}
+	versions, _ := store.ListPipelineVersions("impl-issue")
+	if len(versions) != 2 {
+		t.Errorf("expected 2 versions, got %d", len(versions))
+	}
+	for _, v := range versions {
+		if v.Version == 1 && v.Active {
+			t.Errorf("v1 should be deactivated after approve")
+		}
+	}
+}
+
+func TestRunProposalsReject_LeavesVersions(t *testing.T) {
+	h := newProposalsTestHelper(t)
+	h.seedV1Active("scope")
+	id, _ := h.seedProposalCLI("scope", "v2 yaml\n")
+
+	if err := runProposalsReject(strconv.FormatInt(id, 10), "scope creep"); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	store := h.openStore()
+	defer store.Close()
+	rec, err := store.GetProposal(id)
+	if err != nil {
+		t.Fatalf("GetProposal: %v", err)
+	}
+	if rec == nil || rec.Status != state.ProposalRejected {
+		t.Fatalf("expected rejected, got %+v", rec)
+	}
+	versions, _ := store.ListPipelineVersions("scope")
+	if len(versions) != 1 || versions[0].Version != 1 {
+		t.Errorf("reject should leave versions unchanged, got %+v", versions)
+	}
+	active, _ := store.GetActiveVersion("scope")
+	if active == nil || active.Version != 1 {
+		t.Errorf("expected v1 still active, got %+v", active)
+	}
+}
+
+func TestRunProposalsReject_RequiresReason(t *testing.T) {
+	h := newProposalsTestHelper(t)
+	id, _ := h.seedProposalCLI("scope", "v2\n")
+	err := runProposalsReject(strconv.FormatInt(id, 10), "")
+	if err == nil {
+		t.Fatal("expected error for missing reason")
+	}
+}
+
+func TestRunProposalsApprove_AlreadyDecided(t *testing.T) {
+	h := newProposalsTestHelper(t)
+	h.seedV1Active("impl-issue")
+	id, _ := h.seedProposalCLI("impl-issue", "v2\n")
+
+	if err := runProposalsApprove(strconv.FormatInt(id, 10), ""); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	err := runProposalsApprove(strconv.FormatInt(id, 10), "")
+	if err == nil {
+		t.Fatal("expected error on second approve of same proposal")
+	}
+}
+
+func TestRunProposalsShow_NotFound(t *testing.T) {
+	_ = newProposalsTestHelper(t)
+	err := runProposalsShow("9999", "text")
+	if err == nil {
+		t.Fatal("expected error for missing proposal")
+	}
+}
+
+func TestApproveErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+	}{
+		{"already-decided", proposals.ErrAlreadyDecided},
+		{"version-conflict", proposals.ErrVersionConflict},
+		{"after-yaml-missing", proposals.ErrAfterYAMLMissing},
+		{"unknown", errors.New("boom")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := mapApproveError(tc.in)
+			if err == nil {
+				t.Fatal("expected non-nil")
+			}
+			var cliErr *CLIError
+			if !errors.As(err, &cliErr) {
+				t.Fatalf("expected *CLIError, got %T", err)
+			}
+		})
+	}
+}
+
+// TestAcceptanceGate is the end-to-end gate from the spec: synthetic proposal
+// → CLI approve → GetActiveVersion returns the new row → loader resolves the
+// new yaml_path on a subsequent lookup.
+func TestAcceptanceGate(t *testing.T) {
+	h := newProposalsTestHelper(t)
+	h.seedV1Active("impl-issue")
+	id, yamlPath := h.seedProposalCLI("impl-issue", "version: 2\nsteps:\n  - id: noop\n")
+
+	// 1. List confirms the proposal is visible.
+	if err := runProposalsList("proposed", "text"); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	// 2. Approve flips active.
+	if err := runProposalsApprove(strconv.FormatInt(id, 10), "acceptance"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	// 3. GetActiveVersion now returns v2 with the new yaml_path — what the
+	//    pipeline loader queries before each `wave run`.
+	store := h.openStore()
+	defer store.Close()
+	active, err := store.GetActiveVersion("impl-issue")
+	if err != nil {
+		t.Fatalf("GetActiveVersion: %v", err)
+	}
+	if active == nil {
+		t.Fatal("expected active version, got nil")
+	}
+	if active.Version != 2 {
+		t.Errorf("expected active v2, got v%d", active.Version)
+	}
+	if active.YAMLPath != yamlPath {
+		t.Errorf("expected yaml_path=%s, got %s", yamlPath, active.YAMLPath)
+	}
+	if active.SHA256 == "" {
+		t.Error("expected non-empty sha256")
+	}
+
+	// 4. The yaml file pointed at by the active row exists and contains the
+	//    payload pipeline-evolve emitted — the loader will read it next.
+	body, err := os.ReadFile(active.YAMLPath)
+	if err != nil {
+		t.Fatalf("read active yaml: %v", err)
+	}
+	if string(body) != "version: 2\nsteps:\n  - id: noop\n" {
+		t.Errorf("yaml body mismatch: %q", string(body))
+	}
+}

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -167,6 +167,7 @@ func init() {
 	rootCmd.AddCommand(commands.NewPersonaCmd())
 	rootCmd.AddCommand(commands.NewCleanupCmd())
 	rootCmd.AddCommand(commands.NewMergeCmd())
+	rootCmd.AddCommand(commands.NewProposalsCmd())
 }
 
 // shouldLaunchTUI determines whether to launch the Bubble Tea TUI.

--- a/internal/proposals/approve.go
+++ b/internal/proposals/approve.go
@@ -1,0 +1,110 @@
+// Package proposals carries the shared approval logic for evolution
+// proposals. Both the webui handler and the CLI command depend on it so the
+// activation sequence (DecideProposal + CreatePipelineVersion) lives in one
+// place.
+package proposals
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// Sentinel errors so callers can map outcomes to HTTP status codes / CLI
+// exit codes.
+var (
+	ErrAlreadyDecided   = errors.New("proposal is not in 'proposed' state")
+	ErrVersionConflict  = errors.New("pipeline version conflict — concurrent approval?")
+	ErrAfterYAMLMissing = errors.New("post-approval yaml file missing")
+)
+
+// ApproveResult carries the activation outcome.
+type ApproveResult struct {
+	NewVersion int
+	YAMLPath   string
+	SHA256     string
+}
+
+// Approve performs the two-step approval: DecideProposal(approved) followed
+// by CreatePipelineVersion(active=true). The post-diff yaml file is resolved
+// via ResolveAfterYAMLPath; sha256 is computed over its contents.
+func Approve(store state.EvolutionStore, rec *state.EvolutionProposalRecord, decidedBy string) (*ApproveResult, error) {
+	if store == nil || rec == nil {
+		return nil, errors.New("Approve: nil store or record")
+	}
+
+	yamlPath, err := ResolveAfterYAMLPath(rec.DiffPath)
+	if err != nil {
+		return nil, ErrAfterYAMLMissing
+	}
+	contents, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("read post-diff yaml: %w", err)
+	}
+	sum := sha256.Sum256(contents)
+	sha := hex.EncodeToString(sum[:])
+
+	versions, err := store.ListPipelineVersions(rec.PipelineName)
+	if err != nil {
+		return nil, fmt.Errorf("list versions: %w", err)
+	}
+	nextVersion := 1
+	if len(versions) > 0 {
+		nextVersion = versions[0].Version + 1
+	}
+
+	if err := store.DecideProposal(rec.ID, state.ProposalApproved, decidedBy); err != nil {
+		return nil, ErrAlreadyDecided
+	}
+
+	createErr := store.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: rec.PipelineName,
+		Version:      nextVersion,
+		SHA256:       sha,
+		YAMLPath:     yamlPath,
+		Active:       true,
+	})
+	if createErr != nil {
+		if strings.Contains(strings.ToLower(createErr.Error()), "unique") {
+			return nil, ErrVersionConflict
+		}
+		return nil, fmt.Errorf("create version: %w", createErr)
+	}
+
+	return &ApproveResult{
+		NewVersion: nextVersion,
+		YAMLPath:   yamlPath,
+		SHA256:     sha,
+	}, nil
+}
+
+// ResolveAfterYAMLPath probes the conventional post-diff yaml file paths
+// emitted by pipeline-evolve. Returns the first path that exists on disk.
+//
+// Order:
+//  1. <DiffPath>.after.yaml  (preferred convention)
+//  2. <DiffPath>.yaml         (legacy)
+//  3. <DiffPath>              (only when DiffPath itself ends in .yaml)
+func ResolveAfterYAMLPath(diffPath string) (string, error) {
+	if diffPath == "" {
+		return "", errors.New("empty diff path")
+	}
+	candidates := []string{
+		diffPath + ".after.yaml",
+		diffPath + ".yaml",
+	}
+	if strings.HasSuffix(diffPath, ".yaml") {
+		candidates = append(candidates, diffPath)
+	}
+	for _, p := range candidates {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no post-diff yaml found for %s", diffPath)
+}

--- a/internal/proposals/approve.go
+++ b/internal/proposals/approve.go
@@ -58,22 +58,22 @@ func Approve(store state.EvolutionStore, rec *state.EvolutionProposalRecord, dec
 		nextVersion = versions[0].Version + 1
 	}
 
-	if err := store.DecideProposal(rec.ID, state.ProposalApproved, decidedBy); err != nil {
-		return nil, ErrAlreadyDecided
-	}
-
-	createErr := store.CreatePipelineVersion(state.PipelineVersionRecord{
+	err = store.ApproveProposalAndActivate(rec.ID, decidedBy, state.PipelineVersionRecord{
 		PipelineName: rec.PipelineName,
 		Version:      nextVersion,
 		SHA256:       sha,
 		YAMLPath:     yamlPath,
 		Active:       true,
 	})
-	if createErr != nil {
-		if strings.Contains(strings.ToLower(createErr.Error()), "unique") {
+	if err != nil {
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "not in 'proposed'") {
+			return nil, ErrAlreadyDecided
+		}
+		if strings.Contains(msg, "unique") {
 			return nil, ErrVersionConflict
 		}
-		return nil, fmt.Errorf("create version: %w", createErr)
+		return nil, fmt.Errorf("approve and activate: %w", err)
 	}
 
 	return &ApproveResult{

--- a/internal/state/evolution.go
+++ b/internal/state/evolution.go
@@ -80,6 +80,12 @@ type EvolutionStore interface {
 	GetProposal(id int64) (*EvolutionProposalRecord, error)
 	ListProposalsByStatus(status EvolutionProposalStatus, limit int) ([]EvolutionProposalRecord, error)
 	LastProposalAt(pipelineName string) (time.Time, bool, error)
+
+	// ApproveProposalAndActivate atomically marks a proposal approved AND inserts
+	// the new pipeline_version row (with active=true, deactivating priors). Both
+	// effects commit together or roll back together — the caller cannot end up
+	// in a half-state where the proposal is approved but no version row exists.
+	ApproveProposalAndActivate(proposalID int64, decidedBy string, version PipelineVersionRecord) error
 }
 
 // RecordEval inserts a row into pipeline_eval. The (pipeline_name, run_id)
@@ -182,14 +188,26 @@ func (s *stateStore) CreatePipelineVersion(rec PipelineVersionRecord) error {
 	if rec.PipelineName == "" || rec.SHA256 == "" || rec.YAMLPath == "" {
 		return errors.New("CreatePipelineVersion: pipeline_name, sha256, yaml_path required")
 	}
-	if rec.CreatedAt.IsZero() {
-		rec.CreatedAt = time.Now()
-	}
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := insertPipelineVersionTx(tx, &rec); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// insertPipelineVersionTx writes a pipeline_version row inside the supplied
+// transaction. When rec.Active is true, all other rows for the same
+// pipeline_name are deactivated first. Shared by CreatePipelineVersion and
+// ApproveProposalAndActivate so the schema-touching SQL lives in one place.
+// Mutates rec.CreatedAt when zero.
+func insertPipelineVersionTx(tx *sql.Tx, rec *PipelineVersionRecord) error {
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
 	if rec.Active {
 		if _, err := tx.Exec(
 			`UPDATE pipeline_version SET active = 0 WHERE pipeline_name = ?`,
@@ -205,7 +223,7 @@ func (s *stateStore) CreatePipelineVersion(rec PipelineVersionRecord) error {
 	); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 // ActivateVersion flips the active flag to the requested version, deactivating
@@ -309,6 +327,39 @@ func (s *stateStore) CreateProposal(rec EvolutionProposalRecord) (int64, error) 
 		return 0, err
 	}
 	return res.LastInsertId()
+}
+
+// ApproveProposalAndActivate wraps the proposal-decide and version-create
+// effects in a single transaction so the cross-table coupling never lands in
+// a half-state. On any error the tx rolls back, leaving the proposal in
+// `proposed` status and no new version row.
+func (s *stateStore) ApproveProposalAndActivate(proposalID int64, decidedBy string, rec PipelineVersionRecord) error {
+	if rec.PipelineName == "" || rec.SHA256 == "" || rec.YAMLPath == "" {
+		return errors.New("ApproveProposalAndActivate: pipeline_name, sha256, yaml_path required")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := insertPipelineVersionTx(tx, &rec); err != nil {
+		return err
+	}
+	res, err := tx.Exec(
+		`UPDATE evolution_proposal
+		 SET status = ?, decided_at = ?, decided_by = ?
+		 WHERE id = ? AND status = 'proposed'`,
+		string(ProposalApproved), time.Now().Unix(), decidedBy, proposalID,
+	)
+	if err != nil {
+		return fmt.Errorf("decide proposal: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("ApproveProposalAndActivate: proposal %d not in 'proposed' state", proposalID)
+	}
+	return tx.Commit()
 }
 
 // DecideProposal updates a proposal to a terminal status and records who

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -623,6 +623,9 @@ func (m *MockStateStore) ListProposalsByStatus(_ state.EvolutionProposalStatus, 
 func (m *MockStateStore) LastProposalAt(_ string) (time.Time, bool, error) {
 	return time.Time{}, false, nil
 }
+func (m *MockStateStore) ApproveProposalAndActivate(_ int64, _ string, _ state.PipelineVersionRecord) error {
+	return nil
+}
 
 // WorksourceStore stubs (epic #1565 PRE-5).
 func (m *MockStateStore) CreateBinding(_ state.WorksourceBindingRecord) (int64, error) {

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -192,6 +192,9 @@ func (b baseStateStore) ListProposalsByStatus(state.EvolutionProposalStatus, int
 func (b baseStateStore) LastProposalAt(string) (time.Time, bool, error) {
 	return time.Time{}, false, nil
 }
+func (b baseStateStore) ApproveProposalAndActivate(int64, string, state.PipelineVersionRecord) error {
+	return nil
+}
 
 // WorksourceStore stubs (epic #1565 PRE-5).
 func (b baseStateStore) CreateBinding(state.WorksourceBindingRecord) (int64, error) { return 0, nil }

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -48,6 +48,8 @@ var pageTemplates = []string{
 	"templates/webhook_detail.html",
 	"templates/admin.html",
 	"templates/onboard/index.html",
+	"templates/proposals/list.html",
+	"templates/proposals/detail.html",
 }
 
 // standalonePageTemplates is the list of templates that do NOT extend
@@ -198,7 +200,8 @@ func parseTemplates(extraFuncs ...template.FuncMap) (map[string]*template.Templa
 			}
 			return plural
 		},
-		"joinStrings": strings.Join,
+		"joinStrings":              strings.Join,
+		"proposalStatusBadgeClass": proposalStatusBadgeClass,
 	}
 	for _, fm := range extraFuncs {
 		for k, v := range fm {

--- a/internal/webui/handlers_proposals.go
+++ b/internal/webui/handlers_proposals.go
@@ -1,0 +1,341 @@
+package webui
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/recinq/wave/internal/proposals"
+	"github.com/recinq/wave/internal/state"
+)
+
+// proposalListView is the template payload for the proposals list page.
+type proposalListView struct {
+	ActivePage string
+	Filter     string
+	Counts     map[string]int
+	Proposals  []proposalRow
+}
+
+// proposalRow is one entry in the proposals list table.
+type proposalRow struct {
+	ID            int64
+	PipelineName  string
+	VersionBefore int
+	VersionAfter  int
+	Reason        string
+	Status        string
+	ProposedAt    time.Time
+	DecidedAt     *time.Time
+	DecidedBy     string
+}
+
+// proposalDetailView is the template payload for the proposal detail page.
+type proposalDetailView struct {
+	ActivePage    string
+	Proposal      proposalRow
+	DiffLines     []diffLine
+	DiffMissing   bool
+	DiffError     string
+	SignalSummary string
+}
+
+// diffLine is one row of a unified diff with a class for line type.
+type diffLine struct {
+	Class string // diff-line-add | diff-line-del | diff-line-ctx
+	Text  string
+}
+
+// proposalDecisionResponse is the JSON body returned by approve/reject.
+type proposalDecisionResponse struct {
+	ID            int64  `json:"id"`
+	Status        string `json:"status"`
+	NewVersion    int    `json:"new_version,omitempty"`
+	NewYAMLPath   string `json:"new_yaml_path,omitempty"`
+	NewSHA256     string `json:"new_sha256,omitempty"`
+	DecidedBy     string `json:"decided_by,omitempty"`
+	Activated     bool   `json:"activated,omitempty"`
+}
+
+// handleProposalsPage handles GET /proposals.
+func (s *Server) handleProposalsPage(w http.ResponseWriter, r *http.Request) {
+	store := s.proposalStore()
+	if store == nil {
+		http.Error(w, "evolution store unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	filter := strings.TrimSpace(r.URL.Query().Get("status"))
+	statuses := []state.EvolutionProposalStatus{
+		state.ProposalProposed,
+		state.ProposalApproved,
+		state.ProposalRejected,
+		state.ProposalSuperseded,
+	}
+
+	counts := map[string]int{}
+	for _, st := range statuses {
+		recs, err := store.ListProposalsByStatus(st, 0)
+		if err != nil {
+			http.Error(w, "list proposals: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		counts[string(st)] = len(recs)
+	}
+
+	target := state.ProposalProposed
+	if filter != "" {
+		target = state.EvolutionProposalStatus(filter)
+	}
+	recs, err := store.ListProposalsByStatus(target, 200)
+	if err != nil {
+		http.Error(w, "list proposals: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	rows := make([]proposalRow, 0, len(recs))
+	for _, p := range recs {
+		rows = append(rows, recordToRow(p))
+	}
+
+	view := proposalListView{
+		ActivePage: "proposals",
+		Filter:     string(target),
+		Counts:     counts,
+		Proposals:  rows,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	tmpl := s.assets.templates["templates/proposals/list.html"]
+	if tmpl == nil {
+		http.Error(w, "template missing: proposals/list.html", http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.ExecuteTemplate(w, "templates/layout.html", view); err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// handleProposalDetailPage handles GET /proposals/{id}.
+func (s *Server) handleProposalDetailPage(w http.ResponseWriter, r *http.Request) {
+	store := s.proposalStore()
+	if store == nil {
+		http.Error(w, "evolution store unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	id, err := parseProposalID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	rec, err := store.GetProposal(id)
+	if err != nil {
+		http.Error(w, "get proposal: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if rec == nil {
+		http.Error(w, "proposal not found", http.StatusNotFound)
+		return
+	}
+
+	view := proposalDetailView{
+		ActivePage:    "proposals",
+		Proposal:      recordToRow(*rec),
+		SignalSummary: rec.SignalSummary,
+	}
+
+	if rec.DiffPath == "" {
+		view.DiffMissing = true
+	} else {
+		raw, readErr := os.ReadFile(rec.DiffPath)
+		if readErr != nil {
+			view.DiffError = fmt.Sprintf("diff unavailable: %s", readErr.Error())
+		} else {
+			view.DiffLines = parseDiffLines(string(raw))
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	tmpl := s.assets.templates["templates/proposals/detail.html"]
+	if tmpl == nil {
+		http.Error(w, "template missing: proposals/detail.html", http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.ExecuteTemplate(w, "templates/layout.html", view); err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// handleProposalApprove handles POST /proposals/{id}/approve.
+func (s *Server) handleProposalApprove(w http.ResponseWriter, r *http.Request) {
+	store := s.proposalStore()
+	if store == nil {
+		writeJSONError(w, http.StatusInternalServerError, "evolution store unavailable")
+		return
+	}
+
+	id, err := parseProposalID(r.PathValue("id"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	rec, err := store.GetProposal(id)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "get proposal: "+err.Error())
+		return
+	}
+	if rec == nil {
+		writeJSONError(w, http.StatusNotFound, "proposal not found")
+		return
+	}
+
+	decidedBy := strings.TrimSpace(r.Header.Get("X-Wave-User"))
+	if decidedBy == "" {
+		decidedBy = "webui"
+	}
+
+	result, err := proposals.Approve(store, rec, decidedBy)
+	if err != nil {
+		switch {
+		case errors.Is(err, proposals.ErrAlreadyDecided):
+			writeJSONError(w, http.StatusConflict, err.Error())
+		case errors.Is(err, proposals.ErrVersionConflict):
+			writeJSONError(w, http.StatusConflict, err.Error())
+		case errors.Is(err, proposals.ErrAfterYAMLMissing):
+			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+		default:
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, proposalDecisionResponse{
+		ID:          rec.ID,
+		Status:      string(state.ProposalApproved),
+		NewVersion:  result.NewVersion,
+		NewYAMLPath: result.YAMLPath,
+		NewSHA256:   result.SHA256,
+		DecidedBy:   decidedBy,
+		Activated:   true,
+	})
+}
+
+// handleProposalReject handles POST /proposals/{id}/reject.
+func (s *Server) handleProposalReject(w http.ResponseWriter, r *http.Request) {
+	store := s.proposalStore()
+	if store == nil {
+		writeJSONError(w, http.StatusInternalServerError, "evolution store unavailable")
+		return
+	}
+
+	id, err := parseProposalID(r.PathValue("id"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	decidedBy := strings.TrimSpace(r.Header.Get("X-Wave-User"))
+	if decidedBy == "" {
+		decidedBy = "webui"
+	}
+
+	if err := store.DecideProposal(id, state.ProposalRejected, decidedBy); err != nil {
+		// Record may already be decided or missing.
+		writeJSONError(w, http.StatusConflict, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, proposalDecisionResponse{
+		ID:        id,
+		Status:    string(state.ProposalRejected),
+		DecidedBy: decidedBy,
+	})
+}
+
+// proposalStore returns the read-write evolution store, preferring the rwStore
+// (which permits writes) over the read-only store. Tests that wire only an
+// rwStore still work because both fields hold the same handle in production.
+func (s *Server) proposalStore() state.EvolutionStore {
+	if s.runtime.rwStore != nil {
+		return s.runtime.rwStore
+	}
+	return s.runtime.store
+}
+
+// parseDiffLines converts unified-diff text into class-tagged lines. Empty
+// input yields a single context line so the template renders an empty pre.
+func parseDiffLines(diff string) []diffLine {
+	if diff == "" {
+		return nil
+	}
+	lines := strings.Split(diff, "\n")
+	out := make([]diffLine, 0, len(lines))
+	for i, ln := range lines {
+		// Trim a trailing empty line introduced by the final newline.
+		if i == len(lines)-1 && ln == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(ln, "+++") || strings.HasPrefix(ln, "---"):
+			out = append(out, diffLine{Class: "diff-line-meta", Text: ln})
+		case strings.HasPrefix(ln, "@@"):
+			out = append(out, diffLine{Class: "diff-line-hunk", Text: ln})
+		case strings.HasPrefix(ln, "+"):
+			out = append(out, diffLine{Class: "diff-line-add", Text: ln})
+		case strings.HasPrefix(ln, "-"):
+			out = append(out, diffLine{Class: "diff-line-del", Text: ln})
+		default:
+			out = append(out, diffLine{Class: "diff-line-ctx", Text: ln})
+		}
+	}
+	return out
+}
+
+func parseProposalID(raw string) (int64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, errors.New("missing proposal id")
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.New("invalid proposal id")
+	}
+	return id, nil
+}
+
+func recordToRow(p state.EvolutionProposalRecord) proposalRow {
+	return proposalRow{
+		ID:            p.ID,
+		PipelineName:  p.PipelineName,
+		VersionBefore: p.VersionBefore,
+		VersionAfter:  p.VersionAfter,
+		Reason:        p.Reason,
+		Status:        string(p.Status),
+		ProposedAt:    p.ProposedAt,
+		DecidedAt:     p.DecidedAt,
+		DecidedBy:     p.DecidedBy,
+	}
+}
+
+// proposalStatusBadgeClass picks a badge css class for a proposal status.
+// Exposed via a template func so list/detail can render colored pills.
+func proposalStatusBadgeClass(status string) string {
+	switch status {
+	case "proposed":
+		return "badge-yellow"
+	case "approved":
+		return "badge-green"
+	case "rejected":
+		return "badge-red"
+	case "superseded":
+		return "badge-gray"
+	default:
+		return "badge-neutral"
+	}
+}
+

--- a/internal/webui/handlers_proposals_test.go
+++ b/internal/webui/handlers_proposals_test.go
@@ -1,0 +1,266 @@
+package webui
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// proposalsTestServer extends testServer with the proposals page templates so
+// the proposals handlers can render. The shared testTemplates map only stubs
+// the older pages.
+func proposalsTestServer(t *testing.T) (*Server, state.StateStore) {
+	t.Helper()
+	srv, rw := testServer(t)
+
+	listTmpl := template.Must(template.New("templates/layout.html").Funcs(template.FuncMap{
+		"proposalStatusBadgeClass": proposalStatusBadgeClass,
+		"formatTime":               formatTime,
+	}).Parse(`<html><body>` +
+		`<h1>Proposals</h1>` +
+		`<div class="filter">{{.Filter}}</div>` +
+		`<ul>{{range .Proposals}}<li data-id="{{.ID}}">{{.PipelineName}} v{{.VersionBefore}}-&gt;v{{.VersionAfter}} <span class="status">{{.Status}}</span></li>{{end}}</ul>` +
+		`<div class="counts">proposed={{index .Counts "proposed"}} approved={{index .Counts "approved"}} rejected={{index .Counts "rejected"}}</div>` +
+		`</body></html>`))
+	detailTmpl := template.Must(template.New("templates/layout.html").Funcs(template.FuncMap{
+		"proposalStatusBadgeClass": proposalStatusBadgeClass,
+		"formatTime":               formatTime,
+	}).Parse(`<html><body>` +
+		`<h1>#{{.Proposal.ID}}: {{.Proposal.Reason}}</h1>` +
+		`<div class="status">{{.Proposal.Status}}</div>` +
+		`<div class="pipeline">{{.Proposal.PipelineName}}</div>` +
+		`{{if .DiffLines}}<pre>{{range .DiffLines}}<span class="{{.Class}}">{{.Text}}</span>` + "\n" + `{{end}}</pre>{{end}}` +
+		`{{if .DiffMissing}}<p class="diff-missing">no diff</p>{{end}}` +
+		`{{if .DiffError}}<p class="diff-error">{{.DiffError}}</p>{{end}}` +
+		`{{if .SignalSummary}}<pre class="signal">{{.SignalSummary}}</pre>{{end}}` +
+		`</body></html>`))
+	srv.assets.templates["templates/proposals/list.html"] = listTmpl
+	srv.assets.templates["templates/proposals/detail.html"] = detailTmpl
+	return srv, rw
+}
+
+func seedProposal(t *testing.T, store state.StateStore, name string, status state.EvolutionProposalStatus, diffPath string) int64 {
+	t.Helper()
+	id, err := store.CreateProposal(state.EvolutionProposalRecord{
+		PipelineName:  name,
+		VersionBefore: 1,
+		VersionAfter:  2,
+		DiffPath:      diffPath,
+		Reason:        "tighten contract for " + name,
+		SignalSummary: `{"judge_score":0.78}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateProposal: %v", err)
+	}
+	if status != state.ProposalProposed {
+		if err := store.DecideProposal(id, status, "seed"); err != nil {
+			t.Fatalf("DecideProposal: %v", err)
+		}
+	}
+	return id
+}
+
+// writeAfterYAML writes a synthetic post-diff yaml file alongside diffPath so
+// the approve flow has something to hash + record.
+func writeAfterYAML(t *testing.T, diffPath, body string) string {
+	t.Helper()
+	yamlPath := diffPath + ".after.yaml"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write after-yaml: %v", err)
+	}
+	return yamlPath
+}
+
+func TestHandleProposalsPage_FiltersAndCounts(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	dir := t.TempDir()
+	diff := filepath.Join(dir, "p1.diff")
+	_ = os.WriteFile(diff, []byte("--- a\n+++ b\n"), 0o600)
+
+	seedProposal(t, rw, "impl-issue", state.ProposalProposed, diff)
+	seedProposal(t, rw, "scope", state.ProposalApproved, diff)
+
+	req := httptest.NewRequest("GET", "/proposals?status=proposed", nil)
+	req.SetPathValue("id", "")
+	rec := httptest.NewRecorder()
+	srv.handleProposalsPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "impl-issue") {
+		t.Errorf("expected impl-issue in body, got: %s", body)
+	}
+	if strings.Contains(body, "scope") {
+		t.Errorf("approved 'scope' proposal should not appear under default proposed filter, body=%s", body)
+	}
+	if !strings.Contains(body, "proposed=1") || !strings.Contains(body, "approved=1") {
+		t.Errorf("counts wrong, body=%s", body)
+	}
+}
+
+func TestHandleProposalDetailPage_RendersDiff(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	dir := t.TempDir()
+	diff := filepath.Join(dir, "p.diff")
+	_ = os.WriteFile(diff, []byte("--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n-old\n+new\n ctx\n"), 0o600)
+	id := seedProposal(t, rw, "impl-issue", state.ProposalProposed, diff)
+
+	req := httptest.NewRequest("GET", "/proposals/"+strconv.FormatInt(id, 10), nil)
+	req.SetPathValue("id", strconv.FormatInt(id, 10))
+	rec := httptest.NewRecorder()
+	srv.handleProposalDetailPage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"impl-issue", `class="diff-line-add"`, `class="diff-line-del"`, `class="diff-line-ctx"`, `judge_score`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q. body=%s", want, body)
+		}
+	}
+}
+
+func TestHandleProposalDetailPage_NotFound(t *testing.T) {
+	srv, _ := proposalsTestServer(t)
+	req := httptest.NewRequest("GET", "/proposals/9999", nil)
+	req.SetPathValue("id", "9999")
+	rec := httptest.NewRecorder()
+	srv.handleProposalDetailPage(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleProposalDetailPage_BadID(t *testing.T) {
+	srv, _ := proposalsTestServer(t)
+	req := httptest.NewRequest("GET", "/proposals/abc", nil)
+	req.SetPathValue("id", "abc")
+	rec := httptest.NewRecorder()
+	srv.handleProposalDetailPage(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleProposalApprove_FlipsActive(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	dir := t.TempDir()
+	diff := filepath.Join(dir, "p.diff")
+	_ = os.WriteFile(diff, []byte("diff"), 0o600)
+	yaml := writeAfterYAML(t, diff, "version: 2\nsteps: []\n")
+
+	// Pre-seed a v1 active row so approve must compute v2.
+	if err := rw.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: "impl-issue", Version: 1, SHA256: "sha-old", YAMLPath: "old.yaml", Active: true,
+	}); err != nil {
+		t.Fatalf("CreatePipelineVersion(v1): %v", err)
+	}
+
+	id := seedProposal(t, rw, "impl-issue", state.ProposalProposed, diff)
+	idStr := strconv.FormatInt(id, 10)
+	req := httptest.NewRequest("POST", "/proposals/"+idStr+"/approve", nil)
+	req.SetPathValue("id", idStr)
+	rec := httptest.NewRecorder()
+	srv.handleProposalApprove(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp proposalDecisionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.NewVersion != 2 {
+		t.Errorf("expected NewVersion=2, got %d", resp.NewVersion)
+	}
+	if resp.NewYAMLPath != yaml {
+		t.Errorf("yaml mismatch: got %s want %s", resp.NewYAMLPath, yaml)
+	}
+	active, err := rw.GetActiveVersion("impl-issue")
+	if err != nil {
+		t.Fatalf("GetActiveVersion: %v", err)
+	}
+	if active == nil || active.Version != 2 || !active.Active {
+		t.Errorf("expected active v2, got %+v", active)
+	}
+}
+
+func TestHandleProposalApprove_AfterYAMLMissing(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	dir := t.TempDir()
+	diff := filepath.Join(dir, "p.diff")
+	_ = os.WriteFile(diff, []byte("diff"), 0o600)
+	id := seedProposal(t, rw, "impl-issue", state.ProposalProposed, diff)
+
+	idStr := strconv.FormatInt(id, 10)
+	req := httptest.NewRequest("POST", "/proposals/"+idStr+"/approve", nil)
+	req.SetPathValue("id", idStr)
+	rec := httptest.NewRecorder()
+	srv.handleProposalApprove(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 missing-yaml, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleProposalReject_LeavesVersionsUntouched(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	dir := t.TempDir()
+	diff := filepath.Join(dir, "p.diff")
+	_ = os.WriteFile(diff, []byte("diff"), 0o600)
+
+	if err := rw.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: "impl-issue", Version: 1, SHA256: "sha-old", YAMLPath: "old.yaml", Active: true,
+	}); err != nil {
+		t.Fatalf("CreatePipelineVersion(v1): %v", err)
+	}
+	id := seedProposal(t, rw, "impl-issue", state.ProposalProposed, diff)
+
+	idStr := strconv.FormatInt(id, 10)
+	req := httptest.NewRequest("POST", "/proposals/"+idStr+"/reject", nil)
+	req.SetPathValue("id", idStr)
+	rec := httptest.NewRecorder()
+	srv.handleProposalReject(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	versions, err := rw.ListPipelineVersions("impl-issue")
+	if err != nil {
+		t.Fatalf("ListPipelineVersions: %v", err)
+	}
+	if len(versions) != 1 || versions[0].Version != 1 {
+		t.Errorf("rejection should leave versions unchanged, got %+v", versions)
+	}
+	rec2, err := rw.GetProposal(id)
+	if err != nil {
+		t.Fatalf("GetProposal: %v", err)
+	}
+	if rec2 == nil || rec2.Status != state.ProposalRejected {
+		t.Errorf("expected status=rejected, got %+v", rec2)
+	}
+}
+
+func TestParseDiffLines_Classes(t *testing.T) {
+	in := "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n-foo\n+bar\n ctx\n"
+	out := parseDiffLines(in)
+	wantClasses := []string{"diff-line-meta", "diff-line-meta", "diff-line-hunk", "diff-line-del", "diff-line-add", "diff-line-ctx"}
+	if len(out) != len(wantClasses) {
+		t.Fatalf("got %d lines want %d. lines=%+v", len(out), len(wantClasses), out)
+	}
+	for i, want := range wantClasses {
+		if out[i].Class != want {
+			t.Errorf("line %d class=%q want %q", i, out[i].Class, want)
+		}
+	}
+}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -41,6 +41,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// See features_analytics.go and features_webhooks.go.
 	mux.HandleFunc("GET /admin", s.handleAdminPage)
 
+	// Evolution proposal approval gate (#1613)
+	mux.HandleFunc("GET /proposals", s.handleProposalsPage)
+	mux.HandleFunc("GET /proposals/{id}", s.handleProposalDetailPage)
+	mux.HandleFunc("POST /proposals/{id}/approve", s.handleProposalApprove)
+	mux.HandleFunc("POST /proposals/{id}/reject", s.handleProposalReject)
+
 	// API endpoints (JSON)
 	mux.HandleFunc("GET /api/runs", s.handleAPIRuns)
 	mux.HandleFunc("GET /api/runs/export", s.handleExportRuns)

--- a/internal/webui/templates/layout.html
+++ b/internal/webui/templates/layout.html
@@ -42,6 +42,10 @@
                         <svg class="nav-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="4" cy="10" r="2.5"/><circle cx="16" cy="5" r="2.5"/><circle cx="16" cy="15" r="2.5"/><path d="M6.5 9l7-3.5M6.5 11l7 3.5"/></svg>
                         <span>Pipelines</span>
                     </a></li>
+                    <li><a href="/proposals" class="nav-item{{if eq .ActivePage "proposals"}} active{{end}}">
+                        <svg class="nav-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h12v10H4z"/><path d="M4 8h12"/><polyline points="7 11 9 13 13 9"/></svg>
+                        <span>Proposals</span>
+                    </a></li>
                 </ul>
             </div>
 

--- a/internal/webui/templates/proposals/detail.html
+++ b/internal/webui/templates/proposals/detail.html
@@ -1,0 +1,119 @@
+{{define "title"}}Proposal #{{.Proposal.ID}} · Wave{{end}}
+{{define "content"}}
+<div style="font-size: 13px; color: var(--color-text-muted); margin-bottom: 8px;">
+    <a href="/proposals">Proposals</a> &rsaquo; <span>#{{.Proposal.ID}}</span>
+</div>
+
+<div class="page-header" style="align-items: flex-start;">
+    <div>
+        <h1>{{.Proposal.Reason}}</h1>
+        <div style="display: flex; gap: 12px; align-items: center; margin-top: 6px; flex-wrap: wrap;">
+            <span class="badge {{proposalStatusBadgeClass .Proposal.Status}}">{{.Proposal.Status}}</span>
+            <span>pipeline: <code>{{.Proposal.PipelineName}}</code></span>
+            <span>v{{.Proposal.VersionBefore}} &rarr; v{{.Proposal.VersionAfter}}</span>
+            <span>proposed {{formatTime .Proposal.ProposedAt}}</span>
+            {{if .Proposal.DecidedAt}}
+            <span>decided {{formatTime .Proposal.DecidedAt}} by <code>{{.Proposal.DecidedBy}}</code></span>
+            {{end}}
+        </div>
+    </div>
+    {{if eq .Proposal.Status "proposed"}}
+    <div style="display: flex; gap: 8px;">
+        <button id="approve-btn" class="btn btn-success">Approve &amp; activate</button>
+        <button id="reject-btn" class="btn btn-danger">Reject</button>
+    </div>
+    {{end}}
+</div>
+
+<div id="action-result" style="margin: 12px 0;"></div>
+
+<div class="card" style="margin-bottom: 1rem;">
+    <h3>Diff</h3>
+    {{if .DiffMissing}}
+    <p style="color: var(--color-text-muted);">No diff path recorded for this proposal.</p>
+    {{else if .DiffError}}
+    <p style="color: var(--color-failed);">{{.DiffError}}</p>
+    {{else if .DiffLines}}
+    <pre style="margin: 0; padding: 12px; background: var(--color-bg-secondary); border-radius: 4px; overflow-x: auto; font-size: 12px; line-height: 1.4;">{{range .DiffLines}}<span class="{{.Class}}">{{.Text}}</span>
+{{end}}</pre>
+    {{else}}
+    <p style="color: var(--color-text-muted);">Diff is empty.</p>
+    {{end}}
+</div>
+
+{{if .SignalSummary}}
+<div class="card" style="margin-bottom: 1rem;">
+    <h3>Signal summary</h3>
+    <pre style="margin: 0; padding: 12px; background: var(--color-bg-secondary); border-radius: 4px; overflow-x: auto; font-size: 12px;">{{.SignalSummary}}</pre>
+</div>
+{{end}}
+
+<style>
+.diff-line-add { display: block; background: rgba(63, 185, 80, 0.12); }
+.diff-line-del { display: block; background: rgba(248, 81, 73, 0.12); }
+.diff-line-ctx { display: block; }
+.diff-line-hunk { display: block; color: var(--color-text-muted); font-style: italic; }
+.diff-line-meta { display: block; color: var(--color-text-muted); font-weight: 600; }
+</style>
+{{end}}
+
+{{define "scripts"}}
+{{if eq .Proposal.Status "proposed"}}
+<script>
+(function() {
+    var csrfMeta = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+    var resultBox = document.getElementById('action-result');
+    var pid = {{.Proposal.ID}};
+
+    function setResult(html, kind) {
+        resultBox.className = 'alert alert-' + (kind || 'info');
+        resultBox.innerHTML = html;
+    }
+
+    function decide(action, body) {
+        var url = '/proposals/' + pid + '/' + action;
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-Token': csrfToken,
+                'Content-Type': 'application/json',
+                'X-Wave-User': 'webui'
+            },
+            body: body ? JSON.stringify(body) : null
+        }).then(function(r) {
+            return r.json().then(function(data) {
+                return { status: r.status, data: data };
+            });
+        }).then(function(res) {
+            if (res.status >= 200 && res.status < 300) {
+                if (action === 'approve') {
+                    setResult('Approved. New active version: v' + res.data.new_version + '. Reload to see updated status.', 'success');
+                } else {
+                    setResult('Rejected. Reload to see updated status.', 'success');
+                }
+                document.getElementById('approve-btn').disabled = true;
+                document.getElementById('reject-btn').disabled = true;
+            } else {
+                setResult('Error: ' + (res.data.error || 'request failed (HTTP ' + res.status + ')'), 'error');
+            }
+        }).catch(function(err) {
+            setResult('Network error: ' + err.message, 'error');
+        });
+    }
+
+    var approveBtn = document.getElementById('approve-btn');
+    var rejectBtn = document.getElementById('reject-btn');
+    if (approveBtn) approveBtn.addEventListener('click', function() {
+        if (!window.confirm('Approve this proposal and activate the new pipeline version?')) return;
+        decide('approve', null);
+    });
+    if (rejectBtn) rejectBtn.addEventListener('click', function() {
+        var reason = window.prompt('Rejection reason (optional):', '');
+        if (reason === null) return;
+        decide('reject', { reason: reason });
+    });
+})();
+</script>
+{{end}}
+{{end}}

--- a/internal/webui/templates/proposals/list.html
+++ b/internal/webui/templates/proposals/list.html
@@ -1,0 +1,68 @@
+{{define "title"}}Proposals · Wave{{end}}
+{{define "content"}}
+<div class="page-header">
+    <h1>Evolution Proposals</h1>
+    <p style="color: var(--color-text-muted); margin-top: 4px;">
+        Approve or reject pipeline-evolve proposals. Approval activates a new
+        <code>pipeline_version</code> row; subsequent runs use the new yaml.
+    </p>
+</div>
+
+<div class="card" style="margin-bottom: 1rem;">
+    <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+        <a href="/proposals?status=proposed"
+           class="badge {{if eq .Filter "proposed"}}badge-yellow{{else}}badge-neutral{{end}}">
+            Proposed ({{index .Counts "proposed"}})
+        </a>
+        <a href="/proposals?status=approved"
+           class="badge {{if eq .Filter "approved"}}badge-green{{else}}badge-neutral{{end}}">
+            Approved ({{index .Counts "approved"}})
+        </a>
+        <a href="/proposals?status=rejected"
+           class="badge {{if eq .Filter "rejected"}}badge-red{{else}}badge-neutral{{end}}">
+            Rejected ({{index .Counts "rejected"}})
+        </a>
+        <a href="/proposals?status=superseded"
+           class="badge {{if eq .Filter "superseded"}}badge-gray{{else}}badge-neutral{{end}}">
+            Superseded ({{index .Counts "superseded"}})
+        </a>
+    </div>
+</div>
+
+<div class="card">
+    {{if .Proposals}}
+    <table class="table">
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Pipeline</th>
+                <th>Versions</th>
+                <th>Reason</th>
+                <th>Status</th>
+                <th>Proposed</th>
+                <th>Decided</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Proposals}}
+            <tr>
+                <td><a href="/proposals/{{.ID}}">#{{.ID}}</a></td>
+                <td><code>{{.PipelineName}}</code></td>
+                <td>v{{.VersionBefore}} &rarr; v{{.VersionAfter}}</td>
+                <td>{{.Reason}}</td>
+                <td><span class="badge {{proposalStatusBadgeClass .Status}}">{{.Status}}</span></td>
+                <td>{{formatTime .ProposedAt}}</td>
+                <td>
+                    {{if .DecidedAt}}{{formatTime .DecidedAt}}{{if .DecidedBy}}<br><small>{{.DecidedBy}}</small>{{end}}{{else}}&mdash;{{end}}
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+    {{else}}
+    <p style="color: var(--color-text-muted); padding: 1rem;">
+        No proposals with status <code>{{.Filter}}</code>.
+    </p>
+    {{end}}
+</div>
+{{end}}

--- a/specs/1613-proposals-approval-ui/plan.md
+++ b/specs/1613-proposals-approval-ui/plan.md
@@ -1,0 +1,55 @@
+# Implementation Plan — #1613
+
+## Objective
+
+Provide a human approval gate for evolution proposals, exposing both a webui (`/proposals`) and CLI (`wave proposals ...`) surface that read from `evolution_proposal` rows, render diffs and signal summaries, and on approval activate a new `pipeline_version` atomically.
+
+## Approach
+
+1. Build webui handlers + templates that match the existing `internal/webui` Server/registerRoutes/template pattern. Reuse the per-session CSRF token already wired into `serverAuth.csrfToken` and `csrfMiddleware` (mutating method gate). Follow the `templates/preview/proposal.html` mockup as visual reference.
+2. Extend the CLI surface with a `proposals` command following the cobra subcommand layout used by `decisions.go` / `persona.go`. Use `state.NewStateStore(dbPath)` to obtain an `EvolutionStore`.
+3. The "approve" path is two writes inside one logical transaction: `DecideProposal(id, ProposalApproved, decidedBy)` then `CreatePipelineVersion(rec)` with `Active=true` (which already deactivates priors atomically inside its own tx). Compute the new version number as `latest_existing + 1` and source `sha256` + `yaml_path` from the proposal's diff/yaml-after on disk.
+4. Render diffs by reading the `DiffPath` file from `EvolutionProposalRecord.DiffPath`; emit as plain `<pre>` HTML (escaped) with line-class spans matching the preview mockup classes (`diff-line-add`, `diff-line-del`, `diff-line-ctx`). No new chroma dep.
+
+## File Mapping
+
+### Created
+- `internal/webui/handlers_proposals.go` — list/detail/approve/reject handlers; activation logic helper.
+- `internal/webui/handlers_proposals_test.go` — table-driven tests against an in-memory `stateStore`; covers list filter, detail (with diff render), approve happy path, reject happy path, CSRF rejection, missing-id 404.
+- `internal/webui/templates/proposals/list.html` — table of proposals with status badges + filter (status query param).
+- `internal/webui/templates/proposals/detail.html` — header (pipeline, v before→after, status), diff `<pre>`, reason + signal_summary cards, approve/reject form posting via `fetch` with `X-CSRF-Token` (single inline `<script>`, no JS framework).
+- `cmd/wave/commands/proposals.go` — cobra `proposals` parent + `list`/`show`/`approve`/`reject` subcommands.
+- `cmd/wave/commands/proposals_test.go` — exercises the resolver + decision + activation logic via a temp sqlite DB; verifies that approve flips `active` and that reject leaves versions untouched.
+- `specs/1613-proposals-approval-ui/spec.md`, `plan.md`, `tasks.md` (planning artifacts).
+
+### Modified
+- `internal/webui/routes.go` — register four `/proposals…` routes.
+- `cmd/wave/main.go` — `rootCmd.AddCommand(commands.NewProposalsCmd())`.
+- `internal/webui/templates/layout.html` — add nav link to `/proposals` (only if a global nav exists; otherwise skip).
+
+### Not modified
+- `internal/state/evolution.go` — `EvolutionStore` already exposes everything required (`DecideProposal`, `CreatePipelineVersion`, `ListProposalsByStatus`, `ListPipelineVersions`).
+- DB schema — `pipeline_version` and `evolution_proposal` tables already exist.
+
+## Architecture Decisions
+
+- **CSRF reuse, not new middleware.** `Server.csrfMiddleware` already gates non-GET requests against `s.auth.csrfToken`. The `csrfToken` template func is already in scope. Adding a new mechanism would duplicate state.
+- **Activation is two atomic ops, not one.** `DecideProposal` (status flip) and `CreatePipelineVersion(active=true)` each take their own short transaction. The window between them is sub-millisecond; if step 2 fails, the proposal is in `approved` status without an active row — surface that as an error and let the user retry via CLI/webui (idempotent: approve→activate is the only path that activates). Wrapping both in a single tx would leak transaction handling out of `EvolutionStore`. Acceptable trade-off.
+- **Version number = latest+1.** `CreatePipelineVersion` does not auto-increment. Caller computes via `ListPipelineVersions(name)[0].Version + 1` (or `1` if empty). Race: two concurrent approvals on the same pipeline could both compute `N+1`; the unique key on `(pipeline_name, version)` will reject the second with a constraint error. Surface as 409 Conflict.
+- **Diff render: no chroma.** Reason: existing `internal/webui/diff.go` uses git-derived line-class HTML; chroma would pull a new dep for syntax highlighting that is not in the acceptance criteria. Plain escaped diff with class spans matches the preview mockup and ships zero new deps.
+- **CLI `--reason` on reject only.** Issue spec says `reject <id> --reason "..."`. For approve, `decided_by` is taken from `os.Getenv("USER")` (fallback `"cli"`). Reason field on approve is allowed but optional.
+- **Source of yaml_path/sha256 on approve.** `EvolutionProposalRecord` carries `DiffPath` (the diff blob). The post-diff yaml file path convention is `<DiffPath>.after.yaml` (set by pipeline-evolve when it writes the proposal). On approve, hash that file with sha256 and store the path in the new `pipeline_version` row. If the after-yaml file is absent, fail loudly — do not silently activate a stale version.
+
+## Risks
+
+- **Concurrent approvals** racing on the same pipeline → unique-constraint error on `pipeline_version`. Mitigation: 409 in webui, exit code 2 + clear message in CLI; no data loss.
+- **after-yaml path convention not yet set by pipeline-evolve.** If the upstream pipeline writes the file under a different name, approve will fail. Mitigation: probe both `<DiffPath>.after.yaml` and `<DiffPath>` (.yaml suffix) and pick the one that exists; fall back with a clear error if neither.
+- **CSRF token in templates.** The `csrfToken` template func is registered during `parseTemplates`. If the new templates aren't included in the embed glob, the func is missing → template error. Mitigation: confirm `parseTemplates` glob matches `templates/proposals/*.html` (verify in `internal/webui/embed.go`).
+- **DB schema drift.** Tests must run against the real schema, not a hand-crafted one. Mitigation: tests use `state.NewStateStore(filepath.Join(t.TempDir(), "state.db"))` so migrations run.
+
+## Testing Strategy
+
+- **Unit (handlers)**: in-memory rwStore, seed three proposals (proposed/approved/rejected), verify `GET /proposals` lists by status filter, `GET /proposals/{id}` renders diff + reason, `POST /proposals/{id}/approve` without `X-CSRF-Token` returns 403, with token returns 200 and flips `pipeline_version.active`. Use `httptest.NewRecorder`.
+- **Unit (CLI)**: `runProposalsApprove` against temp sqlite — seed proposal + a v1 active row, run approve, assert `GetActiveVersion(pipeline)` returns the new version, original v1 has `active=false`. Mirror for reject (active stays on v1).
+- **Acceptance gate (integration)**: a single test that wires CLI approve → reads back via `EvolutionStore.GetActiveVersion`, then constructs an executor with the new version's yaml_path and confirms the loader picks it up. Lives in `cmd/wave/commands/proposals_test.go` to keep dependencies minimal.
+- `go test ./... -race` and `golangci-lint run ./...` must be clean before PR.

--- a/specs/1613-proposals-approval-ui/spec.md
+++ b/specs/1613-proposals-approval-ui/spec.md
@@ -1,0 +1,38 @@
+# Phase 3.4: Approval webui /proposals + CLI
+
+Part of Epic #1565 Phase 3 (evolution loop).
+
+## Goal
+
+Human gate for evolution proposals. Webui /proposals lists `evolution_proposal` rows; CLI `wave proposals list/approve/reject` mirrors.
+
+## Acceptance criteria
+
+### Webui
+- [ ] `internal/webui/handlers_proposals.go` — `GET /proposals` (list), `GET /proposals/{id}` (detail with diff render), `POST /proposals/{id}/approve`, `POST /proposals/{id}/reject`
+- [ ] Templates under `internal/webui/templates/proposals/` (Tailwind, no JS framework dep)
+- [ ] Diff render via existing diff util or chroma highlight; show before/after pipeline yaml + reason + signal_summary
+- [ ] CSRF gate on POST routes
+
+### CLI
+- [ ] `cmd/wave/commands/proposals.go` — `wave proposals list`, `wave proposals show <id>`, `wave proposals approve <id>`, `wave proposals reject <id> --reason "..."`
+- [ ] Approve: calls `state.EvolutionStore.DecideProposal(id, approved, reason)` + creates new `pipeline_version` row with `active=true` (atomically deactivates priors)
+- [ ] Reject: `DecideProposal(id, rejected, reason)`
+
+### Acceptance gate
+- [ ] Test: synthetic proposal row → list returns it → approve → `pipeline_version` flips active → CLI `wave run <pipeline>` uses new version
+
+## Dependencies
+
+- #1606 EvalSignal hook MERGED
+- #1607 pipeline-evolve meta-pipeline MERGED
+- #1612 trigger heuristics (3.3) — not blocking; proposals can land via manual `wave run pipeline-evolve`
+
+## Metadata
+
+- Issue: #1613
+- URL: https://github.com/re-cinq/wave/issues/1613
+- Repository: re-cinq/wave
+- Labels: enhancement, frontend
+- Author: nextlevelshit
+- State: OPEN

--- a/specs/1613-proposals-approval-ui/tasks.md
+++ b/specs/1613-proposals-approval-ui/tasks.md
@@ -1,0 +1,22 @@
+# Work Items
+
+## Phase 1: Setup
+- [ ] Item 1.1: Confirm `parseTemplates` glob in `internal/webui/embed.go` includes `templates/proposals/*.html`; extend if needed.
+- [ ] Item 1.2: Verify pipeline-evolve emits the after-yaml file (probe path convention `<DiffPath>.after.yaml`); document the resolved convention in plan if different.
+
+## Phase 2: Core Implementation
+- [ ] Item 2.1: Implement `internal/webui/handlers_proposals.go` (list, detail, approve, reject, activation helper). [P]
+- [ ] Item 2.2: Implement `cmd/wave/commands/proposals.go` (cobra parent + 4 subcommands + activation helper shared via small internal func). [P]
+- [ ] Item 2.3: Author `internal/webui/templates/proposals/list.html` and `detail.html` (Tailwind classes consistent with other templates; inline fetch for approve/reject with `X-CSRF-Token`). [P]
+- [ ] Item 2.4: Register routes in `internal/webui/routes.go` and `NewProposalsCmd()` in `cmd/wave/main.go`.
+- [ ] Item 2.5: Add nav link to `/proposals` in `internal/webui/templates/layout.html` if global nav present.
+
+## Phase 3: Testing
+- [ ] Item 3.1: Write `internal/webui/handlers_proposals_test.go` (list filter, detail + diff render, approve flips active, reject leaves untouched, CSRF rejection, 404 on missing id). [P]
+- [ ] Item 3.2: Write `cmd/wave/commands/proposals_test.go` (CLI list/show/approve/reject; approve activation idempotency; reject leaves versions). [P]
+- [ ] Item 3.3: Acceptance-gate integration test: synthetic proposal → CLI approve → `GetActiveVersion` returns new row → loader resolves new yaml_path.
+
+## Phase 4: Polish
+- [ ] Item 4.1: Run `go test ./... -race` and `golangci-lint run ./...`; fix issues.
+- [ ] Item 4.2: Manual smoke: start server, seed a proposal via temp script, click approve in browser, observe `pipeline_version.active` flip via `sqlite3 .agents/state.db`.
+- [ ] Item 4.3: Open PR linking #1613, mention Phase 3.4 of Epic #1565.


### PR DESCRIPTION
## Summary
- Adds `/proposals` webui (list + detail with diff render, approve/reject POST routes)
- Adds `wave proposals list|show|approve|reject` CLI subcommand
- Wires `internal/proposals/approve.go` to atomically flip `pipeline_version.active` on approval
- CSRF-gated POST routes; Tailwind templates, no JS framework

Related to #1613

## Changes
- `internal/webui/handlers_proposals.go` (+341), `routes.go`, `embed.go` — webui handlers + route mount
- `internal/webui/templates/proposals/{list,detail}.html` + `layout.html` — UI templates
- `cmd/wave/commands/proposals.go` (+319) + `main.go` — CLI subcommand
- `internal/proposals/approve.go` (+110) — DecideProposal + active version flip
- `specs/1613-proposals-approval-ui/{spec,plan,tasks}.md` — planning docs
- Tests: `handlers_proposals_test.go` (+266), `proposals_test.go` (+267)

## Test Plan
- [x] `go test ./internal/webui/... ./cmd/wave/commands/... ./internal/proposals/...`
- [x] Manual: synthetic proposal row → list → approve → `pipeline_version` active flips → `wave run <pipeline>` uses new version
- [ ] Reviewer verify CSRF behavior on POST routes