### PR TITLE
feat(evolution): trigger heuristics for pipeline-evolve

### DIFF
--- a/cmd/wave/commands/run_stages.go
+++ b/cmd/wave/commands/run_stages.go
@@ -23,6 +23,7 @@ import (
 	"github.com/recinq/wave/internal/continuous"
 	"github.com/recinq/wave/internal/display"
 	"github.com/recinq/wave/internal/event"
+	"github.com/recinq/wave/internal/evolution"
 	"github.com/recinq/wave/internal/manifest"
 	"github.com/recinq/wave/internal/metrics"
 	"github.com/recinq/wave/internal/pipeline"
@@ -413,6 +414,18 @@ func assembleExecutorOptions(opts RunOptions, m *manifest.Manifest, store state.
 		relayMon = relay.NewRelayMonitor(relayCfg, compactionAdapter)
 	}
 
+	var evolutionTrigger pipeline.EvolutionTrigger
+	if evolStore, ok := store.(state.EvolutionStore); ok && evolStore != nil {
+		var override *manifest.EvolutionYAML
+		if m != nil {
+			override = m.Evolution
+		}
+		cfg := evolutionConfigFromManifest(override)
+		if cfg.Enabled {
+			evolutionTrigger = evolution.NewService(evolStore, cfg)
+		}
+	}
+
 	return runner.BuildExecutorOptions(runner.ExecutorBuildConfig{
 		RunID:            runID,
 		Manifest:         m,
@@ -428,8 +441,28 @@ func assembleExecutorOptions(opts RunOptions, m *manifest.Manifest, store state.
 		RelayMonitor:     relayMon,
 		SkillStore:       skillStore,
 		StepFilter:       stepFilter,
+		EvolutionTrigger: evolutionTrigger,
 		Debug:            debug,
 	})
+}
+
+// evolutionConfigFromManifest converts the manifest YAML override (which may
+// be nil) into an evolution.Config. Defaults apply when the override is nil
+// or sets the field to its zero value.
+func evolutionConfigFromManifest(o *manifest.EvolutionYAML) evolution.Config {
+	if o == nil {
+		return evolution.DefaultConfig()
+	}
+	overrides := evolution.YAMLOverrides{
+		Enabled:           o.Enabled,
+		EveryNWindow:      o.EveryNWindow,
+		EveryNJudgeDrop:   o.EveryNJudgeDrop,
+		DriftWindow:       o.DriftWindow,
+		DriftPassDrop:     o.DriftPassDrop,
+		RetryWindow:       o.RetryWindow,
+		RetryAvgThreshold: o.RetryAvgThreshold,
+	}
+	return overrides.Apply()
 }
 
 // runOnce executes the pipeline a single time. It transitions the run from

--- a/internal/evolution/config.go
+++ b/internal/evolution/config.go
@@ -1,0 +1,87 @@
+package evolution
+
+// Config holds the threshold parameters that govern Service.ShouldEvolve.
+// Zero values on any non-Enabled field fall back to the corresponding
+// DefaultConfig value, so a partially populated override (e.g. only
+// drift_pass_drop) keeps the unspecified fields sane.
+type Config struct {
+	Enabled           bool
+	EveryNWindow      int     // rows per half-window for the every-N median compare
+	EveryNJudgeDrop   float64 // min median judge_score drop to fire every-N
+	DriftWindow       int     // rows for contract_pass drift heuristic
+	DriftPassDrop     float64 // min absolute pass-rate drop to fire drift
+	RetryWindow       int     // rows for retry-rate heuristic
+	RetryAvgThreshold float64 // avg retry_count over RetryWindow to fire retry-rate
+}
+
+// DefaultConfig returns the compiled-in thresholds documented in the
+// acceptance criteria for issue #1612.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:           true,
+		EveryNWindow:      10,
+		EveryNJudgeDrop:   0.1,
+		DriftWindow:       20,
+		DriftPassDrop:     0.15,
+		RetryWindow:       10,
+		RetryAvgThreshold: 2.0,
+	}
+}
+
+// YAMLOverrides mirrors the wave.yaml `evolution:` block. Only the fields
+// the operator sets carry over; zero / unset numeric fields fall back to
+// DefaultConfig. Enabled defaults to true when nil.
+type YAMLOverrides struct {
+	Enabled           *bool
+	EveryNWindow      int
+	EveryNJudgeDrop   float64
+	DriftWindow       int
+	DriftPassDrop     float64
+	RetryWindow       int
+	RetryAvgThreshold float64
+}
+
+// Apply layers o on top of the defaults. A nil receiver returns DefaultConfig
+// untouched so callers can pass a *YAMLOverrides loaded from manifest without
+// nil-check boilerplate.
+func (o *YAMLOverrides) Apply() Config {
+	cfg := DefaultConfig()
+	if o == nil {
+		return cfg
+	}
+	if o.Enabled != nil {
+		cfg.Enabled = *o.Enabled
+	}
+	if o.EveryNWindow > 0 {
+		cfg.EveryNWindow = o.EveryNWindow
+	}
+	if o.EveryNJudgeDrop > 0 {
+		cfg.EveryNJudgeDrop = o.EveryNJudgeDrop
+	}
+	if o.DriftWindow > 0 {
+		cfg.DriftWindow = o.DriftWindow
+	}
+	if o.DriftPassDrop > 0 {
+		cfg.DriftPassDrop = o.DriftPassDrop
+	}
+	if o.RetryWindow > 0 {
+		cfg.RetryWindow = o.RetryWindow
+	}
+	if o.RetryAvgThreshold > 0 {
+		cfg.RetryAvgThreshold = o.RetryAvgThreshold
+	}
+	return cfg
+}
+
+// maxWindow is the largest row count any heuristic needs. Used to cap the
+// state-store query so hot pipelines do not scan unbounded history.
+func (c Config) maxWindow() int {
+	n := c.EveryNWindow * 2
+	if c.DriftWindow > n {
+		n = c.DriftWindow
+	}
+	if c.RetryWindow > n {
+		n = c.RetryWindow
+	}
+	return n
+}

--- a/internal/evolution/doc.go
+++ b/internal/evolution/doc.go
@@ -1,0 +1,22 @@
+// Package evolution implements the Phase 3.3 trigger surface that decides
+// when a pipeline accumulates enough degraded eval signal to merit a
+// pipeline-evolve run.
+//
+// The package owns Service.ShouldEvolve(pipelineName), which scores rows from
+// state.EvolutionStore.GetEvalsForPipeline against three configurable
+// heuristics (any-of):
+//
+//   - every-N: ≥every_n_window scored evals since last proposal AND median
+//     judge_score has dropped ≥every_n_judge_drop versus the prior window.
+//   - drift: contract_pass rate dropped >drift_pass_drop over the most
+//     recent drift_window evals.
+//   - retry-rate: avg retry_count >retry_avg_threshold over the most
+//     recent retry_window evals.
+//
+// Defaults are compiled-in and overrideable via the top-level evolution:
+// block on wave.yaml. Callers (the executor) feed the trigger advisory
+// emission in recordPipelineEval; firing emits an event with state
+// "evolution_proposed" but never blocks the run.
+//
+// Phase 3.3 of the evolution-loop epic (#1565); issue #1612.
+package evolution

--- a/internal/evolution/triggers.go
+++ b/internal/evolution/triggers.go
@@ -1,0 +1,224 @@
+package evolution
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// Store is the slim subset of state.EvolutionStore that Service needs.
+// Defining it here keeps the package importable from tests with a fake
+// store and avoids a hard coupling to the full aggregate interface.
+type Store interface {
+	GetEvalsForPipeline(pipelineName string, limit int) ([]state.PipelineEvalRecord, error)
+	LastProposalAt(pipelineName string) (time.Time, bool, error)
+}
+
+// Service decides whether a pipeline's accumulated eval rows merit a
+// pipeline-evolve run. It is created per-process by the CLI and reused
+// across pipeline runs.
+type Service struct {
+	store Store
+	cfg   Config
+}
+
+// NewService constructs a Service. A nil store yields a usable zero-value
+// service whose ShouldEvolve always returns (false, "", nil) — convenient
+// for tests and for environments where evolution telemetry is opt-out.
+func NewService(store Store, cfg Config) *Service {
+	return &Service{store: store, cfg: cfg}
+}
+
+// ShouldEvolve evaluates the three configured heuristics in order
+// (every-N → drift → retry) and returns on the first match. It returns
+// (false, "", nil) when no heuristic fires, when evolution is disabled,
+// or when the service has no store.
+//
+// Heuristic precedence is by definition order, not severity. Phase 3.4
+// will replace the first-match return with a richer SignalSummary.
+func (s *Service) ShouldEvolve(pipelineName string) (bool, string, error) {
+	if s == nil || s.store == nil {
+		return false, "", nil
+	}
+	if !s.cfg.Enabled {
+		return false, "", nil
+	}
+	if pipelineName == "" {
+		return false, "", nil
+	}
+
+	limit := s.cfg.maxWindow()
+	if limit <= 0 {
+		return false, "", nil
+	}
+
+	evals, err := s.store.GetEvalsForPipeline(pipelineName, limit)
+	if err != nil {
+		return false, "", fmt.Errorf("evolution: load evals for %s: %w", pipelineName, err)
+	}
+	if len(evals) == 0 {
+		return false, "", nil
+	}
+
+	lastProposal, _, err := s.store.LastProposalAt(pipelineName)
+	if err != nil {
+		return false, "", fmt.Errorf("evolution: last proposal for %s: %w", pipelineName, err)
+	}
+
+	if fire, reason := everyNJudgeDrop(evals, lastProposal, s.cfg); fire {
+		return true, reason, nil
+	}
+	if fire, reason := contractPassDrift(evals, s.cfg); fire {
+		return true, reason, nil
+	}
+	if fire, reason := retryRateSpike(evals, s.cfg); fire {
+		return true, reason, nil
+	}
+	return false, "", nil
+}
+
+// everyNJudgeDrop fires when at least 2*EveryNWindow scored evals exist since
+// the last proposal AND the median judge_score across the more-recent half
+// has dropped by ≥EveryNJudgeDrop versus the older half.
+//
+// evals is expected newest-first (the order returned by GetEvalsForPipeline).
+func everyNJudgeDrop(evals []state.PipelineEvalRecord, lastProposal time.Time, cfg Config) (bool, string) {
+	if cfg.EveryNWindow <= 0 || cfg.EveryNJudgeDrop <= 0 {
+		return false, ""
+	}
+
+	// Filter to scored rows recorded after the last proposal. Empty
+	// lastProposal → all scored rows count.
+	scored := make([]float64, 0, len(evals))
+	for _, e := range evals {
+		if e.JudgeScore == nil {
+			continue
+		}
+		if !lastProposal.IsZero() && !e.RecordedAt.After(lastProposal) {
+			continue
+		}
+		scored = append(scored, *e.JudgeScore)
+	}
+
+	need := cfg.EveryNWindow * 2
+	if len(scored) < need {
+		return false, ""
+	}
+
+	// scored is newest-first; the leading EveryNWindow rows are the recent
+	// window, the next EveryNWindow are the prior window.
+	recent := scored[:cfg.EveryNWindow]
+	prior := scored[cfg.EveryNWindow:need]
+
+	recentMed := medianFloats(recent)
+	priorMed := medianFloats(prior)
+	drop := priorMed - recentMed
+	if drop >= cfg.EveryNJudgeDrop {
+		return true, fmt.Sprintf(
+			"every-N: median judge_score dropped %.3f over %d evals (was %.3f, now %.3f)",
+			drop, cfg.EveryNWindow, priorMed, recentMed,
+		)
+	}
+	return false, ""
+}
+
+// contractPassDrift fires when the contract_pass rate over the most recent
+// DriftWindow rows has dropped by more than DriftPassDrop versus the prior
+// DriftWindow rows. Both halves require DriftWindow rows with a non-nil
+// ContractPass field; insufficient data → no fire.
+func contractPassDrift(evals []state.PipelineEvalRecord, cfg Config) (bool, string) {
+	if cfg.DriftWindow <= 0 || cfg.DriftPassDrop <= 0 {
+		return false, ""
+	}
+	w := cfg.DriftWindow
+	withPass := make([]state.PipelineEvalRecord, 0, len(evals))
+	for _, e := range evals {
+		if e.ContractPass != nil {
+			withPass = append(withPass, e)
+		}
+	}
+	if len(withPass) < 2*w {
+		return false, ""
+	}
+	recent := passRate(withPass[:w])
+	prior := passRate(withPass[w : 2*w])
+	drop := prior - recent
+	if drop > cfg.DriftPassDrop {
+		return true, fmt.Sprintf(
+			"drift: contract_pass rate dropped %.1f%% over %d evals (was %.1f%%, now %.1f%%)",
+			drop*100, w, prior*100, recent*100,
+		)
+	}
+	return false, ""
+}
+
+// retryRateSpike fires when the average retry_count over the most recent
+// RetryWindow rows exceeds RetryAvgThreshold. Rows without a retry_count
+// are treated as zero retries.
+func retryRateSpike(evals []state.PipelineEvalRecord, cfg Config) (bool, string) {
+	if cfg.RetryWindow <= 0 || cfg.RetryAvgThreshold <= 0 {
+		return false, ""
+	}
+	w := cfg.RetryWindow
+	if len(evals) < w {
+		return false, ""
+	}
+	avg := avgRetry(evals[:w])
+	if avg > cfg.RetryAvgThreshold {
+		return true, fmt.Sprintf(
+			"retry-rate: avg retry_count %.2f over %d evals exceeds %.2f",
+			avg, w, cfg.RetryAvgThreshold,
+		)
+	}
+	return false, ""
+}
+
+// medianFloats returns the median of a slice of float64 values. The input
+// is copied before sorting so the caller's order is preserved. Empty
+// input returns 0.
+func medianFloats(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	cp := make([]float64, len(xs))
+	copy(cp, xs)
+	sort.Float64s(cp)
+	mid := len(cp) / 2
+	if len(cp)%2 == 1 {
+		return cp[mid]
+	}
+	return (cp[mid-1] + cp[mid]) / 2
+}
+
+// passRate returns the fraction of rows where ContractPass is non-nil and
+// true. Rows with nil ContractPass are counted as failures — callers that
+// want a strict pass/total ratio should pre-filter, as contractPassDrift does.
+func passRate(rows []state.PipelineEvalRecord) float64 {
+	if len(rows) == 0 {
+		return 0
+	}
+	pass := 0
+	for _, r := range rows {
+		if r.ContractPass != nil && *r.ContractPass {
+			pass++
+		}
+	}
+	return float64(pass) / float64(len(rows))
+}
+
+// avgRetry returns the average retry_count across rows. Nil retry counts
+// count as 0.
+func avgRetry(rows []state.PipelineEvalRecord) float64 {
+	if len(rows) == 0 {
+		return 0
+	}
+	sum := 0
+	for _, r := range rows {
+		if r.RetryCount != nil {
+			sum += *r.RetryCount
+		}
+	}
+	return float64(sum) / float64(len(rows))
+}

--- a/internal/evolution/triggers_test.go
+++ b/internal/evolution/triggers_test.go
@@ -202,7 +202,9 @@ func TestContractPassDrift_FiresOnDrop(t *testing.T) {
 	for i := range prior {
 		prior[i] = row(now.Add(-time.Duration(20+i)*time.Second), nil, ptrBool(true), nil)
 	}
-	all := append(recent, prior...)
+	all := make([]state.PipelineEvalRecord, 0, len(recent)+len(prior))
+	all = append(all, recent...)
+	all = append(all, prior...)
 	svc := NewService(&fakeStore{evals: all}, cfg)
 	fire, reason, err := svc.ShouldEvolve("p")
 	if err != nil {

--- a/internal/evolution/triggers_test.go
+++ b/internal/evolution/triggers_test.go
@@ -1,0 +1,429 @@
+package evolution
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// fakeStore is a minimal Store implementation that returns the configured
+// rows verbatim. Tests assemble synthetic eval slices without touching
+// SQLite.
+type fakeStore struct {
+	evals        []state.PipelineEvalRecord
+	lastProposal time.Time
+	hasProposal  bool
+	getErr       error
+	proposalErr  error
+}
+
+func (f *fakeStore) GetEvalsForPipeline(_ string, _ int) ([]state.PipelineEvalRecord, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	out := make([]state.PipelineEvalRecord, len(f.evals))
+	copy(out, f.evals)
+	return out, nil
+}
+
+func (f *fakeStore) LastProposalAt(_ string) (time.Time, bool, error) {
+	if f.proposalErr != nil {
+		return time.Time{}, false, f.proposalErr
+	}
+	return f.lastProposal, f.hasProposal, nil
+}
+
+// row builds a PipelineEvalRecord with the supplied judge_score, contract_pass,
+// and retry_count. Use nil pointers to mark missing values. recordedAt is set
+// to the supplied offset; tests use this to put rows in newest-first order.
+func row(t time.Time, score *float64, pass *bool, retries *int) state.PipelineEvalRecord {
+	return state.PipelineEvalRecord{
+		PipelineName: "p",
+		RunID:        "r",
+		JudgeScore:   score,
+		ContractPass: pass,
+		RetryCount:   retries,
+		RecordedAt:   t,
+	}
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+func ptrBool(v bool) *bool         { return &v }
+func ptrInt(v int) *int            { return &v }
+
+// scoredRows returns n eval rows newest-first with the supplied judge score.
+// Each row is one second older than the previous so RecordedAt ordering is
+// stable.
+func scoredRows(n int, score float64, base time.Time) []state.PipelineEvalRecord {
+	out := make([]state.PipelineEvalRecord, n)
+	for i := 0; i < n; i++ {
+		out[i] = row(base.Add(-time.Duration(i)*time.Second), ptrFloat(score), nil, nil)
+	}
+	return out
+}
+
+func TestShouldEvolve_DisabledShortCircuits(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = false
+	svc := NewService(&fakeStore{evals: scoredRows(50, 0.1, time.Now())}, cfg)
+	fire, reason, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if fire || reason != "" {
+		t.Fatalf("disabled should not fire, got fire=%v reason=%q", fire, reason)
+	}
+}
+
+func TestShouldEvolve_NilStoreReturnsFalse(t *testing.T) {
+	svc := NewService(nil, DefaultConfig())
+	fire, _, err := svc.ShouldEvolve("p")
+	if err != nil || fire {
+		t.Fatalf("nil store should be a no-op, got fire=%v err=%v", fire, err)
+	}
+}
+
+func TestShouldEvolve_EmptyPipelineNameReturnsFalse(t *testing.T) {
+	svc := NewService(&fakeStore{}, DefaultConfig())
+	fire, _, err := svc.ShouldEvolve("")
+	if err != nil || fire {
+		t.Fatalf("empty name no-op, got fire=%v err=%v", fire, err)
+	}
+}
+
+func TestShouldEvolve_StoreErrorPropagates(t *testing.T) {
+	svc := NewService(&fakeStore{getErr: errors.New("db down")}, DefaultConfig())
+	_, _, err := svc.ShouldEvolve("p")
+	if err == nil {
+		t.Fatal("expected error from store")
+	}
+}
+
+func TestShouldEvolve_ProposalErrorPropagates(t *testing.T) {
+	svc := NewService(&fakeStore{
+		evals:       scoredRows(1, 0.5, time.Now()),
+		proposalErr: errors.New("boom"),
+	}, DefaultConfig())
+	_, _, err := svc.ShouldEvolve("p")
+	if err == nil {
+		t.Fatal("expected error from LastProposalAt")
+	}
+}
+
+// TestEveryNJudgeDrop_FiresOnMedianDrop seeds 10 recent low-score rows and
+// 10 prior high-score rows; median drop > 0.1 should fire.
+func TestEveryNJudgeDrop_FiresOnMedianDrop(t *testing.T) {
+	now := time.Now()
+	recent := scoredRows(10, 0.5, now)
+	prior := scoredRows(10, 0.9, now.Add(-20*time.Second))
+	all := append([]state.PipelineEvalRecord{}, recent...)
+	all = append(all, prior...)
+
+	svc := NewService(&fakeStore{evals: all}, DefaultConfig())
+	fire, reason, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !fire {
+		t.Fatalf("expected every-N to fire, reason=%q", reason)
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty reason")
+	}
+}
+
+// TestEveryNJudgeDrop_NoFireWhenStable seeds two stable windows; no drop →
+// no fire.
+func TestEveryNJudgeDrop_NoFireWhenStable(t *testing.T) {
+	now := time.Now()
+	all := append(scoredRows(10, 0.85, now), scoredRows(10, 0.85, now.Add(-20*time.Second))...)
+	svc := NewService(&fakeStore{evals: all}, DefaultConfig())
+	fire, _, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if fire {
+		t.Fatal("stable scores should not fire every-N")
+	}
+}
+
+// TestEveryNJudgeDrop_RespectsLastProposal seeds rows older than the last
+// proposal; they must be filtered out so the heuristic has insufficient
+// data and does not fire.
+func TestEveryNJudgeDrop_RespectsLastProposal(t *testing.T) {
+	base := time.Now()
+	recent := scoredRows(10, 0.5, base)
+	prior := scoredRows(10, 0.9, base.Add(-20*time.Second))
+	all := append([]state.PipelineEvalRecord{}, recent...)
+	all = append(all, prior...)
+	// Last proposal recorded "now" — so all 20 rows are at or before the
+	// proposal timestamp and must be filtered out.
+	svc := NewService(&fakeStore{
+		evals:        all,
+		lastProposal: base.Add(time.Second),
+		hasProposal:  true,
+	}, DefaultConfig())
+	fire, _, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if fire {
+		t.Fatal("every-N must filter rows recorded before last proposal")
+	}
+}
+
+// TestEveryNJudgeDrop_InsufficientData provides fewer than 2*window rows;
+// must not fire.
+func TestEveryNJudgeDrop_InsufficientData(t *testing.T) {
+	all := scoredRows(15, 0.4, time.Now()) // need 20
+	svc := NewService(&fakeStore{evals: all}, DefaultConfig())
+	fire, _, _ := svc.ShouldEvolve("p")
+	if fire {
+		t.Fatal("insufficient data must not fire every-N")
+	}
+}
+
+// TestContractPassDrift_FiresOnDrop seeds 20 recent failing rows and 20
+// prior passing rows; drift > 15% should fire.
+func TestContractPassDrift_FiresOnDrop(t *testing.T) {
+	cfg := DefaultConfig()
+	// Disable every-N so it can't pre-empt drift in the OR composition.
+	cfg.EveryNWindow = 0
+	cfg.RetryWindow = 0
+
+	now := time.Now()
+	recent := make([]state.PipelineEvalRecord, 20)
+	for i := range recent {
+		recent[i] = row(now.Add(-time.Duration(i)*time.Second), nil, ptrBool(false), nil)
+	}
+	prior := make([]state.PipelineEvalRecord, 20)
+	for i := range prior {
+		prior[i] = row(now.Add(-time.Duration(20+i)*time.Second), nil, ptrBool(true), nil)
+	}
+	all := append(recent, prior...)
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, reason, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !fire {
+		t.Fatalf("drift should fire, reason=%q", reason)
+	}
+}
+
+// TestContractPassDrift_NoFireWhenStable: equal pass rates → no drift.
+func TestContractPassDrift_NoFireWhenStable(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EveryNWindow = 0
+	cfg.RetryWindow = 0
+	now := time.Now()
+	all := make([]state.PipelineEvalRecord, 40)
+	for i := range all {
+		all[i] = row(now.Add(-time.Duration(i)*time.Second), nil, ptrBool(true), nil)
+	}
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, _, _ := svc.ShouldEvolve("p")
+	if fire {
+		t.Fatal("stable pass rate must not fire drift")
+	}
+}
+
+// TestContractPassDrift_InsufficientData: fewer than 2*DriftWindow rows with
+// non-nil ContractPass → no fire.
+func TestContractPassDrift_InsufficientData(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EveryNWindow = 0
+	cfg.RetryWindow = 0
+	now := time.Now()
+	all := make([]state.PipelineEvalRecord, 30) // need 40
+	for i := range all {
+		all[i] = row(now.Add(-time.Duration(i)*time.Second), nil, ptrBool(false), nil)
+	}
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, _, _ := svc.ShouldEvolve("p")
+	if fire {
+		t.Fatal("insufficient data must not fire drift")
+	}
+}
+
+// TestRetryRateSpike_Fires: avg retries = 3 over window of 10; threshold 2.0.
+func TestRetryRateSpike_Fires(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EveryNWindow = 0
+	cfg.DriftWindow = 0
+	now := time.Now()
+	all := make([]state.PipelineEvalRecord, 10)
+	for i := range all {
+		all[i] = row(now.Add(-time.Duration(i)*time.Second), nil, nil, ptrInt(3))
+	}
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, reason, err := svc.ShouldEvolve("p")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !fire {
+		t.Fatalf("retry-rate should fire, reason=%q", reason)
+	}
+}
+
+// TestRetryRateSpike_NoFireBelowThreshold: avg = 1.5 over window of 10.
+func TestRetryRateSpike_NoFireBelowThreshold(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EveryNWindow = 0
+	cfg.DriftWindow = 0
+	now := time.Now()
+	all := make([]state.PipelineEvalRecord, 10)
+	for i := range all {
+		retries := i % 4 // 0,1,2,3 cycles → avg 1.5
+		all[i] = row(now.Add(-time.Duration(i)*time.Second), nil, nil, ptrInt(retries))
+	}
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, _, _ := svc.ShouldEvolve("p")
+	if fire {
+		t.Fatal("avg below threshold must not fire retry-rate")
+	}
+}
+
+// TestRetryRateSpike_InsufficientData: fewer than RetryWindow rows.
+func TestRetryRateSpike_InsufficientData(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EveryNWindow = 0
+	cfg.DriftWindow = 0
+	all := make([]state.PipelineEvalRecord, 5)
+	now := time.Now()
+	for i := range all {
+		all[i] = row(now.Add(-time.Duration(i)*time.Second), nil, nil, ptrInt(10))
+	}
+	svc := NewService(&fakeStore{evals: all}, cfg)
+	fire, _, _ := svc.ShouldEvolve("p")
+	if fire {
+		t.Fatal("insufficient data must not fire retry-rate")
+	}
+}
+
+// TestComposition_EveryNTakesPrecedence: data triggers all three; first match
+// must be every-N because heuristics evaluate in defined order.
+//
+// Layout (newest → oldest):
+//
+//	rows 0..9   — recent window: low judge, contract fail, high retries.
+//	rows 10..19 — prior window:  high judge, contract pass, no retries.
+//	rows 20..39 — older drift/retry padding so contract-pass drift would
+//	              also fire on its own.
+func TestComposition_EveryNTakesPrecedence(t *testing.T) {
+	now := time.Now()
+	all := make([]state.PipelineEvalRecord, 0, 40)
+	// Recent every-N half: low judge.
+	for i := 0; i < 10; i++ {
+		all = append(all, row(
+			now.Add(-time.Duration(i)*time.Second),
+			ptrFloat(0.4),
+			ptrBool(false),
+			ptrInt(3),
+		))
+	}
+	// Prior every-N half: high judge.
+	for i := 0; i < 10; i++ {
+		all = append(all, row(
+			now.Add(-time.Duration(10+i)*time.Second),
+			ptrFloat(0.95),
+			ptrBool(false),
+			ptrInt(3),
+		))
+	}
+	// Older drift padding: passing contracts so drift sees a 100% prior rate.
+	for i := 0; i < 20; i++ {
+		all = append(all, row(
+			now.Add(-time.Duration(20+i)*time.Second),
+			ptrFloat(0.95),
+			ptrBool(true),
+			ptrInt(0),
+		))
+	}
+	svc := NewService(&fakeStore{evals: all}, DefaultConfig())
+	fire, reason, _ := svc.ShouldEvolve("p")
+	if !fire {
+		t.Fatal("composition should fire")
+	}
+	if len(reason) < 7 || reason[:7] != "every-N" {
+		t.Fatalf("expected every-N precedence, got %q", reason)
+	}
+}
+
+// TestCustomConfig_Override: tighten thresholds so a previously-non-firing
+// dataset now fires.
+func TestCustomConfig_Override(t *testing.T) {
+	now := time.Now()
+	all := append(scoredRows(10, 0.85, now), scoredRows(10, 0.90, now.Add(-20*time.Second))...)
+
+	// Default judge_drop = 0.1 → median moves only 0.05; no fire.
+	svc := NewService(&fakeStore{evals: all}, DefaultConfig())
+	if fire, _, _ := svc.ShouldEvolve("p"); fire {
+		t.Fatal("default config should not fire on 0.05 drop")
+	}
+
+	// Tighten threshold to 0.04 → now fires.
+	cfg := DefaultConfig()
+	cfg.EveryNJudgeDrop = 0.04
+	svc = NewService(&fakeStore{evals: all}, cfg)
+	if fire, _, _ := svc.ShouldEvolve("p"); !fire {
+		t.Fatal("tightened threshold should fire")
+	}
+}
+
+// TestYAMLOverridesApply confirms partial overrides retain defaults.
+func TestYAMLOverridesApply(t *testing.T) {
+	enabled := false
+	o := YAMLOverrides{
+		Enabled:           &enabled,
+		EveryNWindow:      5,
+		RetryAvgThreshold: 7,
+	}
+	cfg := o.Apply()
+	if cfg.Enabled {
+		t.Fatal("Enabled override ignored")
+	}
+	if cfg.EveryNWindow != 5 {
+		t.Fatalf("EveryNWindow = %d, want 5", cfg.EveryNWindow)
+	}
+	if cfg.RetryAvgThreshold != 7 {
+		t.Fatalf("RetryAvgThreshold = %v, want 7", cfg.RetryAvgThreshold)
+	}
+	if cfg.DriftWindow != DefaultConfig().DriftWindow {
+		t.Fatalf("unset DriftWindow not defaulted; got %d", cfg.DriftWindow)
+	}
+}
+
+// TestYAMLOverrides_NilApply returns DefaultConfig untouched.
+func TestYAMLOverrides_NilApply(t *testing.T) {
+	var o *YAMLOverrides
+	got := o.Apply()
+	want := DefaultConfig()
+	if got != want {
+		t.Fatalf("nil overrides changed defaults: %+v", got)
+	}
+}
+
+// TestMedianFloats covers even/odd lengths and stable input ordering.
+func TestMedianFloats(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []float64
+		want float64
+	}{
+		{"empty", nil, 0},
+		{"one", []float64{0.5}, 0.5},
+		{"odd", []float64{0.1, 0.3, 0.2}, 0.2},
+		{"even", []float64{0.4, 0.2, 0.6, 0.8}, 0.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := medianFloats(tc.in)
+			if got != tc.want {
+				t.Fatalf("medianFloats(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -41,9 +41,26 @@ type Manifest struct {
 	Skills     []string                 `yaml:"skills,omitempty"`
 	Hooks      []hooks.LifecycleHookDef `yaml:"hooks,omitempty"`
 	Runtime    Runtime                  `yaml:"runtime"`
+	Evolution  *EvolutionYAML           `yaml:"evolution,omitempty"`
 
 	// RootDir is the directory containing wave.yaml. Set by the loader.
 	RootDir string `yaml:"-"`
+}
+
+// EvolutionYAML is the operator-facing override for the Phase 3.3 trigger
+// thresholds. Field names mirror evolution.Config; zero values fall back to
+// the compiled-in defaults so partial overrides keep the rest sane.
+//
+// Conversion to evolution.Config happens at the executor wiring layer to
+// avoid an import cycle between manifest and evolution.
+type EvolutionYAML struct {
+	Enabled           *bool   `yaml:"enabled,omitempty"`
+	EveryNWindow      int     `yaml:"every_n_window,omitempty"`
+	EveryNJudgeDrop   float64 `yaml:"every_n_judge_drop,omitempty"`
+	DriftWindow       int     `yaml:"drift_window,omitempty"`
+	DriftPassDrop     float64 `yaml:"drift_pass_drop,omitempty"`
+	RetryWindow       int     `yaml:"retry_window,omitempty"`
+	RetryAvgThreshold float64 `yaml:"retry_avg_threshold,omitempty"`
 }
 
 type Metadata struct {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -117,6 +117,10 @@ type DefaultPipelineExecutor struct {
 	// recordPipelineEval into a state.PipelineEvalRecord at run finalize.
 	// See internal/pipeline/executor_eval.go (issue #1606).
 	evalCollectors map[string]*contract.SignalSet
+	// evolutionTrigger is consulted after RecordEval succeeds; when it
+	// fires, recordPipelineEval emits an "evolution_proposed" advisory
+	// event. Nil = trigger disabled. See executor_eval.go (issue #1612).
+	evolutionTrigger EvolutionTrigger
 }
 
 type ExecutorOption func(*DefaultPipelineExecutor)
@@ -271,6 +275,12 @@ func WithRegistry(r *adapter.AdapterRegistry) ExecutorOption {
 	return func(ex *DefaultPipelineExecutor) { ex.registry = r }
 }
 
+// WithEvolutionTrigger installs the Phase 3.3 trigger consulted after each
+// successful RecordEval. Nil leaves the trigger disabled (no emission).
+func WithEvolutionTrigger(t EvolutionTrigger) ExecutorOption {
+	return func(ex *DefaultPipelineExecutor) { ex.evolutionTrigger = t }
+}
+
 // workspaceRunIDFor returns the run ID used to compute step workspace paths.
 // When WithWorkspaceRunID has been set (resume), the override wins so the
 // resumed executor reads from the original run's workspace tree. Otherwise it
@@ -395,6 +405,7 @@ func (e *DefaultPipelineExecutor) NewChildExecutor() *DefaultPipelineExecutor {
 		gateHandler:            e.gateHandler,
 		retroGenerator:         e.retroGenerator,
 		evalCollectors:         make(map[string]*contract.SignalSet),
+		evolutionTrigger:       e.evolutionTrigger,
 	}
 	// Share parent security layer's collaborators so child sees identical
 	// path/sanitization config but with its own back-pointer.

--- a/internal/pipeline/executor_eval.go
+++ b/internal/pipeline/executor_eval.go
@@ -27,6 +27,17 @@ import (
 	"github.com/recinq/wave/internal/state"
 )
 
+// EvolutionTrigger decides whether a pipeline's accumulated eval rows merit
+// firing pipeline-evolve. Defined consumer-side so tests can stub the
+// executor's trigger field without depending on internal/evolution.
+//
+// ShouldEvolve is consulted from recordPipelineEval after RecordEval
+// succeeds. A true return causes an advisory "evolution_proposed" event
+// to be emitted; errors are logged as warnings and never fail the run.
+type EvolutionTrigger interface {
+	ShouldEvolve(pipelineName string) (bool, string, error)
+}
+
 // signalSetFor returns (creating if needed) the per-run SignalSet on the
 // executor. Safe for concurrent calls from parallel step goroutines.
 func (e *DefaultPipelineExecutor) signalSetFor(runID string) *contract.SignalSet {
@@ -148,7 +159,44 @@ func (e *DefaultPipelineExecutor) recordPipelineEval(execution *PipelineExecutio
 			State:      "warning",
 			Message:    fmt.Sprintf("eval signal: RecordEval failed: %v", err),
 		})
+		return
 	}
+
+	// Phase 3.3: consult the evolution trigger now that the row has landed.
+	// Best-effort — errors warn, never block finalize.
+	e.maybeEmitEvolutionProposed(runID, pipelineName)
+}
+
+// maybeEmitEvolutionProposed runs the configured EvolutionTrigger (if any)
+// and emits an advisory event when ShouldEvolve fires. Trigger errors emit
+// a warning but never bubble up. Nil trigger is a no-op.
+func (e *DefaultPipelineExecutor) maybeEmitEvolutionProposed(runID, pipelineName string) {
+	if e.evolutionTrigger == nil {
+		return
+	}
+	fire, reason, err := e.evolutionTrigger.ShouldEvolve(pipelineName)
+	if err != nil {
+		e.emit(event.Event{
+			Timestamp:  time.Now(),
+			PipelineID: runID,
+			State:      "warning",
+			Message:    fmt.Sprintf("evolution trigger: %v", err),
+		})
+		return
+	}
+	if !fire {
+		return
+	}
+	msg := pipelineName
+	if reason != "" {
+		msg = fmt.Sprintf("%s: %s", pipelineName, reason)
+	}
+	e.emit(event.Event{
+		Timestamp:  time.Now(),
+		PipelineID: runID,
+		State:      "evolution_proposed",
+		Message:    msg,
+	})
 }
 
 // isContractFailure reports whether err originates from the contract validator

--- a/internal/pipeline/executor_eval_test.go
+++ b/internal/pipeline/executor_eval_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/recinq/wave/internal/adapter/adaptertest"
 	"github.com/recinq/wave/internal/contract"
 	"github.com/recinq/wave/internal/state"
@@ -210,6 +212,162 @@ func TestPipelineEvalHook_StoreErrorIsNonFatal(t *testing.T) {
 	require.NoError(t, err, "RecordEval failure must not bubble up to pipeline result")
 
 	assert.GreaterOrEqual(t, store.calls, 1, "RecordEval should have been attempted")
+}
+
+// stubEvolutionTrigger is a deterministic EvolutionTrigger for testing
+// the executor emission path.
+type stubEvolutionTrigger struct {
+	fire   bool
+	reason string
+	err    error
+	calls  int
+}
+
+func (s *stubEvolutionTrigger) ShouldEvolve(_ string) (bool, string, error) {
+	s.calls++
+	return s.fire, s.reason, s.err
+}
+
+// TestEvolutionTrigger_FireEmitsEvent verifies recordPipelineEval emits
+// "evolution_proposed" with the trigger's reason in Message.
+func TestEvolutionTrigger_FireEmitsEvent(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	collector := testutil.NewEventCollector()
+	trigger := &stubEvolutionTrigger{fire: true, reason: "drift: -20%"}
+
+	mock := adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`))
+	executor := NewDefaultPipelineExecutor(mock,
+		WithStateStore(store),
+		WithEmitter(collector),
+		WithEvolutionTrigger(trigger),
+	)
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "evol-fire-test"},
+		Steps: []Step{
+			{ID: "step-a", Persona: "navigator", Exec: ExecConfig{Source: "A"}},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, executor.Execute(ctx, p, m, "in"))
+
+	assert.GreaterOrEqual(t, trigger.calls, 1, "trigger should be consulted")
+	assert.True(t, collector.HasEventWithState("evolution_proposed"),
+		"firing trigger should emit evolution_proposed event")
+
+	// Verify reason is carried in Message.
+	var found bool
+	for _, e := range collector.GetEvents() {
+		if e.State == "evolution_proposed" {
+			found = true
+			assert.Contains(t, e.Message, "evol-fire-test")
+			assert.Contains(t, e.Message, "drift: -20%")
+		}
+	}
+	require.True(t, found, "evolution_proposed event must exist")
+}
+
+// TestEvolutionTrigger_NoFireNoEvent: trigger returns (false, ...) →
+// no evolution_proposed event.
+func TestEvolutionTrigger_NoFireNoEvent(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	collector := testutil.NewEventCollector()
+	trigger := &stubEvolutionTrigger{fire: false}
+
+	mock := adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`))
+	executor := NewDefaultPipelineExecutor(mock,
+		WithStateStore(store),
+		WithEmitter(collector),
+		WithEvolutionTrigger(trigger),
+	)
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "evol-nofire-test"},
+		Steps: []Step{
+			{ID: "step-a", Persona: "navigator", Exec: ExecConfig{Source: "A"}},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, executor.Execute(ctx, p, m, "in"))
+
+	assert.GreaterOrEqual(t, trigger.calls, 1, "trigger should be consulted")
+	assert.False(t, collector.HasEventWithState("evolution_proposed"),
+		"non-firing trigger must not emit evolution_proposed")
+}
+
+// TestEvolutionTrigger_ErrorWarnsButDoesNotEmit: trigger returns error →
+// warning event, no evolution_proposed.
+func TestEvolutionTrigger_ErrorWarnsButDoesNotEmit(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	collector := testutil.NewEventCollector()
+	trigger := &stubEvolutionTrigger{err: errors.New("trigger boom")}
+
+	mock := adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`))
+	executor := NewDefaultPipelineExecutor(mock,
+		WithStateStore(store),
+		WithEmitter(collector),
+		WithEvolutionTrigger(trigger),
+	)
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "evol-err-test"},
+		Steps: []Step{
+			{ID: "step-a", Persona: "navigator", Exec: ExecConfig{Source: "A"}},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, executor.Execute(ctx, p, m, "in"))
+
+	assert.False(t, collector.HasEventWithState("evolution_proposed"),
+		"erroring trigger must not emit evolution_proposed")
+
+	// Confirm a warning carrying the error message was emitted.
+	var sawWarn bool
+	for _, e := range collector.GetEvents() {
+		if e.State == "warning" && strings.Contains(e.Message, "evolution trigger") {
+			sawWarn = true
+		}
+	}
+	assert.True(t, sawWarn, "trigger error should produce a warning event")
+}
+
+// TestEvolutionTrigger_NilNoPanic: nil trigger → no emission, no panic.
+func TestEvolutionTrigger_NilNoPanic(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	collector := testutil.NewEventCollector()
+
+	mock := adaptertest.NewMockAdapter(adaptertest.WithStdoutJSON(`{"status":"ok"}`))
+	executor := NewDefaultPipelineExecutor(mock,
+		WithStateStore(store),
+		WithEmitter(collector),
+		// no WithEvolutionTrigger
+	)
+
+	tmpDir := t.TempDir()
+	m := testutil.CreateTestManifest(tmpDir)
+	p := &Pipeline{
+		Metadata: PipelineMetadata{Name: "evol-nil-test"},
+		Steps: []Step{
+			{ID: "step-a", Persona: "navigator", Exec: ExecConfig{Source: "A"}},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, executor.Execute(ctx, p, m, "in"))
+
+	assert.False(t, collector.HasEventWithState("evolution_proposed"),
+		"nil trigger must not emit evolution_proposed")
 }
 
 // TestPipelineEvalHook_DuplicateInsertSwallowed verifies that resume safety:

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,10 +59,11 @@ type ExecutorBuildConfig struct {
 	MockOverride  bool
 
 	// CLI extras — webui leaves these nil.
-	RetroGenerator *retro.Generator
-	RelayMonitor   *relay.RelayMonitor
-	SkillStore     skill.Store
-	StepFilter     *pipeline.StepFilter
+	RetroGenerator   *retro.Generator
+	RelayMonitor     *relay.RelayMonitor
+	SkillStore       skill.Store
+	StepFilter       *pipeline.StepFilter
+	EvolutionTrigger pipeline.EvolutionTrigger
 
 	// Debug toggles WithDebug(true). LaunchInProcess hardcodes this; the CLI
 	// threads its --debug flag through.
@@ -167,6 +168,9 @@ func BuildExecutorOptions(cfg ExecutorBuildConfig) []pipeline.ExecutorOption {
 	}
 	if cfg.RelayMonitor != nil {
 		opts = append(opts, pipeline.WithRelayMonitor(cfg.RelayMonitor))
+	}
+	if cfg.EvolutionTrigger != nil {
+		opts = append(opts, pipeline.WithEvolutionTrigger(cfg.EvolutionTrigger))
 	}
 
 	return opts

--- a/internal/state/evolution.go
+++ b/internal/state/evolution.go
@@ -79,6 +79,7 @@ type EvolutionStore interface {
 	DecideProposal(id int64, status EvolutionProposalStatus, decidedBy string) error
 	GetProposal(id int64) (*EvolutionProposalRecord, error)
 	ListProposalsByStatus(status EvolutionProposalStatus, limit int) ([]EvolutionProposalRecord, error)
+	LastProposalAt(pipelineName string) (time.Time, bool, error)
 }
 
 // RecordEval inserts a row into pipeline_eval. The (pipeline_name, run_id)
@@ -389,6 +390,27 @@ func (s *stateStore) ListProposalsByStatus(status EvolutionProposalStatus, limit
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+// LastProposalAt returns the proposed_at timestamp of the most recent
+// evolution_proposal row for pipelineName, regardless of status. The bool
+// reports whether any row exists; on (false, nil) the time return is zero.
+// Phase 3.3 trigger heuristics use this to anchor "since last evolution"
+// windows.
+func (s *stateStore) LastProposalAt(pipelineName string) (time.Time, bool, error) {
+	var ts int64
+	row := s.db.QueryRow(
+		`SELECT proposed_at FROM evolution_proposal
+		 WHERE pipeline_name = ? ORDER BY proposed_at DESC LIMIT 1`,
+		pipelineName,
+	)
+	if err := row.Scan(&ts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, err
+	}
+	return time.Unix(ts, 0), true, nil
 }
 
 func scanProposal(row *sql.Row) (*EvolutionProposalRecord, error) {

--- a/internal/state/evolution_test.go
+++ b/internal/state/evolution_test.go
@@ -131,6 +131,56 @@ func TestProposal_CreateDecideList(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLastProposalAt_EmptyStore(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ts, ok, err := store.LastProposalAt("ghost")
+	require.NoError(t, err)
+	assert.False(t, ok, "no rows → ok=false")
+	assert.True(t, ts.IsZero(), "no rows → zero time")
+}
+
+func TestLastProposalAt_SingleProposal(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	want := time.Unix(time.Now().Unix(), 0) // truncate to second precision (column is int64 seconds)
+	_, err := store.CreateProposal(EvolutionProposalRecord{
+		PipelineName:  "p",
+		VersionBefore: 1,
+		VersionAfter:  2,
+		DiffPath:      "x",
+		Reason:        "y",
+		ProposedAt:    want,
+	})
+	require.NoError(t, err)
+	got, ok, err := store.LastProposalAt("p")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, want.Unix(), got.Unix())
+}
+
+func TestLastProposalAt_ReturnsMostRecent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	older := time.Unix(1_700_000_000, 0)
+	newer := time.Unix(1_700_000_500, 0)
+	for _, ts := range []time.Time{older, newer} {
+		_, err := store.CreateProposal(EvolutionProposalRecord{
+			PipelineName:  "p",
+			VersionBefore: 1,
+			VersionAfter:  2,
+			DiffPath:      "x",
+			Reason:        "y",
+			ProposedAt:    ts,
+		})
+		require.NoError(t, err)
+	}
+	got, ok, err := store.LastProposalAt("p")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, newer.Unix(), got.Unix())
+}
+
 func TestProposal_DecideRejectsProposedTransition(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/testutil/statestore.go
+++ b/internal/testutil/statestore.go
@@ -620,6 +620,9 @@ func (m *MockStateStore) GetProposal(_ int64) (*state.EvolutionProposalRecord, e
 func (m *MockStateStore) ListProposalsByStatus(_ state.EvolutionProposalStatus, _ int) ([]state.EvolutionProposalRecord, error) {
 	return nil, nil
 }
+func (m *MockStateStore) LastProposalAt(_ string) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
 
 // WorksourceStore stubs (epic #1565 PRE-5).
 func (m *MockStateStore) CreateBinding(_ state.WorksourceBindingRecord) (int64, error) {

--- a/internal/tui/pipeline_provider_test.go
+++ b/internal/tui/pipeline_provider_test.go
@@ -189,6 +189,9 @@ func (b baseStateStore) GetProposal(int64) (*state.EvolutionProposalRecord, erro
 func (b baseStateStore) ListProposalsByStatus(state.EvolutionProposalStatus, int) ([]state.EvolutionProposalRecord, error) {
 	return nil, nil
 }
+func (b baseStateStore) LastProposalAt(string) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}
 
 // WorksourceStore stubs (epic #1565 PRE-5).
 func (b baseStateStore) CreateBinding(state.WorksourceBindingRecord) (int64, error) { return 0, nil }

--- a/specs/1612-evolution-trigger-heuristics/plan.md
+++ b/specs/1612-evolution-trigger-heuristics/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan — #1612 Evolution Trigger Heuristics
+
+## 1. Objective
+
+Add `internal/evolution.ShouldEvolve(pipelineName)` that scores accumulated `pipeline_eval` rows against three heuristics (every-N judge drop, contract-pass drift, retry-rate spike) and emits an advisory `evolution_proposed` event from the post-run hook when any fires.
+
+## 2. Approach
+
+- New `internal/evolution` package owns the trigger logic and config.
+- Config struct lives in `internal/evolution` with sensible defaults; loaded from a new `evolution:` block on `manifest.Manifest` (top-level, parallel to `runtime:`/`hooks:`).
+- Trigger reads recent eval rows via existing `state.EvolutionStore.GetEvalsForPipeline`. To find "since last evolution" it needs a new accessor that returns the latest proposal timestamp for a pipeline → add `LastProposalAt(pipelineName) (time.Time, bool, error)` to `EvolutionStore`.
+- Wire into `recordPipelineEval` in `internal/pipeline/executor_eval.go` after the row is persisted: if trigger fires, emit `event.Event{State: "evolution_proposed", ...}`. Best-effort, never blocks finalize.
+- Tests use the existing in-process sqlite test store (see `internal/state` test helpers) to seed synthetic rows.
+
+## 3. File Mapping
+
+### Create
+
+- `internal/evolution/doc.go` — package doc explaining the trigger surface and Phase 3.3 scope.
+- `internal/evolution/config.go` — `Config` struct + `DefaultConfig()` + `Merge(yamlOverrides)` helpers.
+- `internal/evolution/triggers.go` — `Service` with `ShouldEvolve(pipelineName) (bool, reason string, err error)`; private heuristics `everyNJudgeDrop`, `contractPassDrift`, `retryRateSpike`; helpers `medianJudgeScore`, `passRate`, `avgRetry`.
+- `internal/evolution/triggers_test.go` — table-driven tests per heuristic + composition cases + insufficient-data cases + config override case.
+
+### Modify
+
+- `internal/manifest/types.go` — add `Evolution *EvolutionYAML \`yaml:"evolution,omitempty"\`` field on `Manifest`; mirror struct fields from `evolution.Config`.
+- `internal/state/evolution.go` — add `LastProposalAt(pipelineName) (time.Time, bool, error)` to `EvolutionStore` interface and `stateStore` impl.
+- `internal/pipeline/executor.go` — add `evolutionService *evolution.Service` field + `WithEvolutionService` option; thread through `New*` constructors.
+- `internal/pipeline/executor_eval.go` — after `RecordEval` succeeds, call `evolutionService.ShouldEvolve(pipelineName)`; on `(true, reason)` emit `event.Event{State: "evolution_proposed", PipelineID: runID, Message: fmt.Sprintf("%s: %s", pipelineName, reason)}`. Skip silently when service is nil.
+- `internal/pipeline/executor_eval_test.go` — add coverage for the emit path with a stub service that returns true/false.
+- `cmd/wave/...` (constructor wiring) — instantiate `evolution.NewService(store, cfg)` from loaded manifest and pass via `WithEvolutionService`.
+- `wave.yaml` — add commented `evolution:` block documenting defaults.
+
+### Delete
+
+None.
+
+## 4. Architecture Decisions
+
+1. **Package boundary**: `internal/evolution` depends on `internal/state` (EvolutionStore) and on its own `Config`. It does **not** import `internal/manifest` to avoid an import cycle with the executor wiring; instead `manifest.EvolutionYAML` is converted to `evolution.Config` at the call site.
+2. **Trigger interface**: `Service` is a small struct so it can be stubbed in executor tests via a narrow interface (`type Trigger interface { ShouldEvolve(string) (bool, string, error) }`). Define interface in `internal/pipeline` (consumer-side) per Go convention.
+3. **"Since last evolution" semantics**: defined as "evals with `recorded_at >` last `evolution_proposal.proposed_at` for this pipeline". When no prior proposal exists, the threshold falls back to time zero so all evals count.
+4. **Median judge_score window comparison**: split the most recent `2 * every_n_window` rows that have non-nil `JudgeScore` into two halves; compare medians. Insufficient data (< `2 * every_n_window` scored rows) → heuristic does not fire.
+5. **Drift / retry windows** are independent of "since last evolution" — they always look at the most recent N rows regardless of last proposal. This matches the issue language ("over last 20 evals", "over last 10 evals").
+6. **Best-effort emission**: trigger failure (`err != nil`) is logged via `e.emit` warning and never blocks finalize, mirroring the existing `RecordEval` failure handling.
+7. **No dedupe in this PR**: emitting `evolution_proposed` repeatedly across runs is acceptable for Phase 3.3. Phase 3.4 (UI / proposal queue) will own dedupe via the proposal lifecycle.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Median calc on unsorted data → wrong split | Use stable sort by `recorded_at DESC` (already returned by `GetEvalsForPipeline`); slice halves cleanly. |
+| Nil `JudgeScore` rows skew average | Filter nil before median / average; track scored-row count separately. |
+| Overfetch on hot pipelines | Cap query at `max(every_n_window*2, drift_window, retry_window)` rows. |
+| Config-cycle import (`manifest` ↔ `evolution`) | Conversion happens at executor wiring layer; neither package imports the other. |
+| Event spam after threshold met | Acceptable in Phase 3.3 (advisory only); dedupe in Phase 3.4. Document in commit + README. |
+| Tests flaky on time-based comparisons | Inject a `Clock` interface (or pass `time.Time` explicitly) into trigger so tests use fixed timestamps. |
+
+## 6. Testing Strategy
+
+### Unit (`internal/evolution/triggers_test.go`)
+
+- Table-driven cases: each of the three heuristics fires independently with synthetic rows.
+- Composition: two heuristics fire → reason concatenated; precedence is every-N > drift > retry for first-match reason text.
+- Insufficient data per heuristic returns `(false, "")`.
+- Config override path: custom thresholds applied → fires/doesn't fire as expected.
+- `enabled: false` short-circuits to `(false, "")`.
+
+### Unit (`internal/state/evolution_test.go`)
+
+- New `LastProposalAt`: empty store → `(zero, false, nil)`; one proposal → returns its `proposed_at`; multiple → returns most recent.
+
+### Integration (`internal/pipeline/executor_eval_test.go`)
+
+- Stub `Trigger` returns `(true, "drift")` → `recordPipelineEval` emits an `evolution_proposed` event with the reason in `Message`.
+- Stub returns `(false, "")` → no advisory event emitted.
+- Stub returns error → warning event emitted, no `evolution_proposed`.
+- Nil service → no panic, no emission.
+
+### Race
+
+- `go test -race ./internal/evolution/... ./internal/pipeline/... ./internal/state/...`
+
+## 7. Wave.yaml schema
+
+```yaml
+evolution:
+  enabled: true            # master switch (default true)
+  every_n_window: 10       # rows per half-window for judge-score median compare
+  every_n_judge_drop: 0.1  # min median drop to fire every-N
+  drift_window: 20         # rows for contract_pass drift
+  drift_pass_drop: 0.15    # min absolute pass-rate drop to fire drift
+  retry_window: 10         # rows for retry-rate
+  retry_avg_threshold: 2.0 # avg retry_count over window to fire retry-rate
+```

--- a/specs/1612-evolution-trigger-heuristics/spec.md
+++ b/specs/1612-evolution-trigger-heuristics/spec.md
@@ -1,0 +1,49 @@
+# Phase 3.3: Evolution trigger heuristics (every-N + drift + retry-rate)
+
+**Issue:** [#1612](https://github.com/re-cinq/wave/issues/1612)
+**Repository:** re-cinq/wave
+**Labels:** enhancement, pipeline
+**State:** OPEN
+**Author:** nextlevelshit
+
+## Body
+
+Part of Epic #1565 Phase 3 (evolution loop).
+
+## Goal
+
+Implement `EvolutionService.ShouldEvolve(pipelineName)` deciding when to fire `pipeline-evolve` based on accumulated `pipeline_eval` rows.
+
+## Acceptance criteria
+
+- [ ] `internal/evolution/triggers.go` — `ShouldEvolve(name) (bool, reason)`
+- [ ] Heuristics (any-of):
+  - **every-N**: ≥10 evals since last evolution AND median judge_score has dropped ≥0.1 vs prior window
+  - **drift**: contract_pass rate dropped >15% over last 20 evals
+  - **retry-rate**: avg retry_count >2.0 over last 10 evals
+- [ ] Threshold values configurable via wave.yaml `evolution:` block (defaults baked)
+- [ ] Test: synthetic eval rows → each heuristic fires + composes correctly
+- [ ] Wired into post-run hook (#1606) — emit advisory event `evolution_proposed` when trigger fires
+
+## Dependencies
+
+- #1606 EvalSignal hook MERGED
+- #1607 pipeline-evolve meta-pipeline MERGED
+
+## Non-goals
+
+- Auto-rollback (deferred F3)
+- UI surface for proposals (Phase 3.4)
+
+## Acceptance Criteria (extracted)
+
+1. New file `internal/evolution/triggers.go` exposes `ShouldEvolve(name) (bool, reason)`.
+2. Three heuristics evaluated as OR composition.
+3. Thresholds configurable via wave.yaml `evolution:` block; defaults compiled-in.
+4. Unit tests exercise each heuristic and combinations against synthetic eval rows.
+5. Post-run hook emits an advisory event with state `evolution_proposed` when trigger fires.
+
+## Open clarifications (from assessment, decided in plan)
+
+- **wave.yaml schema**: top-level `evolution:` block, fields named `every_n_window`, `every_n_judge_drop`, `drift_window`, `drift_pass_drop`, `retry_window`, `retry_avg_threshold`, `enabled`.
+- **Event payload**: reuse `event.Event` with `State: "evolution_proposed"`, `PipelineID: runID`, `Message: "<reason>"`, plus pipeline name carried in Message.

--- a/specs/1612-evolution-trigger-heuristics/tasks.md
+++ b/specs/1612-evolution-trigger-heuristics/tasks.md
@@ -1,0 +1,31 @@
+# Work Items — #1612
+
+## Phase 1: Setup
+- [X] 1.1 Create `internal/evolution/` directory with `doc.go` package comment
+- [X] 1.2 Add `EvolutionYAML` struct on `manifest.Manifest` (`yaml:"evolution,omitempty"`)
+- [X] 1.3 Extend `state.EvolutionStore` interface with `LastProposalAt(name) (time.Time, bool, error)` and implement on `stateStore`
+
+## Phase 2: Core Implementation
+- [X] 2.1 `internal/evolution/config.go`: `Config` struct, `DefaultConfig()`, `YAMLOverrides.Apply()` converter
+- [X] 2.2 `internal/evolution/triggers.go`: `Service` struct + `NewService(store, cfg)` + `ShouldEvolve(name)` orchestrator
+- [X] 2.3 `internal/evolution/triggers.go`: heuristic helpers `everyNJudgeDrop`, `contractPassDrift`, `retryRateSpike`
+- [X] 2.4 `internal/evolution/triggers.go`: stat helpers `medianFloats`, `passRate`, `avgRetry`
+- [X] 2.5 Define consumer-side `EvolutionTrigger` interface in `internal/pipeline/executor_eval.go`
+- [X] 2.6 Add `evolutionTrigger EvolutionTrigger` field + `WithEvolutionTrigger` option on `DefaultPipelineExecutor`
+- [X] 2.7 Wire trigger call into `recordPipelineEval` after successful `RecordEval`; emit `evolution_proposed` event
+- [X] 2.8 Construct `evolution.Service` from manifest in `cmd/wave` startup and pass via option
+
+## Phase 3: Testing
+- [X] 3.1 `internal/evolution/triggers_test.go`: every-N fires + below threshold no-fire
+- [X] 3.2 `internal/evolution/triggers_test.go`: drift fires + below threshold no-fire
+- [X] 3.3 `internal/evolution/triggers_test.go`: retry-rate fires + below threshold no-fire
+- [X] 3.4 `internal/evolution/triggers_test.go`: composition (multi-fire), insufficient-data, disabled, custom-config cases
+- [X] 3.5 `internal/state/evolution_test.go`: `LastProposalAt` empty / single / multi cases
+- [X] 3.6 `internal/pipeline/executor_eval_test.go`: stub trigger emit / no-emit / error / nil-service paths
+- [X] 3.7 `go test -race ./internal/evolution/... ./internal/pipeline/... ./internal/state/...`
+
+## Phase 4: Polish
+- [X] 4.1 Add commented `evolution:` block to `wave.yaml` (no `internal/defaults/embedfs/wave.yaml` present)
+- [X] 4.2 Lint / vet clean
+- [ ] 4.3 (deferred) Update `docs/scope/onboarding-as-session-plan.md` Phase 3 row 3.3 — out of scope for this PR
+- [ ] 4.4 (deferred) Final manual run with synthetic eval rows — covered by integration tests

--- a/wave.yaml
+++ b/wave.yaml
@@ -454,3 +454,12 @@ runtime:
         warn_at: 25.0
     routing:
         auto_route: true
+# Evolution trigger thresholds (Phase 3.3 / issue #1612). Defaults shown — uncomment to override.
+# evolution:
+#     enabled: true              # master switch (default: true)
+#     every_n_window: 10         # rows per half-window for judge-score median compare
+#     every_n_judge_drop: 0.1    # min median judge_score drop to fire every-N
+#     drift_window: 20           # rows for contract_pass drift heuristic
+#     drift_pass_drop: 0.15      # min absolute pass-rate drop to fire drift
+#     retry_window: 10           # rows for retry-rate heuristic
+#     retry_avg_threshold: 2.0   # avg retry_count over retry_window to fire retry-rate


### PR DESCRIPTION
## Summary
- New `EvolutionService.ShouldEvolve(pipelineName)` decides when accumulated `pipeline_eval` rows warrant firing `pipeline-evolve`
- Three heuristics evaluated as OR: every-N (median judge_score drop), drift (contract_pass drop), retry (avg retry_count)
- Thresholds configurable via `wave.yaml` `evolution:` block with baked defaults
- Wired into post-run hook (#1606) — emits advisory `evolution_proposed` event when trigger fires; best-effort, trigger errors warn but never block finalize
- Adds `LastProposalAt(name)` to `EvolutionStore` to anchor the every-N "since last evolution" window

Related to #1612

## Changes
- `internal/evolution/triggers.go` — `ShouldEvolve` + heuristic logic
- `internal/evolution/config.go` — config plumbing with defaults
- `internal/evolution/triggers_test.go` — synthetic eval rows verifying each heuristic + composition
- `internal/pipeline/executor_eval.go` — post-run hook integration emitting `evolution_proposed`
- `internal/state/evolution.go` — `LastProposalAt` accessor
- `internal/manifest/types.go` + `wave.yaml` — `evolution:` config block
- `cmd/wave/commands/run_stages.go`, `internal/runner/options.go` — service wiring
- `specs/1612-evolution-trigger-heuristics/` — spec, plan, tasks

## Test Plan
- `go test ./internal/evolution/... ./internal/pipeline/... ./internal/state/...` — synthetic eval rows verify each heuristic fires independently and composes correctly
- New tests: `triggers_test.go` (429 lines), `executor_eval_test.go` (158 lines), `evolution_test.go` extension