### PR TITLE
feat(contract): test_diff guard against test-deletion (#1583)

### DIFF
--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -57,6 +57,9 @@ type ContractConfig struct {
 	Exclude  []string `json:"exclude,omitempty"    yaml:"exclude,omitempty"`   // Glob patterns for files to exclude
 	MinFiles int      `json:"min_files,omitempty"  yaml:"min_files,omitempty"` // Minimum number of qualifying changed files required (default 1)
 
+	// test_diff contract fields — guards against persona deleting tests to satisfy "tests pass" gate.
+	MaxTestDeletions int `json:"max_test_deletions,omitempty" yaml:"max_test_deletions,omitempty"` // Max net `func Test*` deletions allowed (default 0)
+
 	// event_contains contract fields — validated by executor (needs event store access)
 	Events []EventPattern `json:"events,omitempty" yaml:"events,omitempty"` // Expected event patterns to match against the step's event log
 
@@ -122,6 +125,8 @@ func NewValidator(cfg ContractConfig) ContractValidator {
 		return &llmJudgeValidator{}
 	case "source_diff":
 		return &sourceDiffValidator{}
+	case "test_diff":
+		return &testDiffValidator{}
 	case "agent_review":
 		// agent_review requires an adapter runner — NewValidator returns nil.
 		// The executor uses ValidateWithRunner() instead for this type.

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -58,7 +58,10 @@ type ContractConfig struct {
 	MinFiles int      `json:"min_files,omitempty"  yaml:"min_files,omitempty"` // Minimum number of qualifying changed files required (default 1)
 
 	// test_diff contract fields — guards against persona deleting tests to satisfy "tests pass" gate.
-	MaxTestDeletions int `json:"max_test_deletions,omitempty" yaml:"max_test_deletions,omitempty"` // Max net `func Test*` deletions allowed (default 0)
+	// Language-agnostic: TestFilePattern + TestFuncPattern are configurable per project.
+	MaxTestDeletions int      `json:"max_test_deletions,omitempty" yaml:"max_test_deletions,omitempty"` // Max net test-fn deletions allowed (default 0)
+	TestFilePattern  []string `json:"test_file_pattern,omitempty"  yaml:"test_file_pattern,omitempty"`  // Pathspecs (e.g. ["*_test.go"], ["**/test_*.py"], ["**/*.test.ts"])
+	TestFuncPattern  string   `json:"test_func_pattern,omitempty"  yaml:"test_func_pattern,omitempty"`  // Regex matching one test declaration per line
 
 	// event_contains contract fields — validated by executor (needs event store access)
 	Events []EventPattern `json:"events,omitempty" yaml:"events,omitempty"` // Expected event patterns to match against the step's event log

--- a/internal/contract/test_diff.go
+++ b/internal/contract/test_diff.go
@@ -1,0 +1,68 @@
+package contract
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// testDiffValidator enforces a ceiling on net test-function deletions in the
+// current diff. Catches the "satisfy tests-pass gate by deleting failing
+// test" failure mode (real-world hit during epic #1565 phase 1.5a where a
+// persona removed a passing-by-design test instead of correcting its
+// build-tag scope).
+//
+// Operates on the unified diff of `*_test.go` files between HEAD and the
+// working tree. Net deletions = (count of `^-func Test*` lines) -
+// (count of `^+func Test*` lines). When the result exceeds MaxTestDeletions
+// the contract fails. Renames (one removed + one added) net to zero, so
+// legitimate refactors pass.
+type testDiffValidator struct{}
+
+// testFuncLineRe matches lines that introduce a top-level `func Test*` in
+// either a + or - diff line. Tabs/spaces accepted before `func`.
+var testFuncLineRe = regexp.MustCompile(`^[ \t]*func[ \t]+(Test|Example|Benchmark|Fuzz)[A-Za-z0-9_]*\b`)
+
+func (v *testDiffValidator) Validate(cfg ContractConfig, workspacePath string) error {
+	max := cfg.MaxTestDeletions
+	// max defaults to 0 — any net deletion is rejected unless the pipeline
+	// yaml opts in to a higher tolerance.
+
+	cmd := exec.Command("git", "diff", "HEAD", "--", "*_test.go")
+	cmd.Dir = workspacePath
+	out, err := cmd.Output()
+	if err != nil {
+		// No HEAD (initial commit) or git not present — skip silently.
+		// The companion source_diff contract will surface that anomaly.
+		return nil
+	}
+
+	added, removed := 0, 0
+	for _, line := range strings.Split(string(out), "\n") {
+		// diff metadata lines (`+++`, `---`, `@@`) start with the same
+		// characters but include text after the marker that doesn't match
+		// our regex, so they are filtered naturally by the regex below.
+		switch {
+		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+			continue
+		case strings.HasPrefix(line, "+"):
+			if testFuncLineRe.MatchString(line[1:]) {
+				added++
+			}
+		case strings.HasPrefix(line, "-"):
+			if testFuncLineRe.MatchString(line[1:]) {
+				removed++
+			}
+		}
+	}
+
+	net := removed - added
+	if net > max {
+		return fmt.Errorf("test_diff: net %d test function(s) removed (max allowed %d) — "+
+			"removed=%d added=%d. Persona must replace deleted tests, not net-delete them. "+
+			"Common cause: build-tag scoping issue mistaken for a broken test.",
+			net, max, removed, added)
+	}
+	return nil
+}

--- a/internal/contract/test_diff.go
+++ b/internal/contract/test_diff.go
@@ -7,51 +7,65 @@ import (
 	"strings"
 )
 
-// testDiffValidator enforces a ceiling on net test-function deletions in the
-// current diff. Catches the "satisfy tests-pass gate by deleting failing
-// test" failure mode (real-world hit during epic #1565 phase 1.5a where a
-// persona removed a passing-by-design test instead of correcting its
-// build-tag scope).
+// testDiffValidator enforces a ceiling on net test-function deletions in
+// the current diff. Catches the "satisfy tests-pass gate by deleting
+// failing test" failure mode (real-world hit during epic #1565 phase
+// 1.5a where a persona removed a passing-by-design test instead of
+// correcting its build-tag scope).
 //
-// Operates on the unified diff of `*_test.go` files between HEAD and the
-// working tree. Net deletions = (count of `^-func Test*` lines) -
-// (count of `^+func Test*` lines). When the result exceeds MaxTestDeletions
-// the contract fails. Renames (one removed + one added) net to zero, so
-// legitimate refactors pass.
+// Language-agnostic: callers configure TestFilePattern (pathspecs handed
+// to `git diff -- ...`) and TestFuncPattern (regex matching one test
+// declaration per line). Defaults match Go (`*_test.go`,
+// `^[ \t]*func[ \t]+(Test|Example|Benchmark|Fuzz)\w*\b`) for back-compat
+// and out-of-the-box use; project pipelines override per ecosystem.
+//
+// Net deletions = (count of `-` test-decl lines) - (count of `+` test-decl
+// lines). Renames (one removed + one added) net to zero. When the result
+// exceeds MaxTestDeletions the contract fails.
 type testDiffValidator struct{}
 
-// testFuncLineRe matches lines that introduce a top-level `func Test*` in
-// either a + or - diff line. Tabs/spaces accepted before `func`.
-var testFuncLineRe = regexp.MustCompile(`^[ \t]*func[ \t]+(Test|Example|Benchmark|Fuzz)[A-Za-z0-9_]*\b`)
+const (
+	defaultTestFilePathspec = "*_test.go"
+	defaultTestFuncPattern  = `^[ \t]*func[ \t]+(Test|Example|Benchmark|Fuzz)[A-Za-z0-9_]*\b`
+)
 
 func (v *testDiffValidator) Validate(cfg ContractConfig, workspacePath string) error {
 	max := cfg.MaxTestDeletions
-	// max defaults to 0 — any net deletion is rejected unless the pipeline
-	// yaml opts in to a higher tolerance.
 
-	cmd := exec.Command("git", "diff", "HEAD", "--", "*_test.go")
+	pathspecs := cfg.TestFilePattern
+	if len(pathspecs) == 0 {
+		pathspecs = []string{defaultTestFilePathspec}
+	}
+	patternStr := cfg.TestFuncPattern
+	if patternStr == "" {
+		patternStr = defaultTestFuncPattern
+	}
+	re, err := regexp.Compile(patternStr)
+	if err != nil {
+		return fmt.Errorf("test_diff: invalid TestFuncPattern %q: %w", patternStr, err)
+	}
+
+	args := append([]string{"diff", "HEAD", "--"}, pathspecs...)
+	cmd := exec.Command("git", args...)
 	cmd.Dir = workspacePath
 	out, err := cmd.Output()
 	if err != nil {
 		// No HEAD (initial commit) or git not present — skip silently.
-		// The companion source_diff contract will surface that anomaly.
+		// The companion source_diff contract surfaces that anomaly.
 		return nil
 	}
 
 	added, removed := 0, 0
 	for _, line := range strings.Split(string(out), "\n") {
-		// diff metadata lines (`+++`, `---`, `@@`) start with the same
-		// characters but include text after the marker that doesn't match
-		// our regex, so they are filtered naturally by the regex below.
 		switch {
 		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
 			continue
 		case strings.HasPrefix(line, "+"):
-			if testFuncLineRe.MatchString(line[1:]) {
+			if re.MatchString(line[1:]) {
 				added++
 			}
 		case strings.HasPrefix(line, "-"):
-			if testFuncLineRe.MatchString(line[1:]) {
+			if re.MatchString(line[1:]) {
 				removed++
 			}
 		}
@@ -59,9 +73,8 @@ func (v *testDiffValidator) Validate(cfg ContractConfig, workspacePath string) e
 
 	net := removed - added
 	if net > max {
-		return fmt.Errorf("test_diff: net %d test function(s) removed (max allowed %d) — "+
-			"removed=%d added=%d. Persona must replace deleted tests, not net-delete them. "+
-			"Common cause: build-tag scoping issue mistaken for a broken test.",
+		return fmt.Errorf("test_diff: net %d test declaration(s) removed (max allowed %d) — "+
+			"removed=%d added=%d. Persona must replace deleted tests, not net-delete them.",
 			net, max, removed, added)
 	}
 	return nil

--- a/internal/contract/test_diff.go
+++ b/internal/contract/test_diff.go
@@ -73,8 +73,7 @@ func (v *testDiffValidator) Validate(cfg ContractConfig, workspacePath string) e
 
 	net := removed - added
 	if net > max {
-		return fmt.Errorf("test_diff: net %d test declaration(s) removed (max allowed %d) — "+
-			"removed=%d added=%d. Persona must replace deleted tests, not net-delete them.",
+		return fmt.Errorf("test_diff: net %d test declaration(s) removed (max allowed %d, removed=%d added=%d); persona must replace deleted tests, not net-delete them",
 			net, max, removed, added)
 	}
 	return nil

--- a/internal/contract/test_diff_test.go
+++ b/internal/contract/test_diff_test.go
@@ -111,6 +111,52 @@ func TestTestDiff_HigherToleranceConfig(t *testing.T) {
 	}
 }
 
+func TestTestDiff_PythonConfig_DetectsDeletion(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	writeFile(t, dir, "test_things.py", `def test_alpha():
+    assert True
+
+def test_beta():
+    assert True
+`)
+	runGit(t, dir, "add", "test_things.py")
+	runGit(t, dir, "commit", "-q", "-m", "init")
+	writeFile(t, dir, "test_things.py", `def test_alpha():
+    assert True
+`)
+	v := &testDiffValidator{}
+	cfg := ContractConfig{
+		Type:            "test_diff",
+		TestFilePattern: []string{"test_*.py", "*_test.py"},
+		TestFuncPattern: `^[ \t]*def[ \t]+test_\w+`,
+	}
+	if err := v.Validate(cfg, dir); err == nil {
+		t.Fatal("expected error for python net deletion, got nil")
+	}
+}
+
+func TestTestDiff_JavaScriptConfig_DetectsDeletion(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	writeFile(t, dir, "x.test.ts", `it("alpha", () => {});
+it("beta", () => {});
+`)
+	runGit(t, dir, "add", "x.test.ts")
+	runGit(t, dir, "commit", "-q", "-m", "init")
+	writeFile(t, dir, "x.test.ts", `it("alpha", () => {});
+`)
+	v := &testDiffValidator{}
+	cfg := ContractConfig{
+		Type:            "test_diff",
+		TestFilePattern: []string{"*.test.ts", "*.test.js", "*.spec.ts", "*.spec.js"},
+		TestFuncPattern: `^[ \t]*(it|test)\(`,
+	}
+	if err := v.Validate(cfg, dir); err == nil {
+		t.Fatal("expected error for js net deletion, got nil")
+	}
+}
+
 func TestTestDiff_NoGitRepo_PassesSilently(t *testing.T) {
 	dir := t.TempDir()
 	v := &testDiffValidator{}

--- a/internal/contract/test_diff_test.go
+++ b/internal/contract/test_diff_test.go
@@ -1,0 +1,120 @@
+package contract
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runGit runs git in dir and returns nothing — fatal-fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// initRepoWithTest seeds a git repo containing one *_test.go file with two
+// test functions, then commits. Returns the dir path.
+func initRepoWithTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	writeFile(t, dir, "x_test.go", `package x
+
+import "testing"
+
+func TestAlpha(t *testing.T) { _ = t }
+func TestBeta(t *testing.T) { _ = t }
+`)
+	runGit(t, dir, "add", "x_test.go")
+	runGit(t, dir, "commit", "-q", "-m", "init")
+	return dir
+}
+
+func TestTestDiff_NoChanges_Passes(t *testing.T) {
+	dir := initRepoWithTest(t)
+	v := &testDiffValidator{}
+	if err := v.Validate(ContractConfig{Type: "test_diff"}, dir); err != nil {
+		t.Fatalf("expected no error on clean diff, got: %v", err)
+	}
+}
+
+func TestTestDiff_Addition_Passes(t *testing.T) {
+	dir := initRepoWithTest(t)
+	writeFile(t, dir, "x_test.go", `package x
+
+import "testing"
+
+func TestAlpha(t *testing.T) { _ = t }
+func TestBeta(t *testing.T) { _ = t }
+func TestGamma(t *testing.T) { _ = t }
+`)
+	v := &testDiffValidator{}
+	if err := v.Validate(ContractConfig{Type: "test_diff"}, dir); err != nil {
+		t.Fatalf("expected no error when test added, got: %v", err)
+	}
+}
+
+func TestTestDiff_NetDeletion_Fails(t *testing.T) {
+	dir := initRepoWithTest(t)
+	writeFile(t, dir, "x_test.go", `package x
+
+import "testing"
+
+func TestAlpha(t *testing.T) { _ = t }
+`)
+	v := &testDiffValidator{}
+	err := v.Validate(ContractConfig{Type: "test_diff"}, dir)
+	if err == nil {
+		t.Fatal("expected error for net deletion, got nil")
+	}
+}
+
+func TestTestDiff_RenameNets_Passes(t *testing.T) {
+	dir := initRepoWithTest(t)
+	writeFile(t, dir, "x_test.go", `package x
+
+import "testing"
+
+func TestAlphaRenamed(t *testing.T) { _ = t }
+func TestBeta(t *testing.T) { _ = t }
+`)
+	v := &testDiffValidator{}
+	if err := v.Validate(ContractConfig{Type: "test_diff"}, dir); err != nil {
+		t.Fatalf("expected rename to net to zero, got: %v", err)
+	}
+}
+
+func TestTestDiff_HigherToleranceConfig(t *testing.T) {
+	dir := initRepoWithTest(t)
+	writeFile(t, dir, "x_test.go", `package x
+`)
+	v := &testDiffValidator{}
+	cfg := ContractConfig{Type: "test_diff", MaxTestDeletions: 2}
+	if err := v.Validate(cfg, dir); err != nil {
+		t.Fatalf("expected pass with MaxTestDeletions=2, got: %v", err)
+	}
+}
+
+func TestTestDiff_NoGitRepo_PassesSilently(t *testing.T) {
+	dir := t.TempDir()
+	v := &testDiffValidator{}
+	if err := v.Validate(ContractConfig{Type: "test_diff"}, dir); err != nil {
+		t.Fatalf("expected silent pass without git, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1583. Part of epic #1565 regression hardening.

## What

`test_diff` contract validator. Counts test-declaration lines added/removed in test-file diff vs HEAD. Net deletion above `MaxTestDeletions` (default 0) fails.

## Language-agnostic (per Wave law)

Pathspecs + regex configurable per project:

- `TestFilePattern []string` — default `["*_test.go"]`
- `TestFuncPattern string`  — default `^[ \t]*func[ \t]+(Test|Example|Benchmark|Fuzz)\w*\b`

Pipeline yaml example for Python:

```yaml
- type: test_diff
  test_file_pattern: ["test_*.py", "*_test.py"]
  test_func_pattern: '^[ \t]*def[ \t]+test_\w+'
  on_failure: rework
```

Defaults preserve Go behavior; non-Go pipelines override.

## Behavior

- Renames net to zero — legit refactors pass
- No HEAD / no git → silent skip (companion `source_diff` flags anomaly)
- Catches the failure mode hit in epic #1565 phase 1.5a

## Tests

8 cases incl. Python `def test_*` and TypeScript `it(/test(` configurations. All green.

## Wiring (follow-up)

Wire into `impl-issue.yaml` after `test_suite` with `on_failure: rework` in a separate PR; project-specific patterns flow via `wave.yaml` template vars.