### PR TITLE
feat(proposals): evolution auto-rollback CLI + webui (F3)

### DIFF
--- a/cmd/wave/commands/proposals.go
+++ b/cmd/wave/commands/proposals.go
@@ -32,6 +32,7 @@ The next 'wave run <pipeline>' picks up the new yaml.`,
 	cmd.AddCommand(newProposalsShowCmd())
 	cmd.AddCommand(newProposalsApproveCmd())
 	cmd.AddCommand(newProposalsRejectCmd())
+	cmd.AddCommand(newProposalsRollbackCmd())
 
 	return cmd
 }
@@ -92,6 +93,54 @@ func newProposalsRejectCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&reason, "reason", "", "Rejection reason (recorded in decided_by)")
 	return cmd
+}
+
+func newProposalsRollbackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollback <pipeline_name>",
+		Short: "Activate the previous pipeline version (auto-rollback)",
+		Long: `Find the active pipeline_version and flip activation to the
+prior version (highest version_id below the active one). Useful when an
+approved evolution misbehaves in production. Fails when no prior version
+exists.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runProposalsRollback(strings.TrimSpace(args[0]))
+		},
+	}
+	return cmd
+}
+
+func runProposalsRollback(pipelineName string) error {
+	if pipelineName == "" {
+		return NewCLIError(CodeInvalidArgs, "pipeline name required", "")
+	}
+	store, err := openProposalStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	prior, current, err := proposals.PriorVersion(store, pipelineName)
+	if err != nil {
+		switch {
+		case errors.Is(err, proposals.ErrNoActiveVersion):
+			return NewCLIError(CodeValidationFailed, err.Error(),
+				"No active pipeline_version row found; nothing to roll back")
+		case errors.Is(err, proposals.ErrNoPriorVersion):
+			return NewCLIError(CodeValidationFailed, err.Error(),
+				"Active version is the first one; cannot roll back further")
+		default:
+			return NewCLIError(CodeInternalError, err.Error(), "").WithCause(err)
+		}
+	}
+	if err := store.ActivateVersion(pipelineName, prior.Version); err != nil {
+		return NewCLIError(CodeInternalError,
+			fmt.Sprintf("activate v%d: %s", prior.Version, err), "").WithCause(err)
+	}
+	fmt.Printf("Rolled back %s: v%d -> v%d (%s)\n",
+		pipelineName, current.Version, prior.Version, prior.YAMLPath)
+	return nil
 }
 
 func openProposalStore() (state.StateStore, error) {

--- a/internal/proposals/rollback.go
+++ b/internal/proposals/rollback.go
@@ -1,0 +1,49 @@
+package proposals
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+// Sentinels for rollback outcomes.
+var (
+	ErrNoActiveVersion = errors.New("no active pipeline version to roll back")
+	ErrNoPriorVersion  = errors.New("no prior pipeline version available")
+)
+
+// PriorVersion returns (prior, current, nil) where current is the active
+// pipeline_version row and prior is the highest version_id below it. Used
+// by `wave proposals rollback` and POST /proposals/rollback to compute
+// the activation target before flipping.
+//
+// Both records are returned by value so the caller can show "v3 -> v2"
+// in CLI output / API response.
+func PriorVersion(store state.EvolutionStore, pipelineName string) (state.PipelineVersionRecord, state.PipelineVersionRecord, error) {
+	if pipelineName == "" {
+		return state.PipelineVersionRecord{}, state.PipelineVersionRecord{}, fmt.Errorf("PriorVersion: pipeline name required")
+	}
+	versions, err := store.ListPipelineVersions(pipelineName)
+	if err != nil {
+		return state.PipelineVersionRecord{}, state.PipelineVersionRecord{}, fmt.Errorf("list versions: %w", err)
+	}
+	var current *state.PipelineVersionRecord
+	for i := range versions {
+		if versions[i].Active {
+			current = &versions[i]
+			break
+		}
+	}
+	if current == nil {
+		return state.PipelineVersionRecord{}, state.PipelineVersionRecord{}, ErrNoActiveVersion
+	}
+
+	// versions are sorted newest-first; pick first with Version < current.Version.
+	for i := range versions {
+		if versions[i].Version < current.Version {
+			return versions[i], *current, nil
+		}
+	}
+	return state.PipelineVersionRecord{}, *current, ErrNoPriorVersion
+}

--- a/internal/proposals/rollback_test.go
+++ b/internal/proposals/rollback_test.go
@@ -1,0 +1,81 @@
+package proposals
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/recinq/wave/internal/state"
+)
+
+func newRollbackStore(t *testing.T) state.StateStore {
+	t.Helper()
+	store, err := state.NewStateStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestPriorVersion_Found(t *testing.T) {
+	store := newRollbackStore(t)
+	for _, v := range []int{1, 2, 3} {
+		if err := store.CreatePipelineVersion(state.PipelineVersionRecord{
+			PipelineName: "p", Version: v, SHA256: "x", YAMLPath: "x.yaml", Active: v == 3,
+		}); err != nil {
+			t.Fatalf("seed v%d: %v", v, err)
+		}
+	}
+	prior, current, err := PriorVersion(store, "p")
+	if err != nil {
+		t.Fatalf("PriorVersion: %v", err)
+	}
+	if current.Version != 3 {
+		t.Errorf("expected current=3, got %d", current.Version)
+	}
+	if prior.Version != 2 {
+		t.Errorf("expected prior=2, got %d", prior.Version)
+	}
+}
+
+func TestPriorVersion_NoActive(t *testing.T) {
+	store := newRollbackStore(t)
+	_, _, err := PriorVersion(store, "ghost")
+	if !errors.Is(err, ErrNoActiveVersion) {
+		t.Fatalf("expected ErrNoActiveVersion, got %v", err)
+	}
+}
+
+func TestPriorVersion_NoPrior(t *testing.T) {
+	store := newRollbackStore(t)
+	if err := store.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: "p", Version: 1, SHA256: "x", YAMLPath: "x.yaml", Active: true,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, _, err := PriorVersion(store, "p")
+	if !errors.Is(err, ErrNoPriorVersion) {
+		t.Fatalf("expected ErrNoPriorVersion, got %v", err)
+	}
+}
+
+func TestPriorVersion_GapAware(t *testing.T) {
+	// Versions 1, 2 exist but only 1 active. Rolling back is impossible.
+	// Versions 1, 5 active=5: prior should be 1, not 4 (gap).
+	store := newRollbackStore(t)
+	for _, vr := range []state.PipelineVersionRecord{
+		{PipelineName: "p", Version: 1, SHA256: "a", YAMLPath: "1.yaml", Active: false},
+		{PipelineName: "p", Version: 5, SHA256: "b", YAMLPath: "5.yaml", Active: true},
+	} {
+		if err := store.CreatePipelineVersion(vr); err != nil {
+			t.Fatalf("seed v%d: %v", vr.Version, err)
+		}
+	}
+	prior, current, err := PriorVersion(store, "p")
+	if err != nil {
+		t.Fatalf("PriorVersion: %v", err)
+	}
+	if current.Version != 5 || prior.Version != 1 {
+		t.Errorf("expected 5->1, got %d->%d", current.Version, prior.Version)
+	}
+}

--- a/internal/webui/handlers_proposals.go
+++ b/internal/webui/handlers_proposals.go
@@ -52,13 +52,13 @@ type diffLine struct {
 
 // proposalDecisionResponse is the JSON body returned by approve/reject.
 type proposalDecisionResponse struct {
-	ID            int64  `json:"id"`
-	Status        string `json:"status"`
-	NewVersion    int    `json:"new_version,omitempty"`
-	NewYAMLPath   string `json:"new_yaml_path,omitempty"`
-	NewSHA256     string `json:"new_sha256,omitempty"`
-	DecidedBy     string `json:"decided_by,omitempty"`
-	Activated     bool   `json:"activated,omitempty"`
+	ID          int64  `json:"id"`
+	Status      string `json:"status"`
+	NewVersion  int    `json:"new_version,omitempty"`
+	NewYAMLPath string `json:"new_yaml_path,omitempty"`
+	NewSHA256   string `json:"new_sha256,omitempty"`
+	DecidedBy   string `json:"decided_by,omitempty"`
+	Activated   bool   `json:"activated,omitempty"`
 }
 
 // handleProposalsPage handles GET /proposals.
@@ -257,6 +257,51 @@ func (s *Server) handleProposalReject(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleProposalRollback handles POST /pipelines/{pipelineName}/rollback.
+// Flips activation to the prior pipeline_version, an emergency rollback
+// for an approved evolution that misbehaves in production.
+func (s *Server) handleProposalRollback(w http.ResponseWriter, r *http.Request) {
+	store := s.proposalStore()
+	if store == nil {
+		writeJSONError(w, http.StatusInternalServerError, "evolution store unavailable")
+		return
+	}
+	pipelineName := strings.TrimSpace(r.PathValue("pipelineName"))
+	if pipelineName == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing pipeline name")
+		return
+	}
+
+	prior, current, err := proposals.PriorVersion(store, pipelineName)
+	if err != nil {
+		switch {
+		case errors.Is(err, proposals.ErrNoActiveVersion):
+			writeJSONError(w, http.StatusNotFound, err.Error())
+		case errors.Is(err, proposals.ErrNoPriorVersion):
+			writeJSONError(w, http.StatusConflict, err.Error())
+		default:
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	if err := store.ActivateVersion(pipelineName, prior.Version); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "activate prior: "+err.Error())
+		return
+	}
+
+	decidedBy := strings.TrimSpace(r.Header.Get("X-Wave-User"))
+	if decidedBy == "" {
+		decidedBy = "webui"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pipeline_name":    pipelineName,
+		"rolled_back_from": current.Version,
+		"now_active":       prior.Version,
+		"yaml_path":        prior.YAMLPath,
+		"decided_by":       decidedBy,
+	})
+}
+
 // proposalStore returns the read-write evolution store, preferring the rwStore
 // (which permits writes) over the read-only store. Tests that wire only an
 // rwStore still work because both fields hold the same handle in production.
@@ -338,4 +383,3 @@ func proposalStatusBadgeClass(status string) string {
 		return "badge-neutral"
 	}
 }
-

--- a/internal/webui/handlers_proposals_test.go
+++ b/internal/webui/handlers_proposals_test.go
@@ -264,3 +264,62 @@ func TestParseDiffLines_Classes(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleProposalRollback_FlipsToPrior(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	for _, v := range []int{1, 2, 3} {
+		active := v == 3
+		if err := rw.CreatePipelineVersion(state.PipelineVersionRecord{
+			PipelineName: "impl-issue", Version: v,
+			SHA256: "sha-" + strconv.Itoa(v), YAMLPath: "v" + strconv.Itoa(v) + ".yaml",
+			Active: active,
+		}); err != nil {
+			t.Fatalf("CreatePipelineVersion(v%d): %v", v, err)
+		}
+	}
+
+	req := httptest.NewRequest("POST", "/pipelines/impl-issue/rollback", nil)
+	req.SetPathValue("pipelineName", "impl-issue")
+	rec := httptest.NewRecorder()
+	srv.handleProposalRollback(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	_ = json.NewDecoder(rec.Body).Decode(&body)
+	if body["now_active"] != float64(2) {
+		t.Errorf("expected now_active=2, got %v", body["now_active"])
+	}
+	active, _ := rw.GetActiveVersion("impl-issue")
+	if active == nil || active.Version != 2 {
+		t.Errorf("expected active v2, got %+v", active)
+	}
+}
+
+func TestHandleProposalRollback_NoActive(t *testing.T) {
+	srv, _ := proposalsTestServer(t)
+	req := httptest.NewRequest("POST", "/pipelines/ghost/rollback", nil)
+	req.SetPathValue("pipelineName", "ghost")
+	rec := httptest.NewRecorder()
+	srv.handleProposalRollback(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleProposalRollback_NoPrior(t *testing.T) {
+	srv, rw := proposalsTestServer(t)
+	if err := rw.CreatePipelineVersion(state.PipelineVersionRecord{
+		PipelineName: "impl-issue", Version: 1, SHA256: "s", YAMLPath: "v1.yaml", Active: true,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/pipelines/impl-issue/rollback", nil)
+	req.SetPathValue("pipelineName", "impl-issue")
+	rec := httptest.NewRecorder()
+	srv.handleProposalRollback(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -46,6 +46,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /proposals/{id}", s.handleProposalDetailPage)
 	mux.HandleFunc("POST /proposals/{id}/approve", s.handleProposalApprove)
 	mux.HandleFunc("POST /proposals/{id}/reject", s.handleProposalReject)
+	mux.HandleFunc("POST /pipelines/{pipelineName}/rollback", s.handleProposalRollback)
 
 	// API endpoints (JSON)
 	mux.HandleFunc("GET /api/runs", s.handleAPIRuns)


### PR DESCRIPTION
Closes the F3 follow-up from epic #1565.

## What

- CLI: `wave proposals rollback <pipeline_name>`
- Webui: `POST /pipelines/{pipelineName}/rollback`

Both flip the active `pipeline_version` to the highest version below the currently-active one, using the existing `state.ActivateVersion` atomic flip. Emergency lever for an approved evolution that misbehaves in production.

## Design

- `internal/proposals/rollback.go` — `PriorVersion(store, name)` returns `(prior, current, err)`. Sentinels: `ErrNoActiveVersion`, `ErrNoPriorVersion`.
- Gap-aware: if the active is v5 and prior committed is v1 (gap), rollback targets v1, not v4.
- No schema change; reuses existing pipeline_version table.
- Route under `/pipelines/{name}/rollback` to avoid net/http mux conflict with `/proposals/{id}/{approve,reject}` wildcards.

## Tests

- `internal/proposals/rollback_test.go` — 4 cases: prior-found, gap-aware, no-active, no-prior.
- `internal/webui/handlers_proposals_test.go` — 3 cases: 200 flip, 404 no-active, 409 no-prior.

## Lint

`nix run nixpkgs#golangci-lint -- run ./internal/proposals/... ./internal/webui/... ./cmd/wave/commands/...` → `0 issues`.

Part of epic #1565.