### PR TITLE
feat(webui): migrate /contracts, /personas, /404 to unified design system

### DIFF
--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -33,11 +33,8 @@ var pageTemplates = []string{
 	"templates/skills.html",
 	"templates/skill_detail.html",
 	"templates/compose.html",
-	"templates/issues.html",
 	"templates/issue_detail.html",
-	"templates/prs.html",
 	"templates/pr_detail.html",
-	"templates/health.html",
 	"templates/analytics.html",
 	"templates/retros.html",
 	"templates/notfound.html",
@@ -62,6 +59,9 @@ var standalonePageTemplates = []string{
 	"templates/proposals/detail.html",
 	"templates/runs.html",
 	"templates/pipelines.html",
+	"templates/issues.html",
+	"templates/prs.html",
+	"templates/health.html",
 }
 
 // parseTemplates parses all embedded HTML templates using a clone-per-page

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -25,10 +25,8 @@ var templatesFS embed.FS
 // "content", and "scripts" blocks without colliding.
 var pageTemplates = []string{
 	"templates/run_detail.html",
-	"templates/personas.html",
 	"templates/persona_detail.html",
 	"templates/pipeline_detail.html",
-	"templates/contracts.html",
 	"templates/contract_detail.html",
 	"templates/skills.html",
 	"templates/skill_detail.html",
@@ -37,7 +35,6 @@ var pageTemplates = []string{
 	"templates/pr_detail.html",
 	"templates/analytics.html",
 	"templates/retros.html",
-	"templates/notfound.html",
 	"templates/compare.html",
 	"templates/webhooks.html",
 	"templates/webhook_detail.html",
@@ -62,6 +59,9 @@ var standalonePageTemplates = []string{
 	"templates/issues.html",
 	"templates/prs.html",
 	"templates/health.html",
+	"templates/contracts.html",
+	"templates/personas.html",
+	"templates/notfound.html",
 }
 
 // parseTemplates parses all embedded HTML templates using a clone-per-page

--- a/internal/webui/handlers_contracts.go
+++ b/internal/webui/handlers_contracts.go
@@ -88,7 +88,7 @@ func (s *Server) handleContractsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/contracts.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/contracts.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_health.go
+++ b/internal/webui/handlers_health.go
@@ -19,7 +19,7 @@ func (s *Server) handleHealthPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/health.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/health.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_issues.go
+++ b/internal/webui/handlers_issues.go
@@ -31,7 +31,7 @@ func (s *Server) handleIssuesPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/issues.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/issues.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_personas.go
+++ b/internal/webui/handlers_personas.go
@@ -26,7 +26,7 @@ func (s *Server) handlePersonasPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/personas.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/personas.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_prs.go
+++ b/internal/webui/handlers_prs.go
@@ -33,7 +33,7 @@ func (s *Server) handlePRsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/prs.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/prs.html"].Execute(w, data); err != nil {
 		log.Printf("[webui] template error rendering prs page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}

--- a/internal/webui/routes.go
+++ b/internal/webui/routes.go
@@ -115,6 +115,6 @@ func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 	tmpl := s.assets.templates["templates/notfound.html"]
 	if tmpl != nil {
-		_ = tmpl.ExecuteTemplate(w, "templates/layout.html", nil)
+		_ = tmpl.Execute(w, nil)
 	}
 }

--- a/internal/webui/templates/contracts.html
+++ b/internal/webui/templates/contracts.html
@@ -1,43 +1,79 @@
-{{define "title"}}Contracts · Wave{{end}}
-{{define "content"}}
-<div class="w-head"><h1>Contracts</h1></div>
-
-{{if .Contracts}}
-<div class="wr-toolbar">
-    <div class="wr-controls">
-        <input type="text" id="contract-search" class="wr-search" placeholder="Search contracts..." oninput="filterItems(this.value)">
-        <span class="wr-count">{{len .Contracts}} contracts</span>
-    </div>
-</div>
-<div class="wr-list">
-{{range .Contracts}}
-    <a href="/contracts/{{.Name}}" class="wr-run">
-        <div class="wr-accent st-defined"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-                {{if .Title}}<span class="ct-title">{{.Title}}</span>{{end}}
-            </div>
-            {{if .Description}}<div class="wr-row2"><span class="ct-desc">{{.Description}}</span></div>{{end}}
-        </div>
-        <div class="wr-meta">
-            <span class="wr-date ct-file">{{.Filename}}</span>
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Contracts &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
-{{else}}
-<div class="wr-empty">No contracts found. Add schemas to <code>.agents/contracts/</code></div>
-{{end}}
-{{end}}
-{{define "scripts"}}
-<script>
-function filterItems(query) {
-    var q = query.toLowerCase().trim();
-    document.querySelectorAll('.wr-list > a.wr-run').forEach(function(card) {
-        if (!q) { card.style.display = ''; return; }
-        card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
-    });
-}
-</script>
-{{end}}
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
+
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Contracts</h1>
+    </div>
+
+  {{if .Contracts}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <div style="margin-left: auto; display: flex; gap: 8px; align-items: center;">
+        <input type="text" id="contract-search" placeholder="Search contracts..." style="background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text-secondary); padding: 6px 10px; border-radius: 6px; font-size: 12px; width: 180px; font-family: inherit;" oninput="filterItems(this.value)">
+        <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Contracts}} contracts</span>
+      </div>
+    </div>
+
+    <div class="w-list standalone" id="contract-list">
+    {{range .Contracts}}
+      <a href="/contracts/{{.Name}}" class="run-card" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div style="width: 4px; border-radius: 2px; background: var(--color-link); flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+            {{if .Title}}<span style="color: var(--color-text-secondary); font-size: 12px;">{{.Title}}</span>{{end}}
+          </div>
+          {{if .Description}}<div style="color: var(--color-text-secondary); font-size: 12px; margin-top: 2px;">{{.Description}}</div>{{end}}
+        </div>
+        <span style="font-size: 12px; color: var(--color-text-muted); flex-shrink: 0;">{{.Filename}}</span>
+      </a>
+    {{end}}
+    </div>
+  {{else}}
+    <div class="w-empty">
+      <h3>No contracts found</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-top: 4px;">Add schemas to <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">.agents/contracts/</code></p>
+    </div>
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+  <script>
+  function filterItems(query) {
+      var q = query.toLowerCase().trim();
+      document.querySelectorAll('#contract-list > a.run-card').forEach(function(card) {
+          if (!q) { card.style.display = ''; return; }
+          card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
+      });
+  }
+  </script>
+</body>
+</html>

--- a/internal/webui/templates/health.html
+++ b/internal/webui/templates/health.html
@@ -1,42 +1,82 @@
-{{define "title"}}Health · Wave{{end}}
-{{define "content"}}
-<div class="page-header">
-    <h1>Health Checks</h1>
-    <button class="btn" onclick="location.reload()">Re-run Checks</button>
-</div>
-{{if .Checks}}
-<div class="health-checks">
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Health &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
+    </a>
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" class="active" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
+
+  <div class="w-container">
+    <div class="w-page-header" style="display: flex; align-items: center; justify-content: space-between;">
+      <h1 class="w-page-title">Health Checks</h1>
+      <button class="w-btn" onclick="location.reload()">Re-run Checks</button>
+    </div>
+
+  {{if .Checks}}
+    <div style="display: grid; gap: 12px;">
     {{range .Checks}}
-    <div class="card health-card health-{{.Status}}">
-        <div class="health-header">
-            <span class="health-icon">
-                {{if eq .Status "ok"}}&#10003;{{else if eq .Status "warn"}}&#9888;{{else}}&#10007;{{end}}
-            </span>
-            <h3>{{.Name}}</h3>
-            <span class="badge badge-{{.Status}}">{{.Status}}</span>
+      <div style="border: 1px solid var(--color-border); border-radius: 8px; overflow: hidden;">
+        <div style="display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--color-border-light);">
+          <span style="font-size: 16px;">
+            {{if eq .Status "ok"}}<span style="color: var(--color-completed);">&#10003;</span>
+            {{else if eq .Status "warn"}}<span style="color: var(--color-completed-empty);">&#9888;</span>
+            {{else}}<span style="color: var(--color-failed);">&#10007;</span>{{end}}
+          </span>
+          <span style="font-weight: 500; flex: 1;">{{.Name}}</span>
+          {{if eq .Status "ok"}}<span class="badge badge-green">ok</span>
+          {{else if eq .Status "warn"}}<span class="badge badge-yellow">warn</span>
+          {{else}}<span class="badge badge-red">error</span>{{end}}
         </div>
-        <p class="health-message">{{.Message}}</p>
+        {{if .Message}}
+        <div style="padding: 8px 16px; font-size: 13px; color: var(--color-text-secondary);">{{.Message}}</div>
+        {{end}}
         {{if .Details}}
-        <details class="health-details">
-            <summary>Details</summary>
-            <table class="details-table">
-                {{range $key, $value := .Details}}
-                <tr>
-                    <td><strong>{{$key}}</strong></td>
-                    <td>{{$value}}</td>
-                </tr>
-                {{end}}
-            </table>
+        <details style="padding: 0 16px 12px;">
+          <summary style="cursor: pointer; font-size: 12px; color: var(--color-text-secondary); padding: 4px 0;">Details</summary>
+          <table style="width: 100%; font-size: 12px; margin-top: 8px;">
+            {{range $key, $value := .Details}}
+            <tr>
+              <td style="padding: 4px 0; color: var(--color-text-secondary); font-weight: 500; width: 40%;">{{$key}}</td>
+              <td style="padding: 4px 0;">{{$value}}</td>
+            </tr>
+            {{end}}
+          </table>
         </details>
         {{end}}
-    </div>
+      </div>
     {{end}}
-</div>
-{{else}}
-<div class="empty-state">
-    <div class="empty-state-icon">&#9825;</div>
-    <p><strong>No health checks available</strong></p>
-    <p>Run <code>wave doctor</code> to check project health.</p>
-</div>
-{{end}}
-{{end}}
+    </div>
+  {{else}}
+    <div class="w-empty">
+      <h3>No health checks available</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-top: 4px;">Run <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">wave doctor</code> to check project health.</p>
+    </div>
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/internal/webui/templates/issues.html
+++ b/internal/webui/templates/issues.html
@@ -1,90 +1,135 @@
-{{define "title"}}Issues · Wave{{end}}
-{{define "content"}}
-<div class="wr-head">
-    <h1>Issues</h1>
-</div>
-
-<div class="wr-toolbar">
-    <div class="wr-filters">
-        <a href="/issues?state=open" class="wr-filter{{if eq .FilterState "open"}} active{{end}}">Open</a>
-        <a href="/issues?state=closed" class="wr-filter{{if eq .FilterState "closed"}} active{{end}}">Closed</a>
-        <a href="/issues?state=all" class="wr-filter{{if eq .FilterState "all"}} active{{end}}">All</a>
-    </div>
-    <div class="wr-controls">
-        <input type="text" id="issue-search" class="wr-search" placeholder="Search issues..." oninput="filterItems(this.value)">
-        <span class="wr-count">
-            {{if .TotalOpen}}<b>{{.TotalOpen}}</b> open{{end}}
-            {{if .TotalClosed}} · <b>{{.TotalClosed}}</b> closed{{end}}
-        </span>
-    </div>
-</div>
-
-{{if .Message}}
-<div class="issue-message">{{.Message}}</div>
-{{else if .Issues}}
-<div class="wr-list">
-{{range .Issues}}
-    <a href="/issues/{{.Number}}" class="wr-run">
-        <div class="wr-accent {{if .LastStatus}}st-{{.LastStatus}}{{else}}st-pending{{end}}"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">#{{.Number}} {{.Title}}</span>
-                {{if eq .State "open"}}<span class="badge badge-issue-open">open</span>
-                {{else}}<span class="badge badge-issue-closed">closed</span>{{end}}
-            </div>
-            <div class="wr-row2">
-                <span>{{.Author}}</span>
-                {{if .RunCount}}<span><b>{{.RunCount}}</b> runs</span>{{end}}
-                {{if .TotalTokens}}<span><b>{{formatTokensShort .TotalTokens}}</b> tok</span>{{end}}
-                {{if .Comments}}<span><b>{{.Comments}}</b> {{if eq .Comments 1}}comment{{else}}comments{{end}}</span>{{end}}
-                {{range .Labels}}<span class="badge badge-label"{{if .Color}} style="background:#{{.Color}}22;color:#{{.Color}};"{{end}}>{{.Name}}</span>{{end}}
-            </div>
-        </div>
-        <div class="wr-meta">
-            <span class="wr-date">{{.CreatedAt}}</span>
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Issues &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
-{{if .HasMore}}
-<div class="wr-loading" id="wr-loader" data-next="/issues?state={{.FilterState}}&page={{add .Page 1}}">
-    <span class="wr-loading-spinner"></span><span class="wr-loading-text">Loading more...</span>
-</div>
-{{end}}
-{{else}}
-<div class="issue-empty">No issues found</div>
-{{end}}
-{{end}}
-{{define "scripts"}}
-<script>
-function filterItems(query) {
-    var q = query.toLowerCase().trim();
-    document.querySelectorAll('.wr-list > a.wr-run').forEach(function(card) {
-        if (!q) { card.style.display = ''; return; }
-        card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
-    });
-}
-(function(){
-    var loader=document.getElementById('wr-loader');
-    if(!loader)return;
-    var list=document.querySelector('.wr-list');
-    if(!list)return;
-    var loading=false;var nextUrl=loader.dataset.next;
-    function loadMore(){
-        if(loading||!nextUrl)return;
-        loading=true;loader.classList.add('active');
-        fetch(nextUrl).then(function(r){return r.text()}).then(function(html){
-            var doc=new DOMParser().parseFromString(html,'text/html');
-            doc.querySelectorAll('.wr-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
-            var nl=doc.getElementById('wr-loader');
-            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');
-                if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
-            }
-            else{loader.remove();}
-        }).catch(function(){loader.classList.remove('active');loading=false;});
-    }
-    window.addEventListener('scroll',function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();});
-    setTimeout(function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();},100);
-})();
-</script>
-{{end}}
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues" class="active">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
+
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Issues</h1>
+    </div>
+
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <a href="/issues?state=open" class="badge {{if eq .FilterState "open"}}badge-green{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">Open</a>
+      <a href="/issues?state=closed" class="badge {{if eq .FilterState "closed"}}badge-dim{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">Closed</a>
+      <a href="/issues?state=all" class="badge {{if eq .FilterState "all"}}badge-blue{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">All</a>
+      <div style="margin-left: auto; display: flex; gap: 8px; align-items: center;">
+        <input type="text" id="issue-search" placeholder="Search issues..." style="background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text-secondary); padding: 6px 10px; border-radius: 6px; font-size: 12px; width: 180px; font-family: inherit;" oninput="filterItems(this.value)">
+        <span style="font-size: 12px; color: var(--color-text-secondary);">
+          {{if .TotalOpen}}<b>{{.TotalOpen}}</b> open{{end}}
+          {{if .TotalClosed}} &middot; <b>{{.TotalClosed}}</b> closed{{end}}
+        </span>
+      </div>
+    </div>
+
+  {{if .Message}}
+    <div class="w-empty">
+      <p>{{.Message}}</p>
+    </div>
+  {{else if .Issues}}
+    <div class="w-list standalone" id="issue-list">
+    {{range .Issues}}
+      <a href="/issues/{{.Number}}" class="run-card" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div class="run-accent st-{{if .LastStatus}}{{.LastStatus}}{{else}}pending{{end}}" style="width: 4px; border-radius: 2px; flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap;">
+            <span style="font-weight: 500;">#{{.Number}} {{.Title}}</span>
+            {{if eq .State "open"}}<span class="badge badge-green" style="font-size: 10px;">open</span>
+            {{else}}<span class="badge badge-dim" style="font-size: 10px;">closed</span>{{end}}
+          </div>
+          <div style="display: flex; align-items: center; gap: 12px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); flex-wrap: wrap;">
+            <span>{{.Author}}</span>
+            {{if .RunCount}}<span><b>{{.RunCount}}</b> runs</span>{{end}}
+            {{if .TotalTokens}}<span><b>{{formatTokensShort .TotalTokens}}</b> tok</span>{{end}}
+            {{if .Comments}}<span><b>{{.Comments}}</b> {{if eq .Comments 1}}comment{{else}}comments{{end}}</span>{{end}}
+            {{range .Labels}}<span class="badge badge-dim" style="font-size: 10px;{{if .Color}} background:#{{.Color}}22;color:#{{.Color}};{{end}}">{{.Name}}</span>{{end}}
+            <span style="margin-left: auto;">{{.CreatedAt}}</span>
+          </div>
+        </div>
+      </a>
+    {{end}}
+    </div>
+    {{if .HasMore}}
+    <div id="wr-loader" data-next="/issues?state={{.FilterState}}&page={{add .Page 1}}" style="text-align: center; padding: 16px; color: var(--color-text-secondary); font-size: 13px;">
+      <span style="display: inline-block; width: 14px; height: 14px; border: 2px solid var(--color-border); border-top-color: var(--color-link); border-radius: 50%; animation: spin 0.6s linear infinite;"></span>
+      <span style="margin-left: 8px;">Loading more...</span>
+    </div>
+    {{end}}
+  {{else}}
+    <div class="w-empty">
+      <h3>No issues found</h3>
+    </div>
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+  <script>
+  function filterItems(query) {
+      var q = query.toLowerCase().trim();
+      document.querySelectorAll('#issue-list > a.run-card').forEach(function(card) {
+          if (!q) { card.style.display = ''; return; }
+          card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
+      });
+  }
+  (function(){
+      var loader=document.getElementById('wr-loader');
+      if(!loader)return;
+      var list=document.querySelector('#issue-list');
+      if(!list)return;
+      var loading=false;var nextUrl=loader.dataset.next;
+      function loadMore(){
+          if(loading||!nextUrl)return;
+          loading=true;loader.style.opacity='0.5';
+          fetch(nextUrl).then(function(r){return r.text()}).then(function(html){
+              var doc=new DOMParser().parseFromString(html,'text/html');
+              doc.querySelectorAll('#issue-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
+              var nl=doc.getElementById('wr-loader');
+              if(nl){nextUrl=nl.dataset.next;loading=false;loader.style.opacity='1';
+                  if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
+              }
+              else{loader.remove();}
+          }).catch(function(){loader.style.opacity='1';loading=false;});
+      }
+      window.addEventListener('scroll',function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();});
+      setTimeout(function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();},100);
+  })();
+  </script>
+
+  <style>
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .run-accent.st-completed { background: var(--color-completed); }
+  .run-accent.st-running { background: var(--color-running); }
+  .run-accent.st-failed { background: var(--color-failed); }
+  .run-accent.st-rejected { background: var(--color-pending); }
+  .run-accent.st-cancelled { background: var(--color-cancelled); }
+  .run-accent.st-pending { background: var(--color-pending); }
+  .run-accent.st-completed_empty { background: var(--color-completed-empty); }
+  .run-accent.st-skipped { background: var(--color-text-muted); }
+  </style>
+</body>
+</html>

--- a/internal/webui/templates/notfound.html
+++ b/internal/webui/templates/notfound.html
@@ -1,13 +1,46 @@
-{{define "title"}}Not Found · Wave{{end}}
-{{define "content"}}
-<div class="empty-state empty-state-404">
-    <div class="empty-state-icon empty-state-icon-lg">404</div>
-    <p><strong>Page not found</strong></p>
-    <p>The page you requested does not exist or has been moved.</p>
-    <div class="empty-state-action">
-        <button class="btn" onclick="window.history.back()">Go Back</button>
-        <a href="/runs" class="btn btn-primary">Go to Runs</a>
-        <a href="/pipelines" class="btn">View Pipelines</a>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Not Found &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
+    </a>
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
     </div>
-</div>
-{{end}}
+  </nav>
+
+  <div class="w-container">
+    <div class="w-empty" style="padding: 80px 20px;">
+      <h2 style="font-size: 64px; font-weight: 700; color: var(--color-text-muted); margin-bottom: 8px;">404</h2>
+      <h3 style="margin-bottom: 4px;">Page not found</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-bottom: 24px;">The page you requested does not exist or has been moved.</p>
+      <div style="display: flex; gap: 8px;">
+        <button class="w-btn" onclick="window.history.back()">Go Back</button>
+        <a href="/runs" class="w-btn w-btn-primary" style="text-decoration: none;">Go to Runs</a>
+        <a href="/pipelines" class="w-btn" style="text-decoration: none;">View Pipelines</a>
+      </div>
+    </div>
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/internal/webui/templates/personas.html
+++ b/internal/webui/templates/personas.html
@@ -1,41 +1,78 @@
-{{define "title"}}Personas · Wave{{end}}
-{{define "content"}}
-<div class="w-head"><h1>Personas</h1></div>
-
-{{if .Personas}}
-<div class="wr-toolbar">
-    <div class="wr-controls">
-        <input type="text" id="persona-search" class="wr-search" placeholder="Search personas..." oninput="filterItems(this.value)">
-        <span class="wr-count">{{len .Personas}} personas</span>
-    </div>
-</div>
-<div class="wr-list">
-{{range .Personas}}
-    <a href="/personas/{{.Name}}" class="wr-run">
-        <div class="wr-accent st-defined"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-                {{if .Model}}<span class="badge badge-model {{modelTierClass .Model}}">{{friendlyModel .Model}}</span>{{end}}
-                {{if .Adapter}}<span class="badge badge-adapter">{{.Adapter}}</span>{{end}}
-            </div>
-            {{if .Description}}<div class="wr-row2"><span class="ps-desc">{{.Description}}</span></div>{{end}}
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Personas &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
-{{else}}
-<div class="wr-empty">No personas configured</div>
-{{end}}
-{{end}}
-{{define "scripts"}}
-<script>
-function filterItems(query) {
-    var q = query.toLowerCase().trim();
-    document.querySelectorAll('.wr-list > a.wr-run').forEach(function(card) {
-        if (!q) { card.style.display = ''; return; }
-        card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
-    });
-}
-</script>
-{{end}}
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
+
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Personas</h1>
+    </div>
+
+  {{if .Personas}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <div style="margin-left: auto; display: flex; gap: 8px; align-items: center;">
+        <input type="text" id="persona-search" placeholder="Search personas..." style="background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text-secondary); padding: 6px 10px; border-radius: 6px; font-size: 12px; width: 180px; font-family: inherit;" oninput="filterItems(this.value)">
+        <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Personas}} personas</span>
+      </div>
+    </div>
+
+    <div class="w-list standalone" id="persona-list">
+    {{range .Personas}}
+      <a href="/personas/{{.Name}}" class="run-card" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div style="width: 4px; border-radius: 2px; background: var(--color-link); flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+            {{if .Model}}<span class="badge badge-model {{modelTierClass .Model}}" style="font-size: 10px;">{{friendlyModel .Model}}</span>{{end}}
+            {{if .Adapter}}<span class="badge badge-dim" style="font-size: 10px;">{{.Adapter}}</span>{{end}}
+          </div>
+          {{if .Description}}<div style="color: var(--color-text-secondary); font-size: 12px; margin-top: 2px;">{{.Description}}</div>{{end}}
+        </div>
+      </a>
+    {{end}}
+    </div>
+  {{else}}
+    <div class="w-empty">
+      <h3>No personas configured</h3>
+    </div>
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+  <script>
+  function filterItems(query) {
+      var q = query.toLowerCase().trim();
+      document.querySelectorAll('#persona-list > a.run-card').forEach(function(card) {
+          if (!q) { card.style.display = ''; return; }
+          card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
+      });
+  }
+  </script>
+</body>
+</html>

--- a/internal/webui/templates/prs.html
+++ b/internal/webui/templates/prs.html
@@ -1,98 +1,146 @@
-{{define "title"}}Pull Requests · Wave{{end}}
-{{define "content"}}
-<div class="wr-head">
-    <h1>Pull Requests</h1>
-</div>
-
-<div class="wr-toolbar">
-    <div class="wr-filters">
-        <a href="/prs?state=open" class="wr-filter{{if eq .FilterState "open"}} active{{end}}">Open</a>
-        <a href="/prs?state=closed" class="wr-filter{{if eq .FilterState "closed"}} active{{end}}">Closed</a>
-        <a href="/prs?state=all" class="wr-filter{{if eq .FilterState "all"}} active{{end}}">All</a>
-    </div>
-    <div class="wr-controls">
-        <input type="text" id="pr-search" class="wr-search" placeholder="Search PRs..." oninput="filterItems(this.value)">
-        <span class="wr-count">
-            {{if .TotalOpen}}<b>{{.TotalOpen}}</b> open{{end}}
-            {{if .TotalClosed}} · <b>{{.TotalClosed}}</b> closed{{end}}
-        </span>
-    </div>
-</div>
-
-{{if .Message}}
-<div class="pr-message">{{.Message}}</div>
-{{else if .PullRequests}}
-<div class="wr-list">
-{{range .PullRequests}}
-    <a href="/prs/{{.Number}}" class="wr-run{{if .Draft}} wr-run-draft{{end}}">
-        <div class="wr-accent {{if .LastStatus}}st-{{.LastStatus}}{{else}}st-pending{{end}}"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">#{{.Number}} {{.Title}}</span>
-                {{if .Merged}}<span class="badge badge-merged">merged</span>
-                {{else if .Draft}}<span class="badge badge-draft">draft</span>
-                {{else if eq .State "open"}}<span class="badge badge-open">open</span>
-                {{else}}<span class="badge badge-closed">closed</span>{{end}}
-                {{if eq .CheckStatus "success"}}<span class="pr-check pr-check-pass" title="Checks passed">&#x2713;</span>
-                {{else if eq .CheckStatus "failure"}}<span class="pr-check pr-check-fail" title="Checks failed">&#x2717;</span>
-                {{else if eq .CheckStatus "pending"}}<span class="pr-check pr-check-pending" title="Checks pending">&#x25CB;</span>{{end}}
-            </div>
-            <div class="wr-row2">
-                <span>{{.Author}}</span>
-                {{if .HeadBranch}}<span style="font-size:0.68rem;color:var(--color-text-secondary);">&#9741; {{.HeadBranch}}</span>{{end}}
-                {{if .RunCount}}<span><b>{{.RunCount}}</b> runs</span>{{end}}
-                {{if .TotalTokens}}<span><b>{{formatTokensShort .TotalTokens}}</b> tok</span>{{end}}
-                {{if .Comments}}<span><b>{{.Comments}}</b> {{if eq .Comments 1}}comment{{else}}comments{{end}}</span>{{end}}
-                <span><span class="pr-additions">+{{.Additions}}</span> <span class="pr-deletions">-{{.Deletions}}</span></span>
-                <span>{{.ChangedFiles}} files</span>
-                {{range .Labels}}<span class="badge badge-label"{{if .Color}} style="background:#{{.Color}}22;color:#{{.Color}};"{{end}}>{{.Name}}</span>{{end}}
-            </div>
-        </div>
-        <div class="wr-meta">
-            <span class="wr-date">{{.CreatedAt}}</span>
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Pull Requests &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
-{{if .HasMore}}
-<div class="wr-loading" id="wr-loader" data-next="/prs?state={{.FilterState}}&page={{add .Page 1}}">
-    <span class="wr-loading-spinner"></span><span class="wr-loading-text">Loading more...</span>
-</div>
-{{end}}
-{{else}}
-<div class="wr-empty">No pull requests found</div>
-{{end}}
-{{end}}
-{{define "scripts"}}
-<script>
-function filterItems(query) {
-    var q = query.toLowerCase().trim();
-    document.querySelectorAll('.wr-list > a.wr-run').forEach(function(card) {
-        if (!q) { card.style.display = ''; return; }
-        card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
-    });
-}
-(function(){
-    var loader=document.getElementById('wr-loader');
-    if(!loader)return;
-    var list=document.querySelector('.wr-list');
-    if(!list)return;
-    var loading=false;var nextUrl=loader.dataset.next;
-    function loadMore(){
-        if(loading||!nextUrl)return;
-        loading=true;loader.classList.add('active');
-        fetch(nextUrl).then(function(r){return r.text()}).then(function(html){
-            var doc=new DOMParser().parseFromString(html,'text/html');
-            doc.querySelectorAll('.wr-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
-            var nl=doc.getElementById('wr-loader');
-            if(nl){nextUrl=nl.dataset.next;loading=false;loader.classList.remove('active');
-                if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
-            }
-            else{loader.remove();}
-        }).catch(function(){loader.classList.remove('active');loading=false;});
-    }
-    window.addEventListener('scroll',function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();});
-    setTimeout(function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();},100);
-})();
-</script>
-{{end}}
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs" class="active">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
+
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Pull Requests</h1>
+    </div>
+
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <a href="/prs?state=open" class="badge {{if eq .FilterState "open"}}badge-green{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">Open</a>
+      <a href="/prs?state=closed" class="badge {{if eq .FilterState "closed"}}badge-dim{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">Closed</a>
+      <a href="/prs?state=all" class="badge {{if eq .FilterState "all"}}badge-blue{{else}}badge-dim{{end}}" style="font-size: 12px; padding: 4px 10px; text-decoration: none; cursor: pointer;">All</a>
+      <div style="margin-left: auto; display: flex; gap: 8px; align-items: center;">
+        <input type="text" id="pr-search" placeholder="Search PRs..." style="background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text-secondary); padding: 6px 10px; border-radius: 6px; font-size: 12px; width: 180px; font-family: inherit;" oninput="filterItems(this.value)">
+        <span style="font-size: 12px; color: var(--color-text-secondary);">
+          {{if .TotalOpen}}<b>{{.TotalOpen}}</b> open{{end}}
+          {{if .TotalClosed}} &middot; <b>{{.TotalClosed}}</b> closed{{end}}
+        </span>
+      </div>
+    </div>
+
+  {{if .Message}}
+    <div class="w-empty">
+      <p>{{.Message}}</p>
+    </div>
+  {{else if .PullRequests}}
+    <div class="w-list standalone" id="pr-list">
+    {{range .PullRequests}}
+      <a href="/prs/{{.Number}}" class="run-card" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;{{if .Draft}} opacity: 0.7;{{end}}" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div class="run-accent st-{{if .LastStatus}}{{.LastStatus}}{{else}}pending{{end}}" style="width: 4px; border-radius: 2px; flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap;">
+            <span style="font-weight: 500;">#{{.Number}} {{.Title}}</span>
+            <span style="display: flex; gap: 6px; align-items: center; flex-shrink: 0;">
+              {{if .Merged}}<span class="badge badge-purple" style="font-size: 10px;">merged</span>
+              {{else if .Draft}}<span class="badge badge-dim" style="font-size: 10px;">draft</span>
+              {{else if eq .State "open"}}<span class="badge badge-green" style="font-size: 10px;">open</span>
+              {{else}}<span class="badge badge-dim" style="font-size: 10px;">closed</span>{{end}}
+              {{if eq .CheckStatus "success"}}<span style="color: var(--color-completed); font-size: 14px;" title="Checks passed">&#10003;</span>
+              {{else if eq .CheckStatus "failure"}}<span style="color: var(--color-failed); font-size: 14px;" title="Checks failed">&#10007;</span>
+              {{else if eq .CheckStatus "pending"}}<span style="color: var(--color-text-muted); font-size: 14px;" title="Checks pending">&#9675;</span>{{end}}
+            </span>
+          </div>
+          <div style="display: flex; align-items: center; gap: 12px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); flex-wrap: wrap;">
+            <span>{{.Author}}</span>
+            {{if .HeadBranch}}<span style="font-size: 11px;">&#9741; {{.HeadBranch}}</span>{{end}}
+            {{if .RunCount}}<span><b>{{.RunCount}}</b> runs</span>{{end}}
+            {{if .TotalTokens}}<span><b>{{formatTokensShort .TotalTokens}}</b> tok</span>{{end}}
+            {{if .Comments}}<span><b>{{.Comments}}</b> {{if eq .Comments 1}}comment{{else}}comments{{end}}</span>{{end}}
+            <span style="color: var(--color-completed);">+{{.Additions}}</span>
+            <span style="color: var(--color-failed);">-{{.Deletions}}</span>
+            <span>{{.ChangedFiles}} files</span>
+            {{range .Labels}}<span class="badge badge-dim" style="font-size: 10px;{{if .Color}} background:#{{.Color}}22;color:#{{.Color}};{{end}}">{{.Name}}</span>{{end}}
+            <span style="margin-left: auto;">{{.CreatedAt}}</span>
+          </div>
+        </div>
+      </a>
+    {{end}}
+    </div>
+    {{if .HasMore}}
+    <div id="wr-loader" data-next="/prs?state={{.FilterState}}&page={{add .Page 1}}" style="text-align: center; padding: 16px; color: var(--color-text-secondary); font-size: 13px;">
+      <span style="display: inline-block; width: 14px; height: 14px; border: 2px solid var(--color-border); border-top-color: var(--color-link); border-radius: 50%; animation: spin 0.6s linear infinite;"></span>
+      <span style="margin-left: 8px;">Loading more...</span>
+    </div>
+    {{end}}
+  {{else}}
+    <div class="w-empty">
+      <h3>No pull requests found</h3>
+    </div>
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+  <script>
+  function filterItems(query) {
+      var q = query.toLowerCase().trim();
+      document.querySelectorAll('#pr-list > a.run-card').forEach(function(card) {
+          if (!q) { card.style.display = ''; return; }
+          card.style.display = card.textContent.toLowerCase().indexOf(q) !== -1 ? '' : 'none';
+      });
+  }
+  (function(){
+      var loader=document.getElementById('wr-loader');
+      if(!loader)return;
+      var list=document.querySelector('#pr-list');
+      if(!list)return;
+      var loading=false;var nextUrl=loader.dataset.next;
+      function loadMore(){
+          if(loading||!nextUrl)return;
+          loading=true;loader.style.opacity='0.5';
+          fetch(nextUrl).then(function(r){return r.text()}).then(function(html){
+              var doc=new DOMParser().parseFromString(html,'text/html');
+              doc.querySelectorAll('#pr-list > *').forEach(function(el){list.appendChild(el.cloneNode(true));});
+              var nl=doc.getElementById('wr-loader');
+              if(nl){nextUrl=nl.dataset.next;loading=false;loader.style.opacity='1';
+                  if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();
+              }
+              else{loader.remove();}
+          }).catch(function(){loader.style.opacity='1';loading=false;});
+      }
+      window.addEventListener('scroll',function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();});
+      setTimeout(function(){if(loader.getBoundingClientRect().top<window.innerHeight+300)loadMore();},100);
+  })();
+  </script>
+
+  <style>
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .run-accent.st-completed { background: var(--color-completed); }
+  .run-accent.st-running { background: var(--color-running); }
+  .run-accent.st-failed { background: var(--color-failed); }
+  .run-accent.st-rejected { background: var(--color-pending); }
+  .run-accent.st-cancelled { background: var(--color-cancelled); }
+  .run-accent.st-pending { background: var(--color-pending); }
+  .run-accent.st-completed_empty { background: var(--color-completed-empty); }
+  .run-accent.st-skipped { background: var(--color-text-muted); }
+  </style>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Migrate `/contracts`, `/personas`, and `404` pages from layout-based to standalone templates with unified `w-*` design system classes
- Also includes `/issues`, `/prs`, `/health` migration (supersedes #1639)
- Add all six to `standalonePageTemplates` in `embed.go`
- Update handlers to use `Execute()` instead of `ExecuteTemplate()`

Preserves all functionality: search filtering, contract/persona card links, 404 navigation buttons.

**Standalone pages after this PR:** work/board, work/detail, onboard, proposals/list, proposals/detail, runs, pipelines, issues, prs, health, contracts, personas, notfound (14 total)

Part of #1624 (WebUI UX consolidation).

## Test plan
- [ ] `go test ./internal/webui/` passes
- [ ] `/contracts` renders with search, contract cards linking to detail
- [ ] `/personas` renders with search, model tier badges
- [ ] 404 page renders with nav, back/runs/pipelines buttons
- [ ] `/issues`, `/prs`, `/health` all render correctly