### PR TITLE
feat(webui): migrate /analytics, /retros, /skills, /compose to unified design system

### DIFF
--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -28,13 +28,9 @@ var pageTemplates = []string{
 	"templates/persona_detail.html",
 	"templates/pipeline_detail.html",
 	"templates/contract_detail.html",
-	"templates/skills.html",
 	"templates/skill_detail.html",
-	"templates/compose.html",
 	"templates/issue_detail.html",
 	"templates/pr_detail.html",
-	"templates/analytics.html",
-	"templates/retros.html",
 	"templates/compare.html",
 	"templates/webhooks.html",
 	"templates/webhook_detail.html",
@@ -62,6 +58,10 @@ var standalonePageTemplates = []string{
 	"templates/contracts.html",
 	"templates/personas.html",
 	"templates/notfound.html",
+	"templates/analytics.html",
+	"templates/retros.html",
+	"templates/skills.html",
+	"templates/compose.html",
 }
 
 // parseTemplates parses all embedded HTML templates using a clone-per-page

--- a/internal/webui/handlers_analytics.go
+++ b/internal/webui/handlers_analytics.go
@@ -80,7 +80,7 @@ func (s *Server) handleAnalyticsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/analytics.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/analytics.html"].Execute(w, data); err != nil {
 		log.Printf("[webui] template error rendering analytics page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}

--- a/internal/webui/handlers_compose.go
+++ b/internal/webui/handlers_compose.go
@@ -33,7 +33,7 @@ func (s *Server) handleComposePage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/compose.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/compose.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/handlers_retro_page.go
+++ b/internal/webui/handlers_retro_page.go
@@ -164,7 +164,7 @@ func (s *Server) handleRetrosPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/retros.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/retros.html"].Execute(w, data); err != nil {
 		log.Printf("[webui] template error rendering retros page: %v", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}

--- a/internal/webui/handlers_skills.go
+++ b/internal/webui/handlers_skills.go
@@ -40,7 +40,7 @@ func (s *Server) handleSkillsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.assets.templates["templates/skills.html"].ExecuteTemplate(w, "templates/layout.html", data); err != nil {
+	if err := s.assets.templates["templates/skills.html"].Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/internal/webui/templates/analytics.html
+++ b/internal/webui/templates/analytics.html
@@ -1,95 +1,127 @@
-{{define "title"}}Analytics · Wave{{end}}
-{{define "content"}}
-<div class="page-header">
-    <h1>Token Usage Analytics</h1>
-    <div class="actions">
-        <span class="analytics-note">Estimated cost: ~80% input ($3/MTok) + ~20% output ($15/MTok)</span>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Analytics &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
+    </a>
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
     </div>
-</div>
+  </nav>
 
-<div class="analytics-summary">
-    <div class="analytics-stat-card">
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Token Usage Analytics</h1>
+      <span style="font-size: 12px; color: var(--color-text-secondary);">Estimated cost: ~80% input ($3/MTok) + ~20% output ($15/MTok)</span>
+    </div>
+
+    <div class="analytics-summary">
+      <div class="analytics-stat-card">
         <div class="analytics-stat-label">This Week</div>
         <div class="analytics-stat-value">{{formatTokens .Analytics.TokensThisWeek}}</div>
         <div class="analytics-stat-sub">{{.Analytics.RunsThisWeek}} {{pluralize .Analytics.RunsThisWeek "run" "runs"}} &middot; {{.Analytics.EstCostThisWeek}}</div>
-    </div>
-    <div class="analytics-stat-card">
+      </div>
+      <div class="analytics-stat-card">
         <div class="analytics-stat-label">This Month</div>
         <div class="analytics-stat-value">{{formatTokens .Analytics.TokensThisMonth}}</div>
         <div class="analytics-stat-sub">{{.Analytics.RunsThisMonth}} {{pluralize .Analytics.RunsThisMonth "run" "runs"}} &middot; {{.Analytics.EstCostThisMonth}}</div>
-    </div>
-    <div class="analytics-stat-card">
+      </div>
+      <div class="analytics-stat-card">
         <div class="analytics-stat-label">All Time (last 200 runs)</div>
         <div class="analytics-stat-value">{{formatTokens .Analytics.TotalTokens}}</div>
         <div class="analytics-stat-sub">{{.Analytics.TotalRuns}} {{pluralize .Analytics.TotalRuns "run" "runs"}}</div>
+      </div>
     </div>
-</div>
 
-<div class="analytics-grid">
-    <div class="analytics-panel">
+    <div class="analytics-grid">
+      <div class="analytics-panel">
         <h3>Tokens per Recent Run</h3>
         {{if .Analytics.RecentRuns}}
         <div class="analytics-bar-chart">
-            {{range .Analytics.RecentRuns}}
-            <a href="/runs/{{.RunID}}" class="analytics-bar-col" title="{{.PipelineName}} — {{formatTokens .Tokens}} tokens — {{.StartedAt}}">
-                <div class="analytics-bar analytics-bar-{{.Status}}" style="height: {{.Pct}}%;"></div>
-                <div class="analytics-bar-label">{{.StartedAt}}</div>
-            </a>
-            {{end}}
+          {{range .Analytics.RecentRuns}}
+          <a href="/runs/{{.RunID}}" class="analytics-bar-col" title="{{.PipelineName}} — {{formatTokens .Tokens}} tokens — {{.StartedAt}}">
+            <div class="analytics-bar analytics-bar-{{.Status}}" style="height: {{.Pct}}%;"></div>
+            <div class="analytics-bar-label">{{.StartedAt}}</div>
+          </a>
+          {{end}}
         </div>
         <div class="analytics-legend">
-            <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-completed"></span> Completed</span>
-            <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-running"></span> Running</span>
-            <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-failed"></span> Failed</span>
-            <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-cancelled"></span> Cancelled</span>
+          <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-completed"></span> Completed</span>
+          <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-running"></span> Running</span>
+          <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-failed"></span> Failed</span>
+          <span class="analytics-legend-item"><span class="analytics-legend-dot analytics-bar-cancelled"></span> Cancelled</span>
         </div>
         {{else}}
-        <div class="empty-state"><p>No run data available.</p></div>
+        <div class="w-empty"><p>No run data available.</p></div>
         {{end}}
-    </div>
+      </div>
 
-    <div class="analytics-panel">
+      <div class="analytics-panel">
         <h3>Top Pipelines (by avg tokens)</h3>
         {{if .Analytics.TopPipelines}}
         <div class="analytics-rank-list">
-            {{range .Analytics.TopPipelines}}
-            <div class="analytics-rank-item">
-                <div class="analytics-rank-header">
-                    <span class="analytics-rank-name">{{.Name}}</span>
-                    <span class="analytics-rank-value">{{formatTokens .AvgTokens}} avg</span>
-                </div>
-                <div class="analytics-rank-bar-bg">
-                    <div class="analytics-rank-bar" style="width: {{.Pct}}%;"></div>
-                </div>
-                <div class="analytics-rank-meta">{{.RunCount}} {{pluralize .RunCount "run" "runs"}} &middot; {{formatTokens .TotalTokens}} total</div>
+          {{range .Analytics.TopPipelines}}
+          <div class="analytics-rank-item">
+            <div class="analytics-rank-header">
+              <span class="analytics-rank-name">{{.Name}}</span>
+              <span class="analytics-rank-value">{{formatTokens .AvgTokens}} avg</span>
             </div>
-            {{end}}
+            <div class="analytics-rank-bar-bg">
+              <div class="analytics-rank-bar" style="width: {{.Pct}}%;"></div>
+            </div>
+            <div class="analytics-rank-meta">{{.RunCount}} {{pluralize .RunCount "run" "runs"}} &middot; {{formatTokens .TotalTokens}} total</div>
+          </div>
+          {{end}}
         </div>
         {{else}}
-        <div class="empty-state"><p>No pipeline data available.</p></div>
+        <div class="w-empty"><p>No pipeline data available.</p></div>
         {{end}}
-    </div>
+      </div>
 
-    <div class="analytics-panel">
+      <div class="analytics-panel">
         <h3>Top Personas (by total tokens)</h3>
         {{if .Analytics.TopPersonas}}
         <div class="analytics-rank-list">
-            {{range .Analytics.TopPersonas}}
-            <div class="analytics-rank-item">
-                <div class="analytics-rank-header">
-                    <span class="analytics-rank-name">{{.Name}}</span>
-                    <span class="analytics-rank-value">{{formatTokens .TotalTokens}}</span>
-                </div>
-                <div class="analytics-rank-bar-bg">
-                    <div class="analytics-rank-bar analytics-rank-bar-persona" style="width: {{.Pct}}%;"></div>
-                </div>
-                <div class="analytics-rank-meta">{{.StepCount}} {{pluralize .StepCount "step" "steps"}} &middot; {{formatTokens .AvgTokens}} avg &middot; est. {{.EstCost}}</div>
+          {{range .Analytics.TopPersonas}}
+          <div class="analytics-rank-item">
+            <div class="analytics-rank-header">
+              <span class="analytics-rank-name">{{.Name}}</span>
+              <span class="analytics-rank-value">{{formatTokens .TotalTokens}}</span>
             </div>
-            {{end}}
+            <div class="analytics-rank-bar-bg">
+              <div class="analytics-rank-bar analytics-rank-bar-persona" style="width: {{.Pct}}%;"></div>
+            </div>
+            <div class="analytics-rank-meta">{{.StepCount}} {{pluralize .StepCount "step" "steps"}} &middot; {{formatTokens .AvgTokens}} avg &middot; est. {{.EstCost}}</div>
+          </div>
+          {{end}}
         </div>
         {{else}}
-        <div class="empty-state"><p>No persona performance data available.</p></div>
+        <div class="w-empty"><p>No persona performance data available.</p></div>
         {{end}}
+      </div>
     </div>
-</div>
-{{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/internal/webui/templates/compose.html
+++ b/internal/webui/templates/compose.html
@@ -1,127 +1,158 @@
-{{define "title"}}Compose · Wave{{end}}
-{{define "content"}}
-<div class="wr-head">
-    <h1>Composition Pipelines</h1>
-</div>
-
-{{if .Pipelines}}
-<div class="wr-toolbar">
-    <div class="wr-controls">
-        <span style="font-size:0.72rem;color:var(--color-text-muted);">{{len .Pipelines}} pipelines</span>
-    </div>
-</div>
-<div class="wr-list">
-{{range .Pipelines}}
-    <a href="/pipelines/{{.Name}}" class="wr-run" data-category="{{.Category}}">
-        <div class="wr-accent st-defined" style="border-left-color:#8b5cf6;"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-                {{if and .Category (ne .Category "composition")}}<span class="badge" style="font-size:0.65rem;background:rgba(139,92,246,0.12);color:#c4b5fd;">{{.Category}}</span>{{end}}
-                <span class="badge" style="font-size:0.65rem;background:rgba(99,102,241,0.12);color:#a5b4fc;">composition</span>
-            </div>
-            {{if .Description}}<div class="wr-row2"><span style="color:var(--color-text-secondary);font-size:0.78rem;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;max-width:48rem;">{{.Description}}</span></div>{{end}}
-            <div class="wr-row2" style="margin-top:0.15rem;">
-                <span style="color:var(--color-text-muted);font-size:0.72rem;"><b>{{.StepCount}}</b> steps</span>
-                {{if .RunCount}}<span style="color:var(--color-text-muted);font-size:0.72rem;"><b>{{.RunCount}}</b> runs</span>{{end}}
-                {{if .Steps}}
-                <span style="color:var(--color-text-muted);font-size:0.68rem;font-family:var(--font-mono);display:flex;align-items:center;gap:0.15rem;">
-                {{range $i, $step := .Steps}}{{if $i}}<span style="color:var(--color-border);">&#8594;</span>{{end}}<span style="background:var(--color-bg-tertiary);padding:0.05rem 0.3rem;border-radius:3px;">{{$step.ID}}</span>{{end}}
-                </span>
-                {{end}}
-                {{range .Skills}}<span class="badge" style="font-size:0.65rem;background:rgba(34,211,238,0.1);color:#67e8f9;">{{.}}</span>{{end}}
-            </div>
-        </div>
-        <div class="wr-meta" style="display:flex;flex-direction:row;gap:0.4rem;align-items:center;">
-            <button class="btn btn-sm" onclick="event.preventDefault();event.stopPropagation();showComposeRun('{{.Name}}')" style="font-size:0.68rem;padding:0.15rem 0.45rem;">Start</button>
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Compose &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
 
-<!-- Run dialog (synced with pipeline overview w-dialog pattern) -->
-<dialog id="compose-run-dialog" class="w-dialog" aria-labelledby="compose-run-title">
-    <div class="w-dialog-head">
-        <h3 id="compose-run-title" style="margin:0;font-size:1rem;">Start: <code id="compose-run-name" style="font-size:0.85rem;"></code></h3>
-        <button class="w-dialog-close" onclick="closeComposeRun()" aria-label="Close">&times;</button>
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Composition Pipelines</h1>
     </div>
-    <div class="w-dialog-body">
-        <div class="form-group">
-            <label for="compose-input" style="font-size:0.78rem;color:var(--color-text-secondary);display:block;margin-bottom:0.2rem;">Input</label>
-            <textarea id="compose-input" rows="3" placeholder="Issue URL, feature description..." style="width:100%;padding:0.4rem 0.5rem;border-radius:var(--radius-sm);border:1px solid var(--color-border);background:var(--color-bg-tertiary);color:var(--color-text);font-family:var(--font-sans);font-size:0.82rem;resize:vertical;"></textarea>
+
+  {{if .Pipelines}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Pipelines}} pipelines</span>
+    </div>
+    <div class="w-list standalone">
+    {{range .Pipelines}}
+      <a href="/pipelines/{{.Name}}" class="run-card" data-category="{{.Category}}" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div style="width: 4px; border-radius: 2px; background: #8b5cf6; flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+            {{if and .Category (ne .Category "composition")}}<span class="badge badge-purple" style="font-size: 10px;">{{.Category}}</span>{{end}}
+            <span class="badge" style="font-size: 10px; background: rgba(99,102,241,0.12); color: #a5b4fc;">composition</span>
+          </div>
+          {{if .Description}}<div style="color: var(--color-text-secondary); font-size: 12px; margin-top: 2px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">{{.Description}}</div>{{end}}
+          <div style="display: flex; align-items: center; gap: 12px; margin-top: 4px; font-size: 12px; color: var(--color-text-secondary); flex-wrap: wrap;">
+            <span><b>{{.StepCount}}</b> steps</span>
+            {{if .RunCount}}<span><b>{{.RunCount}}</b> runs</span>{{end}}
+            {{if .Steps}}
+            <span style="display: flex; align-items: center; gap: 2px; font-family: monospace; font-size: 11px;">
+            {{range $i, $step := .Steps}}{{if $i}}<span style="color: var(--color-border);">&#8594;</span>{{end}}<span style="background: var(--color-bg-tertiary); padding: 1px 6px; border-radius: 3px;">{{$step.ID}}</span>{{end}}
+            </span>
+            {{end}}
+            {{range .Skills}}<span class="badge badge-dim" style="font-size: 10px;">{{.}}</span>{{end}}
+          </div>
         </div>
-        <details class="advanced-options" style="margin-top:0.4rem;">
-            <summary style="font-size:0.78rem;color:var(--color-text-muted);cursor:pointer;">Advanced options</summary>
-            <div style="padding-top:0.4rem;display:grid;grid-template-columns:1fr 1fr;gap:0.4rem;">
-                <div class="form-group">
-                    <label for="compose-adapter" style="font-size:0.72rem;color:var(--color-text-muted);display:block;margin-bottom:0.15rem;">Adapter</label>
-                    <select id="compose-adapter" style="width:100%;padding:0.2rem 0.3rem;border-radius:var(--radius-sm);border:1px solid var(--color-border);background:var(--color-bg-tertiary);color:var(--color-text);font-size:0.78rem;">
-                        <option value="">Default</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="compose-model" style="font-size:0.72rem;color:var(--color-text-muted);display:block;margin-bottom:0.15rem;">Model</label>
-                    <select id="compose-model" style="width:100%;padding:0.2rem 0.3rem;border-radius:var(--radius-sm);border:1px solid var(--color-border);background:var(--color-bg-tertiary);color:var(--color-text);font-size:0.78rem;">
-                        <option value="">Default</option>
-                        <option value="cheapest">Cheapest</option>
-                        <option value="fastest">Fastest</option>
-                        <option value="strongest">Strongest</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label class="checkbox-label" style="font-size:0.78rem;color:var(--color-text-secondary);display:flex;align-items:center;gap:0.3rem;padding-top:0.3rem;"><input type="checkbox" id="compose-dry-run"> Dry Run</label>
-                </div>
+        <div style="flex-shrink: 0;">
+          <button class="w-btn" style="font-size: 11px; padding: 3px 10px;" onclick="event.preventDefault();event.stopPropagation();showComposeRun('{{.Name}}')">Start</button>
+        </div>
+      </a>
+    {{end}}
+    </div>
+
+    <dialog id="compose-run-dialog" style="background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: 8px; padding: 0; color: var(--color-text); max-width: 480px; box-shadow: 0 8px 24px rgba(0,0,0,0.4);">
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--color-border);">
+        <h3 style="margin: 0; font-size: 14px;">Start: <code id="compose-run-name" style="font-size: 13px;"></code></h3>
+        <button onclick="closeComposeRun()" style="background: none; border: none; color: var(--color-text-secondary); font-size: 18px; cursor: pointer; padding: 4px 8px;" aria-label="Close">&times;</button>
+      </div>
+      <div style="padding: 16px;">
+        <div>
+          <label style="display: block; font-size: 12px; color: var(--color-text-secondary); margin-bottom: 4px;">Input</label>
+          <textarea id="compose-input" rows="3" placeholder="Issue URL, feature description..." style="width: 100%; background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text); padding: 8px 12px; border-radius: 6px; font-family: inherit; font-size: 13px; resize: vertical;"></textarea>
+        </div>
+        <details style="margin-top: 12px;">
+          <summary style="cursor: pointer; font-size: 12px; color: var(--color-text-secondary); padding: 4px 0;">Advanced options</summary>
+          <div style="padding-top: 12px; display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+            <div>
+              <label style="display: block; font-size: 12px; color: var(--color-text-secondary); margin-bottom: 4px;">Adapter</label>
+              <select id="compose-adapter" style="width: 100%; background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text); padding: 6px 10px; border-radius: 6px; font-family: inherit; font-size: 13px;">
+                <option value="">Default</option>
+              </select>
             </div>
+            <div>
+              <label style="display: block; font-size: 12px; color: var(--color-text-secondary); margin-bottom: 4px;">Model</label>
+              <select id="compose-model" style="width: 100%; background: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text); padding: 6px 10px; border-radius: 6px; font-family: inherit; font-size: 13px;">
+                <option value="">Default</option>
+                <option value="cheapest">Cheapest</option>
+                <option value="fastest">Fastest</option>
+                <option value="strongest">Strongest</option>
+              </select>
+            </div>
+            <div>
+              <label style="display: flex; align-items: center; gap: 6px; font-size: 13px; padding-top: 12px; color: var(--color-text-secondary); cursor: pointer;"><input type="checkbox" id="compose-dry-run"> Dry Run</label>
+            </div>
+          </div>
         </details>
+      </div>
+      <div style="display: flex; gap: 8px; justify-content: flex-end; padding: 0 16px 12px; border-top: 1px solid var(--color-border-light);">
+        <button class="w-btn" onclick="closeComposeRun()">Cancel</button>
+        <button class="w-btn w-btn-primary" id="compose-submit" onclick="submitComposeRun()">Start Pipeline</button>
+      </div>
+    </dialog>
+  {{else}}
+    <div class="w-empty" style="padding: 60px 20px;">
+      <h3>No composition pipelines</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-top: 4px;">Composition pipelines use primitives like <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">iterate</code>, <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">branch</code>, <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">gate</code>, <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">loop</code>, and <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">aggregate</code>.</p>
     </div>
-    <div class="w-dialog-actions">
-        <button class="btn btn-sm" onclick="closeComposeRun()">Cancel</button>
-        <button class="btn btn-sm btn-primary" id="compose-submit" onclick="submitComposeRun()">Start Pipeline</button>
-    </div>
-</dialog>
-<script>
-var composePipeline = '';
-function populateAdapters(selectId) {
-    var sel = document.getElementById(selectId);
-    if (!sel) return;
-    fetch('/api/adapters').then(function(r){return r.json()}).then(function(d){
-        var adapters = d.adapters || [];
-        adapters.forEach(function(a){ var o = document.createElement('option'); o.value = a; o.textContent = a; sel.appendChild(o); });
-    }).catch(function(){});
-}
-function showComposeRun(name) {
-    composePipeline = name;
-    document.getElementById('compose-run-name').textContent = name;
-    document.getElementById('compose-input').value = '';
-    document.getElementById('compose-run-dialog').showModal();
-    populateAdapters('compose-adapter');
-    document.getElementById('compose-input').focus();
-}
-function closeComposeRun() { document.getElementById('compose-run-dialog').close(); composePipeline = ''; }
-function submitComposeRun() {
-    if (!composePipeline) return;
-    var input = document.getElementById('compose-input').value;
-    var btn = document.getElementById('compose-submit');
-    var body = {input: input || ''};
-    var opts = collectAdvancedOptions('compose');
-    Object.keys(opts).forEach(function(k) { body[k] = opts[k]; });
-    setButtonLoading(btn, true);
-    fetchJSON('/api/pipelines/' + encodeURIComponent(composePipeline) + '/start', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(body)
-    }).then(function(d) {
-        closeComposeRun();
-        if (d.run_id) window.location.href = '/runs/' + d.run_id;
-        else showToast('Pipeline started', 'success');
-    }).catch(function() {}).finally(function() { setButtonLoading(btn, false); });
-}
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeComposeRun(); });
-</script>
-{{else}}
-<div style="padding:2rem;text-align:center;color:var(--color-text-muted);font-size:0.85rem;">
-    <p style="margin-bottom:0.5rem;"><strong>No composition pipelines</strong></p>
-    <p style="font-size:0.78rem;">Composition pipelines use primitives like <code>iterate</code>, <code>branch</code>, <code>gate</code>, <code>loop</code>, and <code>aggregate</code>.</p>
-</div>
-{{end}}
-{{end}}
+  {{end}}
+  </div>
+
+  <script src="/static/app.js"></script>
+  <script>
+  var composePipeline = '';
+  function populateAdapters(selectId) {
+      var sel = document.getElementById(selectId);
+      if (!sel) return;
+      fetch('/api/adapters').then(function(r){return r.json()}).then(function(d){
+          var adapters = d.adapters || [];
+          adapters.forEach(function(a){ var o = document.createElement('option'); o.value = a; o.textContent = a; sel.appendChild(o); });
+      }).catch(function(){});
+  }
+  function showComposeRun(name) {
+      composePipeline = name;
+      document.getElementById('compose-run-name').textContent = name;
+      document.getElementById('compose-input').value = '';
+      document.getElementById('compose-run-dialog').showModal();
+      populateAdapters('compose-adapter');
+      document.getElementById('compose-input').focus();
+  }
+  function closeComposeRun() { document.getElementById('compose-run-dialog').close(); composePipeline = ''; }
+  function submitComposeRun() {
+      if (!composePipeline) return;
+      var input = document.getElementById('compose-input').value;
+      var btn = document.getElementById('compose-submit');
+      var body = {input: input || ''};
+      var opts = collectAdvancedOptions('compose');
+      Object.keys(opts).forEach(function(k) { body[k] = opts[k]; });
+      setButtonLoading(btn, true);
+      fetchJSON('/api/pipelines/' + encodeURIComponent(composePipeline) + '/start', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(body)
+      }).then(function(d) {
+          closeComposeRun();
+          if (d.run_id) window.location.href = '/runs/' + d.run_id;
+          else showToast('Pipeline started', 'success');
+      }).catch(function() {}).finally(function() { setButtonLoading(btn, false); });
+  }
+  document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeComposeRun(); });
+  </script>
+</body>
+</html>

--- a/internal/webui/templates/retros.html
+++ b/internal/webui/templates/retros.html
@@ -1,130 +1,135 @@
-{{define "title"}}Retros · Wave{{end}}
-{{define "content"}}
-<div class="page-header">
-    <h1>Retrospective Trends</h1>
-</div>
-{{if .HasData}}
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Retros &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
+    </a>
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
 
-<!-- Smoothness Trend Chart -->
-<div class="card retro-trends-card">
-    <h2>Smoothness Over Time</h2>
-    <p class="retro-subtitle">Last {{len .Trend}} runs — bar height reflects smoothness rating</p>
-    <div class="retro-chart">
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Retrospective Trends</h1>
+    </div>
+
+  {{if .HasData}}
+    <div class="card retro-trends-card">
+      <h2>Smoothness Over Time</h2>
+      <p class="retro-subtitle">Last {{len .Trend}} runs — bar height reflects smoothness rating</p>
+      <div class="retro-chart">
         {{range .Trend}}
         <div class="retro-bar-wrapper" title="{{.Pipeline}}: {{smoothnessLabel .Smoothness}} ({{.CreatedAt}})">
-            <div class="retro-bar retro-bar-{{.Smoothness}}" style="height: {{.HeightPct}}%;"></div>
-            <span class="retro-bar-label">{{smoothnessLabel .Smoothness}}</span>
+          <div class="retro-bar retro-bar-{{.Smoothness}}" style="height: {{.HeightPct}}%;"></div>
+          <span class="retro-bar-label">{{smoothnessLabel .Smoothness}}</span>
         </div>
         {{end}}
-    </div>
-    <div class="retro-legend">
+      </div>
+      <div class="retro-legend">
         <span class="retro-legend-item"><span class="retro-legend-dot retro-bar-effortless"></span> Effortless</span>
         <span class="retro-legend-item"><span class="retro-legend-dot retro-bar-smooth"></span> Smooth</span>
         <span class="retro-legend-item"><span class="retro-legend-dot retro-bar-bumpy"></span> Bumpy</span>
         <span class="retro-legend-item"><span class="retro-legend-dot retro-bar-struggled"></span> Struggled</span>
         <span class="retro-legend-item"><span class="retro-legend-dot retro-bar-failed"></span> Failed</span>
+      </div>
     </div>
-</div>
 
-<div class="retro-grid">
-    <!-- Friction Points -->
-    <div class="card retro-friction-card">
+    <div class="retro-grid">
+      <div class="card retro-friction-card">
         <h2>Common Friction Points</h2>
         {{if .FrictionPoints}}
         <table class="retro-table">
-            <thead>
-                <tr>
-                    <th>Friction Type</th>
-                    <th>Occurrences</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{range .FrictionPoints}}
-                <tr>
-                    <td><span class="retro-friction-type">{{.Type}}</span> {{frictionLabel .Type}}</td>
-                    <td><strong>{{.Count}}</strong></td>
-                </tr>
-                {{end}}
-            </tbody>
+          <thead><tr><th>Friction Type</th><th>Occurrences</th></tr></thead>
+          <tbody>
+            {{range .FrictionPoints}}
+            <tr>
+              <td><span class="retro-friction-type">{{.Type}}</span> {{frictionLabel .Type}}</td>
+              <td><strong>{{.Count}}</strong></td>
+            </tr>
+            {{end}}
+          </tbody>
         </table>
         {{else}}
         <p class="retro-empty-hint">No friction points recorded yet. Run pipelines with narrative generation to collect friction data.</p>
         {{end}}
-    </div>
+      </div>
 
-    <!-- Pipeline Success Rates -->
-    <div class="card retro-pipeline-card">
+      <div class="card retro-pipeline-card">
         <h2>Pipeline Success Rates</h2>
         {{if .PipelineRates}}
         <table class="retro-table">
-            <thead>
-                <tr>
-                    <th>Pipeline</th>
-                    <th>Runs</th>
-                    <th>Success %</th>
-                    <th>Avg Duration</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{range .PipelineRates}}
-                <tr>
-                    <td><a href="/runs?pipeline={{.Pipeline}}">{{.Pipeline}}</a></td>
-                    <td>{{.TotalRuns}}</td>
-                    <td>
-                        <div class="retro-pct-bar">
-                            <div class="retro-pct-fill {{if ge .SuccessPct 70}}retro-pct-good{{else if ge .SuccessPct 40}}retro-pct-warn{{else}}retro-pct-bad{{end}}" style="width: {{.SuccessPct}}%;"></div>
-                            <span class="retro-pct-label">{{.SuccessPct}}%</span>
-                        </div>
-                    </td>
-                    <td>{{.AvgDuration}}</td>
-                </tr>
-                {{end}}
-            </tbody>
+          <thead><tr><th>Pipeline</th><th>Runs</th><th>Success %</th><th>Avg Duration</th></tr></thead>
+          <tbody>
+            {{range .PipelineRates}}
+            <tr>
+              <td><a href="/runs?pipeline={{.Pipeline}}">{{.Pipeline}}</a></td>
+              <td>{{.TotalRuns}}</td>
+              <td>
+                <div class="retro-pct-bar">
+                  <div class="retro-pct-fill {{if ge .SuccessPct 70}}retro-pct-good{{else if ge .SuccessPct 40}}retro-pct-warn{{else}}retro-pct-bad{{end}}" style="width: {{.SuccessPct}}%;"></div>
+                  <span class="retro-pct-label">{{.SuccessPct}}%</span>
+                </div>
+              </td>
+              <td>{{.AvgDuration}}</td>
+            </tr>
+            {{end}}
+          </tbody>
         </table>
         {{else}}
         <p class="retro-empty-hint">No pipeline data available.</p>
         {{end}}
+      </div>
     </div>
-</div>
 
-<!-- Latest Retros List -->
-<div class="card retro-list-card">
-    <h2>Latest Retrospectives</h2>
-    <table class="retro-table">
-        <thead>
-            <tr>
-                <th>Run</th>
-                <th>Pipeline</th>
-                <th>Smoothness</th>
-                <th>Status</th>
-                <th>Created</th>
-            </tr>
-        </thead>
+    <div class="card retro-list-card">
+      <h2>Latest Retrospectives</h2>
+      <table class="retro-table">
+        <thead><tr><th>Run</th><th>Pipeline</th><th>Smoothness</th><th>Status</th><th>Created</th></tr></thead>
         <tbody>
-            {{range .Retros}}
-            <tr>
-                <td><a href="/runs/{{.RunID}}">{{.RunID}}</a></td>
-                <td><a href="/runs?pipeline={{.Pipeline}}">{{.Pipeline}}</a></td>
-                <td>
-                    {{if .Smoothness}}
-                    <span class="retro-smoothness-{{.Smoothness}}">{{smoothnessLabel .Smoothness}}</span>
-                    {{else}}
-                    <span class="retro-smoothness-pending">-</span>
-                    {{end}}
-                </td>
-                <td><span class="badge">{{.Status}}</span></td>
-                <td>{{.CreatedAt}}</td>
-            </tr>
-            {{end}}
+          {{range .Retros}}
+          <tr>
+            <td><a href="/runs/{{.RunID}}">{{.RunID}}</a></td>
+            <td><a href="/runs?pipeline={{.Pipeline}}">{{.Pipeline}}</a></td>
+            <td>
+              {{if .Smoothness}}<span class="retro-smoothness-{{.Smoothness}}">{{smoothnessLabel .Smoothness}}</span>
+              {{else}}<span class="retro-smoothness-pending">-</span>{{end}}
+            </td>
+            <td><span class="badge">{{.Status}}</span></td>
+            <td>{{.CreatedAt}}</td>
+          </tr>
+          {{end}}
         </tbody>
-    </table>
-</div>
+      </table>
+    </div>
+  {{else}}
+    <div class="w-empty" style="padding: 60px 20px;">
+      <h3>No retrospectives yet</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-top: 4px;">Retrospectives are generated after pipeline runs complete. Run a pipeline to see trends here.</p>
+    </div>
+  {{end}}
+  </div>
 
-{{else}}
-<div class="empty-state">
-    <div class="empty-state-icon">&#9776;</div>
-    <p><strong>No retrospectives yet</strong></p>
-    <p>Retrospectives are generated after pipeline runs complete. Run a pipeline to see trends here.</p>
-</div>
-{{end}}
-{{end}}
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/internal/webui/templates/skills.html
+++ b/internal/webui/templates/skills.html
@@ -1,155 +1,179 @@
-{{define "title"}}Skills · Wave{{end}}
-{{define "content"}}
-<div class="w-head"><h1>Skills</h1></div>
-
-{{if .Installed}}
-<div class="wr-toolbar">
-    <div class="wr-controls">
-        <span style="font-size:0.72rem;color:var(--color-text-muted);">{{len .Installed}} installed</span>
-    </div>
-</div>
-<div class="wr-list">
-{{range .Installed}}
-    <a href="/skills/{{.Name}}" class="wr-run">
-        <div class="wr-accent st-completed"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-                <span class="badge" style="background:var(--color-completed);color:#fff;font-size:0.6rem;">installed</span>
-            </div>
-            {{if .Description}}<div class="wr-row2"><span style="color:var(--color-text-secondary);">{{.Description}}</span></div>{{end}}
-        </div>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Skills &mdash; Wave</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  {{if csrfToken}}<meta name="csrf-token" content="{{csrfToken}}">{{end}}
+</head>
+<body>
+  <nav class="w-nav">
+    <a href="/" class="w-nav-brand">
+      <svg viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true">
+        <path d="M2 14 C6 6, 10 6, 14 14 C18 22, 22 22, 26 14"/>
+        <path d="M2 14 C6 22, 10 22, 14 14 C18 6, 22 6, 26 14" opacity="0.35"/>
+      </svg>
+      Wave
     </a>
-{{end}}
-</div>
-{{end}}
+    <div class="w-nav-links">
+      <a href="/work">Work</a>
+      <a href="/runs">Runs</a>
+      <a href="/pipelines">Pipelines</a>
+      <a href="/proposals">Proposals</a>
+      <a href="/issues">Issues</a>
+      <a href="/prs">PRs</a>
+      <a href="/onboard">Onboard</a>
+      <a href="/health" style="margin-left: auto;">Health</a>
+    </div>
+  </nav>
 
-{{if .Available}}
-<div class="wr-toolbar" style="{{if .Installed}}margin-top:1.5rem;{{end}}">
-    <div class="wr-controls">
-        <span style="font-size:0.72rem;color:var(--color-text-muted);">{{len .Available}} available</span>
+  <div class="w-container">
+    <div class="w-page-header">
+      <h1 class="w-page-title">Skills</h1>
     </div>
-</div>
-<div class="wr-list">
-{{range .Available}}
-    <div class="wr-run" id="skill-card-{{.Name}}" style="cursor:default;">
-        <div class="wr-accent st-defined"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-            </div>
-            {{if .Description}}<div class="wr-row2"><span style="color:var(--color-text-secondary);">{{.Description}}</span></div>{{end}}
-        </div>
-        <div class="wr-meta">
-            <button class="btn btn-primary btn-sm" onclick="installSkill('{{.Name}}')">Install</button>
-        </div>
-    </div>
-{{end}}
-</div>
-{{end}}
 
-{{if .Skills}}
-<div class="wr-toolbar" style="{{if or .Installed .Available}}margin-top:1.5rem;{{end}}">
-    <div class="wr-controls">
-        <span style="font-size:0.72rem;color:var(--color-text-muted);">{{len .Skills}} pipeline requirements</span>
+    {{if .Installed}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);">
+      <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Installed}} installed</span>
     </div>
-</div>
-<div class="wr-list">
-{{range .Skills}}
-    <a href="/skills/{{.Name}}" class="wr-run" id="req-card-{{.Name}}" onclick="event.stopPropagation();">
-        <div class="wr-accent st-defined"></div>
-        <div class="wr-body">
-            <div class="wr-row1">
-                <span class="wr-name">{{.Name}}</span>
-                {{if .InstallPkg}}<span class="badge badge-workspace" style="font-size:0.6rem;">{{.InstallPkg}}</span>{{end}}
-                {{if .InstallMethod}}<span class="badge" style="font-size:0.6rem;">via {{.InstallMethod}}</span>{{end}}
-            </div>
-            {{if .InstallSource}}
-            <div class="wr-row2">
-                <span style="color:var(--color-text-muted);font-size:0.72rem;">{{.InstallSource}}</span>
-            </div>
-            {{end}}
-            {{if .PipelineUsage}}
-            <div class="wr-row2" style="flex-wrap:wrap;gap:0.25rem;">
-                {{range .PipelineUsage}}<span class="badge badge-workspace" style="font-size:0.6rem;">{{.}}</span>{{end}}
-            </div>
-            {{end}}
+    <div class="w-list standalone">
+    {{range .Installed}}
+      <a href="/skills/{{.Name}}" class="run-card" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div style="width: 4px; border-radius: 2px; background: var(--color-completed); flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+            <span class="badge badge-green" style="font-size: 10px;">installed</span>
+          </div>
+          {{if .Description}}<div style="color: var(--color-text-secondary); font-size: 12px; margin-top: 2px;">{{.Description}}</div>{{end}}
+        </div>
+      </a>
+    {{end}}
+    </div>
+    {{end}}
+
+    {{if .Available}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);{{if .Installed}} margin-top: 16px;{{end}}">
+      <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Available}} available</span>
+    </div>
+    <div class="w-list standalone">
+    {{range .Available}}
+      <div class="run-card" id="skill-card-{{.Name}}" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light);">
+        <div style="width: 4px; border-radius: 2px; background: var(--color-link); flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+          </div>
+          {{if .Description}}<div style="color: var(--color-text-secondary); font-size: 12px; margin-top: 2px;">{{.Description}}</div>{{end}}
+        </div>
+        <div style="flex-shrink: 0;">
+          <button class="w-btn w-btn-primary" style="font-size: 11px; padding: 3px 10px;" onclick="installSkill('{{.Name}}')">Install</button>
+        </div>
+      </div>
+    {{end}}
+    </div>
+    {{end}}
+
+    {{if .Skills}}
+    <div class="w-filterbar" style="border-radius: 8px; border-bottom: 1px solid var(--color-border);{{if or .Installed .Available}} margin-top: 16px;{{end}}">
+      <span style="font-size: 12px; color: var(--color-text-secondary);">{{len .Skills}} pipeline requirements</span>
+    </div>
+    <div class="w-list standalone">
+    {{range .Skills}}
+      <a href="/skills/{{.Name}}" class="run-card" id="req-card-{{.Name}}" style="display: flex; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--color-border-light); text-decoration: none; color: inherit;" onmouseover="this.style.background='var(--color-bg-tertiary)'" onmouseout="this.style.background=''">
+        <div style="width: 4px; border-radius: 2px; background: var(--color-link); flex-shrink: 0;"></div>
+        <div style="flex: 1; min-width: 0;">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <span style="font-weight: 500;">{{.Name}}</span>
+            {{if .InstallPkg}}<span class="badge badge-dim" style="font-size: 10px;">{{.InstallPkg}}</span>{{end}}
+            {{if .InstallMethod}}<span class="badge badge-dim" style="font-size: 10px;">via {{.InstallMethod}}</span>{{end}}
+          </div>
+          {{if .InstallSource}}<div style="color: var(--color-text-muted); font-size: 12px; margin-top: 2px;">{{.InstallSource}}</div>{{end}}
+          {{if .PipelineUsage}}
+          <div style="display: flex; gap: 4px; margin-top: 4px; flex-wrap: wrap;">
+            {{range .PipelineUsage}}<span class="badge badge-dim" style="font-size: 10px;">{{.}}</span>{{end}}
+          </div>
+          {{end}}
         </div>
         {{if .InstallCmd}}
-        <div class="wr-meta">
-            <button class="btn btn-primary btn-sm" onclick="event.preventDefault(); event.stopPropagation(); runInstallTool('{{.Name}}')">Install</button>
+        <div style="flex-shrink: 0;">
+          <button class="w-btn w-btn-primary" style="font-size: 11px; padding: 3px 10px;" onclick="event.preventDefault(); event.stopPropagation(); runInstallTool('{{.Name}}')">Install</button>
         </div>
         {{end}}
-    </a>
-{{end}}
-</div>
-{{end}}
+      </a>
+    {{end}}
+    </div>
+    {{end}}
 
-{{if and (not .Installed) (not .Available) (not .Skills)}}
-<div style="padding:2rem;text-align:center;color:var(--color-text-muted);">No skills found. Skills are declared in pipeline YAML files under <code>requires.skills</code>.</div>
-{{end}}
-{{end}}
-{{define "scripts"}}
-<script>
-function runInstallTool(name) {
-    var card = document.getElementById('req-card-' + name);
-    if (!card) return;
-    var btn = card.querySelector('button');
-    if (!btn) return;
-    btn.disabled = true;
-    btn.textContent = 'Installing...';
+    {{if and (not .Installed) (not .Available) (not .Skills)}}
+    <div class="w-empty">
+      <h3>No skills found</h3>
+      <p style="color: var(--color-text-secondary); font-size: 13px; margin-top: 4px;">Skills are declared in pipeline YAML files under <code style="background: var(--color-bg-secondary); padding: 2px 6px; border-radius: 4px;">requires.skills</code>.</p>
+    </div>
+    {{end}}
+  </div>
 
-    fetch('/api/skills/' + encodeURIComponent(name) + '/run-install', {
-        method: 'POST',
-        headers: {'X-CSRF-Token': getCSRFToken()}
-    })
-    .then(function(resp) { return resp.json(); })
-    .then(function(data) {
-        if (data.success) {
-            btn.textContent = 'Installed';
-            btn.classList.remove('btn-primary');
-            btn.style.background = 'var(--color-completed)';
-            btn.style.color = '#fff';
-        } else {
-            btn.textContent = 'Failed';
-            btn.disabled = false;
-            btn.title = data.error || 'unknown error';
-        }
-    })
-    .catch(function() {
-        btn.textContent = 'Error';
-        btn.disabled = false;
-    });
-}
-
-function installSkill(name) {
-    var card = document.getElementById('skill-card-' + name);
-    if (!card) return;
-    var btn = card.querySelector('button');
-    if (!btn) return;
-    btn.disabled = true;
-    btn.textContent = 'Installing...';
-
-    fetch('/api/skills/' + encodeURIComponent(name) + '/install', {
-        method: 'POST',
-        headers: {'X-CSRF-Token': getCSRFToken()}
-    })
-    .then(function(resp) { return resp.json(); })
-    .then(function(data) {
-        if (data.success) {
-            btn.textContent = 'Installed';
-            btn.classList.remove('btn-primary');
-            btn.style.background = 'var(--color-completed)';
-            btn.style.color = '#fff';
-        } else {
-            btn.textContent = 'Failed: ' + (data.error || 'unknown error');
-            btn.disabled = false;
-        }
-    })
-    .catch(function(err) {
-        btn.textContent = 'Error';
-        btn.disabled = false;
-    });
-}
-</script>
-{{end}}
+  <script src="/static/app.js"></script>
+  <script>
+  function runInstallTool(name) {
+      var card = document.getElementById('req-card-' + name);
+      if (!card) return;
+      var btn = card.querySelector('button');
+      if (!btn) return;
+      btn.disabled = true;
+      btn.textContent = 'Installing...';
+      fetch('/api/skills/' + encodeURIComponent(name) + '/run-install', {
+          method: 'POST',
+          headers: {'X-CSRF-Token': getCSRFToken()}
+      })
+      .then(function(resp) { return resp.json(); })
+      .then(function(data) {
+          if (data.success) {
+              btn.textContent = 'Installed';
+              btn.classList.remove('w-btn-primary');
+              btn.style.background = 'var(--color-completed)';
+              btn.style.color = '#fff';
+          } else {
+              btn.textContent = 'Failed';
+              btn.disabled = false;
+              btn.title = data.error || 'unknown error';
+          }
+      })
+      .catch(function() {
+          btn.textContent = 'Error';
+          btn.disabled = false;
+      });
+  }
+  function installSkill(name) {
+      var card = document.getElementById('skill-card-' + name);
+      if (!card) return;
+      var btn = card.querySelector('button');
+      if (!btn) return;
+      btn.disabled = true;
+      btn.textContent = 'Installing...';
+      fetch('/api/skills/' + encodeURIComponent(name) + '/install', {
+          method: 'POST',
+          headers: {'X-CSRF-Token': getCSRFToken()}
+      })
+      .then(function(resp) { return resp.json(); })
+      .then(function(data) {
+          if (data.success) {
+              btn.textContent = 'Installed';
+              btn.classList.remove('w-btn-primary');
+              btn.style.background = 'var(--color-completed)';
+              btn.style.color = '#fff';
+          } else {
+              btn.textContent = 'Failed: ' + (data.error || 'unknown error');
+              btn.disabled = false;
+          }
+      })
+      .catch(function(err) {
+          btn.textContent = 'Error';
+          btn.disabled = false;
+      });
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Migrate `/analytics`, `/retros`, `/skills`, `/compose` pages from layout-based to standalone templates with unified `w-*` design system classes
- Analytics and retros retain their existing `analytics-*`/`retro-*` CSS classes (already in style.css)
- Skills and compose converted from `wr-*` to `w-*` design system classes
- Add all four to `standalonePageTemplates` in `embed.go`
- Update handlers to use `Execute()` instead of `ExecuteTemplate()`

Preserves all functionality: bar charts, rank lists, install buttons, compose dialog with advanced options.

**Standalone pages after this PR:** 18 total (work/board, work/detail, onboard, proposals/list, proposals/detail, runs, pipelines, issues, prs, health, contracts, personas, notfound, analytics, retros, skills, compose)

**Remaining layout-based pages:** run_detail, pipeline_detail, issue_detail, pr_detail, persona_detail, contract_detail, skill_detail, webhook_detail, compare, webhooks, admin (11 — mostly detail pages + admin/compare/webhooks which are complex)

Part of #1624 (WebUI UX consolidation).

## Test plan
- [ ] `go test ./internal/webui/` passes
- [ ] `/analytics` renders stat cards, bar chart, rank lists
- [ ] `/retros` renders smoothness chart, friction table, pipeline rates
- [ ] `/skills` renders installed/available/required sections, install buttons work
- [ ] `/compose` renders pipeline list, start dialog with advanced options